### PR TITLE
docs: clarify AUTH_SERVER_EXTERNAL_URL config in macOS setup guide

### DIFF
--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -118,6 +118,10 @@ In the `.env` file, make these changes:
 # Set authentication provider to Keycloak
 AUTH_PROVIDER=keycloak
 
+# Set auth server URL for local development
+# This URL must be accessible from your browser for OAuth redirects
+AUTH_SERVER_EXTERNAL_URL=http://localhost
+
 # Set secure passwords (CHANGE THESE!)
 KEYCLOAK_ADMIN_PASSWORD=your_secure_admin_password_here
 KEYCLOAK_DB_PASSWORD=your_secure_db_password_here


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

- **File affected**: docs/macos-setup-guide.md
- **Change**: Added clarification in Section 4 (Environment Configuration) regarding the AUTH_SERVER_EXTERNAL_URL setting. Users are now explicitly instructed to set this value to http://localhost for local development.
- **Reasoning**: AUTH_SERVER_EXTERNAL_URL defines the public-facing URL that browsers use for OAuth callback redirects. Previously, the guide did not explicitly instruct users to configure this variable for local development. The .env.example template contains a placeholder value (https://your-domain.com) that doesn't work for local setups, causing OAuth callback errors during authentication.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
