### PR TITLE
fix: Return correct 4xx status codes from auth server /validate endpoint

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1395,10 +1395,10 @@ async def validate_request(request: Request):
             headers={"WWW-Authenticate": "Bearer", "Connection": "close"},
         )
     except HTTPException as e:
-        # If it's a 403 HTTPException, re-raise it as is
-        if e.status_code == 403:
+        # Re-raise client error HTTPExceptions (4xx) as-is
+        if 400 <= e.status_code < 500:
             raise
-        # For other HTTPExceptions, let them fall through to general handler
+        # For non-client HTTPExceptions, convert to 500
         logger.error(f"HTTP error during validation: {e}")
         raise HTTPException(
             status_code=500,

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -654,13 +654,7 @@ class TestValidateEndpoint:
 
     @patch("auth_server.server.get_auth_provider")
     def test_validate_missing_auth_header(self, mock_get_provider, auth_env_vars):
-        """Test validation without Authorization header.
-
-        Note: Due to a bug in server.py lines 1121-1131, HTTPException(401) is
-        caught and converted to 500. See .scratchpad/fixes/auth_server/fix-http-exception-handling.md
-        This test verifies the actual (buggy) behavior. When the bug is fixed,
-        this test should expect 401 and check for "Missing or invalid Authorization header".
-        """
+        """Test validation without Authorization header returns 401."""
         # Arrange
         import auth_server.server as server_module
 
@@ -669,12 +663,9 @@ class TestValidateEndpoint:
         # Act
         response = client.get("/validate")
 
-        # Assert - actual behavior is 500 due to HTTPException handling bug
-        # Expected behavior (when bug is fixed) would be:
-        # assert response.status_code == 401
-        # assert "Missing or invalid Authorization header" in response.json()["detail"]
-        assert response.status_code == 500
-        assert "Internal validation error" in response.json()["detail"]
+        # Assert
+        assert response.status_code == 401
+        assert "Missing or invalid Authorization header" in response.json()["detail"]
 
     @patch("auth_server.server.get_auth_provider")
     def test_validate_with_session_cookie(


### PR DESCRIPTION
## Summary
- Fix auth server `/validate` endpoint returning HTTP 500 instead of the correct 401/400 for client authentication errors
- The `except HTTPException` handler was only re-raising 403 errors; all other 4xx exceptions (401, 400) were incorrectly converted to 500
- Changed the condition to re-raise all 4xx client errors, so NGINX and callers can distinguish auth failures from actual server errors

Closes #419

## Test plan
- [x] Updated `test_validate_missing_auth_header` to assert 401 instead of 500
- [x] Verified unit test passes
- [x] Manually tested with `curl` against running auth server -- confirmed 401 with correct detail message