### PR TITLE
Fix: Terraform - Module-level depends_on - causes cascading resource recreation

### DIFF
--- a/terraform/aws-ecs/documentdb.tf
+++ b/terraform/aws-ecs/documentdb.tf
@@ -238,7 +238,7 @@ resource "aws_docdb_cluster" "registry" {
   preferred_backup_window      = "02:00-04:00"
   preferred_maintenance_window = "sun:04:00-sun:05:00"
   skip_final_snapshot          = false
-  final_snapshot_identifier    = "${var.name}-registry-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
+  final_snapshot_identifier    = "${var.name}-registry-final-snapshot"
 
   # Encryption
   storage_encrypted = true

--- a/terraform/aws-ecs/keycloak-database.tf
+++ b/terraform/aws-ecs/keycloak-database.tf
@@ -8,8 +8,10 @@ resource "aws_db_proxy" "keycloak" {
   engine_family = "MYSQL"
 
   auth {
-    auth_scheme = "SECRETS"
-    secret_arn  = aws_secretsmanager_secret.keycloak_db_secret.arn
+    auth_scheme               = "SECRETS"
+    secret_arn                = aws_secretsmanager_secret.keycloak_db_secret.arn
+    client_password_auth_type = "MYSQL_CACHING_SHA2_PASSWORD"
+    iam_auth                  = "DISABLED"
   }
 
   role_arn               = aws_iam_role.rds_proxy_role.arn

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -702,7 +702,6 @@ module "ecs_service_registry" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_auth]
 }
 
 
@@ -837,7 +836,6 @@ module "ecs_service_currenttime" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_registry]
 }
 
 
@@ -990,7 +988,6 @@ module "ecs_service_mcpgw" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_registry]
 }
 
 
@@ -1112,7 +1109,6 @@ module "ecs_service_realserverfaketools" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_registry]
 }
 
 
@@ -1234,7 +1230,6 @@ module "ecs_service_flight_booking_agent" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_registry]
 }
 
 
@@ -1356,5 +1351,4 @@ module "ecs_service_travel_assistant_agent" {
 
   tags = local.common_tags
 
-  depends_on = [module.ecs_service_registry]
 }


### PR DESCRIPTION
*Issue*

Using `depends_on` with module references (e.g., `depends_on = [module.ecs_service_auth]`) causes Terraform to treat **all resources** within that module as a dependency. This leads to cascading recreation of resources whenever any resource in the dependent module changes, even for unrelated updates.

