### PR TITLE
fix: metrics-service build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,8 @@ services:
   # Metrics Collection Service
   metrics-service:
     build:
-      context: .
-      dockerfile: metrics-service/Dockerfile
+      context: metrics-service
+      dockerfile: Dockerfile
     environment:
       - METRICS_SERVICE_PORT=8890
       - METRICS_SERVICE_HOST=0.0.0.0


### PR DESCRIPTION
./build-and-run.sh won't work for local deployment. Metrics service is building in wrong path. This commit fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
