### PR TITLE
feat: Add Registry-Only Deployment Mode (#478)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,24 @@ ADMIN_USER=admin
 ADMIN_PASSWORD=your-secure-password-here
 
 # =============================================================================
+# Deployment Mode Configuration
+# =============================================================================
+
+# DEPLOYMENT_MODE controls how the registry integrates with the gateway/nginx
+# Options:
+#   - with-gateway (default): Full integration with nginx reverse proxy
+#   - registry-only: Registry operates as catalog/discovery service only
+DEPLOYMENT_MODE=with-gateway
+
+# REGISTRY_MODE controls which features are enabled in the registry
+# Options:
+#   - full (default): All features enabled
+#   - skills-only: Only skills-related functionality enabled
+#   - mcp-servers-only: Only MCP server functionality
+#   - agents-only: Only A2A agent functionality
+REGISTRY_MODE=full
+
+# =============================================================================
 # AUTH SERVER CONFIGURATION
 # =============================================================================
 

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -62,6 +62,11 @@ spec:
             - secretRef:
                 name: {{ .Values.global.sharedSecretName }}
             {{- end }}
+          env:
+            - name: DEPLOYMENT_MODE
+              value: {{ .Values.app.deployment_mode | default "with-gateway" | quote }}
+            - name: REGISTRY_MODE
+              value: {{ .Values.app.registry_mode | default "full" | quote }}
       volumes:
         - name: script
           configMap:

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -26,6 +26,12 @@ app:
   federationEncryptionKey: # If not provided, a Fernet key is auto-generated
   registryId: # Unique identifier for this registry instance (optional)
 
+  # Deployment mode: with-gateway (nginx integration) or registry-only (catalog only)
+  deployment_mode: with-gateway
+
+  # Registry mode: full, skills-only, mcp-servers-only, agents-only
+  registry_mode: full
+
 # Service configuration
 service:
   type: ClusterIP

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -33,6 +33,19 @@ fi
 # --- Environment Variable Setup ---
 echo "Setting up environment variables..."
 
+# Get deployment mode (default: with-gateway)
+DEPLOYMENT_MODE="${DEPLOYMENT_MODE:-with-gateway}"
+REGISTRY_MODE="${REGISTRY_MODE:-full}"
+
+echo "============================================================"
+echo "Starting MCP Gateway Registry"
+echo "  DEPLOYMENT_MODE: ${DEPLOYMENT_MODE}"
+echo "  REGISTRY_MODE: ${REGISTRY_MODE}"
+if [ "$DEPLOYMENT_MODE" = "registry-only" ]; then
+    echo "  Note: Dynamic MCP server location blocks will NOT be generated"
+fi
+echo "============================================================"
+
 # Generate secret key if not provided
 if [ -z "$SECRET_KEY" ]; then
     SECRET_KEY=$(python -c 'import secrets; print(secrets.token_hex(32))')

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,9 +31,20 @@
         "typescript": "^4.9.5"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jest": "^30.0.0",
         "patch-package": "^8.0.1",
         "postinstall-postinstall": "^2.1.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2395,6 +2406,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "license": "MIT",
@@ -2406,6 +2427,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.2.0.tgz",
+      "integrity": "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -2423,6 +2457,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "27.5.1",
       "license": "MIT",
@@ -2433,6 +2477,30 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -3217,6 +3285,107 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3230,6 +3399,14 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3407,6 +3584,234 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
+      "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.2.0.tgz",
+      "integrity": "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.2.0",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.2.0",
+        "jest-message-util": "30.2.0",
+        "jest-mock": "30.2.0",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.2.0.tgz",
+      "integrity": "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.2.0",
+        "pretty-format": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
+      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.2.0",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.2.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
+      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "jest-util": "30.2.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
+      "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.2.0",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -5600,6 +6005,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssdb": {
       "version": "7.11.2",
       "funding": [
@@ -6041,6 +6453,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -8375,6 +8795,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "license": "ISC",
@@ -10237,6 +10667,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "license": "MIT",
@@ -11177,6 +11618,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -13618,6 +14069,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "license": "MIT",
@@ -14806,6 +15271,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,9 +19,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.0",
     "react-router-dom": "^6.30.3",
     "react-scripts": "5.0.1",
+    "remark-gfm": "^4.0.0",
     "tailwindcss": "^3.3.6",
     "typescript": "^4.9.5"
   },
@@ -57,6 +57,10 @@
     "resolve-url-loader": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jest": "^30.0.0",
     "patch-package": "^8.0.1",
     "postinstall-postinstall": "^2.1.0"
   }

