### PR TITLE
split registry image build process and use torch cpu wheel

### DIFF
--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -1,22 +1,29 @@
-# Registry Dockerfile - includes nginx, SSL, FAISS, models, and registry service
-FROM python:3.12-slim
+# Registry Dockerfile - Multi-stage build with frontend and backend stages
+
+# ===== FRONTEND BUILD STAGE =====
+FROM node:20-slim AS frontend-builder
+
+WORKDIR /app/frontend
+
+# Copy package files and install dependencies
+COPY frontend/package.json frontend/package-lock.json* ./
+RUN npm install --legacy-peer-deps
+
+# Copy frontend source and build
+COPY frontend/ ./
+RUN npm run build
+
+# ===== BACKEND BUILD STAGE =====
+FROM python:3.12-slim AS backend-builder
 
 ENV PYTHONUNBUFFERED=1 \
     DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies including nginx with lua module and Node.js
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nginx \
-    nginx-extras \
-    lua-cjson \
-    curl \
-    procps \
-    openssl \
-    git \
     build-essential \
+    git \
     ca-certificates \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -26,9 +33,13 @@ WORKDIR /app
 ARG BUILD_VERSION="1.0.0"
 ENV BUILD_VERSION=$BUILD_VERSION
 
+# Install Python dependencies with CPU-only PyTorch
 RUN pip install uv && \
     uv venv .venv --python 3.12 && \
     . .venv/bin/activate && \
+    uv pip install --index-url https://download.pytorch.org/whl/cpu \
+    "torch>=2.0.0" \
+    "torchvision" && \
     uv pip install \
     "fastapi>=0.115.12" \
     "itsdangerous>=2.2.0" \
@@ -43,30 +54,50 @@ RUN pip install uv && \
     "sentence-transformers>=2.2.2" \
     "websockets>=15.0.1" \
     "scikit-learn>=1.3.0" \
-    "torch>=1.6.0" \
     "huggingface-hub[cli,hf_xet]>=0.31.1" \
     "hf_xet>=0.1.0" \
     "cisco-ai-mcp-scanner==3.2.3"
 
-# Copy the application code
+# Copy application code and install the registry package
 COPY . /app/
+RUN . .venv/bin/activate && uv pip install -e .
 
-# Copy nginx configurations (both HTTP-only and HTTP+HTTPS versions)
-COPY docker/nginx_rev_proxy_http_only.conf /app/docker/nginx_rev_proxy_http_only.conf
-COPY docker/nginx_rev_proxy_http_and_https.conf /app/docker/nginx_rev_proxy_http_and_https.conf
+# ===== FINAL RUNTIME STAGE =====
+FROM python:3.12-slim AS runtime
 
-# Build React frontend
-WORKDIR /app/frontend
-COPY frontend/package.json ./
-RUN npm install --legacy-peer-deps
-COPY frontend/ ./
-RUN npm run build
+ENV PYTHONUNBUFFERED=1 \
+    DEBIAN_FRONTEND=noninteractive
 
-# Return to app directory
+# Install runtime dependencies including nginx with lua module
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    nginx \
+    nginx-extras \
+    lua-cjson \
+    curl \
+    procps \
+    openssl \
+    ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-# Install the registry package
-RUN . .venv/bin/activate && uv pip install -e .
+# Build argument for version
+ARG BUILD_VERSION="1.0.0"
+ENV BUILD_VERSION=$BUILD_VERSION
+
+# Copy Python virtual environment from backend builder
+COPY --from=backend-builder /app/.venv /app/.venv
+
+# Copy application code from backend builder
+COPY --from=backend-builder /app /app
+
+# Copy built frontend from frontend builder
+COPY --from=frontend-builder /app/frontend/build /app/frontend/build
+
+# Copy nginx configurations
+COPY docker/nginx_rev_proxy_http_only.conf /app/docker/nginx_rev_proxy_http_only.conf
+COPY docker/nginx_rev_proxy_http_and_https.conf /app/docker/nginx_rev_proxy_http_and_https.conf
 
 # Create logs directory
 RUN mkdir -p /app/logs
@@ -82,4 +113,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 COPY docker/registry-entrypoint.sh /app/registry-entrypoint.sh
 RUN chmod +x /app/registry-entrypoint.sh
 
-ENTRYPOINT ["/app/registry-entrypoint.sh"] 
+ENTRYPOINT ["/app/registry-entrypoint.sh"]


### PR DESCRIPTION
*Issue #, if available:*

Fixes #319 

*Description of changes:*

Updates the registry docker to use a multistage build for the front/back end. This reduces the image from 2.6 GB to 1.6 GB and reduces the build time by leveraging cache (if available). It also uses the torch CPU wheel to further reduce the library size. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
