### PR TITLE
Use oci repository for bitnami keycloak

### DIFF
--- a/charts/mcp-gateway-registry-stack/Chart.yaml
+++ b/charts/mcp-gateway-registry-stack/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "1.0.0"
 dependencies:
   - name: keycloak
     version: 25.2.0
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
   - name: auth-server
     version: 0.1.0
     repository: "file://../auth-server"


### PR DESCRIPTION
*Issue #, if available:*

Fixes #302 

*Description of changes:*

Switches to using the OCI repository for Keycloak

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
