### PR TITLE
Cleanup ingress annotations, add allowed inboud cidr range

### DIFF
--- a/charts/auth-server/templates/ingress.yaml
+++ b/charts/auth-server/templates/ingress.yaml
@@ -12,8 +12,14 @@ metadata:
     alb.ingress.kubernetes.io/group.name: mcp-gateway-stack
     alb.ingress.kubernetes.io/group.order: '10'
     {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/success-codes: 200,302
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    {{- if .Values.global.ingress.inboundCidrs }}
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.global.ingress.inboundCidrs }}
     {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/mcp-gateway-registry-stack/templates/keycloak-ingress-patch.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/keycloak-ingress-patch.yaml
@@ -11,7 +11,14 @@ metadata:
     alb.ingress.kubernetes.io/group.name: mcp-gateway-stack
     alb.ingress.kubernetes.io/group.order: '30'
     {{- end }}
-    {{- toYaml .Values.global.ingress.annotations | nindent 4 }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/success-codes: 200,302
+    {{- if .Values.global.ingress.inboundCidrs }}
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.global.ingress.inboundCidrs }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.global.ingress.className }}
   rules:

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -16,6 +16,7 @@ global:
 
   # Common ingress settings
   ingress:
+    inboundCidrs: # optional comma separated list of allowed inbound CIDR ranges
     className: alb
     tls: true
     # Routing mode: "subdomain" or "path"
@@ -27,12 +28,6 @@ global:
       authServer: /auth-server
       registry: /registry
       keycloak: /keycloak # make sure to update keycloak.httpRelativePath (/keycloak/)
-    annotations:
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/ssl-redirect: '443'
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/success-codes: 200,302
 
 mongodb-kubernetes:
   operator:
@@ -128,12 +123,6 @@ registry:
   ingress:
     enabled: true
     ingressClassName: alb
-    annotations:
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/ssl-redirect: '443'
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/success-codes: 200,302
 
 # Auth server configuration
 auth-server:
@@ -147,10 +136,3 @@ auth-server:
   ingress:
     enabled: true
     ingressClassName: alb
-    annotations:
-      alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
-      alb.ingress.kubernetes.io/scheme: internet-facing
-      alb.ingress.kubernetes.io/ssl-redirect: '443'
-      alb.ingress.kubernetes.io/target-type: ip
-      alb.ingress.kubernetes.io/success-codes: 200,302
-      alb.ingress.kubernetes.io/healthcheck-path: /health

--- a/charts/registry/templates/ingress.yaml
+++ b/charts/registry/templates/ingress.yaml
@@ -12,8 +12,13 @@ metadata:
     alb.ingress.kubernetes.io/group.name: mcp-gateway-stack
     alb.ingress.kubernetes.io/group.order: '20'
     {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/success-codes: 200,302
+    {{- if .Values.global.ingress.inboundCidrs }}
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.global.ingress.inboundCidrs }}
     {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- cleans up the duplicated ingress annotations in the `values.yaml`
- adds `global.ingress.inboundCidrs` as an optional key for restricting inbound ALB IPs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
