### PR TITLE
Feature: Add Device Code Flow CLI for End-User Authentication

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2404,3 +2404,115 @@ async def oauth2_logout(provider: str, request: Request, redirect_uri: str = Non
             "success_redirect", "/login"
         )
         return RedirectResponse(url=redirect_url, status_code=302)
+
+
+@app.post("/oauth2/exchange-token", tags=["OAuth2"])
+async def exchange_token_for_session(request: Request):
+    """Exchange a verified Entra ID token for a registry session cookie.
+
+    This enables CLI/device code flow authentication:
+    1. Client authenticates with Entra directly (device code flow)
+    2. Client sends the id_token here
+    3. Server validates the token signature and claims
+    4. Returns a session cookie for direct registry API access
+
+    Request body: {"id_token": "eyJ..."}
+    Returns: {"session_cookie": "...", "username": "...", "expires_in": 28800}
+    """
+    try:
+        body = await request.json()
+        id_token = body.get("id_token")
+
+        if not id_token:
+            raise HTTPException(status_code=400, detail="id_token is required")
+
+        # Get Entra provider for token validation
+        if "entra" not in OAUTH2_CONFIG.get("providers", {}):
+            raise HTTPException(status_code=400, detail="Entra provider not configured")
+
+        provider_config = OAUTH2_CONFIG["providers"]["entra"]
+        if not provider_config.get("enabled", False):
+            raise HTTPException(status_code=400, detail="Entra provider is disabled")
+
+        auth_provider = get_auth_provider("entra")
+
+        # Validate ID token signature and claims using Entra's JWKS
+        try:
+            # Get JWKS for signature verification
+            jwks = auth_provider.get_jwks()
+
+            # Get the key ID from token header
+            unverified_header = jwt.get_unverified_header(id_token)
+            kid = unverified_header.get("kid")
+
+            if not kid:
+                raise HTTPException(status_code=400, detail="Token missing key ID")
+
+            # Find the signing key
+            signing_key = None
+            for key in jwks.get("keys", []):
+                if key.get("kid") == kid:
+                    signing_key = PyJWK(key).key
+                    break
+
+            if not signing_key:
+                raise HTTPException(status_code=400, detail="Token signing key not found")
+
+            # Validate and decode token with full verification
+            claims = jwt.decode(
+                id_token,
+                signing_key,
+                algorithms=["RS256"],
+                audience=auth_provider.client_id,  # Must match our app's client_id
+                options={"verify_exp": True, "verify_aud": True}
+            )
+
+        except jwt.ExpiredSignatureError:
+            raise HTTPException(status_code=401, detail="Token has expired")
+        except jwt.InvalidAudienceError:
+            raise HTTPException(status_code=401, detail="Token audience mismatch")
+        except jwt.InvalidTokenError as e:
+            logger.error(f"Token validation failed: {e}")
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        # Extract user info from validated claims
+        username = (
+            claims.get("preferred_username") or
+            claims.get("email") or
+            claims.get("upn") or
+            claims.get("sub")
+        )
+        email = claims.get("email") or claims.get("preferred_username")
+        groups = claims.get("groups", []) or claims.get("roles", [])
+
+        if not username:
+            raise HTTPException(status_code=400, detail="Could not extract username from token")
+
+        logger.info(f"Token exchange for user: {hash_username(username)}, groups: {groups}")
+
+        # Create session cookie (same format as OAuth2 callback)
+        session_data = {
+            "username": username,
+            "email": email,
+            "groups": groups,
+            "auth_method": "oauth2",
+            "provider": "entra"
+        }
+        session_cookie = signer.dumps(session_data)
+
+        # Map groups to scopes for the response
+        scopes = await map_groups_to_scopes(groups)
+
+        return {
+            "session_cookie": session_cookie,
+            "username": username,
+            "groups": groups,
+            "scopes": scopes,
+            "expires_in": 28800  # 8 hours (session cookie lifetime)
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error exchanging token: {e}")
+        raise HTTPException(status_code=500, detail="Token exchange failed")

--- a/cli/mcp_gateway_cli.py
+++ b/cli/mcp_gateway_cli.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""MCP Gateway CLI - Authentication and management tool."""
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import msal
+import requests
+import typer
+from rich.console import Console
+from rich.status import Status
+from rich.table import Table
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(
+    name="mcp-gateway",
+    help="MCP Gateway CLI - Authenticate and interact with MCP Gateway",
+)
+console = Console()
+
+# Sub-apps for command groups
+mcp_app = typer.Typer(help="MCP server management commands")
+agent_app = typer.Typer(help="A2A agent management commands")
+
+# Register sub-apps
+app.add_typer(mcp_app, name="mcp")
+app.add_typer(agent_app, name="agent")
+
+# Config locations (in cli/ folder of project)
+CONFIG_DIR = Path(__file__).parent
+SESSION_FILE = CONFIG_DIR / ".mcp_session"
+CONFIG_FILE = CONFIG_DIR / ".mcp_config.json"
+
+
+def _load_config() -> dict:
+    """Load configuration from file and environment.
+
+    Returns:
+        Dictionary with configuration values from environment and config file.
+    """
+    config = {
+        "tenant_id": os.environ.get("ENTRA_TENANT_ID", ""),
+        "client_id": os.environ.get("ENTRA_CLIENT_ID", ""),
+        "auth_server_url": os.environ.get("MCP_AUTH_SERVER_URL", "http://localhost:8888"),
+        "registry_url": os.environ.get("MCP_REGISTRY_URL", "http://localhost:7860"),
+    }
+
+    if CONFIG_FILE.exists():
+        with open(CONFIG_FILE) as f:
+            file_config = json.load(f)
+            config.update({k: v for k, v in file_config.items() if v})
+
+    return config
+
+
+def _save_config(
+    config: dict,
+) -> None:
+    """Save configuration to file.
+
+    Args:
+        config: Configuration dictionary to save.
+    """
+    CONFIG_FILE.write_text(json.dumps(config, indent=2))
+    logger.debug(f"Configuration saved to {CONFIG_FILE}")
+
+
+def _get_session() -> Optional[str]:
+    """Load stored session cookie.
+
+    Returns:
+        Session cookie string if exists, None otherwise.
+    """
+    if SESSION_FILE.exists():
+        return SESSION_FILE.read_text().strip()
+    return None
+
+
+def _save_session(
+    session_cookie: str,
+) -> None:
+    """Save session cookie to file with secure permissions.
+
+    Args:
+        session_cookie: Session cookie string to save.
+    """
+    SESSION_FILE.write_text(session_cookie)
+    SESSION_FILE.chmod(0o600)
+    logger.debug(f"Session saved to {SESSION_FILE}")
+
+
+def _clear_session() -> bool:
+    """Clear stored session.
+
+    Returns:
+        True if session was cleared, False if no session existed.
+    """
+    if SESSION_FILE.exists():
+        SESSION_FILE.unlink()
+        return True
+    return False
+
+
+def _make_request(
+    method: str,
+    endpoint: str,
+    params: Optional[dict] = None,
+) -> requests.Response:
+    """Make authenticated request to registry API.
+
+    Args:
+        method: HTTP method (GET, POST, etc.)
+        endpoint: API endpoint path (e.g., /api/servers)
+        params: Optional query parameters
+
+    Returns:
+        Response object from the request
+
+    Raises:
+        typer.Exit: If not logged in, session expired, or connection fails
+    """
+    config = _load_config()
+    session = _get_session()
+
+    if not session:
+        console.print("[yellow]Not logged in.[/yellow] Run: mcp-gateway login")
+        raise typer.Exit(1)
+
+    url = f"{config['registry_url']}{endpoint}"
+    try:
+        resp = requests.request(
+            method,
+            url,
+            params=params,
+            cookies={"mcp_gateway_session": session},
+            timeout=30,
+        )
+    except requests.exceptions.RequestException as e:
+        console.print(f"[red]Error:[/red] Failed to connect: {e}")
+        raise typer.Exit(1)
+
+    if resp.status_code == 401:
+        console.print("[yellow]Session expired.[/yellow] Run: mcp-gateway login")
+        raise typer.Exit(1)
+
+    return resp
+
+
+@app.command()
+def login(
+    tenant_id: Optional[str] = typer.Option(
+        None,
+        "--tenant-id",
+        "-t",
+        envvar="ENTRA_TENANT_ID",
+        help="Azure AD tenant ID",
+    ),
+    client_id: Optional[str] = typer.Option(
+        None,
+        "--client-id",
+        "-c",
+        envvar="ENTRA_CLIENT_ID",
+        help="App registration client ID",
+    ),
+    auth_server: Optional[str] = typer.Option(
+        None,
+        "--auth-server",
+        envvar="MCP_AUTH_SERVER_URL",
+        help="MCP Auth server URL",
+    ),
+) -> None:
+    """Authenticate with MCP Gateway using device code flow."""
+    config = _load_config()
+    tenant_id = tenant_id or config.get("tenant_id")
+    client_id = client_id or config.get("client_id")
+    auth_server = auth_server or config.get("auth_server_url")
+
+    if not tenant_id or not client_id:
+        console.print("[red]Error:[/red] ENTRA_TENANT_ID and ENTRA_CLIENT_ID are required")
+        console.print("Set via environment variables or --tenant-id/--client-id options")
+        raise typer.Exit(1)
+
+    logger.debug(f"Using tenant_id: {tenant_id}")
+    logger.debug(f"Using auth_server: {auth_server}")
+
+    # Step 1: Initiate device code flow
+    authority = f"https://login.microsoftonline.com/{tenant_id}"
+    msal_app = msal.PublicClientApplication(client_id, authority=authority)
+
+    # Note: MSAL automatically includes 'openid', 'profile', 'offline_access'
+    # We only need to request 'email' explicitly
+    flow = msal_app.initiate_device_flow(scopes=["email"])
+    if "error" in flow:
+        console.print(f"[red]Error:[/red] {flow.get('error_description', flow.get('error'))}")
+        raise typer.Exit(1)
+
+    # Step 2: Show instructions
+    console.print("\n[bold]To sign in:[/bold]")
+    console.print(f"  1. Open: [cyan]{flow['verification_uri']}[/cyan]")
+    console.print(f"  2. Enter code: [bold yellow]{flow['user_code']}[/bold yellow]\n")
+
+    # Step 3: Wait for authentication
+    with Status("[bold blue]Waiting for authentication...", console=console):
+        result = msal_app.acquire_token_by_device_flow(flow)
+
+    if "error" in result:
+        console.print(
+            f"[red]Authentication failed:[/red] "
+            f"{result.get('error_description', result.get('error'))}"
+        )
+        raise typer.Exit(1)
+
+    id_token = result.get("id_token")
+    if not id_token:
+        console.print("[red]Error:[/red] No ID token received")
+        raise typer.Exit(1)
+
+    # Step 4: Exchange for session cookie
+    with Status("[bold blue]Exchanging token...", console=console):
+        try:
+            resp = requests.post(
+                f"{auth_server}/oauth2/exchange-token",
+                json={"id_token": id_token},
+                timeout=10,
+            )
+        except requests.exceptions.RequestException as e:
+            console.print(f"[red]Error:[/red] Failed to connect to auth server: {e}")
+            raise typer.Exit(1)
+
+    if resp.status_code != 200:
+        console.print(f"[red]Error:[/red] Token exchange failed: {resp.text}")
+        raise typer.Exit(1)
+
+    data = resp.json()
+    session_cookie = data.get("session_cookie")
+    if not session_cookie:
+        console.print("[red]Error:[/red] No session cookie received")
+        raise typer.Exit(1)
+
+    # Step 5: Save session
+    _save_session(session_cookie)
+
+    username = data.get("username", "Unknown")
+    console.print(f"[green]Logged in as:[/green] {username}")
+    console.print("[dim]Session saved to cli/.mcp_session[/dim]")
+
+
+@app.command()
+def whoami(
+    registry_url: Optional[str] = typer.Option(
+        None,
+        "--registry-url",
+        "-r",
+        envvar="MCP_REGISTRY_URL",
+        help="MCP Registry URL",
+    ),
+) -> None:
+    """Show current authenticated user."""
+    config = _load_config()
+    registry_url = registry_url or config.get("registry_url")
+    session = _get_session()
+
+    if not session:
+        console.print("[yellow]Not logged in.[/yellow] Run: mcp-gateway login")
+        raise typer.Exit(1)
+
+    try:
+        resp = requests.get(
+            f"{registry_url}/api/auth/me",
+            cookies={"mcp_gateway_session": session},
+            timeout=10,
+        )
+    except requests.exceptions.RequestException as e:
+        console.print(f"[red]Error:[/red] Failed to connect to registry: {e}")
+        raise typer.Exit(1)
+
+    if resp.status_code == 401:
+        console.print("[yellow]Session expired.[/yellow] Run: mcp-gateway login")
+        raise typer.Exit(1)
+
+    if resp.status_code != 200:
+        console.print(f"[red]Error:[/red] {resp.text}")
+        raise typer.Exit(1)
+
+    user = resp.json()
+    console.print(f"[bold]Username:[/bold] {user.get('username', 'Unknown')}")
+    console.print(f"[bold]Groups:[/bold] {', '.join(user.get('groups', []))}")
+    console.print(f"[bold]Scopes:[/bold] {', '.join(user.get('scopes', []))}")
+
+
+@app.command()
+def logout() -> None:
+    """Clear stored session."""
+    if _clear_session():
+        console.print("[green]Logged out.[/green]")
+    else:
+        console.print("[dim]No active session.[/dim]")
+
+
+@app.command()
+def config(
+    set_value: Optional[str] = typer.Option(
+        None,
+        "--set",
+        help="Set config: key=value",
+    ),
+) -> None:
+    """View or modify CLI configuration.
+
+    Without options, shows current configuration.
+    Use --set key=value to set a configuration value.
+    """
+    if set_value:
+        key, _, value = set_value.partition("=")
+        if not value:
+            console.print("[red]Error:[/red] Use --set key=value")
+            raise typer.Exit(1)
+
+        existing = {}
+        if CONFIG_FILE.exists():
+            existing = json.loads(CONFIG_FILE.read_text())
+        existing[key] = value
+        _save_config(existing)
+        console.print(f"[green]Set {key}[/green]")
+        return
+
+    # Show config (default behavior)
+    cfg = _load_config()
+    console.print("[bold]Current configuration:[/bold]")
+    for key, value in cfg.items():
+        display = value if value else "[dim]not set[/dim]"
+        console.print(f"  {key}: {display}")
+
+
+@mcp_app.command("list")
+def mcp_list(
+    query: Optional[str] = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Search filter",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format: table, json",
+    ),
+) -> None:
+    """List available MCP servers."""
+    params = {}
+    if query:
+        params["query"] = query
+
+    resp = _make_request("GET", "/api/servers", params=params)
+
+    if resp.status_code != 200:
+        console.print(f"[red]Error:[/red] {resp.text}")
+        raise typer.Exit(1)
+
+    data = resp.json()
+    servers = data.get("servers", [])
+
+    if output_format == "json":
+        console.print_json(json.dumps(servers, indent=2))
+        return
+
+    if not servers:
+        console.print("[dim]No servers found.[/dim]")
+        return
+
+    table = Table(title="MCP Servers")
+    table.add_column("Name", style="cyan")
+    table.add_column("Path", style="dim")
+    table.add_column("Tools", justify="right")
+    table.add_column("Status", style="green")
+
+    for server in servers:
+        health_status = server.get("health_status", "unknown")
+        status_style = "green" if health_status == "healthy" else "red"
+        table.add_row(
+            server.get("display_name", ""),
+            server.get("path", ""),
+            str(server.get("num_tools", 0)),
+            f"[{status_style}]{health_status}[/{status_style}]",
+        )
+
+    console.print(table)
+
+
+@agent_app.command("list")
+def agent_list(
+    query: Optional[str] = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Search filter",
+    ),
+    enabled_only: bool = typer.Option(
+        False,
+        "--enabled",
+        "-e",
+        help="Show only enabled agents",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--format",
+        "-f",
+        help="Output format: table, json",
+    ),
+) -> None:
+    """List available A2A agents."""
+    params = {}
+    if query:
+        params["query"] = query
+    if enabled_only:
+        params["enabled_only"] = "true"
+
+    resp = _make_request("GET", "/api/agents", params=params)
+
+    if resp.status_code != 200:
+        console.print(f"[red]Error:[/red] {resp.text}")
+        raise typer.Exit(1)
+
+    data = resp.json()
+    agents = data.get("agents", [])
+
+    if output_format == "json":
+        console.print_json(json.dumps(agents, indent=2))
+        return
+
+    if not agents:
+        console.print("[dim]No agents found.[/dim]")
+        return
+
+    table = Table(title="A2A Agents")
+    table.add_column("Name", style="cyan")
+    table.add_column("Path", style="dim")
+    table.add_column("Skills", justify="right")
+    table.add_column("Trust", style="yellow")
+    table.add_column("Enabled")
+
+    for agent in agents:
+        enabled_icon = "[green]Yes[/green]" if agent.get("isEnabled") else "[red]No[/red]"
+        table.add_row(
+            agent.get("name", ""),
+            agent.get("path", ""),
+            str(agent.get("numSkills", 0)),
+            agent.get("trustLevel", "unknown"),
+            enabled_icon,
+        )
+
+    console.print(table)
+
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     "pymongo>=4.6.0",
     "dnspython>=2.4.0",
     "litellm>=1.50.0",
+    "typer>=0.21.1",
+    "msal>=1.34.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1706,6 +1706,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mcp" },
     { name = "motor" },
+    { name = "msal" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1722,6 +1723,7 @@ dependencies = [
     { name = "strands-agents" },
     { name = "strands-agents-tools" },
     { name = "torch" },
+    { name = "typer" },
     { name = "typing-extensions" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
@@ -1792,6 +1794,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.7.0" },
     { name = "motor", specifier = ">=3.3.0" },
+    { name = "msal", specifier = ">=1.34.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -1816,6 +1819,7 @@ requires-dist = [
     { name = "strands-agents", specifier = ">=0.1.6" },
     { name = "strands-agents-tools", specifier = ">=0.1.4" },
     { name = "torch", specifier = ">=1.6.0" },
+    { name = "typer", specifier = ">=0.21.1" },
     { name = "typing-extensions", specifier = ">=4.8.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.2" },
     { name = "websockets", specifier = ">=15.0.1" },
@@ -1967,6 +1971,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msal"
+version = "1.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/0e/c857c46d653e104019a84f22d4494f2119b4fe9f896c92b4b864b3b045cc/msal-1.34.0.tar.gz", hash = "sha256:76ba83b716ea5a6d75b0279c0ac353a0e05b820ca1f6682c0eb7f45190c43c2f", size = 153961, upload-time = "2025-09-22T23:05:48.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/18d48843499e278538890dc709e9ee3dea8375f8be8e82682851df1b48b5/msal-1.34.0-py3-none-any.whl", hash = "sha256:f669b1644e4950115da7a176441b0e13ec2975c29528d8b9e81316023676d6e1", size = 116987, upload-time = "2025-09-22T23:05:47.294Z" },
 ]
 
 [[package]]
@@ -3408,6 +3426,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3767,6 +3794,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
     { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
     { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hey Amit, here is an idea/concept on how we could support the device code flow for developers. We add a new CLI tool (`mcp-gateway`) that provides AWS SSO-like authentication for end users, enabling seamless programmatic access to MCP Gateway Registry without requiring Azure App Registration Client Secrets.

Especially point 3) below caused a lot of friction for us. Let me know what you think 🚀 

----

### The Problem Today

Currently, developers who want to interact with the registry programmatically face significant friction:

1. **No unified CLI exists**: The registry has a web UI and REST API, but no official command-line tool for end users.

2. **Token acquisition is fragmented**: Multiple scripts exist for different purposes, but none provide a "login once, use everywhere" experience:
   - `api/registry_management.py` - Powerful but requires externally-obtained tokens via `--token-file`
   - `cli/get_user_token.py` - Obtains MS Graph tokens that don't map to registry permissions
   - `scripts/refresh_m2m_token.sh` - Service accounts only (M2M), not for interactive users

3. **Scope mismatch**: The existing token tools obtain tokens with MS Graph scopes, but the registry requires session cookies with group-to-scope mappings. These are fundamentally incompatible - you can't just pass a raw Entra token to the registry API ❗ 

4. **No session persistence**: Every API call requires manual token management, unlike tools like `aws sso login` that handle this automatically.

### The Developer Journey We Want

```bash
# First time setup (once)
export ENTRA_TENANT_ID="..."
export ENTRA_CLIENT_ID="..."

# Login (once per session, ~8 hours)
$ mcp-gateway login
To sign in:
  1. Open: https://microsoft.com/devicelogin
  2. Enter code: ABCD-EFGH

Logged in as: developer@company.com

# Now just use it - no more thinking about auth
$ mcp-gateway mcp list
+------------------+------------+-------+---------+
| Name             | Path       | Tools | Status  |
+------------------+------------+-------+---------+
| CurrentTime      | /time      | 2     | healthy |
| Weather Service  | /weather   | 5     | healthy |
+------------------+------------+-------+---------+

$ mcp-gateway agent list --enabled
+------------------+------------+--------+--------+---------+
| Name             | Path       | Skills | Trust  | Enabled |
+------------------+------------+--------+--------+---------+
| Travel Assistant | /travel    | 3      | medium | Yes     |
+------------------+------------+--------+--------+---------+

# Session expired? Clear message.
$ mcp-gateway mcp list
Session expired. Run: mcp-gateway login
```

This is the same experience developers expect from `aws sso login`, `gh auth login`, or `gcloud auth login`.

---

## Solution

### 1. New Auth Server Endpoint: `/oauth2/exchange-token`

A minimal, secure endpoint that exchanges a verified Entra ID token for a registry session cookie.

**Request:**
```json
POST /oauth2/exchange-token
{"id_token": "eyJ..."}
```

**Response:**
```json
{
  "session_cookie": "...",
  "username": "user@company.com",
  "groups": ["group-uuid-1", "group-uuid-2"],
  "scopes": ["mcp-servers-unrestricted/read", "..."],
  "expires_in": 28800
}
```

**Security:**
- Validates ID token signature using Entra's JWKS (public keys)
- Verifies audience matches the configured client_id
- Checks token expiration
- Only accepts tokens from the configured Entra tenant

### 2. New CLI Tool: `mcp-gateway`

A Typer-based CLI that mimics the AWS SSO login experience:

```bash
# Authenticate (device code flow)
mcp-gateway login

# Check current session
mcp-gateway whoami

# List MCP servers
mcp-gateway mcp list
mcp-gateway mcp list --query "weather" --format json

# List A2A agents
mcp-gateway agent list
mcp-gateway agent list --enabled --format json

# Clear session
mcp-gateway logout

# View/set configuration
mcp-gateway config
mcp-gateway config --set registry_url=https://mcp-gateway.example.com
```

**Session Management:**
- Session stored in `cli/.mcp_session` with `chmod 600`
- Automatic session expiry detection with helpful re-login prompts
- Configuration via environment variables or `cli/.mcp_config.json`

---

## Comparison with Existing Approaches

| Approach | User Type | Session Mgmt | Multi-Provider | Dependencies |
|----------|-----------|--------------|----------------|--------------|
| `api/registry_management.py` | Admin | None (manual token) | N/A | requests |
| `cli/get_user_token.py` | Developer | None (file only) | Entra only | requests |
| `scripts/refresh_m2m_token.sh` | Service | None | Keycloak only | curl, jq |
| **`mcp-gateway` CLI (new)** | **End User** | **Automatic** | **Via auth server** | msal, typer, rich |

---

## Limitations

1. **Entra ID Only**: The current implementation focuses on Entra ID. Other providers (Keycloak, Cognito) would require similar `exchange-token` logic with their respective JWKS validation.

2. **No Token Refresh**: Sessions last 8 hours. Users must re-run `login` after expiry. Future enhancement could add automatic refresh using MSAL's token cache.

3. **MSAL Dependency**: The CLI uses MSAL for device code flow. A lighter implementation using raw HTTP requests (like `get_user_token.py`) could be added as an alternative.

4. **Local Session Storage**: Session is stored in a file. For shared environments, consider environment variable support or system keyring integration.

---

## Entra ID App Registration Requirements

The app registration must have:
- **Public client flows enabled** (for device code flow)
- **ID tokens enabled** (for the exchange endpoint)
- Optional: Group claims configured in token configuration

---

## Future Enhancements

1. **Multi-provider support**: Add Keycloak and Cognito token exchange
2. **Token refresh**: Leverage MSAL token cache for automatic refresh
3. **System keyring**: Store sessions in OS keyring instead of file
4. **Shell completion**: Add bash/zsh completion scripts
5. **MCP server management commands**: `mcp-gateway mcp enable/disable/register`


----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
