### PR TITLE
feat: Add delete action to Server and Agent cards (#418)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,9 +198,15 @@ cookies.txt
 # Roo IDE files
 .roo/
 
+# VS Code / IDE files
+.vscode/
+
 # Kiro files
 .kiro
 .kiro/
+
+# Agent config
+agents/agent_config.json
 
 # Jules files
 .Jules/

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -14,10 +14,12 @@ import {
   GlobeAltIcon,
   LockClosedIcon,
   InformationCircleIcon,
+  TrashIcon,
 } from '@heroicons/react/24/outline';
 import AgentDetailsModal from './AgentDetailsModal';
 import SecurityScanModal from './SecurityScanModal';
 import StarRatingWidget from './StarRatingWidget';
+import DeleteConfirmation from './DeleteConfirmation';
 
 /**
  * Agent interface representing an A2A agent.
@@ -49,6 +51,8 @@ interface AgentCardProps {
   canModify?: boolean;
   canHealthCheck?: boolean;  // Whether user can run health check on this agent
   canToggle?: boolean;       // Whether user can enable/disable this agent
+  canDelete?: boolean;       // Whether user can delete this agent
+  onDelete?: (path: string) => Promise<void>;  // Callback to delete the agent
   onRefreshSuccess?: () => void;
   onShowToast?: (message: string, type: 'success' | 'error') => void;
   onAgentUpdate?: (path: string, updates: Partial<Agent>) => void;
@@ -120,6 +124,8 @@ const AgentCard: React.FC<AgentCardProps> = React.memo(({
   canModify,
   canHealthCheck = true,
   canToggle = true,
+  canDelete,
+  onDelete,
   onRefreshSuccess,
   onShowToast,
   onAgentUpdate,
@@ -132,6 +138,7 @@ const AgentCard: React.FC<AgentCardProps> = React.memo(({
   const [showSecurityScan, setShowSecurityScan] = useState(false);
   const [securityScanResult, setSecurityScanResult] = useState<any>(null);
   const [loadingSecurityScan, setLoadingSecurityScan] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // Fetch security scan status on mount to show correct icon color
   useEffect(() => {
@@ -303,246 +310,274 @@ const AgentCard: React.FC<AgentCardProps> = React.memo(({
   return (
     <>
       <div className="group rounded-2xl shadow-sm hover:shadow-xl transition-all duration-300 h-full flex flex-col bg-gradient-to-br from-cyan-50 to-blue-50 dark:from-cyan-900/20 dark:to-blue-900/20 border-2 border-cyan-200 dark:border-cyan-700 hover:border-cyan-300 dark:hover:border-cyan-600">
-        {/* Header */}
-        <div className="p-5 pb-4">
-          <div className="flex items-start justify-between mb-4">
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-3">
-                <h3 className="text-lg font-bold text-gray-900 dark:text-white truncate">
-                  {agent.name}
-                </h3>
-                <span className="px-2 py-0.5 text-xs font-semibold bg-gradient-to-r from-cyan-100 to-blue-100 text-cyan-700 dark:from-cyan-900/30 dark:to-blue-900/30 dark:text-cyan-300 rounded-full flex-shrink-0 border border-cyan-200 dark:border-cyan-600">
-                  AGENT
-                </span>
-                {/* Check if this is an ASOR agent */}
-                {(agent.tags?.includes('asor') || (agent as any).provider === 'ASOR') && (
-                  <span className="px-2 py-0.5 text-xs font-semibold bg-gradient-to-r from-orange-100 to-red-100 text-orange-700 dark:from-orange-900/30 dark:to-red-900/30 dark:text-orange-300 rounded-full flex-shrink-0 border border-orange-200 dark:border-orange-600">
-                    ASOR
-                  </span>
-                )}
-                {agent.trust_level && (
-                  <span className={`px-2 py-0.5 text-xs font-semibold rounded-full flex-shrink-0 flex items-center gap-1 ${getTrustLevelColor()}`}>
-                    {getTrustLevelIcon()}
-                    {agent.trust_level.toUpperCase()}
-                  </span>
-                )}
-                {agent.visibility && (
-                  <span className={`px-2 py-0.5 text-xs font-semibold rounded-full flex-shrink-0 flex items-center gap-1 ${
-                    agent.visibility === 'public'
-                      ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-200 dark:border-blue-700'
-                      : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
-                  }`}>
-                    {getVisibilityIcon()}
-                    {agent.visibility.toUpperCase()}
-                  </span>
-                )}
-              </div>
-
-              <code className="text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 px-2 py-1 rounded font-mono">
-                {agent.path}
-              </code>
-              {agent.version && (
-                <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
-                  v{agent.version}
-                </span>
-              )}
-              {agent.url && (
-                <a
-                  href={agent.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-2 inline-flex items-center gap-1 text-xs text-cyan-700 dark:text-cyan-300 break-all hover:underline"
-                >
-                  <span className="font-mono">{agent.url}</span>
-                </a>
-              )}
-            </div>
-
-            {canModify && (
-              <button
-                className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
-                onClick={() => onEdit?.(agent)}
-                title="Edit agent"
-              >
-                <PencilIcon className="h-4 w-4" />
-              </button>
-            )}
-
-            {/* Security Scan Button */}
-            <button
-              onClick={handleViewSecurityScan}
-              className={`p-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition-all duration-200 flex-shrink-0 ${getSecurityIconState().color}`}
-              title={getSecurityIconState().title}
-              aria-label="View security scan results"
-            >
-              {React.createElement(getSecurityIconState().Icon, { className: "h-4 w-4" })}
-            </button>
-
-            {/* Full Details Button */}
-            <button
-              onClick={async () => {
-                setShowDetails(true);
-                setLoadingDetails(true);
-                try {
-                  const response = await axios.get(`/api/agents${agent.path}`);
-                  setFullAgentDetails(response.data);
-                } catch (error) {
-                  console.error('Failed to fetch agent details:', error);
-                  if (onShowToast) {
-                    onShowToast('Failed to load full agent details', 'error');
-                  }
-                } finally {
-                  setLoadingDetails(false);
-                }
-              }}
-              className="p-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
-              title="View full agent details (JSON)"
-            >
-              <InformationCircleIcon className="h-4 w-4" />
-            </button>
-          </div>
-
-          {/* Description */}
-          <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed line-clamp-2 mb-4">
-            {agent.description || 'No description available'}
-          </p>
-
-          {/* Tags */}
-          {agent.tags && agent.tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mb-4">
-              {agent.tags.slice(0, 3).map((tag) => (
-                <span
-                  key={tag}
-                  className="px-2 py-1 text-xs font-medium bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 rounded"
-                >
-                  #{tag}
-                </span>
-              ))}
-              {agent.tags.length > 3 && (
-                <span className="px-2 py-1 text-xs font-medium bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded">
-                  +{agent.tags.length - 3}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Stats */}
-        <div className="px-5 pb-4">
-          <div className="grid grid-cols-2 gap-4">
-            <StarRatingWidget
-              resourceType="agents"
-              path={agent.path}
-              initialRating={agent.rating || 0}
-              initialCount={agent.rating_details?.length || 0}
-              authToken={authToken}
-              onShowToast={onShowToast}
-              onRatingUpdate={(newRating) => {
-                // Update local agent rating when user submits rating
-                if (onAgentUpdate) {
-                  onAgentUpdate(agent.path, { rating: newRating });
-                }
-              }}
+        {showDeleteConfirm ? (
+          /* Delete Confirmation - replaces card content when active */
+          <div className="p-5 h-full flex flex-col justify-center">
+            <DeleteConfirmation
+              entityType="agent"
+              entityName={agent.name || agent.path.replace(/^\//, '')}
+              entityPath={agent.path}
+              onConfirm={onDelete!}
+              onCancel={() => setShowDeleteConfirm(false)}
             />
-            <div className="flex items-center gap-2">
-              <div className="p-1.5 bg-cyan-50 dark:bg-cyan-900/30 rounded">
-                <CpuChipIcon className="h-4 w-4 text-cyan-600 dark:text-cyan-400" />
-              </div>
-              <div>
-                <div className="text-sm font-semibold text-gray-900 dark:text-white">{agent.usersCount || 0}</div>
-                <div className="text-xs text-gray-500 dark:text-gray-400">Users</div>
-              </div>
-            </div>
           </div>
-        </div>
-
-        {/* Footer */}
-        <div className="mt-auto px-5 py-4 border-t border-cyan-100 dark:border-cyan-700 bg-cyan-50/50 dark:bg-cyan-900/30 rounded-b-2xl">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              {/* Status Indicators */}
-              <div className="flex items-center gap-2">
-                <div className={`w-3 h-3 rounded-full ${
-                  agent.enabled
-                    ? 'bg-green-400 shadow-lg shadow-green-400/30'
-                    : 'bg-gray-300 dark:bg-gray-600'
-                }`} />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  {agent.enabled ? 'Enabled' : 'Disabled'}
-                </span>
-              </div>
-
-              <div className="w-px h-4 bg-cyan-200 dark:bg-cyan-600" />
-
-              <div className="flex items-center gap-2">
-                <div className={`w-3 h-3 rounded-full ${
-                  agent.status === 'healthy'
-                    ? 'bg-emerald-400 shadow-lg shadow-emerald-400/30'
-                    : agent.status === 'healthy-auth-expired'
-                    ? 'bg-orange-400 shadow-lg shadow-orange-400/30'
-                    : agent.status === 'unhealthy'
-                    ? 'bg-red-400 shadow-lg shadow-red-400/30'
-                    : 'bg-amber-400 shadow-lg shadow-amber-400/30'
-                }`} />
-                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                  {agent.status === 'healthy' ? 'Healthy' :
-                   agent.status === 'healthy-auth-expired' ? 'Healthy (Auth Expired)' :
-                   agent.status === 'unhealthy' ? 'Unhealthy' : 'Unknown'}
-                </span>
-              </div>
-            </div>
-
-            {/* Controls */}
-            <div className="flex items-center gap-3">
-              {/* Last Checked */}
-              {(() => {
-                const timeText = formatTimeSince(agent.last_checked_time);
-                return agent.last_checked_time && timeText ? (
-                  <div className="text-xs text-gray-500 dark:text-gray-300 flex items-center gap-1.5">
-                    <ClockIcon className="h-3.5 w-3.5" />
-                    <span>{timeText}</span>
+        ) : (
+          /* Normal card content */
+          <>
+            {/* Header */}
+            <div className="p-5 pb-4">
+              <div className="flex items-start justify-between mb-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-3">
+                    <h3 className="text-lg font-bold text-gray-900 dark:text-white truncate">
+                      {agent.name}
+                    </h3>
+                    <span className="px-2 py-0.5 text-xs font-semibold bg-gradient-to-r from-cyan-100 to-blue-100 text-cyan-700 dark:from-cyan-900/30 dark:to-blue-900/30 dark:text-cyan-300 rounded-full flex-shrink-0 border border-cyan-200 dark:border-cyan-600">
+                      AGENT
+                    </span>
+                    {/* Check if this is an ASOR agent */}
+                    {(agent.tags?.includes('asor') || (agent as any).provider === 'ASOR') && (
+                      <span className="px-2 py-0.5 text-xs font-semibold bg-gradient-to-r from-orange-100 to-red-100 text-orange-700 dark:from-orange-900/30 dark:to-red-900/30 dark:text-orange-300 rounded-full flex-shrink-0 border border-orange-200 dark:border-orange-600">
+                        ASOR
+                      </span>
+                    )}
+                    {agent.trust_level && (
+                      <span className={`px-2 py-0.5 text-xs font-semibold rounded-full flex-shrink-0 flex items-center gap-1 ${getTrustLevelColor()}`}>
+                        {getTrustLevelIcon()}
+                        {agent.trust_level.toUpperCase()}
+                      </span>
+                    )}
+                    {agent.visibility && (
+                      <span className={`px-2 py-0.5 text-xs font-semibold rounded-full flex-shrink-0 flex items-center gap-1 ${
+                        agent.visibility === 'public'
+                          ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-200 dark:border-blue-700'
+                          : 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-600'
+                      }`}>
+                        {getVisibilityIcon()}
+                        {agent.visibility.toUpperCase()}
+                      </span>
+                    )}
                   </div>
-                ) : null;
-              })()}
 
-              {/* Refresh Button - only show if user has health_check_agent permission */}
-              {canHealthCheck && (
+                  <code className="text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-gray-800/50 px-2 py-1 rounded font-mono">
+                    {agent.path}
+                  </code>
+                  {agent.version && (
+                    <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                      v{agent.version}
+                    </span>
+                  )}
+                  {agent.url && (
+                    <a
+                      href={agent.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center gap-1 text-xs text-cyan-700 dark:text-cyan-300 break-all hover:underline"
+                    >
+                      <span className="font-mono">{agent.url}</span>
+                    </a>
+                  )}
+                </div>
+
+                {canModify && (
+                  <button
+                    className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
+                    onClick={() => onEdit?.(agent)}
+                    title="Edit agent"
+                  >
+                    <PencilIcon className="h-4 w-4" />
+                  </button>
+                )}
+
+                {/* Security Scan Button */}
                 <button
-                  onClick={handleRefreshHealth}
-                  disabled={loadingRefresh}
-                  className="p-2.5 text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/20 rounded-lg transition-all duration-200 disabled:opacity-50"
-                  title="Refresh agent health status"
+                  onClick={handleViewSecurityScan}
+                  className={`p-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition-all duration-200 flex-shrink-0 ${getSecurityIconState().color}`}
+                  title={getSecurityIconState().title}
+                  aria-label="View security scan results"
                 >
-                  <ArrowPathIcon className={`h-4 w-4 ${loadingRefresh ? 'animate-spin' : ''}`} />
+                  {React.createElement(getSecurityIconState().Icon, { className: "h-4 w-4" })}
                 </button>
-              )}
 
-              {/* Toggle Switch - only show if user has toggle_agent permission */}
-              {canToggle && (
-                <label className="relative inline-flex items-center cursor-pointer" onClick={(e) => e.stopPropagation()}>
-                  <input
-                    type="checkbox"
-                    checked={agent.enabled}
-                    onChange={(e) => {
-                      e.stopPropagation();
-                      onToggle(agent.path, e.target.checked);
-                    }}
-                    className="sr-only peer"
-                  />
-                  <div className={`relative w-12 h-6 rounded-full transition-colors duration-200 ease-in-out ${
-                    agent.enabled
-                      ? 'bg-cyan-600'
-                      : 'bg-gray-300 dark:bg-gray-600'
-                  }`}>
-                    <div className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-200 ease-in-out ${
-                      agent.enabled ? 'translate-x-6' : 'translate-x-0'
-                    }`} />
-                  </div>
-                </label>
+                {/* Full Details Button */}
+                <button
+                  onClick={async () => {
+                    setShowDetails(true);
+                    setLoadingDetails(true);
+                    try {
+                      const response = await axios.get(`/api/agents${agent.path}`);
+                      setFullAgentDetails(response.data);
+                    } catch (error) {
+                      console.error('Failed to fetch agent details:', error);
+                      if (onShowToast) {
+                        onShowToast('Failed to load full agent details', 'error');
+                      }
+                    } finally {
+                      setLoadingDetails(false);
+                    }
+                  }}
+                  className="p-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
+                  title="View full agent details (JSON)"
+                >
+                  <InformationCircleIcon className="h-4 w-4" />
+                </button>
+
+                {/* Delete Button */}
+                {canDelete && (
+                  <button
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className="p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
+                    title="Delete agent"
+                    aria-label={`Delete ${agent.name}`}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
+
+              {/* Description */}
+              <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed line-clamp-2 mb-4">
+                {agent.description || 'No description available'}
+              </p>
+
+              {/* Tags */}
+              {agent.tags && agent.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-4">
+                  {agent.tags.slice(0, 3).map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2 py-1 text-xs font-medium bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 rounded"
+                    >
+                      #{tag}
+                    </span>
+                  ))}
+                  {agent.tags.length > 3 && (
+                    <span className="px-2 py-1 text-xs font-medium bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-300 rounded">
+                      +{agent.tags.length - 3}
+                    </span>
+                  )}
+                </div>
               )}
             </div>
-          </div>
-        </div>
+
+            {/* Stats */}
+            <div className="px-5 pb-4">
+              <div className="grid grid-cols-2 gap-4">
+                <StarRatingWidget
+                  resourceType="agents"
+                  path={agent.path}
+                  initialRating={agent.rating || 0}
+                  initialCount={agent.rating_details?.length || 0}
+                  authToken={authToken}
+                  onShowToast={onShowToast}
+                  onRatingUpdate={(newRating) => {
+                    // Update local agent rating when user submits rating
+                    if (onAgentUpdate) {
+                      onAgentUpdate(agent.path, { rating: newRating });
+                    }
+                  }}
+                />
+                <div className="flex items-center gap-2">
+                  <div className="p-1.5 bg-cyan-50 dark:bg-cyan-900/30 rounded">
+                    <CpuChipIcon className="h-4 w-4 text-cyan-600 dark:text-cyan-400" />
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900 dark:text-white">{agent.usersCount || 0}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">Users</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="mt-auto px-5 py-4 border-t border-cyan-100 dark:border-cyan-700 bg-cyan-50/50 dark:bg-cyan-900/30 rounded-b-2xl">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  {/* Status Indicators */}
+                  <div className="flex items-center gap-2">
+                    <div className={`w-3 h-3 rounded-full ${
+                      agent.enabled
+                        ? 'bg-green-400 shadow-lg shadow-green-400/30'
+                        : 'bg-gray-300 dark:bg-gray-600'
+                    }`} />
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {agent.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </div>
+
+                  <div className="w-px h-4 bg-cyan-200 dark:bg-cyan-600" />
+
+                  <div className="flex items-center gap-2">
+                    <div className={`w-3 h-3 rounded-full ${
+                      agent.status === 'healthy'
+                        ? 'bg-emerald-400 shadow-lg shadow-emerald-400/30'
+                        : agent.status === 'healthy-auth-expired'
+                        ? 'bg-orange-400 shadow-lg shadow-orange-400/30'
+                        : agent.status === 'unhealthy'
+                        ? 'bg-red-400 shadow-lg shadow-red-400/30'
+                        : 'bg-amber-400 shadow-lg shadow-amber-400/30'
+                    }`} />
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {agent.status === 'healthy' ? 'Healthy' :
+                       agent.status === 'healthy-auth-expired' ? 'Healthy (Auth Expired)' :
+                       agent.status === 'unhealthy' ? 'Unhealthy' : 'Unknown'}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Controls */}
+                <div className="flex items-center gap-3">
+                  {/* Last Checked */}
+                  {(() => {
+                    const timeText = formatTimeSince(agent.last_checked_time);
+                    return agent.last_checked_time && timeText ? (
+                      <div className="text-xs text-gray-500 dark:text-gray-300 flex items-center gap-1.5">
+                        <ClockIcon className="h-3.5 w-3.5" />
+                        <span>{timeText}</span>
+                      </div>
+                    ) : null;
+                  })()}
+
+                  {/* Refresh Button - only show if user has health_check_agent permission */}
+                  {canHealthCheck && (
+                    <button
+                      onClick={handleRefreshHealth}
+                      disabled={loadingRefresh}
+                      className="p-2.5 text-gray-500 hover:text-cyan-600 dark:hover:text-cyan-400 hover:bg-cyan-50 dark:hover:bg-cyan-900/20 rounded-lg transition-all duration-200 disabled:opacity-50"
+                      title="Refresh agent health status"
+                    >
+                      <ArrowPathIcon className={`h-4 w-4 ${loadingRefresh ? 'animate-spin' : ''}`} />
+                    </button>
+                  )}
+
+                  {/* Toggle Switch - only show if user has toggle_agent permission */}
+                  {canToggle && (
+                    <label className="relative inline-flex items-center cursor-pointer" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        type="checkbox"
+                        checked={agent.enabled}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          onToggle(agent.path, e.target.checked);
+                        }}
+                        className="sr-only peer"
+                      />
+                      <div className={`relative w-12 h-6 rounded-full transition-colors duration-200 ease-in-out ${
+                        agent.enabled
+                          ? 'bg-cyan-600'
+                          : 'bg-gray-300 dark:bg-gray-600'
+                      }`}>
+                        <div className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-200 ease-in-out ${
+                          agent.enabled ? 'translate-x-6' : 'translate-x-0'
+                        }`} />
+                      </div>
+                    </label>
+                  )}
+                </div>
+              </div>
+            </div>
+          </>
+        )}
       </div>
 
       <AgentDetailsModal

--- a/frontend/src/components/DeleteConfirmation.tsx
+++ b/frontend/src/components/DeleteConfirmation.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
+
+/**
+ * Props for the DeleteConfirmation component.
+ */
+export interface DeleteConfirmationProps {
+  entityType: 'server' | 'agent';
+  entityName: string;
+  entityPath: string;
+  onConfirm: (path: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+/**
+ * DeleteConfirmation component provides an inline confirmation UI for delete operations.
+ * 
+ * Displays a red-tinted container with warning text, requiring users to type the entity
+ * name exactly before the delete button becomes enabled. Shows loading state during
+ * API calls and displays error messages on failure.
+ * 
+ * Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8
+ */
+const DeleteConfirmation: React.FC<DeleteConfirmationProps> = ({
+  entityType,
+  entityName,
+  entityPath,
+  onConfirm,
+  onCancel,
+}) => {
+  const [typedName, setTypedName] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isConfirmed = typedName === entityName;
+
+  const handleDelete = async () => {
+    if (!isConfirmed || isDeleting) return;
+
+    setIsDeleting(true);
+    setError(null);
+
+    try {
+      await onConfirm(entityPath);
+      onCancel(); // Close on success - parent handles list refresh + toast
+    } catch (err: any) {
+      setError(
+        err.response?.data?.detail ||
+        err.response?.data?.reason ||
+        `Failed to delete ${entityType}`
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const entityTypeLabel = entityType === 'server' ? 'Server' : 'Agent';
+
+  return (
+    <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg border border-red-200 dark:border-red-800">
+      <h4 className="text-red-800 dark:text-red-200 font-semibold mb-2">
+        Delete {entityTypeLabel}
+      </h4>
+      <p className="text-sm text-red-700 dark:text-red-300 mb-2">
+        This action is irreversible. This will permanently delete the {entityType}{' '}
+        "<strong>{entityName}</strong>" and remove it from the registry.
+      </p>
+      <p className="text-sm text-red-700 dark:text-red-300 mb-3">
+        Type <strong>{entityName}</strong> to confirm:
+      </p>
+      <input
+        type="text"
+        value={typedName}
+        onChange={(e) => setTypedName(e.target.value)}
+        className="w-full px-3 py-2 border border-red-300 dark:border-red-700 rounded mb-3 
+                   bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+        placeholder={entityName}
+        disabled={isDeleting}
+      />
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400 mb-3">{error}</p>
+      )}
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={onCancel}
+          disabled={isDeleting}
+          className="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 
+                     rounded hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleDelete}
+          disabled={!isConfirmed || isDeleting}
+          className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 
+                     disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          {isDeleting && <ArrowPathIcon className="h-4 w-4 animate-spin" />}
+          Delete {entityTypeLabel}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteConfirmation;

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -13,12 +13,14 @@ import {
   CogIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
+  TrashIcon,
 } from '@heroicons/react/24/outline';
 import ServerConfigModal from './ServerConfigModal';
 import SecurityScanModal from './SecurityScanModal';
 import StarRatingWidget from './StarRatingWidget';
 import VersionBadge from './VersionBadge';
 import VersionSelectorModal from './VersionSelectorModal';
+import DeleteConfirmation from './DeleteConfirmation';
 
 interface ServerVersion {
   version: string;
@@ -62,9 +64,11 @@ interface ServerCardProps {
   canModify?: boolean;
   canHealthCheck?: boolean;
   canToggle?: boolean;
+  canDelete?: boolean;
   onRefreshSuccess?: () => void;
   onShowToast?: (message: string, type: 'success' | 'error') => void;
   onServerUpdate?: (path: string, updates: Partial<Server>) => void;
+  onDelete?: (path: string) => Promise<void>;
   authToken?: string | null;
 }
 
@@ -114,7 +118,7 @@ const formatTimeSince = (timestamp: string | null | undefined): string | null =>
   }
 };
 
-const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, onRefreshSuccess, onShowToast, onServerUpdate, authToken }) => {
+const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, canDelete, onRefreshSuccess, onShowToast, onServerUpdate, onDelete, authToken }) => {
   const [tools, setTools] = useState<Tool[]>([]);
   const [loadingTools, setLoadingTools] = useState(false);
   const [showTools, setShowTools] = useState(false);
@@ -124,6 +128,7 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
   const [securityScanResult, setSecurityScanResult] = useState<any>(null);
   const [loadingSecurityScan, setLoadingSecurityScan] = useState(false);
   const [showVersionSelector, setShowVersionSelector] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   // Fetch security scan status on mount to show correct icon color
   useEffect(() => {
@@ -331,6 +336,19 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
           ? 'bg-gradient-to-br from-purple-50 to-indigo-50 dark:from-purple-900/20 dark:to-indigo-900/20 border-2 border-purple-200 dark:border-purple-700 hover:border-purple-300 dark:hover:border-purple-600'
           : 'bg-white dark:bg-gray-800 border border-gray-100 dark:border-gray-700 hover:border-gray-200 dark:hover:border-gray-600'
       }`}>
+        {/* Render DeleteConfirmation inline when showDeleteConfirm is true */}
+        {showDeleteConfirm ? (
+          <div className="p-5 h-full flex flex-col justify-center">
+            <DeleteConfirmation
+              entityType="server"
+              entityName={server.name || server.path.replace(/^\//, '')}
+              entityPath={server.path}
+              onConfirm={onDelete!}
+              onCancel={() => setShowDeleteConfirm(false)}
+            />
+          </div>
+        ) : (
+        <>
         {/* Header */}
         <div className="p-5 pb-4">
           <div className="flex items-start justify-between mb-4">
@@ -397,6 +415,18 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
             >
               {React.createElement(getSecurityIconState().Icon, { className: "h-4 w-4" })}
             </button>
+
+            {/* Delete Button */}
+            {canDelete && (
+              <button
+                onClick={() => setShowDeleteConfirm(true)}
+                className="p-2 text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
+                title="Delete server"
+                aria-label={`Delete ${server.name}`}
+              >
+                <TrashIcon className="h-4 w-4" />
+              </button>
+            )}
           </div>
 
           {/* Description */}
@@ -585,6 +615,8 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
             </div>
           </div>
         </div>
+        </>
+        )}
       </div>
 
       {/* Tools Modal */}

--- a/frontend/src/hooks/useServerStats.ts
+++ b/frontend/src/hooks/useServerStats.ts
@@ -28,6 +28,7 @@ interface Server {
   mcp_server_version?: string;
   mcp_server_version_previous?: string;
   mcp_server_version_updated_at?: string;
+  registered_by?: string | null;
 }
 
 interface ServerStats {
@@ -159,6 +160,7 @@ export const useServerStats = (): UseServerStatsReturn => {
           status: 'unknown' as const, // Agents don't have health status yet
           num_tools: agentInfo.num_skills || 0, // Use num_skills for agents
           type: 'agent' as const,
+          registered_by: agentInfo.registered_by || agentInfo.registeredBy || null,
         };
         
         console.log(`🔄 Transformed agent ${transformed.name}:`, {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -44,6 +44,7 @@ interface Agent {
   usersCount?: number;
   rating?: number;
   status?: 'healthy' | 'healthy-auth-expired' | 'unhealthy' | 'unknown';
+  registered_by?: string | null;
 }
 
 // Toast notification component
@@ -248,7 +249,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
       url: '',  // Will be populated if needed
       version: '',
       visibility: 'public',
-      trust_level: 'community'
+      trust_level: 'community',
+      registered_by: a.registered_by,
     }));
   }, [agentsFromStats]);
 
@@ -601,6 +603,27 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
     }
   }, [setServers, showToast]);
 
+  const handleDeleteServer = useCallback(async (path: string) => {
+    const formData = new FormData();
+    formData.append('path', path);
+
+    await axios.post('/api/servers/remove', formData, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    // Remove from local state immediately for responsive UI
+    setServers(prevServers => prevServers.filter(s => s.path !== path));
+    showToast('Server deleted successfully', 'success');
+  }, [setServers, showToast]);
+
+  const handleDeleteAgent = useCallback(async (path: string) => {
+    await axios.delete(`/api/agents${path}`);
+
+    // Remove from local state immediately for responsive UI
+    setAgents(prevAgents => prevAgents.filter(a => a.path !== path));
+    showToast('Agent deleted successfully', 'success');
+  }, [setAgents, showToast]);
+
   const handleToggleAgent = useCallback(async (path: string, enabled: boolean) => {
     // Optimistically update the UI first
     setAgents(prevAgents =>
@@ -735,9 +758,11 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
             onToggle={handleToggleServer}
             onEdit={handleEditServer}
             canModify={user?.can_modify_servers || false}
+            canDelete={user?.is_admin || hasUiPermission('delete_service', server.path)}
             onRefreshSuccess={refreshData}
             onShowToast={showToast}
             onServerUpdate={handleServerUpdate}
+            onDelete={handleDeleteServer}
             authToken={agentApiToken}
           />
         ))}
@@ -790,9 +815,11 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                     canModify={user?.can_modify_servers || false}
                     canHealthCheck={hasUiPermission('health_check_service', server.path)}
                     canToggle={hasUiPermission('toggle_service', server.path)}
+                    canDelete={user?.is_admin || hasUiPermission('delete_service', server.path)}
                     onRefreshSuccess={refreshData}
                     onShowToast={showToast}
                     onServerUpdate={handleServerUpdate}
+                    onDelete={handleDeleteServer}
                     authToken={agentApiToken}
                   />
                 ))}
@@ -844,6 +871,12 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                     canModify={user?.can_modify_servers || false}
                     canHealthCheck={hasUiPermission('health_check_agent', agent.path)}
                     canToggle={hasUiPermission('toggle_agent', agent.path)}
+                    canDelete={
+                      user?.is_admin || 
+                      hasUiPermission('delete_agent', agent.path) || 
+                      agent.registered_by === user?.username
+                    }
+                    onDelete={handleDeleteAgent}
                     onRefreshSuccess={refreshData}
                     onShowToast={showToast}
                     onAgentUpdate={handleAgentUpdate}
@@ -895,9 +928,11 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                         onToggle={handleToggleServer}
                         onEdit={handleEditServer}
                         canModify={user?.can_modify_servers || false}
+                        canDelete={user?.is_admin || hasUiPermission('delete_service', server.path)}
                         onRefreshSuccess={refreshData}
                         onShowToast={showToast}
                         onServerUpdate={handleServerUpdate}
+                        onDelete={handleDeleteServer}
                         authToken={agentApiToken}
                       />
                     ))}
@@ -927,6 +962,12 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                         canModify={user?.can_modify_servers || false}
                         canHealthCheck={hasUiPermission('health_check_agent', agent.path)}
                         canToggle={hasUiPermission('toggle_agent', agent.path)}
+                        canDelete={
+                          user?.is_admin || 
+                          hasUiPermission('delete_agent', agent.path) || 
+                          agent.registered_by === user?.username
+                        }
+                        onDelete={handleDeleteAgent}
                         onRefreshSuccess={refreshData}
                         onShowToast={showToast}
                         onAgentUpdate={handleAgentUpdate}

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -212,6 +212,45 @@ def _check_agent_permission(
         )
 
 
+def _has_delete_agent_permission(user_context: Dict[str, Any], agent_path: str) -> bool:
+    """
+    Check if user has permission to delete an agent.
+
+    Permission hierarchy:
+    1. Admin users can delete any agent
+    2. Users with delete_agent UI permission for "all" can delete any agent
+    3. Users with delete_agent UI permission for the specific agent path can delete it
+
+    Note: Agent ownership is checked separately in the delete endpoint.
+
+    Args:
+        user_context: User context from auth containing is_admin and ui_permissions
+        agent_path: Path of the agent to delete (e.g., "/code-reviewer")
+
+    Returns:
+        bool: True if user has delete permission, False otherwise
+    """
+    # Admin users can delete any agent
+    if user_context.get("is_admin", False):
+        return True
+
+    # Check delete_agent UI permission
+    ui_permissions = user_context.get("ui_permissions", {})
+    delete_perms = ui_permissions.get("delete_agent", [])
+
+    # "all" grants permission to delete any agent
+    if "all" in delete_perms:
+        return True
+
+    # Check if user has permission for this specific agent path
+    # Normalize path for comparison (remove leading slash if present)
+    normalized_path = agent_path.lstrip("/")
+    if agent_path in delete_perms or normalized_path in delete_perms:
+        return True
+
+    return False
+
+
 def _filter_agents_by_access(
     agents: List[AgentCard],
     user_context: Dict[str, Any],
@@ -487,6 +526,7 @@ async def list_agents(
                 provider=provider_name,
                 streaming=streaming,
                 trust_level=agent.trust_level,
+                registered_by=agent.registered_by,
             )
             filtered_agents.append(agent_info)
 
@@ -895,7 +935,7 @@ async def delete_agent(
     """
     Delete an agent from the registry.
 
-    Requires admin permission or agent ownership.
+    Requires admin permission, delete_agent UI permission, or agent ownership.
 
     Args:
         path: Agent path
@@ -916,16 +956,16 @@ async def delete_agent(
             detail=f"Agent not found at path '{path}'",
         )
 
-    if not user_context["is_admin"] and existing_agent.registered_by != user_context[
-        "username"
-    ]:
+    # Check delete permission: admin, delete_agent permission, or owner
+    if not _has_delete_agent_permission(user_context, path) and \
+       existing_agent.registered_by != user_context["username"]:
         logger.warning(
             f"User {user_context['username']} attempted to delete agent {path} "
             f"without permission"
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admins or agent owners can delete agents",
+            detail="Only admins, agent owners, or users with delete_agent permission can delete agents",
         )
 
     success = await agent_service.remove_agent(path)

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -3175,6 +3175,23 @@ async def remove_service_api(
             },
         )
 
+    # Fine-grained delete permission check (gateway already validated api.servers access)
+    if not user_context.get("is_admin", False):
+        ui_permissions = user_context.get("ui_permissions", {})
+        delete_service_perms = ui_permissions.get("delete_service", [])
+        server_name = path.strip("/")
+        if "all" not in delete_service_perms and server_name not in delete_service_perms:
+            logger.warning(
+                f"User {user_context.get('username')} denied delete for server {path}"
+            )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "Permission denied",
+                    "reason": f"User does not have delete_service permission for '{path}'",
+                },
+            )
+
     # Remove the server
     success = await server_service.remove_server(path)
 

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -687,6 +687,11 @@ class AgentInfo(BaseModel):
         alias="trustLevel",
         description="unverified, community, verified, trusted",
     )
+    registered_by: Optional[str] = Field(
+        None,
+        alias="registeredBy",
+        description="Username who registered the agent",
+    )
 
     model_config = ConfigDict(
         populate_by_name=True  # Allow both snake_case and camelCase on input

--- a/scripts/mcp-registry-admin.json
+++ b/scripts/mcp-registry-admin.json
@@ -22,6 +22,7 @@
     "register_service": ["all"],
     "health_check_service": ["all"],
     "toggle_service": ["all"],
-    "modify_service": ["all"]
+    "modify_service": ["all"],
+    "delete_service": ["all"]
   }
 }

--- a/scripts/registry-admins.json
+++ b/scripts/registry-admins.json
@@ -31,6 +31,7 @@
     "register_service": ["all"],
     "health_check_service": ["all"],
     "toggle_service": ["all"],
-    "modify_service": ["all"]
+    "modify_service": ["all"],
+    "delete_service": ["all"]
   }
 }

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -1105,7 +1105,7 @@ class TestDeleteAgent:
 
     @pytest.mark.asyncio
     async def test_delete_agent_not_owner(self, test_app, mock_user_context):
-        """Test deleting agent as non-owner (403)."""
+        """Test deleting agent as non-owner without delete_agent permission (403)."""
         # Arrange
         other_user_agent = AgentCardFactory(
             path="/agents/other-agent",
@@ -1121,7 +1121,8 @@ class TestDeleteAgent:
 
             # Assert
             assert response.status_code == status.HTTP_403_FORBIDDEN
-            assert "admins or agent owners" in response.json()["detail"].lower()
+            # Updated error message includes delete_agent permission option
+            assert "delete_agent permission" in response.json()["detail"].lower()
 
     @pytest.mark.asyncio
     async def test_delete_agent_not_found(self, test_app, mock_user_context):


### PR DESCRIPTION
*Issue #, if available:* #418

*Description of changes:*

## Summary

Implements the delete functionality for servers and agents from the Dashboard UI as described in #418. Users can now delete servers and agents directly from their cards using a trash icon, with a confirmation dialog requiring the user to type the entity name (GitHub-style).

### Backend Changes

| File | Change |
|------|--------|
| `registry/api/server_routes.py` | Added fine-grained `delete_service` permission check to `remove_service_api` endpoint |
| `registry/api/agent_routes.py` | Added `_has_delete_agent_permission` helper; updated delete endpoint to check `delete_agent` UI permission |
| `registry/schemas/agent_models.py` | Added `registered_by` field to agent response for ownership check |
| `scripts/registry-admins.json` | Added `delete_service: ["all"]` to `ui_permissions` |
| `scripts/mcp-registry-admin.json` | Added `delete_service: ["all"]` to `ui_permissions` |

### Frontend Changes

| File | Change |
|------|--------|
| `frontend/src/components/DeleteConfirmation.tsx` | **NEW** - Reusable inline confirmation component with red-tinted danger styling |
| `frontend/src/components/ServerCard.tsx` | Added TrashIcon button and DeleteConfirmation integration |
| `frontend/src/components/AgentCard.tsx` | Added TrashIcon button and DeleteConfirmation integration |
| `frontend/src/pages/Dashboard.tsx` | Added `handleDeleteServer` and `handleDeleteAgent` callbacks; pass `canDelete` and `onDelete` props to cards |

### Access Control

| User Type | Can Delete Server? | Can Delete Agent? |
|-----------|-------------------|-------------------|
| Admin (`is_admin: true`) | Yes (all) | Yes (all) |
| User with `delete_service` scope | Yes (scoped servers only) | N/A |
| User with `delete_agent` scope | N/A | Yes (scoped agents only) |
| Agent owner | No | Yes (own agents only) |
| No relevant permission | No | No |


## Upgrade Notes (Existing Deployments)

New deployments will automatically get `delete_service` permission. For existing deployments, re-run the mongodb-init container:

```bash
docker compose up mongodb-init
```

Or manually update MongoDB:

```bash
docker exec <mongodb-container> mongosh "mongodb://admin:admin@localhost:27017/mcp_registry?authSource=admin" --eval '
  db.mcp_scopes_default.updateOne({_id: "mcp-registry-admin"}, {$set: {"ui_permissions.delete_service": ["all"]}});
  db.mcp_scopes_default.updateOne({_id: "registry-admins"}, {$set: {"ui_permissions.delete_service": ["all"]}})
'
```