### PR TITLE
Add Settings navigation and improve Dashboard UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Interactive terminal interface for chatting with AI models and discovering MCP t
 
 ## What's New
 
+- **Peer-to-Peer Registry Federation** - Connect multiple MCP Gateway Registry instances for bidirectional server and agent synchronization. Central IT teams can aggregate visibility across Line of Business registries, or LOBs can inherit shared tools from a central hub. Features include configurable sync modes (all, whitelist, tag filter), scheduled and on-demand sync, static token authentication for IdP-agnostic deployments, Fernet-encrypted credential storage, generation-based orphan detection, and path namespacing to prevent collisions. Synced items are read-only and display their source registry. A VS Code-style Settings UI provides peer management, sync triggering, and status monitoring. [Architecture Design](docs/design/federation-architecture.md) | [Operational Guide](docs/federation-operational-guide.md)
+
 - **Static Token Auth for Registry API** - Access Registry API endpoints (`/api/*`, `/v0.1/*`) using a static API key instead of IdP-based JWT validation. Designed for trusted network environments, CI/CD pipelines, and CLI tooling where configuring a full identity provider may not be practical. MCP Gateway endpoints continue to require full IdP authentication. Includes startup validation that disables the feature if no token is configured. [Static Token Auth Guide](docs/static-token-auth.md)
 
 - **MCP Server Version Routing** - Run multiple versions of the same MCP server simultaneously behind a single gateway endpoint. Register new versions as inactive, test them with the `X-MCP-Server-Version` header, then promote to active with a single API call or UI click. Features include instant rollback, version pinning for clients, deprecation lifecycle with sunset dates, automatic nginx map-based O(1) routing, cascade deletion of all versions, and post-swap health checks. The dashboard displays both the admin-controlled routing version and the MCP server-reported software version independently. Only the active version appears in search results and health checks. [Design Document](docs/design/server-versioning.md) | [Operations Guide](docs/server-versioning-operations.md)
@@ -797,7 +799,8 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 | [Installation Guide](docs/installation.md)<br/>Complete setup instructions for EC2 and EKS | [AWS ECS Deployment](terraform/aws-ecs/README.md)<br/>Production-ready deployment on AWS ECS Fargate | [API Reference](docs/registry_api.md)<br/>Programmatic registry management |
 | [Keycloak Integration](docs/keycloak-integration.md)<br/>Enterprise identity with agent audit trails | [Token Refresh Service](docs/token-refresh-service.md)<br/>Automated token refresh and lifecycle management | [MCP Registry CLI](docs/mcp-registry-cli.md)<br/>Command-line client for registry management |
 | [Configuration Reference](docs/configuration.md)<br/>Environment variables and settings | [Amazon Cognito Setup](docs/cognito.md)<br/>Step-by-step IdP configuration | [Observability Guide](docs/OBSERVABILITY.md)<br/>**NEW!** Metrics, monitoring, and OpenTelemetry setup |
-| | [Anthropic Registry Import](docs/anthropic-registry-import.md)<br/>**NEW!** Import servers from Anthropic MCP Registry | [Federation Guide](docs/federation.md)<br/>**NEW!** External registry integration (Anthropic, ASOR) |
+| | [Anthropic Registry Import](docs/anthropic-registry-import.md)<br/>**NEW!** Import servers from Anthropic MCP Registry | [Federation Guide](docs/federation.md)<br/>External registry integration (Anthropic, ASOR) |
+| | | [P2P Federation Guide](docs/federation-operational-guide.md)<br/>**NEW!** Peer-to-peer registry federation |
 | | [Service Management](docs/service-management.md)<br/>Server lifecycle and operations | [Anthropic Registry API](docs/anthropic_registry_api.md)<br/>**NEW!** REST API compatibility |
 | | | [Fine-Grained Access Control](docs/scopes.md)<br/>Permission management and security |
 | | | [Dynamic Tool Discovery](docs/dynamic-tool-discovery.md)<br/>Autonomous agent capabilities |
