### PR TITLE
set git hash/tag to BUILD_VERSION in images

### DIFF
--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -70,6 +70,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -74,6 +74,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -75,6 +75,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For images built from GHA, set the githash on untagged images or the tag as the version in the registry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
