### PR TITLE
Edited Podman documentation, enhancing PR #308

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,14 +357,13 @@ flowchart TB
 - Dual authentication supporting both human and machine authentication
 
 ---
-
 ## Quick Start
 
-> **📱 Running on macOS?** See our [macOS Setup Guide](docs/macos-setup-guide.md) for platform-specific instructions and optimizations.
-> 
-> **🐋 Using Podman?** This project supports both Docker and Podman. Use the `--podman` flag for rootless container deployment.
-> 
-> **⚠️ Apple Silicon (M1/M2/M3)?** Don't use `--prebuilt` with Podman on ARM64. See [Podman on Apple Silicon Guide](docs/podman-apple-silicon.md).
+There are 3 options for setting up the MCP Gateway & Registry:
+
+- **Option A: Pre-built Images** — Fastest setup using pre-built Docker or Podman containers. Recommended for most users.
+- **Option B: Podman (Rootless)** — Detailed Podman-specific instructions for macOS and rootless Linux environments.
+- **Option C: Build from Source** — Full source build for customization or development.
 
 ### Option A: Pre-built Images (Instant Setup)
 
@@ -390,18 +389,22 @@ export DOCKERHUB_ORG=mcpgateway
 ```
 
 **Step 4: Deploy with pre-built images**
+Our service can be deployed with two platforms for pre-built images: Docker and Podman. 
 
 **With Docker (default):**
 ```bash
 ./build_and_run.sh --prebuilt
 ```
 
-**With Podman (rootless, macOS friendly):**
+**With Podman (rootless, macOS (but NOT Apple Silicon) friendly):**
 ```bash
 ./build_and_run.sh --prebuilt --podman
+
+# If running on macOS Apple Silicon, remove the --prebuilt flag (more details in Podman option below) 
+./build_and_run.sh --podman # For Apple Silicon 
 ```
 
-> **📍 Port Differences:**
+> **Port Differences:**
 > - **Docker**: Services run on privileged ports (`http://localhost`, `https://localhost`)
 > - **Podman**: Services run on non-privileged ports (`http://localhost:8080`, `https://localhost:8443`)
 > - All internal service ports remain the same (Registry: 7860, Auth: 8888, etc.)
@@ -454,13 +457,17 @@ Podman provides rootless container execution without requiring privileged ports,
 - **Linux** users preferring rootless containers
 - **Development** environments where Docker daemon isn't available
 
-**Quick Podman Setup (macOS):**
+**Quick Podman Setup (macOS non-Apple Silicon):**
 
 ```bash
 # Install Podman Desktop
 brew install podman-desktop
 # OR download from: https://podman-desktop.io/
+```
 
