### PR TITLE
Changed line 365 of docker-compose.prebuilt.yml to reference the official mongo8:2 image

### DIFF
--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -362,7 +362,7 @@ services:
   # Vector search is implemented in application code (see search_repository.py)
   # Running without authentication for local development simplicity
   mongodb:
-    image: mongo:${MONGODB_VERSION:-latest}
+    image: ${DOCKERHUB_ORG:-mcpgateway}/mongo:${MONGODB_VERSION:-latest}
     container_name: mcp-mongodb
     command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb
     ports:


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* 

- *bug*: --prebuilt was failing because docker-compose.prebuilt.yml was referencing an image mcpgateway/mongo:8.2 that can't be recognized by machines deploying locally, instead of the official mongo:8.2 image
- *fix*: Changed line 365 of docker-compose.prebuilt.yml from -mcpgateway}/mongo:${MONGODB_VERSION:-8.2} to mongo:8.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
