### PR TITLE
Fix registry nginx config

### DIFF
--- a/charts/registry/templates/ingress.yaml
+++ b/charts/registry/templates/ingress.yaml
@@ -20,5 +20,5 @@ spec:
               service:
                 name: {{ .Values.app.name }}
                 port:
-                  name: registry
+                  name: http
 {{- end }}

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -10,3 +10,4 @@ data:
   AUTH_SERVER_URL: {{ printf "http://auth-server.%s.svc.cluster.local:8888" .Release.Namespace | b64enc | quote }}
   KEYCLOAK_URL: {{ printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace | b64enc | quote }}
   SECRET_KEY: {{ (.Values.global.secretKey | default .Values.app.secretKey) | b64enc | quote }}
+  GATEWAY_ADDITIONAL_SERVER_NAMES: {{ printf "mcpregistry.%s" .Values.global.domain | b64enc | quote }}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #304 and #303

*Description of changes:*

- Adds the missing `GATEWAY_ADDITIONAL_SERVER_NAMES` to the registry secret so nginx config is properly templates. 
- Updates the port for the ingress to point to the now working nginx server instead of the registry API backend


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
