### PR TITLE
Fix: Terraform - Add missing security group rule for MCPGW → Registry communication

### DIFF
--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -706,6 +706,19 @@ module "ecs_service_registry" {
 }
 
 
+# Allow mcpgw to communicate with registry on port 7860
+resource "aws_vpc_security_group_ingress_rule" "mcpgw_to_registry" {
+  security_group_id            = module.ecs_service_registry.security_group_id
+  referenced_security_group_id = module.ecs_service_mcpgw.security_group_id
+  from_port                    = 7860
+  to_port                      = 7860
+  ip_protocol                  = "tcp"
+  description                  = "Allow mcpgw to access registry API"
+
+  tags = local.common_tags
+}
+
+
 # Allow registry to communicate with auth server on port 8888
 resource "aws_vpc_security_group_ingress_rule" "registry_to_auth" {
   security_group_id            = module.ecs_service_auth.security_group_id


### PR DESCRIPTION
*Issue:*

Adds a missing security group ingress rule to allow the MCPGW service to communicate with the Registry service on port 7860. This was preventing MCP Gateway management tools from functioning correctly.

*Description of changes:*

Problem
The MCPGW service needs to make internal API calls to the Registry service at http://registry:7860 for operations like:

Listing registered MCP servers
Refreshing service tool lists
Managing server registrations
Other registry management operations
While ECS Service Connect DNS resolution was working correctly ([registry](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) resolved to the Service Connect proxy), the connection was being rejected because the Registry service's security group did not allow inbound traffic from the MCPGW service on port 7860.

*Solution:*
Added an explicit security group ingress rule to allow traffic from the MCPGW security group to the Registry security group on port 7860:

This follows the same pattern as the existing registry_to_auth rule that allows Registry → Auth Server communication on port 8888.

*Testing:*
Before fix:

MCPGW service could resolve registry via Service Connect DNS
Connection attempts to http://registry:7860 resulted in "Connection reset by peer"
MCP Gateway tools (list_services, refresh_service, etc.) failed with connection errors

*After fix*:

MCPGW can successfully connect to Registry on port 7860
MCP Gateway management tools work correctly
Internal API calls succeed (though authentication may need configuration)

Files Changed
- ecs-services.tf - Added security group ingress rule
