### PR TITLE
Add registry/deployment modes to mcp gateway registry stack chart

### DIFF
--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -146,6 +146,11 @@ mongodb-configure:
 registry:
   app:
     replicas: 2 # set to > 1 replica for high availability
+    # Deployment mode: with-gateway (nginx integration) or registry-only (catalog only)
+    deploymentMode: with-gateway
+
+    # Registry mode: full, skills-only, mcp-servers-only, agents-only
+    registryMode: full
   ingress:
     enabled: true
     ingressClassName: alb

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -64,9 +64,9 @@ spec:
             {{- end }}
           env:
             - name: DEPLOYMENT_MODE
-              value: {{ .Values.app.deployment_mode | default "with-gateway" | quote }}
+              value: {{ .Values.app.deploymentMode | default "with-gateway" | quote }}
             - name: REGISTRY_MODE
-              value: {{ .Values.app.registry_mode | default "full" | quote }}
+              value: {{ .Values.app.registryMode | default "full" | quote }}
       volumes:
         - name: script
           configMap:

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -27,10 +27,10 @@ app:
   registryId: # Unique identifier for this registry instance (optional)
 
   # Deployment mode: with-gateway (nginx integration) or registry-only (catalog only)
-  deployment_mode: with-gateway
+  deploymentMode: with-gateway
 
   # Registry mode: full, skills-only, mcp-servers-only, agents-only
-  registry_mode: full
+  registryMode: full
 
 # Service configuration
 service:

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -115,6 +115,7 @@ EXPOSE 80 443 7860
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:7860/health || exit 1
 
+ARG BUILD_VERSION="1.0.0"
 ENV BUILD_VERSION=$BUILD_VERSION
 
 ENTRYPOINT ["/app/registry-entrypoint.sh"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- updates `deployment_mode` and `registry_mode` to `deploymentMode` and `registryMode` to maintain consistency
- Support `deploymentMode` and `registryMode` in mcp-gateway-registry-stack helm chart.
- fixes a missed update in the registry dockerfile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
