### PR TITLE
feat: expose mcp_endpoint in API response and React frontend

### DIFF
--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -31,6 +31,8 @@ export interface Server {
   rating_details?: Array<{ user: string; rating: number }>;
   status?: 'healthy' | 'healthy-auth-expired' | 'unhealthy' | 'unknown';
   num_tools?: number;
+  proxy_pass_url?: string;
+  mcp_endpoint?: string;
 }
 
 interface ServerCardProps {

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -28,7 +28,9 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
 
     // Clean up server path - remove trailing slashes and ensure single leading slash
     const cleanPath = server.path.replace(/\/+$/, '').replace(/^\/+/, '/');
-    const url = `${baseUrl}${cleanPath}/mcp`;
+
+    // Use custom mcp_endpoint if available, otherwise construct default URL
+    const url = server.mcp_endpoint || `${baseUrl}${cleanPath}/mcp`;
 
     switch (selectedIDE) {
       case 'vscode':
@@ -156,12 +158,22 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
           </div>
 
           <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
-            <h4 className="font-medium text-amber-900 dark:text-amber-100 mb-2">🔐 Authentication Required</h4>
+            <h4 className="font-medium text-amber-900 dark:text-amber-100 mb-2">Authentication Required</h4>
             <p className="text-sm text-amber-800 dark:text-amber-200">
               This configuration requires gateway authentication tokens. The tokens authenticate your AI assistant with
               the MCP Gateway, not the individual server. Visit the authentication documentation for setup instructions.
             </p>
           </div>
+
+          {server.mcp_endpoint && (
+            <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
+              <h4 className="font-medium text-purple-900 dark:text-purple-100 mb-2">Custom Endpoint Configured</h4>
+              <p className="text-sm text-purple-800 dark:text-purple-200">
+                This server uses a custom MCP endpoint:{' '}
+                <code className="bg-purple-100 dark:bg-purple-800 px-1 rounded break-all">{server.mcp_endpoint}</code>
+              </p>
+            </div>
+          )}
 
           <div className="bg-gray-50 dark:bg-gray-900 border dark:border-gray-700 rounded-lg p-4">
             <h4 className="font-medium text-gray-900 dark:text-white mb-3">Select your IDE/Tool:</h4>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -26,6 +26,7 @@ interface Server {
   license?: string;
   num_stars?: number;
   is_python?: boolean;
+  mcp_endpoint?: string;
 }
 
 interface Agent {
@@ -127,7 +128,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
     license: 'N/A',
     num_tools: 0,
     num_stars: 0,
-    is_python: false
+    is_python: false,
+    mcp_endpoint: ''
   });
   const [editLoading, setEditLoading] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
@@ -429,7 +431,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
         license: serverDetails.license || 'N/A',
         num_tools: serverDetails.num_tools || 0,
         num_stars: serverDetails.num_stars || 0,
-        is_python: serverDetails.is_python || false
+        is_python: serverDetails.is_python || false,
+        mcp_endpoint: serverDetails.mcp_endpoint || ''
       });
     } catch (error) {
       console.error('Failed to fetch server details:', error);
@@ -444,7 +447,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
         license: 'N/A',
         num_tools: server.num_tools || 0,
         num_stars: 0,
-        is_python: false
+        is_python: false,
+        mcp_endpoint: server.mcp_endpoint || ''
       });
     }
   }, []);
@@ -492,6 +496,9 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
       formData.append('num_tools', editForm.num_tools.toString());
       formData.append('num_stars', editForm.num_stars.toString());
       formData.append('is_python', editForm.is_python.toString());
+      if (editForm.mcp_endpoint) {
+        formData.append('mcp_endpoint', editForm.mcp_endpoint);
+      }
 
       // Use the correct edit endpoint with the server path
       await axios.post(`/api/edit${editingServer.path}`, formData, {
@@ -1364,6 +1371,19 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                 <label htmlFor="is_python" className="ml-2 block text-sm text-gray-700 dark:text-gray-200">
                   Python-based server
                 </label>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                  MCP Endpoint (optional)
+                </label>
+                <input
+                  type="url"
+                  value={editForm.mcp_endpoint}
+                  onChange={(e) => setEditForm(prev => ({ ...prev, mcp_endpoint: e.target.value }))}
+                  className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-purple-500 focus:border-purple-500"
+                  placeholder="Custom MCP endpoint URL (overrides default)"
+                />
               </div>
 
               <div>

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -235,6 +235,7 @@ async def read_root(
                     "license": server_info.get("license", "N/A"),
                     "health_status": normalized_status,
                     "last_checked_iso": health_data["last_checked_iso"],
+                    "mcp_endpoint": server_info.get("mcp_endpoint"),
                 }
             )
 
@@ -341,6 +342,7 @@ async def get_servers_json(
                     "license": server_info.get("license", "N/A"),
                     "health_status": normalized_status,
                     "last_checked_iso": health_data["last_checked_iso"],
+                    "mcp_endpoint": server_info.get("mcp_endpoint"),
                 }
             )
 
@@ -4042,9 +4044,10 @@ async def get_servers_json(
                     "num_stars": server_info.get("num_stars", 0),
                     "is_python": server_info.get("is_python", False),
                     "license": server_info.get("license", "N/A"),
-                    "health_status": health_data["status"],  
-                    "last_checked_iso": health_data["last_checked_iso"]
+                    "health_status": health_data["status"],
+                    "last_checked_iso": health_data["last_checked_iso"],
+                    "mcp_endpoint": server_info.get("mcp_endpoint"),
                 }
             )
-    
+
     return {"servers": service_data}


### PR DESCRIPTION
## Summary

Follow-up to PR #382 (centralized endpoint URL resolution). This PR exposes the `mcp_endpoint` field in the API response and React frontend so users can view and edit custom MCP endpoints.

## Changes

- Add `mcp_endpoint` to `/api/servers` response (3 locations in `server_routes.py`)
- Update React `Server` interface with `mcp_endpoint` field
- Add `mcp_endpoint` to Edit Server Modal form (view and edit)
- Update `ServerConfigModal` to use custom endpoint in config generation
- Show info box when custom endpoint is configured

## Test plan

- [x] Verify `/api/servers` returns `mcp_endpoint` field
- [x] Verify Edit Server Modal displays `mcp_endpoint` value
- [x] Verify ServerConfigModal uses custom endpoint in generated config
- [x] Frontend builds successfully