### PR TITLE
Fix outdated placeholder checks in registry-entrypoint.sh

### DIFF
--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -209,7 +209,8 @@ MAX_WAIT=120
 while [ $WAIT_TIME -lt $MAX_WAIT ]; do
     if [ -f "/etc/nginx/conf.d/nginx_rev_proxy.conf" ]; then
         # Check if placeholders have been replaced
-        if ! grep -q "{{EC2_PUBLIC_DNS}}" "/etc/nginx/conf.d/nginx_rev_proxy.conf" && \
+        if ! grep -q "{{ADDITIONAL_SERVER_NAMES}}" "/etc/nginx/conf.d/nginx_rev_proxy.conf" && \
+           ! grep -q "{{ANTHROPIC_API_VERSION}}" "/etc/nginx/conf.d/nginx_rev_proxy.conf" && \
            ! grep -q "{{LOCATION_BLOCKS}}" "/etc/nginx/conf.d/nginx_rev_proxy.conf"; then
             echo "Nginx configuration generated successfully"
             break


### PR DESCRIPTION
## Summary
Replace deprecated `{{EC2_PUBLIC_DNS}}` placeholder check with current nginx template placeholders in `docker/registry-entrypoint.sh`.

## Changes
- Replace `{{EC2_PUBLIC_DNS}}` with `{{ADDITIONAL_SERVER_NAMES}}`
- Add `{{ANTHROPIC_API_VERSION}}` check
- Keep existing `{{LOCATION_BLOCKS}}` check
- Now verifies all three critical placeholders before starting nginx

## Rationale
- `{{EC2_PUBLIC_DNS}}` is no longer used in nginx templates
- `{{ADDITIONAL_SERVER_NAMES}}` is the current placeholder for server names/domains
- `{{ANTHROPIC_API_VERSION}}` is always present in templates
- Checking all three ensures complete config generation

---

Thank you for maintaining this excellent registry gateway tool! This is a small cleanup to keep the entrypoint script in sync with the current nginx template placeholders.