### PR TITLE
fix: Use nginx_proxied_auth for /api/auth/me to support Bearer tokens

### DIFF
--- a/registry/main.py
+++ b/registry/main.py
@@ -32,8 +32,8 @@ from registry.health.routes import router as health_router
 
 # Import auth dependencies
 from registry.auth.dependencies import (
-    enhanced_auth,
     get_ui_permissions_for_user,
+    nginx_proxied_auth,
 )
 
 # Import services for initialization
@@ -359,7 +359,7 @@ app.openapi = custom_openapi
 
 # Add user info endpoint for React auth context
 @app.get("/api/auth/me")
-async def get_current_user(user_context: Dict[str, Any] = Depends(enhanced_auth)):
+async def get_current_user(user_context: Dict[str, Any] = Depends(nginx_proxied_auth)):
     """Get current user information for React auth context"""
     # Get user's scopes
     user_scopes = user_context.get("scopes", [])


### PR DESCRIPTION
The `/api/auth/me` endpoint was using `enhanced_auth` dependency which only supports session cookies. This made it inconsistent with other API endpoints like `/api/servers` that use `nginx_proxied_auth`.

Changed to `nginx_proxied_auth` which supports both:
- Bearer tokens (via nginx-proxied X-User headers after JWT validation)
- Session cookies (fallback)

This allows API clients using Bearer token authentication to access the `/api/auth/me` endpoint for user info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.