@@ -847,8 +850,8 @@ The following major features span multiple milestones and represent significant 
 - **[#232 - A2A Curated Registry Discovery](https://github.com/agentic-community/mcp-gateway-registry/issues/232)** ✅ **COMPLETED**
   Enable agent-to-agent discovery and tool invocation through curated registry patterns.
 
-- **[#260 - Federation Between MCP Registry Instances](https://github.com/agentic-community/mcp-gateway-registry/issues/260)** 📅 **PLANNED** (Jan 2026 Week 4)
-  Support for federated registry discovery and access across multiple registry instances.
+- **[#260 - Federation Between MCP Registry Instances](https://github.com/agentic-community/mcp-gateway-registry/issues/260)** 🚧 **IN PROGRESS**
+  Support for federated registry discovery and access across multiple registry instances. UI implementation complete.
 
 - **[#295 - Multi-Level Tool Usage Rate Limiting](https://github.com/agentic-community/mcp-gateway-registry/issues/295)** 📅 **PLANNED** (Jan 2026 Week 3)
   Comprehensive rate limiting architecture with detailed implementation guide for tool usage control.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -50,10 +50,12 @@ This document provides a comprehensive overview of the MCP Gateway & Registry so
 - **Development Tools**: Docker Compose for local development and testing
 
 ## Federation & External Registries
+- **Peer-to-Peer Registry Federation**: Connect MCP Gateway Registry instances for bidirectional server and agent sync with static token or OAuth2 authentication
+- **Federation UI**: VS Code-style Settings page for managing peer registries, sync modes (all, whitelist, tag filter), and monitoring sync status
 - **Federated Registry**: Import servers and agents from external registries
 - **Anthropic MCP Registry**: Import curated MCP servers with API compatibility
 - **Workday ASOR**: Import AI agents from Agent System of Record
-- **Automatic Sync**: Scheduled synchronization with external registries
+- **Automatic Sync**: Scheduled synchronization with external registries and peer registries
 - **Amazon Bedrock AgentCore**: Gateway support with dual authentication
 
 ## Enterprise Integration

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import RegisterPage from './pages/RegisterPage';
 import Login from './pages/Login';
 import OAuthCallback from './pages/OAuthCallback';
 import ProtectedRoute from './components/ProtectedRoute';
+import SettingsPage from './pages/SettingsPage';
 
 // Get basename from <base> tag for path-based routing (e.g., /registry)
 const getBasename = () => {
@@ -46,6 +47,13 @@ function App() {
               <ProtectedRoute>
                 <Layout>
                   <RegisterPage />
+                </Layout>
+              </ProtectedRoute>
+            } />
+            <Route path="/settings/*" element={
+              <ProtectedRoute>
+                <Layout>
+                  <SettingsPage />
                 </Layout>
               </ProtectedRoute>
             } />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -112,6 +112,17 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 </div>
               )}
 
+              {/* Settings gear icon (admin only) */}
+              {user?.is_admin && (
+                <Link
+                  to="/settings"
+                  className="p-2 text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-gray-100 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+                  title="Settings"
+                >
+                  <Cog6ToothIcon className="h-5 w-5" />
+                </Link>
+              )}
+
               {/* Theme toggle */}
               <button
                 onClick={toggleTheme}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1024,6 +1024,42 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                     ? 'Local Registry'
                     : registryId.replace('peer-registry-', '').replace('peer-', '').toUpperCase() + ' (Federated)';
 
+                  // When there's only one registry (local), skip the collapsible wrapper
+                  const showRegistryHeader = registryIds.length > 1 || registryId !== 'local';
+
+                  // Render servers without registry header when it's the only registry
+                  if (!showRegistryHeader) {
+                    return (
+                      <div key={registryId} className="overflow-visible">
+                        <div
+                          className="grid overflow-visible"
+                          style={{
+                            gridTemplateColumns: 'repeat(auto-fit, minmax(380px, 1fr))',
+                            gap: 'clamp(1.5rem, 3vw, 2.5rem)'
+                          }}
+                        >
+                          {filteredRegistryServers.map((server) => (
+                            <ServerCard
+                              key={server.path}
+                              server={server}
+                              onToggle={handleToggleServer}
+                              onEdit={handleEditServer}
+                              canModify={user?.can_modify_servers || false}
+                              canHealthCheck={hasUiPermission('health_check_service', server.path)}
+                              canToggle={hasUiPermission('toggle_service', server.path)}
+                              canDelete={(user?.is_admin || hasUiPermission('delete_service', server.path)) && !server.sync_metadata?.is_federated}
+                              onDelete={handleDeleteServer}
+                              onRefreshSuccess={refreshData}
+                              onShowToast={showToast}
+                              onServerUpdate={handleServerUpdate}
+                              authToken={agentApiToken}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  }
+
                   return (
                     <div key={registryId} id={`server-registry-${registryId}`} className="border border-gray-200 dark:border-gray-700 rounded-xl scroll-mt-4">
                       {/* Collapsible Header */}
@@ -1211,6 +1247,47 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                   const displayName = registryId === 'local'
                     ? 'Local Registry'
                     : registryId.replace('peer-registry-', '').replace('peer-', '').toUpperCase() + ' (Federated)';
+
+                  // When there's only one registry (local), skip the collapsible wrapper
+                  const showRegistryHeader = agentRegistryIds.length > 1 || registryId !== 'local';
+
+                  // Render agents without registry header when it's the only registry
+                  if (!showRegistryHeader) {
+                    return (
+                      <div key={registryId} className="overflow-visible">
+                        <div
+                          className="grid overflow-visible"
+                          style={{
+                            gridTemplateColumns: 'repeat(auto-fit, minmax(380px, 1fr))',
+                            gap: 'clamp(1.5rem, 3vw, 2.5rem)'
+                          }}
+                        >
+                          {filteredRegistryAgents.map((agent) => (
+                            <AgentCard
+                              key={agent.path}
+                              agent={agent}
+                              onToggle={handleToggleAgent}
+                              onEdit={handleEditAgent}
+                              canModify={user?.can_modify_servers || false}
+                              canHealthCheck={hasUiPermission('health_check_agent', agent.path)}
+                              canToggle={hasUiPermission('toggle_agent', agent.path)}
+                              canDelete={
+                                (user?.is_admin ||
+                                hasUiPermission('delete_agent', agent.path) ||
+                                agent.registered_by === user?.username) &&
+                                !agent.sync_metadata?.is_federated
+                              }
+                              onDelete={handleDeleteAgent}
+                              onRefreshSuccess={refreshData}
+                              onShowToast={showToast}
+                              onAgentUpdate={handleAgentUpdate}
+                              authToken={agentApiToken}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  }
 
                   return (
                     <div key={registryId} id={`agent-registry-${registryId}`} className="border border-cyan-200 dark:border-cyan-700 rounded-xl overflow-hidden scroll-mt-4">


### PR DESCRIPTION
## Summary
- Add Settings gear icon in header for admin users
- Add `/settings/*` route to App.tsx for Settings page navigation
- Hide registry collapsible section on Dashboard when only local registry exists (cleaner UX when federation is not in use)
- Update README and FEATURES docs for P2P federation feature

## Test plan
- [ ] Verify Settings icon appears in header for admin users
- [ ] Verify Settings icon does not appear for non-admin users
- [ ] Verify clicking Settings icon navigates to /settings page
- [ ] Verify Dashboard shows servers/agents without registry grouping when only local registry exists
- [ ] Verify Dashboard shows registry grouping when federated items are present