This is a well-documented anti-pattern: [Beware of depends_on for modules — it might bite you](https://itnext.io/beware-of-depends-on-for-modules-it-might-bite-you-da4741caac70)

## Current Behavior

When using module-level `depends_on`:

```hcl
module "ecs_service_registry" {
  source  = "terraform-aws-modules/ecs/aws//modules/service"
  version = "~> 6.0"
  
  # ... configuration ...
  
  depends_on = [module.ecs_service_auth]  # ⚠️ PROBLEMATIC
}
```

**What happens:**
1. Any resource change in `module.ecs_service_auth` (e.g., updating a tag, environment variable, or image)
2. Triggers Terraform to see `module.ecs_service_registry` as affected
3. Results in recreation of:
   - Task definitions (marked as "deposed objects")
   - Security groups (destroyed and recreated)
   - ECS services (modified to use new task definitions)
   - ALL dependent modules in a cascade

**Example output:**
```
Plan: 29 to add, 75 to change, 29 to destroy.

module.ecs_service_registry.aws_ecs_task_definition.this[0] (deposed object 10570654): Destroying...
module.ecs_service_registry.aws_security_group.this[0] (deposed object 3cd84ff1): Destroying...
module.ecs_service_mcpgw.aws_security_group.this[0] (deposed object 92242ebd): Destroying...
module.ecs_service_currenttime.aws_security_group.this[0] (deposed object bf7210ac): Destroying...
# ... and so on for dozens of resources
```

This causes:
- **Unnecessary downtime** during deployments
- **Resource churn** and potential service disruptions
- **Slow deployments** recreating many resources
- **State file bloat** with deposed objects

## Root Cause

Terraform's `depends_on` with modules creates an implicit dependency on **every resource** inside that module. When Terraform evaluates whether resources need to be updated, it sees the entire module as having changed, not individual resources.

From the Terraform documentation:
> "Module dependencies are opaque to Terraform, so any resource within the module can potentially affect any resource within the dependent module."

## Expected Behavior

Dependencies should be expressed at the **resource level**, not the module level. This allows Terraform to track precise relationships and only recreate what actually changed.

## Steps to Reproduce

1. Create a deployment with module-level `depends_on`:
```hcl
module "service_a" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
}

module "service_b" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
  depends_on = [module.service_a]
}

module "service_c" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
  depends_on = [module.service_b]
}
```

2. Run `terraform apply` - succeeds
3. Make a minor change to `service_a` (e.g., update an environment variable)
4. Run `terraform plan` - shows recreation of `service_b`, `service_c`, and all their resources
5. Run `terraform apply` - recreates everything in a cascade

## Recommended Solution

**Use resource-level dependencies instead of module-level dependencies.**

### ❌ Bad (Module-level dependency):
```hcl
module "ecs_service_registry" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
  
  depends_on = [module.ecs_service_auth]  # Depends on entire module
}
```

### ✅ Good (Resource-level dependency):
```hcl
module "ecs_service_registry" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
}

# Express the dependency through security group rules
resource "aws_vpc_security_group_ingress_rule" "registry_to_auth" {
  security_group_id            = module.ecs_service_auth.security_group_id
  referenced_security_group_id = module.ecs_service_registry.security_group_id
  from_port                    = 8888
  to_port                      = 8888
  ip_protocol                  = "tcp"
  description                  = "Allow registry to access auth server"
}
```

**Benefits:**
- Terraform tracks the **specific resource** dependency (security group ID)
- Changes to unrelated auth service resources don't affect registry
- Only actual dependencies trigger updates
- Clear, explicit relationships in code

### Alternative: Use outputs for ordering
If you truly need module ordering without resource recreation:

```hcl
module "ecs_service_registry" {
  source = "terraform-aws-modules/ecs/aws//modules/service"
  # ... config ...
  
  # Reference a specific output to create implicit dependency
  # without triggering recreation
  tags = merge(
    var.tags,
    {
      DependsOnAuth = module.ecs_service_auth.service_id
    }
  )
}
```

## Impact

This anti-pattern affects any Terraform infrastructure using module-level `depends_on`, particularly:
- **Multi-tier architectures** where services depend on each other
- **ECS/Kubernetes deployments** with multiple interconnected services
- **Database and application layers** with initialization ordering requirements
- **Any modular infrastructure** where modules have dependencies

## Additional Related Issues

While investigating this issue, we also identified two other common causes of unnecessary resource recreation:

### 1. Using `timestamp()` in resource attributes
```hcl
# ❌ Bad - causes recreation every apply
resource "aws_docdb_cluster" "example" {
  final_snapshot_identifier = "snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}"
}

# ✅ Good - static identifier
resource "aws_docdb_cluster" "example" {
  final_snapshot_identifier = "final-snapshot"
}
```

### 2. Using `timestamp()` in tags
```hcl
# ❌ Bad - changes every apply
locals {
  common_tags = {
    ManagedBy = "terraform"
    CreatedAt = timestamp()  # Always different!
  }
}

# ✅ Good - static values
locals {
  common_tags = {
    ManagedBy = "terraform"
  }
}
```



Another issue with `terraform/aws-ecs/keycloak-database.tf`is that our plan/apply shows `iam_auth = "DISABLED"` in the actual resource but it's not in our Terraform config.

This causes the auth block to be removed and re-added on every apply.

By adding `iam_auth = "DISABLED"`and `client_password_auth_type = "MYSQL_CACHING_SHA2_PASSWORD"` explicitly, all three computed fields in the auth block (auth_scheme, client_password_auth_type, and iam_auth) now match what AWS has, so there should be no more drift.



Lastly, DocumentDB final snapshot - Uses timestamp() which generates a new value each time.
Removed the `timestamp()` function which was generating a new value on every plan. Changed from "${var.name}-registry-final-snapshot-${formatdate("YYYY-MM-DD-hhmm", timestamp())}" to just "${var.name}-registry-final-snapshot". The snapshot identifier is only used when the cluster is destroyed anyway, so a static name is fine.

## References

- [Beware of depends_on for modules — it might bite you (ITNEXT)](https://itnext.io/beware-of-depends-on-for-modules-it-might-bite-you-da4741caac70)
- [Terraform docs - Resource Dependencies](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on)
- [Terraform docs - Module Dependencies](https://developer.hashicorp.com/terraform/language/modules/develop/composition#module-dependencies)