### PR TITLE
fix: strip newlines from X-Body header to prevent scope validation bypass

### DIFF
--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -116,8 +116,11 @@ ngx.req.read_body()
 local body_data = ngx.req.get_body_data()
 
 if body_data then
-    -- Set the X-Body header with the raw body data
-    ngx.req.set_header("X-Body", body_data)
+    -- Strip newlines to prevent breaking HTTP header format
+    -- (JSON whitespace is insignificant per RFC 8259, so this is safe)
+    local clean_body = body_data:gsub("[\r\n]+", " ")
+    -- Set the X-Body header with the cleaned body data
+    ngx.req.set_header("X-Body", clean_body)
     ngx.log(ngx.INFO, "Captured request body (" .. string.len(body_data) .. " bytes) for auth validation")
 else
     ngx.log(ngx.INFO, "No request body found")


### PR DESCRIPTION
## Summary

Multi-line (pretty-printed) JSON request bodies break scope validation for all non-admin users with fine-grained scopes. The `capture_body.lua` script sets the raw POST body as an `X-Body` HTTP header for `auth_request` validation, but newline characters in the body corrupt the header. The auth server cannot parse the body, falls back to URL-path-based method validation, and denies access.

**Impact:** All non-admin users with fine-grained `server_access` scopes are affected when using Pattern B routing (`POST /{server}/mcp`) and any MCP client that pretty-prints JSON.

**Fix:** Strip `\r\n` from the body before setting the header value. JSON whitespace is insignificant per RFC 8259.

## Root Cause

`docker/registry-entrypoint.sh` generates `capture_body.lua` which does:
```lua
ngx.req.set_header("X-Body", body_data)
```

HTTP header values cannot contain raw newline characters. When `body_data` contains newlines (pretty-printed JSON), the header is malformed. The auth server (`auth_server/server.py`) receives null/partial body and falls back to the URL endpoint as the validation method.

### Why admin users are unaffected

Admin scopes include a wildcard entry (`methods: ["all"]`). The wildcard check passes regardless of the method value, so admin access succeeds even when the body is not parsed. This is why the bug went undetected.

## Reproduction

```bash
# Single-line body: WORKS
curl -X POST $GATEWAY/cloudflare-docs/mcp \
  -H "Authorization: Bearer $LOB1_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}'

# Multi-line body: FAILS with "Access forbidden"
curl -X POST $GATEWAY/cloudflare-docs/mcp \
  -H "Authorization: Bearer $LOB1_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "initialize",
    "params": {
      "protocolVersion": "2024-11-05",
      "capabilities": {},
      "clientInfo": { "name": "test", "version": "1.0.0" }
    }
  }'
```

Prerequisites: any non-admin user with a fine-grained scope (e.g., `registry-users-lob1`), Pattern B routing (`/{server}/mcp`), and at least one enabled MCP server.

## Test Plan

- [ ] Non-admin user with fine-grained scope sends single-line JSON body -- access granted
- [ ] Non-admin user with fine-grained scope sends multi-line JSON body -- access granted (was denied before fix)
- [ ] Admin user with wildcard scope -- access granted (unchanged)
- [ ] Empty body (initialize without params) -- access granted (unchanged)

Tested on AWS ECS CloudFormation deployment (v1.0.12 base + this fix) with automated test suite (25/25 passing).