### PR TITLE
fix: Add nginx config for /api/auth/me Bearer token support

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -253,6 +253,50 @@ server {
 
     # A2A Agent API - Internal API with JWT authentication
     # Public API endpoints (no authentication required)
+
+    # /api/auth/me requires authentication (exact match takes precedence over prefix)
+    location = /api/auth/me {
+        # Authenticate request via auth server (validates JWT Bearer tokens)
+        auth_request /validate;
+
+        # Capture auth server response headers
+        auth_request_set $auth_user $upstream_http_x_user;
+        auth_request_set $auth_username $upstream_http_x_username;
+        auth_request_set $auth_client_id $upstream_http_x_client_id;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+        auth_request_set $auth_method $upstream_http_x_auth_method;
+
+        # Proxy to FastAPI service
+        proxy_pass http://127.0.0.1:7860/api/auth/me;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+
+        # Forward validated auth context to FastAPI
+        proxy_set_header X-User $auth_user;
+        proxy_set_header X-Username $auth_username;
+        proxy_set_header X-Client-Id $auth_client_id;
+        proxy_set_header X-Scopes $auth_scopes;
+        proxy_set_header X-Auth-Method $auth_method;
+
+        # Pass through original Authorization header
+        proxy_set_header Authorization $http_authorization;
+
+        # Pass all request headers
+        proxy_pass_request_headers on;
+
+        # Timeouts
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+
+        # Handle auth errors
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }
+
     # Public auth endpoints - no authentication required (priority prefix match)
     location ^~ /api/auth {
         proxy_pass http://127.0.0.1:7860;
@@ -800,6 +844,50 @@ server {
 
     # A2A Agent API - Internal API with JWT authentication (HTTPS)
     # Public API endpoints (no authentication required)
+
+    # /api/auth/me requires authentication (exact match takes precedence over prefix)
+    location = /api/auth/me {
+        # Authenticate request via auth server (validates JWT Bearer tokens)
+        auth_request /validate;
+
+        # Capture auth server response headers
+        auth_request_set $auth_user $upstream_http_x_user;
+        auth_request_set $auth_username $upstream_http_x_username;
+        auth_request_set $auth_client_id $upstream_http_x_client_id;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+        auth_request_set $auth_method $upstream_http_x_auth_method;
+
+        # Proxy to FastAPI service
+        proxy_pass http://127.0.0.1:7860/api/auth/me;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+
+        # Forward validated auth context to FastAPI
+        proxy_set_header X-User $auth_user;
+        proxy_set_header X-Username $auth_username;
+        proxy_set_header X-Client-Id $auth_client_id;
+        proxy_set_header X-Scopes $auth_scopes;
+        proxy_set_header X-Auth-Method $auth_method;
+
+        # Pass through original Authorization header
+        proxy_set_header Authorization $http_authorization;
+
+        # Pass all request headers
+        proxy_pass_request_headers on;
+
+        # Timeouts
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+
+        # Handle auth errors
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }
+
     # Public auth endpoints - no authentication required (priority prefix match)
     location ^~ /api/auth {
         proxy_pass http://127.0.0.1:7860;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -33,6 +33,49 @@ server {
     # Add this to trigger the named location for 403 errors
     error_page 403 = @forbidden_error;
 
+    # /api/auth/me requires authentication (exact match takes precedence over prefix)
+    location = /api/auth/me {
+        # Authenticate request via auth server (validates JWT Bearer tokens)
+        auth_request /validate;
+
+        # Capture auth server response headers
+        auth_request_set $auth_user $upstream_http_x_user;
+        auth_request_set $auth_username $upstream_http_x_username;
+        auth_request_set $auth_client_id $upstream_http_x_client_id;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+        auth_request_set $auth_method $upstream_http_x_auth_method;
+
+        # Proxy to FastAPI service
+        proxy_pass http://127.0.0.1:7860/api/auth/me;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+
+        # Forward validated auth context to FastAPI
+        proxy_set_header X-User $auth_user;
+        proxy_set_header X-Username $auth_username;
+        proxy_set_header X-Client-Id $auth_client_id;
+        proxy_set_header X-Scopes $auth_scopes;
+        proxy_set_header X-Auth-Method $auth_method;
+
+        # Pass through original Authorization header
+        proxy_set_header Authorization $http_authorization;
+
+        # Pass all request headers
+        proxy_pass_request_headers on;
+
+        # Timeouts
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+
+        # Handle auth errors
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }
+
     # Public auth endpoints - no authentication required (priority prefix match)
     location ^~ /api/auth {
         proxy_pass http://127.0.0.1:7860;


### PR DESCRIPTION
## Summary
- Adds nginx location blocks for `/api/auth/me` endpoint to support Bearer token authentication
- Uses `auth_request` to validate JWT tokens via the auth server
- Completes the fix started in PR #431

## Context
This PR was mentioned in PR #431 as a follow-up to add the missing nginx configuration files.

## Changes
- `docker/nginx_rev_proxy_http_and_https.conf`: Added location blocks for both HTTP and HTTPS server blocks
- `docker/nginx_rev_proxy_http_only.conf`: Added location block for HTTP server

## Test plan
- [ ] Verify `/api/auth/me` endpoint accepts Bearer tokens
- [ ] Confirm auth_request properly validates JWT tokens
- [ ] Test that session-based auth still works