### PR TITLE
Fix MongoDB replica set initialization race condition

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -99,8 +99,12 @@ services:
       - ${HOME}/mcp-gateway/federation.json:/app/config/federation.json
       - ${HOME}/mcp-gateway/ssl:/etc/ssl:ro
     depends_on:
-      - auth-server
-      - metrics-service
+      auth-server:
+        condition: service_started
+      metrics-service:
+        condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Metrics Collection Service
@@ -199,6 +203,8 @@ services:
     depends_on:
       metrics-service:
         condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Current Time MCP Server

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -102,8 +102,12 @@ services:
       - ${HOME}/mcp-gateway/federation.json:/app/config/federation.json
       - ${HOME}/mcp-gateway/ssl:/etc/ssl:ro
     depends_on:
-      - auth-server
-      - metrics-service
+      auth-server:
+        condition: service_started
+      metrics-service:
+        condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Metrics Collection Service - using pre-built image
@@ -196,6 +200,8 @@ services:
     depends_on:
       metrics-service:
         condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Current Time MCP Server - using pre-built image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,8 @@ services:
         condition: service_started
       metrics-service:
         condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Metrics Collection Service
@@ -264,6 +266,8 @@ services:
     depends_on:
       metrics-service:
         condition: service_healthy
+      mongodb-init:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   # Current Time MCP Server


### PR DESCRIPTION
## Summary
- Add `mongodb-init` as a dependency for `registry` and `auth-server` services in all docker-compose files
- Ensures MongoDB replica set is fully initialized before services attempt to connect

## Problem
On fresh installations, a race condition occurs where `registry` and `auth-server` services start before `mongodb-init` has completed initializing the replica set. This causes the error:

```
ServerSelectionTimeoutError: No servers match selector "Primary()", Timeout: 30s, 
Topology Description: <TopologyDescription id: ..., topology_type: Unknown, 
servers: [<ServerDescription ('mongodb', 27017) server_type: RSGhost, ...>]>
```

The `RSGhost` server type indicates the MongoDB driver connected to a replica set member that hasn't been initialized yet.

## Solution
Add `mongodb-init` with `condition: service_completed_successfully` to the `depends_on` section of both `registry` and `auth-server` services. This ensures:
1. MongoDB container starts
2. `mongodb-init` runs and initializes the replica set
3. Only after successful initialization do `registry` and `auth-server` start

## Files Changed
- `docker-compose.yml`
- `docker-compose.prebuilt.yml`
- `docker-compose.podman.yml`

## Test plan
- [ ] Fresh install with `build_and_run.sh --prebuilt` should work without errors
- [ ] Existing installations continue to work normally
- [ ] Verify services start in correct order: mongodb -> mongodb-init -> auth-server/registry

Fixes #438