### PR TITLE
Fix .well-known/mcp-servers endpoint to display tool descriptions and route properly

### DIFF
--- a/registry/api/wellknown_routes.py
+++ b/registry/api/wellknown_routes.py
@@ -154,9 +154,11 @@ def _get_tools_preview(server_info: dict, max_tools: int = 5) -> list:
     preview_tools = []
     for tool in tools[:max_tools]:
         if isinstance(tool, dict):
+            # Try to get description from parsed_description.main first, then fall back to description field
+            description = tool.get("parsed_description", {}).get("main", tool.get("description", "No description available"))
             preview_tools.append({
                 "name": tool.get("name", "unknown"),
-                "description": tool.get("description", "No description available")
+                "description": description
             })
         elif isinstance(tool, str):
             # Handle case where tools are just strings

--- a/registry/main.py
+++ b/registry/main.py
@@ -195,10 +195,10 @@ if FRONTEND_BUILD_PATH.exists():
     @app.get("/{full_path:path}")
     async def serve_react_app(full_path: str):
         """Serve React app for all non-API routes"""
-        # Don't serve React for API routes
-        if full_path.startswith("api/") or full_path.startswith("health"):
+        # Don't serve React for API routes and well-known discovery endpoints
+        if full_path.startswith("api/") or full_path.startswith("health") or full_path.startswith(".well-known/"):
             raise HTTPException(status_code=404)
-        
+
         return FileResponse(FRONTEND_BUILD_PATH / "index.html")
 else:
     logger.warning("React build directory not found. Serve React app separately during development.")


### PR DESCRIPTION
## Summary
- Fixed tool descriptions not displaying in .well-known/mcp-servers endpoint
- Fixed route interception causing HTML to be served instead of JSON
- Resolves issue #152

## Changes
1. **Tool Descriptions Fix** ([registry/api/wellknown_routes.py](registry/api/wellknown_routes.py))
   - Updated `_get_tools_preview()` to extract descriptions from `parsed_description.main`
   - Added fallback to `description` field for compatibility
   - Previously returned "No description available" for all tools

2. **Route Fix** ([registry/main.py](registry/main.py))
   - Added `.well-known/` to catch-all route exclusion list
   - Prevents React SPA from intercepting API discovery endpoints
   - Previously served HTML UI instead of JSON response

## Test Plan
- [x] Verified endpoint returns JSON (not HTML)
- [x] Confirmed tool descriptions display correctly
- [x] Tested on production: https://mcpgateway.ddns.net/.well-known/mcp-servers
- [x] All tools now show actual descriptions instead of "No description available"

## Before
```json
{
  "name": "get_stock_aggregates",
  "description": "No description available"
}
```

## After  
```json
{
  "name": "get_stock_aggregates",
  "description": "Retrieve stock aggregate data from Polygon.io API."
}
```

Closes #152