### PR TITLE
Fix scopes.yml path resolution and optimize FAISS loading in intelligent tool finder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - "8888:8888"
     volumes:
       - /var/log/mcp-gateway:/app/logs
-      - /opt/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
+      - /opt/mcp-gateway/auth_server/scopes.yml:/app/scopes.yml
     restart: unless-stopped
 
   # Current Time MCP Server


### PR DESCRIPTION
## Description

This PR addresses two key improvements to the mcpgw server's functionality:

### 🔧 Fix scopes.yml Path Resolution

**Problem**: The scopes configuration loading was not robust across different deployment environments (Docker vs local development).

**Solution**: 
- Implemented fallback path resolution for `scopes.yml` file location
- First attempts Docker container path: `/app/auth_server/scopes.yml`  
- Falls back to local development path: `../auth_server/scopes.yml` (relative to server.py)
- Added proper error handling and logging for missing scopes files

**Impact**: Ensures fine-grained access control (FGAC) works consistently in both containerized and local development environments.

### ⚡ Optimize FAISS Loading Performance

**Problem**: The intelligent tool finder was reloading FAISS index and metadata on every call, causing unnecessary disk I/O and performance degradation.

**Solution**:
- Added time-based caching mechanism with 5-second check interval
- Tracks last modification times for both FAISS index and metadata files
- Only reloads data when files have actually changed or sufficient time has passed
- Maintains thread-safe access with existing async lock

**Impact**: 
- Significantly improves `intelligent_tool_finder` response times
- Reduces unnecessary file system operations
- Maintains data freshness while optimizing performance

### 🔒 Enhanced Access Control Integration

Both changes work together to improve the scope-based tool access filtering in `intelligent_tool_finder`, ensuring users only see tools they have permission to access while maintaining optimal performance.

### Testing Notes

- Verify scopes.yml loading works in both Docker and local environments
- Confirm FAISS data updates when files change
- Test performance improvement in repeated intelligent tool finder calls
- Validate scope-based filtering continues to work correctly

Closes #62 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
