### PR TITLE
Add tag-based filtering to intelligent_tool_finder and streamline authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Transform how both autonomous AI agents and development teams access enterprise 
 
 ## What's New
 
+- **Tag-Based Tool Filtering** - Enhanced intelligent_tool_finder now supports filtering tools by server tags for precise categorical discovery alongside semantic search
 - **🔐 Keycloak Identity Provider Integration** - Enterprise-grade authentication with individual AI agent audit trails, group-based authorization, and production-ready service account management. [Learn more](docs/keycloak-integration.md)
 - **Amazon Bedrock AgentCore Integration** - Direct access to AWS services through managed MCP endpoints
 - **Three-Legged OAuth (3LO) Support** - External service integration (Atlassian, Google, GitHub)

--- a/registry/servers/mcpgw.json
+++ b/registry/servers/mcpgw.json
@@ -6,7 +6,7 @@
   "supported_transports": ["streamable-http"],
   "auth_type": "none",
   "tags": ["registry", "management"],
-  "num_tools": 5,
+  "num_tools": 6,
   "num_stars": 0,
   "is_python": true,
   "license": "N/A",
@@ -260,6 +260,76 @@
           "params"
         ],
         "title": "refresh_serviceArguments",
+        "type": "object"
+      }
+    },
+    {
+      "name": "intelligent_tool_finder",
+      "parsed_description": {
+        "main": "Finds the most relevant MCP tool(s) across all registered and enabled services based on a natural language query and/or tag filtering. IMPORTANT FOR AI AGENTS: Only use the 'tags' parameter if the user explicitly provides specific tags. DO NOT infer or guess tags from the query - incorrect tags will exclude valid results. When tags are provided with a query, results must match BOTH. If unsure about tags, use natural_language_query alone for best results.",
+        "args": "natural_language_query: Optional - Your query in natural language (recommended for AI agents unless user specifies tags). tags: Optional - List of tags to filter by using AND logic (CAUTION: Only use if explicitly provided by user). top_k_services: Number of top services from FAISS search (default: 3, ignored for tags-only). top_n_tools: Number of best tools to return (default: 1).",
+        "returns": "List[Dict[str, Any]]: A list of dictionaries, each describing a recommended tool, its parent service, and similarity score (if semantic search used).",
+        "raises": "Exception: If neither query nor tags is provided, or if FAISS index/model is unavailable."
+      },
+      "schema": {
+        "$defs": {
+          "IntelligentToolFinderParams": {
+            "properties": {
+              "natural_language_query": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "Your query in natural language describing the task you want to perform. Optional if tags are provided.",
+                "title": "Natural Language Query"
+              },
+              "tags": {
+                "anyOf": [
+                  {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "default": null,
+                "description": "List of tags to filter tools by using AND logic. IMPORTANT: AI agents should ONLY use this if the user explicitly provides specific tags. DO NOT infer tags - incorrect tags will exclude valid results.",
+                "title": "Tags"
+              },
+              "top_k_services": {
+                "default": 3,
+                "description": "Number of top services to consider from initial FAISS search (ignored if only tags provided).",
+                "title": "Top K Services",
+                "type": "integer"
+              },
+              "top_n_tools": {
+                "default": 1,
+                "description": "Number of best matching tools to return.",
+                "title": "Top N Tools",
+                "type": "integer"
+              }
+            },
+            "title": "IntelligentToolFinderParams",
+            "type": "object"
+          }
+        },
+        "properties": {
+          "params": {
+            "$ref": "#/$defs/IntelligentToolFinderParams"
+          }
+        },
+        "required": [
+          "params"
+        ],
+        "title": "intelligent_tool_finderArguments",
         "type": "object"
       }
     }


### PR DESCRIPTION
## Summary

This PR implements tag-based filtering for the `intelligent_tool_finder` function and streamlines the agent authentication system.

### Enhanced intelligent_tool_finder (Addresses Issue #126)

- **New `tags` parameter**: Filter tools by server tags using AND logic
- **Three operation modes**:
  - Semantic search only (current behavior) 
  - Tags only (new)
  - Combined semantic + tags (new)
- **Backward compatible**: All existing calls work unchanged
- **AI agent safety**: Comprehensive warnings against inferring tags

### Authentication System Cleanup

- **Streamlined flow**: Primary authentication via `.oauth-tokens/` directory
- **Removed complexity**: Eliminated confusing .env file handling
- **Cleaner UX**: No more "ENVIRONMENT CONFIGURATION" banners
- **Preserved fallbacks**: System environment variables still supported

## Technical Implementation

### intelligent_tool_finder Changes
```python
# New signature with optional tags parameter
async def intelligent_tool_finder(
    natural_language_query: Optional[str] = None,
    tags: Optional[List[str]] = None,
    top_k_services: int = 3,
    top_n_tools: int = 1
)
```

### Behavior Matrix
| Query | Tags | Behavior |
|-------|------|----------|
| ✅ Provided | ❌ None | Semantic search only |
| ✅ Provided | ✅ Provided | Semantic search AND filtered by tags |
| ❌ None | ✅ Provided | Return tools matching tags only |

### Bug Fixes
- **Fixed KeyError**: Tags-only mode no longer crashes on missing similarity scores
- **Proper logging**: Shows "(tags-only mode)" vs similarity scores appropriately

## Testing

### ✅ Verified Scenarios
- **Tags only**: `tags=["sre"]` returns only SRE Gateway tools
- **Combined**: Query + tags returns semantically relevant tools from tag-matched services
- **Semantic only**: Original behavior preserved exactly
- **Authentication**: Clean token-based auth without .env complexity

### Test Results
```bash
# Tags-only mode working
MCPGW: Service /mcpgw/ does not match required tags ['sre'], has tags ['registry', 'management']. Skipping.
MCPGW: Service /realserverfaketools/ does not match required tags ['sre'], has tags ['demo', 'fake', 'tools', 'testing']. Skipping.
MCPGW: Tags-only mode - 21 tools found without semantic ranking
```

## Documentation Updates

- **Enhanced docstring**: Clear usage examples and AI agent warnings
- **Updated schema**: mcpgw.json includes new tags parameter with descriptions
- **Agent safety**: Explicit warnings about not inferring tags from queries

## Benefits

1. **Improved Precision**: Filter tools by specific categories
2. **Better UX**: Combine semantic search with categorical filtering  
3. **AI Agent Efficiency**: Enable precise tool discovery using known categories
4. **Performance**: Tags-only mode faster than semantic search for category-based discovery
5. **Cleaner Auth**: Simplified authentication flow using `.oauth-tokens/`

## Breaking Changes

**None** - All existing functionality preserved and backward compatible.

## Files Changed

- `servers/mcpgw/server.py`: Enhanced intelligent_tool_finder with tag support
- `registry/servers/mcpgw.json`: Updated tool schema and documentation
- `agents/agent.py`: Streamlined authentication, removed .env complexity

## Related Issues

Closes #126 - Enhancement: Add tag-based filtering to intelligent tool finder