### PR TITLE
Standardize logging format across all Python files

### DIFF
--- a/GITHUB_ISSUE_CONTENT.md
+++ b/GITHUB_ISSUE_CONTENT.md
@@ -1,0 +1,127 @@
+# Standardize Logging Format Across All Python Files
+
+## Issue Description
+
+Currently, Python files in this repository use inconsistent logging formats. We need to standardize all logging configurations to use the following format specifier:
+
+```python
+format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+```
+
+## Current State Analysis
+
+### Root Logger Configuration Files (Entry Points):
+
+1. **`registry/main.py:44-47`** - **Registry Application Entry Point**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Configures root logger, affects all registry/* modules
+   - **Status**: ❌ Needs update (different format structure)
+
+2. **`auth_server/server.py:31-35`** - **Auth Server Entry Point**
+   - **Current format**: `"[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"`
+   - **Scope**: Configures root logger via basicConfig, affects auth server modules
+   - **Status**: ❌ Needs update (brackets around timestamp, missing comma separators)
+
+3. **`agents/agent.py:71-75`** - **Agent Entry Point**
+   - **Current format**: `"%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"`
+   - **Scope**: Configures root logger via basicConfig, affects agent modules
+   - **Status**: ✅ Already compliant
+
+### MCP Server Entry Points (servers/ directory):
+
+4. **`servers/mcpgw/server.py:24-28`** - **MCP Gateway Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+5. **`servers/currenttime/server.py:16-20`** - **Current Time MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+6. **`servers/fininfo/server.py:17-21`** - **Financial Info MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+7. **`servers/realserverfaketools/server.py:18-22`** - **Fake Tools MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+### Files That Inherit Logging Format (No Changes Needed):
+
+8. **`registry/auth/routes.py:13`**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+9. **`registry/search/service.py:14`**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+10. **`registry/health/routes.py:7`**
+    - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+    - **Status**: ✅ Will inherit correct format once main.py is updated
+
+11. **`registry/core/nginx_service.py:9`**
+    - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+    - **Status**: ✅ Will inherit correct format once main.py is updated
+
+### Files Without Logging:
+
+12. **`registry/core/schemas.py`**
+    - **Status**: ✅ No logging configuration needed (data models only)
+
+13. **`registry/core/config.py`**
+    - **Status**: ✅ No logging configuration needed (configuration only)
+
+## Implementation Requirements
+
+### Target Format Specification:
+```python
+format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+```
+
+### Expected Output Format:
+```
+2025-06-15 17:48:37,p12345,{server.py:123},INFO,Server started successfully
+```
+
+## Files Requiring Changes Summary:
+
+**Total files needing updates: 6** (Entry points only)
+
+### Main Application Entry Points:
+1. `registry/main.py` - Format modification (affects all registry/* modules)
+2. `auth_server/server.py` - Format modification (affects auth server modules)
+
+### MCP Server Entry Points:
+3. `servers/mcpgw/server.py` - Format modification (standalone server)
+4. `servers/currenttime/server.py` - Format modification (standalone server)
+5. `servers/fininfo/server.py` - Format modification (standalone server)
+6. `servers/realserverfaketools/server.py` - Format modification (standalone server)
+
+**Already Compliant:**
+- `agents/agent.py` - Already uses target format ✅
+
+**Note**: Files using `logging.getLogger(__name__)` will automatically inherit the correct format once their respective entry points are updated, thanks to Python's logging hierarchy. The MCP servers in the `servers/` directory are standalone applications that each configure their own logging.
+
+## Benefits
+
+- **Consistency**: Uniform log format across all components
+- **Parsing**: Easier automated log parsing and analysis
+- **Debugging**: Consistent structure for troubleshooting
+- **Monitoring**: Standardized format for log aggregation tools
+
+## Acceptance Criteria
+
+- [ ] All Python files use the standardized logging format
+- [ ] Existing functionality remains unchanged
+- [ ] Log output follows the expected format pattern
+- [ ] No breaking changes to current logging behavior
+
+## Labels
+`enhancement`, `logging`, `maintenance`
+
+## Priority
+Medium

--- a/LOGGING_FORMAT_STANDARDIZATION_ISSUE.md
+++ b/LOGGING_FORMAT_STANDARDIZATION_ISSUE.md
@@ -1,0 +1,121 @@
+# Standardize Logging Format Across All Python Files
+
+## Issue Description
+
+Currently, Python files in this repository use inconsistent logging formats. We need to standardize all logging configurations to use the following format specifier:
+
+```python
+format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+```
+
+## Current State Analysis
+
+### Root Logger Configuration Files (Entry Points):
+
+1. **[`registry/main.py`](registry/main.py:44-47)** - **Registry Application Entry Point**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Configures root logger, affects all registry/* modules
+   - **Status**: ❌ Needs update (different format structure)
+
+2. **[`auth_server/server.py`](auth_server/server.py:31-35)** - **Auth Server Entry Point**
+   - **Current format**: `"[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s"`
+   - **Scope**: Configures root logger via basicConfig, affects auth server modules
+   - **Status**: ❌ Needs update (brackets around timestamp, missing comma separators)
+
+3. **[`agents/agent.py`](agents/agent.py:71-75)** - **Agent Entry Point**
+   - **Current format**: `"%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"`
+   - **Scope**: Configures root logger via basicConfig, affects agent modules
+   - **Status**: ✅ Already compliant
+
+### MCP Server Entry Points (servers/ directory):
+
+4. **[`servers/mcpgw/server.py`](servers/mcpgw/server.py:24-28)** - **MCP Gateway Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+5. **[`servers/currenttime/server.py`](servers/currenttime/server.py:16-20)** - **Current Time MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+6. **[`servers/fininfo/server.py`](servers/fininfo/server.py:17-21)** - **Financial Info MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+7. **[`servers/realserverfaketools/server.py`](servers/realserverfaketools/server.py:18-22)** - **Fake Tools MCP Server**
+   - **Current format**: `'%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s'`
+   - **Scope**: Standalone MCP server
+   - **Status**: ❌ Needs update (different format structure, same as registry/main.py)
+
+### Files That Inherit Logging Format (No Changes Needed):
+
+4. **[`registry/auth/routes.py`](registry/auth/routes.py:13)**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+5. **[`registry/search/service.py`](registry/search/service.py:14)**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+6. **[`registry/health/routes.py`](registry/health/routes.py:7)**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+7. **[`registry/core/nginx_service.py`](registry/core/nginx_service.py:9)**
+   - **Current**: Uses `logging.getLogger(__name__)` - inherits from registry/main.py
+   - **Status**: ✅ Will inherit correct format once main.py is updated
+
+### Files Without Logging:
+
+8. **[`registry/core/schemas.py`](registry/core/schemas.py)**
+   - **Status**: ✅ No logging configuration needed (data models only)
+
+9. **[`registry/core/config.py`](registry/core/config.py)**
+   - **Status**: ✅ No logging configuration needed (configuration only)
+
+## Implementation Requirements
+
+### Target Format Specification:
+```python
+format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+```
+
+### Expected Output Format:
+```
+2025-06-15 17:48:37,p12345,{server.py:123},INFO,Server started successfully
+```
+
+## Files Requiring Changes Summary:
+
+**Total files needing updates: 6** (Entry points only)
+
+### Main Application Entry Points:
+1. `registry/main.py` - Format modification (affects all registry/* modules)
+2. `auth_server/server.py` - Format modification (affects auth server modules)
+
+### MCP Server Entry Points:
+3. `servers/mcpgw/server.py` - Format modification (standalone server)
+4. `servers/currenttime/server.py` - Format modification (standalone server)
+5. `servers/fininfo/server.py` - Format modification (standalone server)
+6. `servers/realserverfaketools/server.py` - Format modification (standalone server)
+
+**Already Compliant:**
+- `agents/agent.py` - Already uses target format ✅
+
+**Note**: Files using `logging.getLogger(__name__)` will automatically inherit the correct format once their respective entry points are updated, thanks to Python's logging hierarchy. The MCP servers in the `servers/` directory are standalone applications that each configure their own logging.
+
+## Benefits
+
+- **Consistency**: Uniform log format across all components
+- **Parsing**: Easier automated log parsing and analysis
+- **Debugging**: Consistent structure for troubleshooting
+- **Monitoring**: Standardized format for log aggregation tools
+
+## Acceptance Criteria
+
+- [ ] All Python files use the standardized logging format
+- [ ] Existing functionality remains unchanged
+- [ ] Log output follows the expected format pattern
+- [ ] No breaking changes to current logging behavior

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -71,7 +71,7 @@ from cognito_utils import generate_token
 logging.basicConfig(
     level=logging.INFO,  # Set the log level to INFO
     # Define log message format
-    format="[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 
 # Get logger

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -31,7 +31,7 @@ from string import Template
 logging.basicConfig(
     level=logging.INFO,  # Set the log level to INFO
     # Define log message format
-    format="[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 logger = logging.getLogger(__name__)
 # Load scopes configuration

--- a/registry/main.py
+++ b/registry/main.py
@@ -42,13 +42,11 @@ def setup_logging():
     
     # Create formatters
     file_formatter = logging.Formatter(
-        '%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        '%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
     )
     
     console_formatter = logging.Formatter(
-        '%(asctime)s.%(msecs)03d - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        '%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
     )
     
     # Get root logger

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -15,8 +15,7 @@ from typing import Annotated
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 logger = logging.getLogger(__name__)
 

--- a/servers/fininfo/server.py
+++ b/servers/fininfo/server.py
@@ -16,8 +16,7 @@ from dotenv import load_dotenv
 # Configure logging
 logging.basicConfig(
     level=logging.DEBUG,
-    format='%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 logger = logging.getLogger(__name__)
 

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -23,8 +23,7 @@ import faiss # Added
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 logger = logging.getLogger(__name__)
 

--- a/servers/realserverfaketools/server.py
+++ b/servers/realserverfaketools/server.py
@@ -17,8 +17,7 @@ from typing import Annotated, List, Dict, Optional, Union, Any
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s.%(msecs)03d - PID:%(process)d - %(filename)s:%(lineno)d - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    format='%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s'
 )
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Update registry/main.py to use standardized format for both file and console handlers
- Update auth_server/server.py to use standardized format
- Update all MCP servers in servers/ directory:
  - servers/mcpgw/server.py
  - servers/currenttime/server.py
  - servers/fininfo/server.py
  - servers/realserverfaketools/server.py

All logging now uses format: %(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s

Fixes #33

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