--- a/frontend/src/components/DeploymentModeIndicator.tsx
+++ b/frontend/src/components/DeploymentModeIndicator.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useRegistryConfig } from '../hooks/useRegistryConfig';
+
+export const DeploymentModeIndicator: React.FC = () => {
+  const { config } = useRegistryConfig();
+
+  if (!config || config.deployment_mode === 'with-gateway') {
+    return null;
+  }
+
+  return (
+    <span
+      className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+      title="Registry is running without gateway integration. Nginx reverse proxy features are disabled."
+    >
+      Registry Only
+    </span>
+  );
+};

--- a/frontend/src/components/__tests__/ServerConfigModal.test.tsx
+++ b/frontend/src/components/__tests__/ServerConfigModal.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ServerConfigModal from '../ServerConfigModal';
+import type { Server } from '../ServerCard';
+
+// Mock the useRegistryConfig hook
+const mockUseRegistryConfig = jest.fn();
+jest.mock('../../hooks/useRegistryConfig', () => ({
+  useRegistryConfig: () => mockUseRegistryConfig(),
+}));
+
+// Mock clipboard API
+Object.assign(navigator, {
+  clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+});
+
+const baseServer: Server = {
+  name: 'Test Server',
+  path: '/test-server',
+  enabled: true,
+  proxy_pass_url: 'http://internal-host:8080/mcp',
+};
+
+function renderModal(serverOverrides: Partial<Server> = {}, configOverride?: ReturnType<typeof mockUseRegistryConfig>) {
+  const server = { ...baseServer, ...serverOverrides };
+  return render(
+    <ServerConfigModal
+      server={server}
+      isOpen={true}
+      onClose={jest.fn()}
+      onShowToast={jest.fn()}
+    />
+  );
+}
+
+function getDisplayedConfig(): any {
+  // The config JSON is rendered inside a <pre> tag
+  const preElement = screen.getByText(/{/, { selector: 'pre' });
+  return JSON.parse(preElement.textContent || '');
+}
+
+describe('ServerConfigModal URL generation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: jsdom sets window.location.origin to http://localhost
+  });
+
+  test('should use gateway URL in with-gateway mode', () => {
+    mockUseRegistryConfig.mockReturnValue({
+      config: {
+        deployment_mode: 'with-gateway',
+        registry_mode: 'full',
+        nginx_updates_enabled: true,
+        features: { mcp_servers: true, agents: true, skills: true, federation: true, gateway_proxy: true },
+      },
+      loading: false,
+      error: null,
+    });
+
+    renderModal();
+    const config = getDisplayedConfig();
+
+    // VS Code is the default IDE — config uses "servers" key
+    const serverConfig = config.servers['test-server'];
+    expect(serverConfig.url).toBe('http://localhost/test-server/mcp');
+    // Gateway mode includes auth headers
+    expect(serverConfig.headers).toBeDefined();
+    expect(serverConfig.headers.Authorization).toContain('Bearer');
+  });
+
+  test('should use proxy_pass_url in registry-only mode', () => {
+    mockUseRegistryConfig.mockReturnValue({
+      config: {
+        deployment_mode: 'registry-only',
+        registry_mode: 'full',
+        nginx_updates_enabled: false,
+        features: { mcp_servers: true, agents: true, skills: true, federation: true, gateway_proxy: false },
+      },
+      loading: false,
+      error: null,
+    });
+
+    renderModal({ proxy_pass_url: 'http://internal-host:8080/mcp' });
+    const config = getDisplayedConfig();
+
+    const serverConfig = config.servers['test-server'];
+    expect(serverConfig.url).toBe('http://internal-host:8080/mcp');
+    // Registry-only mode should NOT include auth headers
+    expect(serverConfig.headers).toBeUndefined();
+  });
+
+  test('should always use mcp_endpoint when provided', () => {
+    // Test with with-gateway mode
+    mockUseRegistryConfig.mockReturnValue({
+      config: {
+        deployment_mode: 'with-gateway',
+        registry_mode: 'full',
+        nginx_updates_enabled: true,
+        features: { mcp_servers: true, agents: true, skills: true, federation: true, gateway_proxy: true },
+      },
+      loading: false,
+      error: null,
+    });
+
+    const { unmount } = renderModal({
+      mcp_endpoint: 'https://custom-endpoint.example.com/mcp',
+      proxy_pass_url: 'http://internal-host:8080/mcp',
+    });
+    let config = getDisplayedConfig();
+    let serverConfig = config.servers['test-server'];
+    expect(serverConfig.url).toBe('https://custom-endpoint.example.com/mcp');
+
+    unmount();
+
+    // Test with registry-only mode — mcp_endpoint still takes precedence
+    mockUseRegistryConfig.mockReturnValue({
+      config: {
+        deployment_mode: 'registry-only',
+        registry_mode: 'full',
+        nginx_updates_enabled: false,
+        features: { mcp_servers: true, agents: true, skills: true, federation: true, gateway_proxy: false },
+      },
+      loading: false,
+      error: null,
+    });
+
+    renderModal({
+      mcp_endpoint: 'https://custom-endpoint.example.com/mcp',
+      proxy_pass_url: 'http://internal-host:8080/mcp',
+    });
+    config = getDisplayedConfig();
+    serverConfig = config.servers['test-server'];
+    expect(serverConfig.url).toBe('https://custom-endpoint.example.com/mcp');
+  });
+});

