### PR TITLE
Add GitHub badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 ![Under Construction](https://img.shields.io/badge/Status-Under%20Construction-yellow)
 ![Stability](https://img.shields.io/badge/API%20Stability-Experimental-orange)
+![GitHub stars](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![GitHub forks](https://img.shields.io/github/forks/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![GitHub issues](https://img.shields.io/github/issues/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![GitHub release](https://img.shields.io/github/v/release/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![GitHub commits](https://img.shields.io/github/commit-activity/m/agentic-community/mcp-gateway-registry?style=flat&logo=github)
+![License](https://img.shields.io/github/license/agentic-community/mcp-gateway-registry?style=flat)
 
 # MCP Gateway & Registry
 


### PR DESCRIPTION
## Description
This PR adds GitHub badges to the README.md file to improve project visibility and provide quick project statistics.

## Changes Made
- Added 7 new GitHub badges after the existing status badges:
  - GitHub stars
  - GitHub forks  
  - GitHub issues
  - GitHub pull requests
  - GitHub release
  - GitHub commits (monthly activity)
  - License

## Technical Details
- All badges use consistent flat styling with GitHub logos where appropriate
- Badges are functional and will display current repository statistics
- Maintained consistent formatting with existing badges
- Added to lines 9-15 in README.md

## Testing
- Verified badges render correctly in markdown
- Confirmed all badge URLs are functional
- Maintained existing README structure and formatting

## Related Issue
Closes #9

## Screenshots
The badges will appear at the top of the README after the logo and existing status badges, providing immediate visibility of key repository metrics.