### PR TITLE
Add docker build/push workflows

### DIFF
--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -2,7 +2,7 @@ name: Build Auth Server Image
 
 on:
   push:
-    # branches: [main]
+    branches: [main]
     paths:
       - 'auth_server/**'
       - 'registry/**'

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -2,7 +2,7 @@ name: Build Registry Image
 
 on:
   push:
-    # branches: [main]
+    branches: [main]
     paths:
       - 'registry/**'
       - 'auth_server/**'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR creates build/push workflows for the `auth-server` and `registry` container images. It generates and pushes attestations for the images and only runs on merges to main if a file for either project has changed. Images are tagged as `latest` and with the commit hash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