+Inside Podman Desktop, go to Preferences > Podman Machine and create a new machine with at least 4 CPUs and 8GB RAM. Alternatively, see more detailed [Podman installation guide] (docs/installation.md#podman-installation) for instructions on setting this up on CLI. 
+
+```bash
 # Initialize Podman machine
 podman machine init
 podman machine start
@@ -468,32 +475,48 @@ podman machine start
 # Verify installation
 podman --version
 podman compose version
+
+# Configure environment
+cp .env.example .env
+# Edit .env with your credentials
 ```
 
-**Deploy with Podman:**
+**Deploy with Podman** see full Podman setup instructions (downloading, installing, and initializing a first Podman container, as well as troubleshooting) in our [Installation Guide](docs/installation.md#podman-installation).
+
+**Build with Podman:**
+
 ```bash
 # Auto-detect (will use Podman if Docker not available)
 ./build_and_run.sh --prebuilt
 
-# Explicit Podman mode
+# Explicit Podman mode (only non-Apple Silicon)
 ./build_and_run.sh --prebuilt --podman
 
 # Access registry at non-privileged ports
 open http://localhost:8080
 ```
 
-**Key Differences:**
-- ✅ No root/sudo required
-- ✅ Works on macOS without privileged port access
-- ✅ HTTP port: `8080` (instead of `80`)
-- ✅ HTTPS port: `8443` (instead of `443`)
-- ✅ All other service ports unchanged
+> Note: **Apple Silicon (M1/M2/M3)?** Don't use `--prebuilt` with Podman on ARM64. This will cause a "proxy already running" error. See [Podman on Apple Silicon Guide](docs/podman-apple-silicon.md). 
+
+```bash
+# To run on Apple Silicon Macs:
+./build_and_run.sh --podman
+```
+
+**Key Differences vs. Docker:**
+- No root/sudo required
+- Works on macOS without privileged port access
+- HTTP port: `8080` (instead of `80`)
+- HTTPS port: `8443` (instead of `443`)
+- All other service ports unchanged
 
 For detailed Podman setup instructions, see [Installation Guide](docs/installation.md#podman-installation) and [macOS Setup Guide](docs/macos-setup-guide.md#podman-deployment).
 
 ### Option C: Build from Source
 
 **New to MCP Gateway?** Start with our [Complete Setup Guide](docs/complete-setup-guide.md) for detailed step-by-step instructions from scratch on AWS EC2.
+
+**Running on macOS?** See our [macOS Setup Guide](docs/macos-setup-guide.md) for platform-specific instructions and optimizations.
 
 ### Testing & Integration Options
 
@@ -507,6 +530,7 @@ For detailed Podman setup instructions, see [Installation Guide](docs/installati
 **Next Steps:** [Testing Guide](docs/testing.md) | [Complete Installation Guide](docs/installation.md) | [Authentication Setup](docs/auth.md) | [AI Assistant Integration](docs/ai-coding-assistants-setup.md)
 
 ---
+
 
 ## Enterprise Features
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -79,8 +79,8 @@ if [ "$USE_PODMAN" = true ]; then
         COMPOSE_CMD="podman compose"
         # Use standalone Podman compose file to avoid port merge issues
         COMPOSE_FILES="-f $PODMAN_COMPOSE_FILE"
-        log "🐋 Using Podman (rootless mode)"
-        log "📍 Services will be available at:"
+        log "Using Podman (rootless mode)"
+        log "Services will be available at:"
         log "   - HTTP:  http://localhost:8080"
         log "   - HTTPS: https://localhost:8443"
     else
@@ -93,17 +93,17 @@ else
     if command -v docker &> /dev/null && docker compose version &> /dev/null; then
         COMPOSE_CMD="docker compose"
         COMPOSE_FILES="-f $DOCKER_COMPOSE_FILE"
-        log "🐳 Using Docker"
-        log "📍 Services will be available at:"
+        log "Using Docker"
+        log "Services will be available at:"
         log "   - HTTP:  http://localhost"
         log "   - HTTPS: https://localhost"
     elif command -v podman &> /dev/null; then
-        log "⚠️  Docker not found, automatically using Podman (rootless mode)"
-        log "💡 To suppress this message, use --podman flag explicitly"
+        log "WARNING: Docker not found, automatically using Podman (rootless mode)"
+        log "To suppress this message, use --podman flag explicitly"
         COMPOSE_CMD="podman compose"
         # Use standalone Podman compose file to avoid port merge issues
         COMPOSE_FILES="-f $PODMAN_COMPOSE_FILE"
-        log "📍 Services will be available at:"
+        log "Services will be available at:"
         log "   - HTTP:  http://localhost:8080"
         log "   - HTTPS: https://localhost:8443"
     else
@@ -116,19 +116,19 @@ else
 fi
 
 if [ "$USE_PREBUILT" = true ]; then
-    log "🚀 Using pre-built container images for fast deployment"
-    log "📥 Will pull latest images from container registry during startup..."
-    
+    log "Using pre-built container images for fast deployment"
+    log "Will pull latest images from container registry during startup..."
+
     # Warn about ARM64 compatibility with Podman
     if [[ "$COMPOSE_CMD" == "podman compose" ]] && [[ $(uname -m) == "arm64" ]]; then
-        log "⚠️  WARNING: Pre-built images are amd64. On Apple Silicon, consider:"
+        log "WARNING: Pre-built images are amd64. On Apple Silicon, consider:"
         log "   - Building locally: ./build_and_run.sh --podman"
         log "   - Or using Docker Desktop: ./build_and_run.sh --prebuilt"
         log "   Continuing in 5 seconds... (Ctrl+C to cancel)"
         sleep 5
     fi
 else
-    log "🔨 Building containers locally (this may take several minutes)"
+    log "Building containers locally (this may take several minutes)"
 fi
 
 log "Using compose files: $COMPOSE_FILES"
@@ -217,7 +217,7 @@ done
 if [ "$FAISS_EXISTS" = true ]; then
     echo ""
     echo "╔════════════════════════════════════════════════════════════════════════════╗"
-    echo "║                       ⚠️  FAISS INDEX FILES EXIST  ⚠️                       ║"
+    echo "║                         FAISS INDEX FILES EXIST                            ║"
     echo "╠════════════════════════════════════════════════════════════════════════════╣"
     echo "║                                                                            ║"
     echo "║  Existing FAISS index files were found in:                                ║"
@@ -310,7 +310,7 @@ if [ -f "auth_server/scopes.yml" ]; then
     if [ -f "$TARGET_SCOPES_FILE" ]; then
         echo ""
         echo "╔════════════════════════════════════════════════════════════════════════════╗"
-        echo "║                          ⚠️  SCOPES.YML EXISTS  ⚠️                          ║"
+        echo "║                            SCOPES.YML EXISTS                               ║"
         echo "╠════════════════════════════════════════════════════════════════════════════╣"
         echo "║                                                                            ║"
         echo "║  An existing scopes.yml file was found at:                                ║"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,9 +62,14 @@ cp .env.example .env
 # 5. Deploy with Podman
 ./build_and_run.sh --prebuilt --podman
 
+# Apple Silicon: Use without --prebuilt
+# ./build_and_run.sh --podman
+
 # 6. Access registry (note the different port for Podman)
 open http://localhost:8080
 ```
+
+> **Note for Apple Silicon:** Don't use `--prebuilt` with Podman on ARM64. Use `./build_and_run.sh --podman` instead. See [Podman on Apple Silicon Guide](podman-apple-silicon.md).
 
 **Podman Port Mapping:**
 - Main interface: `http://localhost:8080` (HTTP) or `https://localhost:8443` (HTTPS)
@@ -206,9 +211,14 @@ nano .env  # Configure required values
 # Deploy with Podman (explicit)
 ./build_and_run.sh --prebuilt --podman
 
+# Apple Silicon: Use without --prebuilt
+# ./build_and_run.sh --podman
+
 # Or let the script auto-detect (will use Podman if Docker not available)
 ./build_and_run.sh --prebuilt
 ```
+
+> **Apple Silicon Warning:** Don't use `--prebuilt` with Podman on Apple Silicon Macs. Use `./build_and_run.sh --podman` instead. See [Podman on Apple Silicon Guide](podman-apple-silicon.md).
 
 ### Accessing Services with Podman
 

--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -654,12 +654,14 @@ cd ../..
 **4. Deploy All Services with Podman**
 
 ```bash
-# Deploy using pre-built images (recommended)
+# Deploy using pre-built images (recommended for Intel Macs)
 ./build_and_run.sh --prebuilt --podman
 
-# Or build locally
+# For Apple Silicon, build locally instead
 ./build_and_run.sh --podman
 ```
+
+> **Apple Silicon Users:** Don't use `--prebuilt` with Podman on ARM64. The pre-built images are amd64 and will cause errors. Use `./build_and_run.sh --podman` to build natively. See [Podman on Apple Silicon Guide](podman-apple-silicon.md).
 
 **The script automatically:**
 - Detects Podman usage
@@ -841,13 +843,18 @@ You can switch between Docker and Podman without changing configurations:
 # Stop Docker services
 docker compose down
 
-# Start with Podman
+# Start with Podman (Intel Mac)
 ./build_and_run.sh --prebuilt --podman
+
+# Start with Podman (Apple Silicon - omit --prebuilt)
+# ./build_and_run.sh --podman
 
 # Or vice versa:
 podman compose down
 ./build_and_run.sh --prebuilt
 ```
+
+> **Apple Silicon Note:** When switching to Podman on Apple Silicon, use `./build_and_run.sh --podman` (without `--prebuilt`).
 
 **Note**: Database volumes and configurations are separate between Docker and Podman. You'll need to reconfigure Keycloak when switching.
 

--- a/docs/podman-apple-silicon.md
+++ b/docs/podman-apple-silicon.md
@@ -1,14 +1,14 @@
-# Podman on Apple Silicon (M1/M2/M3) - Known Issues & Solutions
+# Podman on Apple Silicon - Known Issues & Solutions
 
 ## TL;DR - Quick Solution
 
 **Don't use `--prebuilt` with Podman on Apple Silicon. Build locally instead:**
 
 ```bash
-# ✅ CORRECT - Build for ARM64
+# CORRECT - Build for ARM64
 ./build_and_run.sh --podman
 
-# ❌ WRONG - Causes "proxy already running" error
+# WRONG - Causes "proxy already running" error
 ./build_and_run.sh --prebuilt --podman
 ```
 
@@ -44,14 +44,13 @@ podman machine init --cpus 4 --memory 8192 --disk-size 50
 podman machine start
 
 # Build for ARM64 (takes 10-15 minutes first time)
-cd /Users/gabe/git/mcp-gateway-registry
 ./build_and_run.sh --podman
 ```
 
 **Pros:**
-- ✅ Native ARM64 images (better performance)
-- ✅ No architecture warnings
-- ✅ Reliable container startup
+- Native ARM64 images (better performance)
+- No architecture warnings
+- Reliable container startup
 
 **Cons:**
 - ⏱️ Slower first build (10-15 minutes)
@@ -74,13 +73,13 @@ podman machine stop
 ```
 
 **Pros:**
-- ✅ Fast deployment (2-3 minutes)
-- ✅ Pre-built images work reliably
-- ✅ Better multi-arch support
+- Fast deployment (2-3 minutes)
+- Pre-built images work reliably
+- Better multi-arch support
 
 **Cons:**
-- ⚠️ Requires Docker Desktop
-- ⚠️ Uses privileged ports (80/443)
+- Requires Docker Desktop
+- Uses privileged ports (80/443)
 
 ### Option 3: Fix Stuck Proxy Manually
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -114,7 +114,12 @@ podman compose version
 **With Podman:**
 ```bash
 ./build_and_run.sh --prebuilt --podman
+
+# Apple Silicon: Build locally instead
+# ./build_and_run.sh --podman
 ```
+
+> **Apple Silicon:** Don't use `--prebuilt` with Podman on ARM64. Use `./build_and_run.sh --podman` instead. This will take 10-15 minutes for first build. See [Podman on Apple Silicon Guide](podman-apple-silicon.md).
 
 ⏱️ **This takes about 2-3 minutes** - Container images will be pulled and services started.
 


### PR DESCRIPTION
*Issue #, if available:* 308

*Description of changes:*

I tested PR #308 (Podman macOS support) on my Apple Silicon M4 Pro Mac and made the following documentation improvements:


1. Removed emojis per style guidelines in Claude.md

- README.md: Removed all emojis in documentation added in the #308 PR
- build_and_run.sh: Removed emojis from terminal log outputs 

**2. Improved README.md setup instructions**

- Organized Podman specific information more intuitively and added all steps for setup from the quick start guide
- Added inline warnings for Apple Silicon users directly in the Quick Start instructions 

**3. Fixed Apple Silicon documentation gaps**

The Apple Silicon warning was only in docs/podman-apple-silicon.md, but other documentation files recommended ./build_and_run.sh --prebuilt --podman without mentioning this would fail on ARM64 Macs, so I added consistent Apple Silicon warnings to all documentation files:

- docs/installation.md 
- docs/quick-start.md 
- docs/macos-setup-guide.md 

In all places that instruct CLI command build_and_run.sh --prebuilt --podman, it is now clarified that Apple Silicon users should **not use --prebuilt flag** with Podman on ARM64. Use ./build_and_run.sh --podman instead.

Also, I changed all "M1/M2/M3" references to "Apple Silicon" throughout all documentation (in README.md and docs/podman-apple-silicon.md, it was originally stated that the changes applied to Apple Silicon (M1/M2/M3), but I changed this because M4 (and future M-series chips) are also ARM64 and have the same issue with amd64 pre-built images. 

**Justification**: including the --prebuilt flag caused some discrepancies/errors on my M4 pro chip macbook. 

**Testing Notes**

Confirmed: 
- ./build_and_run.sh --podman (without --prebuilt) works correctly
- All 13 containers started successfully
- the existing instructions comprehensively guide the correct setup (nothing is missing) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
