### PR TITLE
docs: add HuggingFace CLI explanation and installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ cp .env.example .env
 ```
 
 **Step 2: Download embeddings model**
-Download the required sentence-transformers model to the shared models directory:
+Download the required sentence-transformers model to the shared models directory using the [HuggingFace CLI](https://huggingface.co/docs/huggingface_hub/main/en/guides/cli) (`pip install -U huggingface_hub`):
 ```bash
 hf download sentence-transformers/all-MiniLM-L6-v2 --local-dir ${HOME}/mcp-gateway/models/all-MiniLM-L6-v2
 ```


### PR DESCRIPTION
## Summary
- Add documentation for the `hf` command in README.md
- Include link to HuggingFace CLI documentation
- Provide installation command `pip install -U huggingface_hub`

Closes #361