### PR TITLE
fix: inject server-specific headers into nginx proxy config

### DIFF
--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -319,14 +319,19 @@ class NginxConfigService:
         # The proxy_pass URL is used exactly as provided in the server configuration
         logger.info(f"Server {path}: Using proxy_pass URL as configured: {proxy_url}")
         
-        block = self._create_location_block(path, proxy_url, transport_type)
+        # Extract server-specific headers for injection
+        server_headers = server_info.get("headers", [])
+        block = self._create_location_block(path, proxy_url, transport_type, server_headers)
         blocks.append(block)
         
         return blocks
 
 
-    def _create_location_block(self, path: str, proxy_pass_url: str, transport_type: str) -> str:
+    def _create_location_block(self, path: str, proxy_pass_url: str, transport_type: str, server_headers: list = None) -> str:
         """Create a single nginx location block with transport-specific configuration."""
+        
+        if server_headers is None:
+            server_headers = []
         
         # Extract hostname from proxy_pass_url for external services
         parsed_url = urlparse(proxy_pass_url)
@@ -344,7 +349,38 @@ class NginxConfigService:
             host_header = '$host'
             logger.info(f"Using original host for Host header: $host")
         
+        # Build server-specific header directives
+        # If server has Authorization header configured, use it; otherwise pass client's Authorization
+        server_auth_header = None
+        extra_headers = []
+        for header_dict in server_headers:
+            if isinstance(header_dict, dict):
+                for header_name, header_value in header_dict.items():
+                    if header_name.lower() == 'authorization':
+                        server_auth_header = header_value
+                        logger.info(f"Using server-specific Authorization header for {path}")
+                    else:
+                        extra_headers.append((header_name, header_value))
+        
+        # Build the authorization header directive
+        if server_auth_header:
+            auth_header_directive = f'proxy_set_header Authorization "{server_auth_header}";'
+        else:
+            auth_header_directive = 'proxy_set_header Authorization $http_authorization;'
+        
+        # Build extra header directives
+        extra_header_directives = '\n'.join([
+            f'        proxy_set_header {name} "{value}";' for name, value in extra_headers
+        ])
+        
         # Common proxy settings
+        # Build extra headers section if any
+        extra_headers_section = ""
+        if extra_header_directives:
+            extra_headers_section = f"""
+        # Server-specific custom headers
+{extra_header_directives}"""
+        
         common_settings = f"""
         # Use IPv4 resolver (disable IPv6)
         resolver 8.8.8.8 8.8.4.4 valid=10s;
@@ -374,13 +410,13 @@ class NginxConfigService:
         # Add original URL for auth server scope validation
         proxy_set_header X-Original-URL $scheme://$host$request_uri;
         
-        # Pass through the original authentication headers
-        proxy_set_header Authorization $http_authorization;
+        # Backend authentication (server-specific or pass-through)
+        {auth_header_directive}
         proxy_set_header X-Authorization $http_x_authorization;
         proxy_set_header X-User-Pool-Id $http_x_user_pool_id;
         proxy_set_header X-Client-Id $http_x_client_id;
         proxy_set_header X-Region $http_x_region;
-
+{extra_headers_section}
         
         # Forward auth server response headers to backend
         proxy_set_header X-User $auth_user;


### PR DESCRIPTION
*Issue #, if available:* 
Fixes #285

*Description of changes:*
Injects server-specific headers (especially Authorization) into nginx proxy configuration.

**Problem:**
Headers configured during server registration were only used for health checks (`health/service.py`) and internal MCP client calls (`core/mcp_client.py`), but NOT injected into the nginx proxy config. This caused 401 errors when backends require their own Bearer tokens (e.g., Home Assistant).

**Solution:**
- Extract `headers` from `server_info` in `_generate_transport_location_blocks()`
- Pass headers to `_create_location_block()` as new optional parameter
- Generate `proxy_set_header Authorization "Bearer ..."` when a server has an Authorization header configured
- Also supports injection of other custom headers

**Testing:**
Tested with Home Assistant MCP server - gateway now correctly forwards the configured Bearer token instead of the client's Keycloak JWT.

**Known Limitations:**
- Header values containing `"` or `\` characters could break nginx config syntax. This is unlikely with JWT/Bearer tokens (base64url encoded) but could occur with other auth schemes. Happy to add escaping in a follow-up if needed.
- If `headers` is accidentally registered as a dict instead of a list of dicts, headers will be silently ignored (consistent with existing behavior in `health/service.py`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.