### PR TITLE
Fix documentation and nginx config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,9 @@ For production deployments with SSL certificates:
    sudo mkdir -p /home/ubuntu/ssl_data/certs
    sudo mkdir -p /home/ubuntu/ssl_data/private
    # Copy your certificate and private key files to these directories
+   # Important: Name your files as follows:
+   # - Certificate file: fullchain.pem (goes in /home/ubuntu/ssl_data/certs/)
+   # - Private key file: privkey.pem (goes in /home/ubuntu/ssl_data/private/)
    ```
 
 4. **Deploy with HTTPS:** Run the deployment script as normal:
@@ -400,6 +403,7 @@ For production deployments with SSL certificates:
 
 3. **Run the agent with session cookie:**
    ```bash
+   # your_registry_url would typically be http://localhost/mcpgw/sse or https://mymcpgateway.mycorp.com/mcpgw/sse
    python agents/agent.py --use-session-cookie --mcp-registry-url your_registry_url --message "what is the current time in clarksburg, md"
    ```
 
@@ -418,6 +422,7 @@ For production deployments with SSL certificates:
    The agent will communicate with Cognito to obtain a JWT token which will include information about the groups it is part of. This information is then used by the Auth server for authorization decisions.
    
    ```bash
+   # your_registry_url would typically be http://localhost/mcpgw/sse or https://mymcpgateway.mycorp.com/mcpgw/sse
    python agents/agent.py --mcp-registry-url your_registry_url --message "what is the current time in clarksburg, md"
    ```
 

--- a/docker/nginx_rev_proxy.conf
+++ b/docker/nginx_rev_proxy.conf
@@ -1,3 +1,6 @@
+# Nginx configuration directive for handling long server names
+server_names_hash_bucket_size 128;
+
 # First server block now directly handles HTTP requests instead of redirecting
 server {
     listen 80;

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -258,6 +258,9 @@ The script handles Docker image building, service orchestration, and health chec
    sudo mkdir -p /home/ubuntu/ssl_data/certs
    sudo mkdir -p /home/ubuntu/ssl_data/private
    # Copy your certificate files to these directories
+   # Important: Name your files as follows:
+   # - Certificate file: fullchain.pem (goes in /home/ubuntu/ssl_data/certs/)
+   # - Private key file: privkey.pem (goes in /home/ubuntu/ssl_data/private/)
    ```
 
 2. **Update security group** to allow port 443

--- a/docs/cognito.md
+++ b/docs/cognito.md
@@ -201,6 +201,7 @@ Create `.env.user` file in the `agents/` directory:
 # Cognito Configuration
 COGNITO_USER_POOL_ID=us-east-1_XXXXXXXXX
 COGNITO_CLIENT_ID=your-public-client-id
+COGNITO_CLIENT_SECRET=your-client-secret
 SECRET_KEY=your-secret-key-matching-registry
 
 # Optional: Custom domain


### PR DESCRIPTION
This PR addresses issue #51 with the following changes:

## Changes Made

1. **SSL Certificate Documentation Updates**:
   - Added filename requirements (fullchain.pem, privkey.pem) to README.md and docs/FAQ.md
   - Clarified that certificates must use these specific names to match nginx configuration

2. **MCP Registry URL Documentation**:
   - Added explanatory comments for --mcp-registry-url parameter in agent examples
   - Shows typical formats: http://localhost/mcpgw/sse or https://mymcpgateway.mycorp.com/mcpgw/sse

3. **Nginx Configuration Update**:
   - Added server_names_hash_bucket_size 128 directive to docker/nginx_rev_proxy.conf

4. **Cognito Environment Variables**:
   - Added missing COGNITO_CLIENT_SECRET to user authentication section in docs/cognito.md

## Files Modified
- README.md
- docs/FAQ.md  
- docs/cognito.md
- docker/nginx_rev_proxy.conf

Fixes #51