### PR TITLE
fix: Check mcp-registry-admin in both groups and scopes for modify permission

### DIFF
--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -363,16 +363,17 @@ def user_can_modify_servers(user_groups: list[str], user_scopes: list[str]) -> b
     Returns:
         True if user can modify servers, False otherwise
     """
-    # Admin users can always modify
-    if "mcp-registry-admin" in user_groups:
+    # Admin users can always modify (check both groups and scopes)
+    if "mcp-registry-admin" in user_groups or "mcp-registry-admin" in user_scopes:
         return True
 
     # Users with unrestricted execute access can modify
     if "mcp-servers-unrestricted/execute" in user_scopes:
         return True
 
-    # mcp-registry-user group cannot modify servers
-    if "mcp-registry-user" in user_groups and "mcp-registry-admin" not in user_groups:
+    # mcp-registry-user group cannot modify servers (unless they're also admin)
+    is_admin = "mcp-registry-admin" in user_groups or "mcp-registry-admin" in user_scopes
+    if "mcp-registry-user" in user_groups and not is_admin:
         return False
 
     # For other cases, check if they have any execute permissions


### PR DESCRIPTION
## Summary
- Fixed `user_can_modify_servers` function to check for `mcp-registry-admin` in both groups AND scopes
- Self-signed auth tokens have the admin role in `scopes`, not `groups`, causing `can_modify_servers=false`
- This fix restores the edit pencil icon visibility for admin users on server/agent/skill cards

## Test plan
- [ ] Login as admin user with self-signed token
- [ ] Verify `/api/auth/me` returns `can_modify_servers: true`
- [ ] Confirm pencil edit icons appear on server, agent, and skill cards