### PR TITLE
dynamically generate shared secretKey

### DIFF
--- a/charts/auth-server/templates/deployment.yaml
+++ b/charts/auth-server/templates/deployment.yaml
@@ -52,6 +52,10 @@ spec:
                 name: keycloak-client-secret
             - secretRef:
                 name: mongo-credentials
+            {{- if .Values.global.sharedSecretName }}
+            - secretRef:
+                name: {{ .Values.global.sharedSecretName }}
+            {{- end }}
       volumes:
         - name: script
           configMap:

--- a/charts/auth-server/templates/secret.yaml
+++ b/charts/auth-server/templates/secret.yaml
@@ -30,7 +30,9 @@ data:
   KEYCLOAK_URL: {{ $keycloakUrl | b64enc | quote }}
   REGISTRY_URL: {{ printf "http://registry.%s.svc.cluster.local:8000" .Release.Namespace | b64enc | quote }}
   ROOT_PATH: {{ $rootPath | b64enc | quote }}
-  SECRET_KEY: {{ (.Values.global.secretKey | default .Values.app.secretKey) | b64enc | quote }}
   SESSION_COOKIE_SECURE: {{ .Values.app.sessionCookieSecure | toString | b64enc | quote }}
   SESSION_COOKIE_DOMAIN: {{ printf ".%s" $domain | b64enc | quote }}
-
+{{- if not .Values.global.sharedSecretName }}
+  {{/* SECRET_KEY required for standalone deployment - must match registry's key */}}
+  SECRET_KEY: {{ required "app.secretKey or global.secretKey is required for standalone deployment" (.Values.global.secretKey | default .Values.app.secretKey) | b64enc | quote }}
+{{- end }}

--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -15,7 +15,10 @@ app:
   externalUrl: http://localhost:8888
 
   # Security settings
-  secretKey: apassword
+  # secretKey: If not provided, a random 64-character key is auto-generated.
+  # When deployed via mcp-gateway-registry-stack, the key is shared with registry.
+  # Uncomment to use a specific key:
+  # secretKey: "your-secure-key-here"
   sessionCookieDomain: ""  # Auto-inferred from Host header if empty
   sessionCookieSecure: true
 

--- a/charts/mcp-gateway-registry-stack/templates/shared-secret.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/shared-secret.yaml
@@ -1,0 +1,25 @@
+{{/*
+Shared secret for auth-server and registry.
+Generates a random secretKey if not provided via global.secretKey.
+Both services reference this single secret for SECRET_KEY.
+*/}}
+{{- $secretName := .Values.global.sharedSecretName | default "shared-secret" }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- $secretKey := "" }}
+{{- if .Values.global.secretKey }}
+  {{- $secretKey = .Values.global.secretKey }}
+{{- else if $existingSecret }}
+  {{- $secretKey = index $existingSecret.data "SECRET_KEY" | b64dec }}
+{{- else }}
+  {{- $secretKey = randAlphaNum 64 }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mcp-gateway-registry-stack.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SECRET_KEY: {{ $secretKey | b64enc | quote }}

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -3,8 +3,16 @@ global:
   # Domain configuration - update this to your actual domain
   domain: "DOMAIN"
 
-  # Security settings - CHANGE THESE IN PRODUCTION
-  secretKey: "aReallyGoodKeyThatShouldBeChanged"
+  # Security settings
+  # secretKey: If not provided, a random 64-character key is auto-generated
+  # and shared between auth-server and registry via a shared secret.
+  # The generated key persists across helm upgrades.
+  # Uncomment and set to use a specific key:
+  # secretKey: "your-secure-key-here"
+
+  # Shared secret name - automatically set for stack deployment
+  # Both auth-server and registry will use this secret for SECRET_KEY
+  sharedSecretName: "shared-secret"
 
   # Common ingress settings
   ingress:
@@ -115,7 +123,6 @@ mongodb-configure:
 
 # Registry service configuration
 registry:
-  # app.secretKey and app.authServerUrl will be templated in the subchart using global values
   app:
     replicas: 1
   ingress:
@@ -130,7 +137,6 @@ registry:
 
 # Auth server configuration
 auth-server:
-  # app.secretKey, app.externalUrl, app.sessionCookieDomain will be templated using global values
   app:
     replicas: 1
   keycloak:

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
                 name: keycloak-client-secret
             - secretRef:
                 name: mongo-credentials
+            {{- if .Values.global.sharedSecretName }}
+            - secretRef:
+                name: {{ .Values.global.sharedSecretName }}
+            {{- end }}
       volumes:
         - name: script
           configMap:

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -30,6 +30,9 @@ data:
   AUTH_SERVER_EXTERNAL_URL: {{ $authServerExternalUrl | b64enc | quote }}
   AUTH_SERVER_URL: {{ printf "http://auth-server.%s.svc.cluster.local:8888" .Release.Namespace | b64enc | quote }}
   KEYCLOAK_URL: {{ $keycloakUrl | b64enc | quote }}
-  SECRET_KEY: {{ (.Values.global.secretKey | default .Values.app.secretKey) | b64enc | quote }}
   GATEWAY_ADDITIONAL_SERVER_NAMES: {{ $gatewayAdditionalServerNames| b64enc | quote }}
   ROOT_PATH: {{ $rootPath | b64enc | quote }}
+{{- if not .Values.global.sharedSecretName }}
+  {{/* SECRET_KEY required for standalone deployment - must match auth-server's key */}}
+  SECRET_KEY: {{ required "app.secretKey or global.secretKey is required for standalone deployment" (.Values.global.secretKey | default .Values.app.secretKey) | b64enc | quote }}
+{{- end }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -15,7 +15,10 @@ app:
   authServerUrl: http://localhost:8888
 
   # Security settings
-  secretKey: apassword
+  # secretKey: If not provided, a random 64-character key is auto-generated.
+  # When deployed via mcp-gateway-registry-stack, the key is shared with auth-server.
+  # Uncomment to use a specific key:
+  # secretKey: "your-secure-key-here"
 
 # Service configuration
 service:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When using the `mcp-gateway-registry-stack` chart, the `secretKey` is now dynamically generated and shared between the `registry` and `auth-server` (default). There is little reason to set this manually as it is unused except between the services to sign cookies. This behavior can be overridden for the stack or can be manually overridden in each chart if the components are deployed separately. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
