### PR TITLE
Add OAuth2 nginx routes for Entra, GitHub, and Google providers

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -92,6 +92,87 @@ server {
     proxy_pass_request_headers on;
     }
 
+    # OAuth2 Entra ID callback endpoint
+    location /oauth2/callback/entra {
+        proxy_pass http://auth-server:8888/oauth2/callback/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through cookies, query parameters, and headers
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Entra ID login endpoint
+    location /oauth2/login/entra {
+        proxy_pass http://auth-server:8888/oauth2/login/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 GitHub callback endpoint
+    location /oauth2/callback/github {
+        proxy_pass http://auth-server:8888/oauth2/callback/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 GitHub login endpoint
+    location /oauth2/login/github {
+        proxy_pass http://auth-server:8888/oauth2/login/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 Google callback endpoint
+    location /oauth2/callback/google {
+        proxy_pass http://auth-server:8888/oauth2/callback/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Google login endpoint
+    location /oauth2/login/google {
+        proxy_pass http://auth-server:8888/oauth2/login/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
     # Anthropic MCP Registry API - Public REST API with JWT authentication
     location /{{ANTHROPIC_API_VERSION}}/ {
         # Authenticate request via auth server (validates JWT Bearer tokens)
@@ -476,6 +557,87 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_pass_request_headers on;
+    }
+
+    # OAuth2 Entra ID callback endpoint (HTTPS)
+    location /oauth2/callback/entra {
+        proxy_pass http://auth-server:8888/oauth2/callback/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through cookies, query parameters, and headers
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Entra ID login endpoint (HTTPS)
+    location /oauth2/login/entra {
+        proxy_pass http://auth-server:8888/oauth2/login/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 GitHub callback endpoint (HTTPS)
+    location /oauth2/callback/github {
+        proxy_pass http://auth-server:8888/oauth2/callback/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 GitHub login endpoint (HTTPS)
+    location /oauth2/login/github {
+        proxy_pass http://auth-server:8888/oauth2/login/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 Google callback endpoint (HTTPS)
+    location /oauth2/callback/google {
+        proxy_pass http://auth-server:8888/oauth2/callback/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Google login endpoint (HTTPS)
+    location /oauth2/login/google {
+        proxy_pass http://auth-server:8888/oauth2/login/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
     }
 
     # Keycloak proxy (HTTPS)

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -174,6 +174,87 @@ server {
     proxy_pass_request_headers on;
     }
 
+    # OAuth2 Entra ID callback endpoint
+    location /oauth2/callback/entra {
+        proxy_pass http://auth-server:8888/oauth2/callback/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through cookies, query parameters, and headers
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Entra ID login endpoint
+    location /oauth2/login/entra {
+        proxy_pass http://auth-server:8888/oauth2/login/entra;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 GitHub callback endpoint
+    location /oauth2/callback/github {
+        proxy_pass http://auth-server:8888/oauth2/callback/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 GitHub login endpoint
+    location /oauth2/login/github {
+        proxy_pass http://auth-server:8888/oauth2/login/github;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
+    # OAuth2 Google callback endpoint
+    location /oauth2/callback/google {
+        proxy_pass http://auth-server:8888/oauth2/callback/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through all headers for OAuth2 flow
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+    }
+
+    # OAuth2 Google login endpoint
+    location /oauth2/login/google {
+        proxy_pass http://auth-server:8888/oauth2/login/google;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Pass through query parameters and headers
+        proxy_pass_request_headers on;
+    }
+
     # Anthropic MCP Registry API - Public REST API with JWT authentication
     location /{{ANTHROPIC_API_VERSION}}/ {
         # Authenticate request via auth server (validates JWT Bearer tokens)


### PR DESCRIPTION
## Summary

This PR adds the missing nginx proxy routes for OAuth2 authentication with additional identity providers:

- **Microsoft Entra ID**: login and callback endpoints
- **GitHub**: login and callback endpoints  
- **Google**: login and callback endpoints

These routes complement the existing Keycloak and Cognito configurations, ensuring all 5 supported OAuth2 providers have complete nginx routing.

## Details

- Logout endpoints are already covered by the existing generic `/oauth2/logout/` prefix route
- All new routes follow the same pattern as existing provider configurations
- The auth-server already supports these providers via `oauth2_providers.yml`

## Changes

- `docker/nginx_rev_proxy_http_only.conf`: Added 6 new location blocks for the 3 providers
- `docker/nginx_rev_proxy_http_and_https.conf`: Added 6 new location blocks for the 3 providers (both HTTP and HTTPS server blocks)

Thank you for maintaining this project!