--- a/frontend/src/hooks/useRegistryConfig.ts
+++ b/frontend/src/hooks/useRegistryConfig.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+
+interface RegistryConfig {
+  deployment_mode: 'with-gateway' | 'registry-only';
+  registry_mode: 'full' | 'skills-only' | 'mcp-servers-only' | 'agents-only';
+  nginx_updates_enabled: boolean;
+  features: {
+    mcp_servers: boolean;
+    agents: boolean;
+    skills: boolean;
+    federation: boolean;
+    gateway_proxy: boolean;
+  };
+}
+
+const DEFAULT_CONFIG: RegistryConfig = {
+  deployment_mode: 'with-gateway',
+  registry_mode: 'full',
+  nginx_updates_enabled: true,
+  features: {
+    mcp_servers: true,
+    agents: true,
+    skills: true,
+    federation: true,
+    gateway_proxy: true,
+  },
+};
+
+let cachedConfig: RegistryConfig | null = null;
+
+export function useRegistryConfig(): {
+  config: RegistryConfig | null;
+  loading: boolean;
+  error: Error | null;
+} {
+  const [config, setConfig] = useState<RegistryConfig | null>(cachedConfig);
+  const [loading, setLoading] = useState(!cachedConfig);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (cachedConfig) return;
+
+    setLoading(true);
+    axios
+      .get<RegistryConfig>('/api/config')
+      .then((res) => {
+        cachedConfig = res.data;
+        setConfig(res.data);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error('Failed to load registry config:', err);
+        setError(err);
+        setConfig(DEFAULT_CONFIG);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { config, loading, error };
+}

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "dnspython>=2.4.0",
     "litellm>=1.50.0",
     "cryptography>=46.0.3",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.optional-dependencies]

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -1,0 +1,39 @@
+"""Configuration API endpoint for deployment mode awareness."""
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from ..core.config import settings, DeploymentMode, RegistryMode
+
+router = APIRouter()
+
+
+@router.get(
+    "",
+    summary="Get registry configuration",
+    description="Returns the current deployment mode, registry mode, and enabled features",
+)
+async def get_config() -> Dict[str, Any]:
+    """Get current registry configuration."""
+    return {
+        "deployment_mode": settings.deployment_mode.value,
+        "registry_mode": settings.registry_mode.value,
+        "nginx_updates_enabled": settings.nginx_updates_enabled,
+        "features": {
+            "mcp_servers": settings.registry_mode in (
+                RegistryMode.FULL,
+                RegistryMode.MCP_SERVERS_ONLY,
+            ),
+            "agents": settings.registry_mode in (
+                RegistryMode.FULL,
+                RegistryMode.AGENTS_ONLY,
+            ),
+            "skills": settings.registry_mode in (
+                RegistryMode.FULL,
+                RegistryMode.SKILLS_ONLY,
+            ),
+            "federation": settings.registry_mode == RegistryMode.FULL,
+            "gateway_proxy": settings.deployment_mode == DeploymentMode.WITH_GATEWAY,
+        },
+    }

--- a/registry/core/metrics.py
+++ b/registry/core/metrics.py
@@ -1,0 +1,17 @@
+"""Prometheus metrics for deployment mode monitoring."""
+
+from prometheus_client import Counter, Gauge
+
+# Deployment mode info gauge
+DEPLOYMENT_MODE_INFO = Gauge(
+    'registry_deployment_mode_info',
+    'Current deployment mode configuration',
+    ['deployment_mode', 'registry_mode']
+)
+
+# Counter for skipped nginx updates
+NGINX_UPDATES_SKIPPED = Counter(
+    'registry_nginx_updates_skipped_total',
+    'Number of nginx updates skipped due to registry-only mode',
+    ['operation']  # generate_config, reload
+)

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, Optional
 from urllib.parse import urlparse
 
 from .config import settings
+from .metrics import NGINX_UPDATES_SKIPPED
 from registry.constants import HealthStatus, REGISTRY_CONSTANTS
 
 logger = logging.getLogger(__name__)
@@ -143,6 +144,14 @@ class NginxConfigService:
 
     def generate_config(self, servers: Dict[str, Dict[str, Any]]) -> bool:
         """Generate Nginx configuration (synchronous version for non-async contexts)."""
+        if not settings.nginx_updates_enabled:
+            logger.debug(
+                f"Skipping MCP server location block generation - "
+                f"DEPLOYMENT_MODE={settings.deployment_mode.value}"
+            )
+            NGINX_UPDATES_SKIPPED.labels(operation="generate_config").inc()
+            return True
+
         try:
             # Check if we're in an async context
             try:
@@ -159,7 +168,19 @@ class NginxConfigService:
             return False
         
     async def generate_config_async(self, servers: Dict[str, Dict[str, Any]]) -> bool:
-        """Generate Nginx configuration with additional server names and dynamic location blocks."""
+        """Generate Nginx configuration with additional server names and dynamic location blocks.
+
+        In registry-only mode, this is a no-op - we don't generate
+        location blocks for registered servers.
+        """
+        if not settings.nginx_updates_enabled:
+            logger.debug(
+                f"Skipping MCP server location block generation - "
+                f"DEPLOYMENT_MODE={settings.deployment_mode.value}"
+            )
+            NGINX_UPDATES_SKIPPED.labels(operation="generate_config").inc()
+            return True
+
         try:
             # Read template
             if not self.nginx_template_path.exists():
@@ -339,7 +360,17 @@ class NginxConfigService:
             return False
             
     def reload_nginx(self) -> bool:
-        """Reload Nginx configuration (if running in appropriate environment)."""
+        """Reload Nginx configuration (if running in appropriate environment).
+
+        In registry-only mode, skip reload since no config changes were made.
+        """
+        if not settings.nginx_updates_enabled:
+            logger.debug(
+                f"Skipping nginx reload - DEPLOYMENT_MODE={settings.deployment_mode.value}"
+            )
+            NGINX_UPDATES_SKIPPED.labels(operation="reload").inc()
+            return True
+
         try:
             import subprocess
 

--- a/release-notes/v1.0.14.md
+++ b/release-notes/v1.0.14.md
@@ -1,0 +1,130 @@
+# Release v1.0.14 - Registry-Only Deployment Mode
+
+**February 2026**
+
+---
+
+## Major Features
+
+### Registry-Only Deployment Mode
+
+Deploy the registry as a standalone catalog/discovery service without gateway integration:
+
+- **New `DEPLOYMENT_MODE` parameter**: Choose between `with-gateway` (default) or `registry-only`
+- **Works with `REGISTRY_MODE`**: Combine deployment mode with registry mode (`full`, `skills-only`, `mcp-servers-only`, `agents-only`)
+- **Lightweight deployments**: Run registry without nginx dynamic location block generation for catalog-only use cases
+- **Auto-correction**: Invalid combinations (e.g., `with-gateway` + `skills-only`) are automatically corrected with warnings
+- **Prometheus metrics**: Monitor deployment mode via `registry_deployment_mode_info` gauge and track skipped nginx updates via `registry_nginx_updates_skipped_total` counter
+- **Health check enhancement**: `/health` endpoint now includes `deployment_mode`, `registry_mode`, and `nginx_updates_enabled` fields
+- **Configuration API**: New `/api/config` endpoint exposes deployment mode and feature flags to the frontend
+- **Frontend awareness**: UI adapts to deployment mode — shows direct server URLs and hides gateway auth instructions in registry-only mode
+
+[PR #478](https://github.com/agentic-community/mcp-gateway-registry/pull/478)
+
+---
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Deployment mode: with-gateway (default) or registry-only
+DEPLOYMENT_MODE=with-gateway
+
+# Registry mode: full (default), skills-only, mcp-servers-only, agents-only
+REGISTRY_MODE=full
+```
+
+### Example: Skills-Only Registry
+
+```bash
+DEPLOYMENT_MODE=registry-only
+REGISTRY_MODE=skills-only
+```
+
+### Auto-Correction Behavior
+
+If an invalid combination is detected at startup, the registry auto-corrects and logs a warning banner:
+
+| Configuration | Auto-Corrected To |
+|---|---|
+| `with-gateway` + `skills-only` | `registry-only` + `skills-only` |
+
+All other combinations are valid and pass through unchanged.
+
+### Helm Chart
+
+```yaml
+registry:
+  deployment_mode: with-gateway
+  registry_mode: full
+```
+
+### Terraform
+
+```hcl
+deployment_mode = "with-gateway"
+registry_mode   = "full"
+```
+
+---
+
+## What's Changed
+
+- New `DeploymentMode` and `RegistryMode` enums in configuration
+- `nginx_updates_enabled` property on Settings controls nginx behavior
+- Nginx service methods (`generate_config`, `generate_config_async`, `reload_nginx`) return early in registry-only mode
+- Prometheus metrics for deployment mode info and skipped nginx operations
+- `/api/config` endpoint for frontend deployment mode awareness
+- `/health` endpoint enhanced with deployment mode fields
+- Docker entrypoint logs deployment mode at container startup
+- `useRegistryConfig` React hook for frontend components
+- `DeploymentModeIndicator` badge component for registry-only mode
+- `ServerConfigModal` uses `proxy_pass_url` in registry-only mode instead of constructed gateway URL
+- Helm chart, Terraform, and `.env.example` updated with new variables
+
+---
+
+## Upgrade Instructions
+
+### For Docker Compose Deployments
+
+1. **Pull the latest changes:**
+```bash
+cd mcp-gateway-registry
+git pull origin main
+git checkout v1.0.14
+```
+
+2. **Rebuild and restart:**
+```bash
+./build_and_run.sh
+```
+
+No configuration changes required — defaults to `with-gateway` + `full` for backward compatibility.
+
+### For Kubernetes/Helm Deployments
+
+1. **Update chart values** if you want registry-only mode:
+```yaml
+registry:
+  deployment_mode: registry-only
+  registry_mode: skills-only  # or full, mcp-servers-only, agents-only
+```
+
+2. **Apply changes:**
+```bash
+helm upgrade mcp-gateway ./charts/mcp-gateway -f your-values.yaml
+```
+
+---
+
+## Support
+
+- [GitHub Issues](https://github.com/agentic-community/mcp-gateway-registry/issues)
+- [GitHub Discussions](https://github.com/agentic-community/mcp-gateway-registry/discussions)
+- [Documentation](https://github.com/agentic-community/mcp-gateway-registry/tree/main/docs)
+
+---
+
+**Full Changelog:** [v1.0.13...v1.0.14](https://github.com/agentic-community/mcp-gateway-registry/compare/v1.0.13...v1.0.14)

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -294,3 +294,17 @@ registry_api_token = "m3zT65wREARMVDToKosg_DgNkKqS_434hNxy3sslGPY"
 #   - Azure China: https://login.chinacloudapi.cn
 #   - Azure Germany: https://login.microsoftonline.de
 # entra_login_base_url = "https://login.microsoftonline.com"
+
+# ============================================================================
+# DEPLOYMENT MODE CONFIGURATION
+# ============================================================================
+
+# Deployment mode: "with-gateway" or "registry-only"
+# with-gateway: Full integration with nginx reverse proxy
+# registry-only: Registry operates as catalog/discovery service only
+deployment_mode = "with-gateway"
+
+# Registry mode: "full", "skills-only", "mcp-servers-only", "agents-only"
+# full: All features enabled
+# skills-only: Only skills functionality (automatically uses registry-only deployment)
+registry_mode = "full"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -556,3 +556,36 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.integration)
         elif "auth_server/" in str(item.fspath):
             item.add_marker(pytest.mark.auth)
+
+
+# =============================================================================
+# DEPLOYMENT MODE FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def client_registry_only(mock_settings) -> Generator[Any, None, None]:
+    """Test client with registry-only deployment mode."""
+    from fastapi.testclient import TestClient
+    from registry.core.config import DeploymentMode, RegistryMode
+
+    object.__setattr__(mock_settings, 'deployment_mode', DeploymentMode.REGISTRY_ONLY)
+    object.__setattr__(mock_settings, 'registry_mode', RegistryMode.FULL)
+
+    from registry.main import app
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def client_skills_only(mock_settings) -> Generator[Any, None, None]:
+    """Test client with skills-only registry mode."""
+    from fastapi.testclient import TestClient
+    from registry.core.config import DeploymentMode, RegistryMode
+
+    object.__setattr__(mock_settings, 'deployment_mode', DeploymentMode.REGISTRY_ONLY)
+    object.__setattr__(mock_settings, 'registry_mode', RegistryMode.SKILLS_ONLY)
+
+    from registry.main import app
+    with TestClient(app) as client:
+        yield client

--- a/tests/integration/test_deployment_mode_integration.py
+++ b/tests/integration/test_deployment_mode_integration.py
@@ -1,0 +1,111 @@
+"""Integration tests for deployment mode configuration endpoints."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from registry.core.config import DeploymentMode, RegistryMode
+
+
+@pytest.fixture
+def mock_peer_federation():
+    """Mock peer federation service to avoid MongoDB event loop issues."""
+    mock_service = AsyncMock()
+    mock_service.registered_peers = []
+    mock_service.load_peers_and_state = AsyncMock()
+
+    mock_scheduler = AsyncMock()
+    mock_scheduler.start = AsyncMock()
+    mock_scheduler.stop = AsyncMock()
+
+    with patch(
+        "registry.main.get_peer_federation_service",
+        return_value=mock_service,
+    ), patch(
+        "registry.main.get_peer_sync_scheduler",
+        return_value=mock_scheduler,
+    ):
+        yield mock_service
+
+
+@pytest.fixture
+def mock_auth_admin():
+    """Mock authentication returning admin user context."""
+    admin_context = {
+        "username": "admin",
+        "groups": ["mcp-registry-admin"],
+        "scopes": [
+            "mcp-servers-unrestricted/read",
+            "mcp-servers-unrestricted/execute",
+        ],
+        "is_admin": True,
+        "can_modify_servers": True,
+    }
+    with patch(
+        "registry.api.server_routes.nginx_proxied_auth",
+        return_value=admin_context,
+    ):
+        yield admin_context
+
+
+@pytest.fixture
+def integration_client(mock_settings, mock_peer_federation):
+    """Test client with peer federation mocked to avoid event loop issues."""
+    from fastapi.testclient import TestClient
+    from registry.main import app
+
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.mark.integration
+class TestDeploymentModeIntegration:
+    """Integration tests for deployment mode endpoints."""
+
+    def test_config_endpoint_returns_mode(self, integration_client):
+        """Config endpoint should return deployment mode fields."""
+        response = integration_client.get("/api/config")
+        assert response.status_code == 200
+        data = response.json()
+        assert "deployment_mode" in data
+        assert "registry_mode" in data
+        assert "nginx_updates_enabled" in data
+        assert "features" in data
+        assert "gateway_proxy" in data["features"]
+        assert "mcp_servers" in data["features"]
+        assert "agents" in data["features"]
+        assert "skills" in data["features"]
+        assert "federation" in data["features"]
+
+    def test_health_includes_deployment_mode(self, integration_client):
+        """Health endpoint should include deployment mode info."""
+        response = integration_client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "deployment_mode" in data
+        assert "registry_mode" in data
+        assert "nginx_updates_enabled" in data
+
+    def test_server_registration_works_in_registry_only(
+        self, integration_client, mock_auth_admin
+    ):
+        """Server registration should not 500 in registry-only mode."""
+        response = integration_client.post(
+            "/api/servers/register",
+            json={
+                "server_name": "test-server",
+                "path": "/test-server",
+                "transport": "sse",
+                "proxy_pass_url": "http://localhost:8080/mcp",
+            },
+        )
+        assert response.status_code != 500
+
+    def test_server_toggle_works_in_registry_only(
+        self, integration_client, mock_auth_admin
+    ):
+        """Server toggle should not fail due to nginx in registry-only mode."""
+        response = integration_client.post(
+            "/api/servers/test-server/toggle",
+            json={"enabled": True},
+        )
+        assert response.status_code != 500

--- a/tests/unit/test_deployment_mode.py
+++ b/tests/unit/test_deployment_mode.py
@@ -1,0 +1,163 @@
+"""
+Unit tests for deployment mode configuration and validation.
+
+Tests the DeploymentMode/RegistryMode enums, validation logic,
+and nginx_updates_enabled property.
+"""
+
+import pytest
+
+from registry.core.config import (
+    DeploymentMode,
+    RegistryMode,
+    Settings,
+    _validate_mode_combination,
+)
+
+
+# =============================================================================
+# TEST CLASS: Deployment Mode Validation
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeploymentModeValidation:
+    """Test deployment mode validation logic."""
+
+    def test_default_mode_valid(self):
+        """Default modes should be valid."""
+        deployment, registry, corrected = _validate_mode_combination(
+            DeploymentMode.WITH_GATEWAY,
+            RegistryMode.FULL
+        )
+        assert deployment == DeploymentMode.WITH_GATEWAY
+        assert registry == RegistryMode.FULL
+        assert corrected is False
+
+    def test_gateway_skills_only_invalid(self):
+        """Gateway + skills-only should auto-correct to registry-only."""
+        deployment, registry, corrected = _validate_mode_combination(
+            DeploymentMode.WITH_GATEWAY,
+            RegistryMode.SKILLS_ONLY
+        )
+        assert deployment == DeploymentMode.REGISTRY_ONLY
+        assert registry == RegistryMode.SKILLS_ONLY
+        assert corrected is True
+
+    def test_registry_only_full_valid(self):
+        """Registry-only + full should be valid."""
+        deployment, registry, corrected = _validate_mode_combination(
+            DeploymentMode.REGISTRY_ONLY,
+            RegistryMode.FULL
+        )
+        assert deployment == DeploymentMode.REGISTRY_ONLY
+        assert registry == RegistryMode.FULL
+        assert corrected is False
+
+    def test_registry_only_skills_valid(self):
+        """Registry-only + skills-only should be valid."""
+        deployment, registry, corrected = _validate_mode_combination(
+            DeploymentMode.REGISTRY_ONLY,
+            RegistryMode.SKILLS_ONLY
+        )
+        assert deployment == DeploymentMode.REGISTRY_ONLY
+        assert registry == RegistryMode.SKILLS_ONLY
+        assert corrected is False
+
+    def test_gateway_mcp_servers_only_valid(self):
+        """Gateway + mcp-servers-only should be valid."""
+        deployment, registry, corrected = _validate_mode_combination(
+            DeploymentMode.WITH_GATEWAY,
+            RegistryMode.MCP_SERVERS_ONLY
+        )
+        assert deployment == DeploymentMode.WITH_GATEWAY
+        assert registry == RegistryMode.MCP_SERVERS_ONLY
+        assert corrected is False
+
+
+# =============================================================================
+# TEST CLASS: Nginx Updates Enabled
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestNginxUpdatesEnabled:
+    """Test nginx_updates_enabled property."""
+
+    def test_enabled_with_gateway(self):
+        """Should be enabled in with-gateway mode."""
+        settings = Settings(deployment_mode=DeploymentMode.WITH_GATEWAY)
+        assert settings.nginx_updates_enabled is True
+
+    def test_disabled_registry_only(self):
+        """Should be disabled in registry-only mode."""
+        settings = Settings(deployment_mode=DeploymentMode.REGISTRY_ONLY)
+        assert settings.nginx_updates_enabled is False
+
+from unittest.mock import MagicMock, patch
+
+
+# =============================================================================
+# TEST CLASS: Nginx Service Deployment Mode
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestNginxServiceDeploymentMode:
+    """Test nginx service respects deployment mode."""
+
+    @patch('registry.core.nginx_service.NGINX_UPDATES_SKIPPED')
+    @patch('registry.core.nginx_service.settings')
+    @patch('registry.core.nginx_service.Path')
+    def test_generate_config_skipped_in_registry_only(
+        self,
+        mock_path_class,
+        mock_settings,
+        mock_counter,
+    ):
+        """Nginx config generation should be skipped in registry-only mode."""
+        mock_settings.nginx_updates_enabled = False
+        mock_settings.deployment_mode = MagicMock()
+        mock_settings.deployment_mode.value = "registry-only"
+
+        # Mock Path for constructor SSL checks
+        mock_path_instance = MagicMock()
+        mock_path_instance.exists.return_value = True
+        mock_path_class.return_value = mock_path_instance
+
+        from registry.core.nginx_service import NginxConfigService
+        service = NginxConfigService()
+
+        result = service.generate_config({})
+
+        assert result is True
+        mock_counter.labels.assert_called_with(operation="generate_config")
+        mock_counter.labels().inc.assert_called_once()
+
+    @patch('registry.core.nginx_service.NGINX_UPDATES_SKIPPED')
+    @patch('registry.core.nginx_service.settings')
+    @patch('registry.core.nginx_service.Path')
+    def test_reload_nginx_skipped_in_registry_only(
+        self,
+        mock_path_class,
+        mock_settings,
+        mock_counter,
+    ):
+        """Nginx reload should be skipped in registry-only mode."""
+        mock_settings.nginx_updates_enabled = False
+        mock_settings.deployment_mode = MagicMock()
+        mock_settings.deployment_mode.value = "registry-only"
+
+        # Mock Path for constructor SSL checks
+        mock_path_instance = MagicMock()
+        mock_path_instance.exists.return_value = True
+        mock_path_class.return_value = mock_path_instance
+
+        from registry.core.nginx_service import NginxConfigService
+        service = NginxConfigService()
+
+        result = service.reload_nginx()
+
+        assert result is True
+        mock_counter.labels.assert_called_with(operation="reload")
+        mock_counter.labels().inc.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1729,6 +1729,7 @@ dependencies = [
     { name = "matplotlib" },
     { name = "mcp" },
     { name = "motor" },
+    { name = "prometheus-client" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1820,6 +1821,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
     { name = "mkdocs-minify-plugin", marker = "extra == 'docs'", specifier = ">=0.7.0" },
     { name = "motor", specifier = ">=3.3.0" },
+    { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psutil", specifier = ">=6.1.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -2561,6 +2563,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Issue #478:**

## Description of changes:

### Summary

Implements the Registry-Only Deployment Mode feature as described in #478. This allows the registry to operate as a standalone catalog/discovery service without managing nginx reverse proxy configuration. Introduces `DEPLOYMENT_MODE` and `REGISTRY_MODE` environment variables with auto-correction for invalid combinations.

### Backend Changes

| File | Change |
|------|--------|
| `registry/core/config.py` | Added `DeploymentMode` and `RegistryMode` enums, `deployment_mode` and `registry_mode` settings, `nginx_updates_enabled` property, `_validate_mode_combination` and `_print_config_warning_banner` functions |
| `registry/core/metrics.py` | NEW - Prometheus metrics: `registry_deployment_mode_info` gauge and `registry_nginx_updates_skipped_total` counter |
| `registry/core/nginx_service.py` | Added early return checks in `generate_config`, `generate_config_async`, and `reload_nginx` when `nginx_updates_enabled` is False |
| `registry/main.py` | Added mode validation at startup, conditional nginx config generation, startup logging (`_log_startup_configuration`), metrics initialization (`_initialize_deployment_metrics`), deployment mode fields in `/health` endpoint |
| `registry/api/config_routes.py` | NEW - GET `/api/config` endpoint returning deployment mode, registry mode, and feature flags |

### Frontend Changes

| File | Change |
|------|--------|
| `frontend/src/hooks/useRegistryConfig.ts` | NEW - React hook to fetch and cache registry config from `/api/config` |
| `frontend/src/components/DeploymentModeIndicator.tsx` | NEW - "Registry Only" badge component, renders nothing in with-gateway mode |
| `frontend/src/components/ServerConfigModal.tsx` | Uses `proxy_pass_url` in registry-only mode instead of constructed gateway URL; hides gateway auth instructions; shows "Direct Connection Mode" banner |
| `frontend/src/components/__tests__/ServerConfigModal.test.tsx` | NEW - 3 tests for URL generation logic across deployment modes |
| `frontend/src/setupTests.ts` | NEW - Jest/testing-library setup |

### Infrastructure Changes

| File | Change |
|------|--------|
| `docker/registry-entrypoint.sh` | Logs `DEPLOYMENT_MODE` and `REGISTRY_MODE` at container startup |
| `.env.example` | Added `DEPLOYMENT_MODE` and `REGISTRY_MODE` with documentation |
| `charts/registry/values.yaml` | Added `deployment_mode` and `registry_mode` values |
| `charts/registry/templates/deployment.yaml` | Added `DEPLOYMENT_MODE` and `REGISTRY_MODE` env vars |
| `terraform/aws-ecs/terraform.tfvars.example` | Added `deployment_mode` and `registry_mode` variables |
| `release-notes/v1.0.14.md` | NEW - Release notes for registry-only deployment mode |

### Tests

| File | Change |
|------|--------|
| `tests/unit/test_deployment_mode.py` | NEW - 9 unit tests (validation, nginx_updates_enabled, nginx service skip behavior) |
| `tests/integration/test_deployment_mode_integration.py` | NEW - 4 integration tests (config endpoint, health endpoint, server registration/toggle in registry-only mode) |
| `tests/conftest.py` | Added `client_registry_only` and `client_skills_only` test fixtures |

### Deployment Mode Combinations

| DEPLOYMENT_MODE | REGISTRY_MODE | Status | Behavior |
|---|---|---|---|
| `with-gateway` | `full` | DEFAULT | Full registry + nginx config updates |
| `with-gateway` | `skills-only` | Invalid | Auto-corrects to `registry-only` + `skills-only` with warning |
| `registry-only` | `full` | Valid | Full registry features, no nginx updates |
| `registry-only` | `skills-only` | Valid | Lightweight skills-only registry, no nginx updates |

### Upgrade Notes (Existing Deployments)

No action required. Defaults to `with-gateway` + `full` for full backward compatibility. To enable registry-only mode, add to your `.env`:

```bash
DEPLOYMENT_MODE=registry-only
```
