### PR TITLE
docs: Use more precise language in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <img src="registry/static/mcp_gateway_horizontal_white_logo.png" alt="MCP Gateway & Registry Logo" width="100%">
 
-**Unified Agent & MCP Server Registry – Enterprise-Ready Gateway for AI Development Tools**
+**Unified Agent & MCP Server Registry – Gateway for AI Development Tools**
 
 [![GitHub stars](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/network)
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/github/license/agentic-community/mcp-gateway-registry?style=flat)](https://github.com/agentic-community/mcp-gateway-registry/blob/main/LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/releases)
 
-[🚀 Get Running Now](#option-a-pre-built-images-instant-setup) | [Production Deployment](terraform/aws-ecs/README.md) | [Quick Start](#quick-start) | [Documentation](docs/) | [Enterprise Features](#enterprise-features) | [Community](#community)
+[🚀 Get Running Now](#option-a-pre-built-images-instant-setup) | [AWS Deployment](terraform/aws-ecs/README.md) | [Quick Start](#quick-start) | [Documentation](docs/) | [Enterprise Features](#enterprise-features) | [Community](#community)
 
 **Demo Videos:** ⭐ [MCP Registry CLI Demo](https://github.com/user-attachments/assets/98200866-e8bd-4ac3-bad6-c6d42b261dbe) | [Full End-to-End Functionality](https://github.com/user-attachments/assets/5ffd8e81-8885-4412-a4d4-3339bbdba4fb) | [OAuth 3-Legged Authentication](https://github.com/user-attachments/assets/3c3a570b-29e6-4dd3-b213-4175884396cc) | [Dynamic Tool Discovery](https://github.com/user-attachments/assets/cee25b31-61e4-4089-918c-c3757f84518c) | [Agent Skills](https://github.com/user-attachments/assets/5d1f227a-25f8-480d-9ff9-acba2498844b) | [Virtual MCP Servers](https://app.vidcast.io/share/954e6296-f217-4559-8d86-88cec25af763)
 
@@ -19,7 +19,7 @@
 
 ## What is MCP Gateway & Registry?
 
-The **MCP Gateway & Registry** is a unified, enterprise-ready platform that centralizes access to both MCP Servers and AI Agents using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction). It serves three core functions:
+The **MCP Gateway & Registry** is a unified platform designed for centralizing access to both MCP Servers and AI Agents using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction). It serves three core functions:
 
 1. **Unified MCP Server Gateway** – Centralized access point for multiple MCP servers
 2. **MCP Servers Registry** – Register, discover, and manage access to MCP servers with unified governance
@@ -53,7 +53,7 @@ The platform integrates with external registries such as Anthropic's MCP Registr
 ✅ Developers use standard OAuth 2LO/3LO flows for enterprise MCP servers
 ✅ Centralized credential management with secure vault integration
 ✅ Complete visibility and audit trail for all tool usage
-✅ Enterprise-grade security with governed tool access
+✅ Security features with governed tool access
 ✅ Dynamic tool discovery and invocation for autonomous workflows
 ✅ Registry provides discoverable, curated MCP servers for multi-tenant use
 ✅ Agents can discover and communicate with other agents through unified Agent Registry
@@ -152,7 +152,7 @@ Interactive terminal interface for chatting with AI models and discovering MCP t
 - **🔧 Registry Management API** - New programmatic API for managing servers, groups, and users. Python client (`api/registry_client.py`) with type-safe interfaces, RESTful HTTP endpoints (`/api/management/*`), and comprehensive error handling. Replaces shell scripts with modern API approach while maintaining backward compatibility. [API Documentation](api/README.md) | [Service Management Guide](docs/service-management.md)
 - **⭐ Server & Agent Rating System** - Rate and review agents with an interactive 5-star rating widget. Users can submit ratings via the UI or CLI, view aggregate ratings with individual rating details, and update their existing ratings. Features include a rotating buffer (max 100 ratings per agent), one rating per user, float average calculations, and full OpenAPI documentation. Enables community-driven agent quality assessment and discovery.
 - **🧠 Flexible Embeddings Support** - Choose from three embedding provider options for semantic search: local sentence-transformers, OpenAI, or any LiteLLM-supported provider including Amazon Bedrock Titan, Cohere, and 100+ other models. Switch providers with simple configuration changes. [Embeddings Guide](docs/embeddings.md)
-- **☁️ AWS ECS Production Deployment** - Production-ready deployment on Amazon ECS Fargate with multi-AZ architecture, Application Load Balancer with HTTPS, auto-scaling, CloudWatch monitoring, and NAT Gateway high availability. Complete Terraform configuration for deploying the entire stack. [ECS Deployment Guide](terraform/aws-ecs/README.md)
+- **☁️ AWS ECS Deployment** - Deployment configuration on Amazon ECS Fargate with multi-AZ architecture, Application Load Balancer with HTTPS, auto-scaling, CloudWatch monitoring, and NAT Gateway redundancy. Complete Terraform configuration for deploying the entire stack. [ECS Deployment Guide](terraform/aws-ecs/README.md)
 - **📦 Flexible Deployment Modes** - Three deployment options to match your requirements: (1) CloudFront Only for quick setup without custom domains, (2) Custom Domain with Route53/ACM for branded URLs, or (3) CloudFront + Custom Domain for production with CDN benefits. [Deployment Modes Guide](docs/deployment-modes.md)
 - **🔗 Federated Registry** - MCP Gateway registry now supports federation of servers and agents from other registries. [Federation Guide](docs/federation.md)
 - **🔗 Agent-to-Agent (A2A) Protocol Support** - Agents can now register, discover, and communicate with other agents through a secure, centralized registry. Enable autonomous agent ecosystems with Keycloak-based access control and fine-grained permissions. [A2A Guide](docs/a2a.md)
@@ -393,9 +393,9 @@ flowchart TB
 
 ## Key Advantages
 
-### **Enterprise-Grade Security**
+### **Security Features**
 - OAuth 2.0/3.0 compliance with IdP integration
-- Fine-grained access control at tool and method level  
+- Fine-grained access control at tool and method level
 - Zero-trust network architecture
 - Complete audit trails and comprehensive analytics for compliance
 
@@ -405,7 +405,7 @@ flowchart TB
 - Instant onboarding for new team members and AI agent deployments
 - Unified governance for both AI agents and human developers
 
-### **Production Ready**
+### **Deployment Features**
 - Container-native (Docker/Kubernetes)
 - Real-time health monitoring and alerting
 - Dual authentication supporting both human and machine authentication
@@ -656,7 +656,7 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 
 **Fine-Grained Permissions:** Tool-level, method-level, team-based, and temporary access controls. [Learn more](docs/scopes.md)
 
-### Production Deployment
+### Deployment Options
 
 **Cloud Platforms:** Amazon EC2, Amazon EKS
 
@@ -670,13 +670,13 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 <img src="terraform/aws-ecs/img/MCP-Gateway-Registry-first-login.png" alt="MCP Gateway Registry on AWS ECS" width="800"/>
 </div>
 
-**Production-ready deployment** on Amazon ECS Fargate with comprehensive enterprise features:
+**Deployment configuration** on Amazon ECS Fargate with comprehensive enterprise features:
 
-- **Multi-AZ Architecture** - High availability across multiple availability zones
+- **Multi-AZ Architecture** - Redundancy across multiple availability zones
 - **Application Load Balancer** - HTTPS/SSL termination with automatic certificate management via ACM
 - **Auto-scaling** - Dynamic scaling based on CPU and memory utilization
 - **CloudWatch Integration** - Comprehensive monitoring, logging, and alerting
-- **NAT Gateway HA** - High-availability NAT gateway configuration for secure outbound connectivity
+- **NAT Gateway HA** - Redundant NAT gateway configuration for secure outbound connectivity
 - **Keycloak Integration** - Enterprise authentication with RDS Aurora PostgreSQL backend
 - **EFS Shared Storage** - Persistent storage for models, logs, and configuration
 - **Service Discovery** - AWS Cloud Map for service-to-service communication
@@ -694,7 +694,7 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 | Getting Started | Enterprise Setup | Developer & Operations |
 |------------------|-------------------|------------------------|
 | [Complete Setup Guide](docs/complete-setup-guide.md)<br/>**NEW!** Step-by-step from scratch on AWS EC2 | [Authentication Guide](docs/auth.md)<br/>OAuth and identity provider integration | [AI Coding Assistants Setup](docs/ai-coding-assistants-setup.md)<br/>VS Code, Cursor, Claude Code integration |
-| [Installation Guide](docs/installation.md)<br/>Complete setup instructions for EC2 and EKS | [AWS ECS Deployment](terraform/aws-ecs/README.md)<br/>Production-ready deployment on AWS ECS Fargate | [API Reference](docs/registry_api.md)<br/>Programmatic registry management |
+| [Installation Guide](docs/installation.md)<br/>Complete setup instructions for EC2 and EKS | [AWS ECS Deployment](terraform/aws-ecs/README.md)<br/>Deployment guide for AWS ECS Fargate | [API Reference](docs/registry_api.md)<br/>Programmatic registry management |
 | [Keycloak Integration](docs/keycloak-integration.md)<br/>Enterprise identity with agent audit trails | [Token Refresh Service](docs/token-refresh-service.md)<br/>Automated token refresh and lifecycle management | [MCP Registry CLI](docs/mcp-registry-cli.md)<br/>Command-line client for registry management |
 | [Configuration Reference](docs/configuration.md)<br/>Environment variables and settings | [Amazon Cognito Setup](docs/cognito.md)<br/>Step-by-step IdP configuration | [Observability Guide](docs/OBSERVABILITY.md)<br/>**NEW!** Metrics, monitoring, and OpenTelemetry setup |
 | | [Anthropic Registry Import](docs/anthropic-registry-import.md)<br/>**NEW!** Import servers from Anthropic MCP Registry | [Federation Guide](docs/federation.md)<br/>External registry integration (Anthropic, ASOR) |
@@ -702,7 +702,7 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 | | [Service Management](docs/service-management.md)<br/>Server lifecycle and operations | [Anthropic Registry API](docs/anthropic_registry_api.md)<br/>**NEW!** REST API compatibility |
 | | | [Fine-Grained Access Control](docs/scopes.md)<br/>Permission management and security |
 | | | [Dynamic Tool Discovery](docs/dynamic-tool-discovery.md)<br/>Autonomous agent capabilities |
-| | | [Production Deployment](docs/installation.md)<br/>Complete setup for production environments |
+| | | [Deployment Guide](docs/installation.md)<br/>Complete setup for deployment environments |
 | | | [Troubleshooting Guide](docs/FAQ.md)<br/>Common issues and solutions |
 
 ---

--- a/charts/README.md
+++ b/charts/README.md
@@ -6,7 +6,7 @@ This directory contains Helm charts for deploying the MCP Gateway Registry stack
 
 ### EKS Cluster Setup
 
-For deploying on Amazon EKS, we recommend using the [AWS AI/ML on Amazon EKS](https://github.com/awslabs/ai-on-eks) blueprints to provision a production-ready EKS cluster with GPU support, autoscaling, and AI/ML optimizations.
+For deploying on Amazon EKS, we recommend using the [AWS AI/ML on Amazon EKS](https://github.com/awslabs/ai-on-eks) blueprints to provision an EKS cluster with GPU support, autoscaling, and AI/ML optimizations.
 
 **Quick Start with AI on EKS:**
 

--- a/charts/mcp-gateway-registry-stack/README.md
+++ b/charts/mcp-gateway-registry-stack/README.md
@@ -7,7 +7,7 @@ This collection of charts deploys everything needed to install the MCP Gateway R
 ### Amazon EKS Cluster
 
 For production deployments, we recommend using the [AWS AI/ML on Amazon EKS](https://github.com/awslabs/ai-on-eks)
-blueprints to provision a production-ready EKS cluster:
+blueprints to provision an EKS cluster:
 
 ```bash
 # Clone AI on EKS repository
@@ -28,7 +28,7 @@ The ai-on-eks blueprints provide:
 - EKS-optimized configurations
 - Security best practices
 - Observability with Prometheus/Grafana
-- Proven, battle-tested infrastructure
+- Well-documented infrastructure patterns
 
 ### Additional Requirements
 
@@ -309,7 +309,7 @@ Ensure that:
 
 See the [Entra ID documentation](../../docs/entra.md) for complete setup instructions.
 
-## Scaling and High Availability
+## Scaling and Redundancy
 
 ### Replica Configuration
 
@@ -323,7 +323,7 @@ registry:
   replicaCount: 2
 ```
 
-For production environments, we recommend running at least 2 replicas of each service to ensure high availability.
+For production environments, we recommend running at least 2 replicas of each service for redundancy.
 
 ### Topology Spread Constraints
 

--- a/cli/examples/README.md
+++ b/cli/examples/README.md
@@ -158,7 +158,7 @@ DevOps automation agent for infrastructure and deployment management.
 - Auto-Scale Application
 
 **Security:** AWS SigV4 + Client Certificate
-**Features:** Multi-cloud support, verified trust level, 99.95% SLA
+**Features:** Multi-cloud support, verified trust level
 
 **Usage:**
 ```bash

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -185,7 +185,7 @@ except AuthenticationError as e:
 **Recommended for Production**:
 - **EC2 Instance**: `t3.2xlarge` (8 vCPU, 32GB RAM)
 - **Storage**: 50GB+ SSD storage
-- **Load Balancer**: Application Load Balancer for high availability
+- **Load Balancer**: Application Load Balancer for load distribution and redundancy
 - **SSL Certificate**: Valid SSL certificate for HTTPS
 
 ### Q9: How do I set up Amazon Cognito for authentication?

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -760,7 +760,7 @@ docker compose exec otel-collector env | grep -i key
 
 ### Example Complete Setup
 
-See `config/otel-collector-config.example.yaml` for a complete production-ready configuration template.
+See `config/otel-collector-config.example.yaml` for a complete configuration template.
 
 ## Grafana Dashboards
 

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -1,6 +1,6 @@
 # Agent-to-Agent (A2A) Protocol Support
 
-The MCP Gateway & Registry now supports **Agent-to-Agent (A2A) communication**, enabling AI agents to securely register themselves and discover other agents within a centralized registry. This creates a self-managed agent ecosystem where agents can autonomously find, connect to, and communicate with other agents while maintaining enterprise-grade security and access control.
+The MCP Gateway & Registry now supports **Agent-to-Agent (A2A) communication**, enabling AI agents to securely register themselves and discover other agents within a centralized registry. This creates a self-managed agent ecosystem where agents can autonomously find, connect to, and communicate with other agents while maintaining security and access control features.
 
 ## Overview
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication and Authorization
 
-The MCP Gateway Registry provides enterprise-ready authentication and authorization using industry-standard OAuth 2.0 flows with fine-grained access control.
+The MCP Gateway Registry provides authentication and authorization using industry-standard OAuth 2.0 flows with fine-grained access control.
 
 ## Overview
 

--- a/docs/complete-setup-guide.md
+++ b/docs/complete-setup-guide.md
@@ -278,7 +278,7 @@ ls -la ${HOME}/mcp-gateway/models/all-MiniLM-L6-v2/
 
 ## 5. Setting Up Keycloak Identity Provider
 
-Keycloak provides enterprise-grade authentication with support for both human users and AI agents.
+Keycloak provides authentication with support for both human users and AI agents.
 
 ### Set Keycloak Passwords
 
@@ -1290,7 +1290,7 @@ curl -f https://mcpgateway.mycorp.com/realms/mcp-gateway
 ### Configure Production Settings
 
 1. **Domain Name**: Set up a domain name and update configurations
-2. **Load Balancer**: Add an Application Load Balancer for high availability
+2. **Load Balancer**: Add an Application Load Balancer for redundancy and load distribution
 3. **Backup Strategy**: Implement regular backups of PostgreSQL database
 4. **Scaling**: Consider EKS deployment for auto-scaling capabilities
 
@@ -1307,7 +1307,7 @@ curl -f https://mcpgateway.mycorp.com/realms/mcp-gateway
 - [Keycloak Advanced Configuration](keycloak-integration.md) - Enterprise features
 - [API Reference](registry_api.md) - Programmatic registry management
 - [Dynamic Tool Discovery](dynamic-tool-discovery.md) - AI agent capabilities
-- [Production Deployment](production-deployment.md) - Best practices for production
+- [AWS ECS Deployment](../terraform/aws-ecs/README.md) - Deployment best practices
 
 ### Getting Help
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ This document provides a comprehensive reference for all configuration files in 
 
 The MCP Gateway Registry supports multiple authentication providers. Choose one by setting the `AUTH_PROVIDER` environment variable:
 
-- **`keycloak`**: Enterprise-grade open-source identity and access management with individual agent audit trails
+- **`keycloak`**: Open-source identity and access management with individual agent audit trails
 - **`cognito`**: Amazon managed authentication service
 
 Based on your selection, configure the corresponding provider-specific variables below.
@@ -529,7 +529,7 @@ When using Keycloak as the authentication provider, the following configuration 
 
 ### Supported Providers
 
-- **Keycloak**: Enterprise-grade open-source identity and access management
+- **Keycloak**: Open-source identity and access management
 - **Amazon Cognito**: Amazon managed authentication service
 - **GitHub**: Repository and development services (planned)
 - **Google**: Google Workspace and consumer services (planned)

--- a/docs/database-design.md
+++ b/docs/database-design.md
@@ -18,7 +18,7 @@ The MCP Gateway Registry supports three storage backends for data persistence:
 
 3. **AWS DocumentDB** (Production, Recommended)
    - MongoDB-compatible managed service
-   - Production-ready with clustering support
+   - Supports clustering configuration
    - Native vector search with HNSW indexes
    - Multi-tenancy support via namespaces
    - Recommended for all production deployments

--- a/docs/design/a2a-protocol-integration.md
+++ b/docs/design/a2a-protocol-integration.md
@@ -1121,4 +1121,4 @@ Now the agent is discoverable by other agents and will appear in semantic search
 
 **FAISS Indexing**: Agents are automatically indexed for semantic search alongside MCP servers.
 
-This design enables autonomous agent ecosystems where agents discover and coordinate with each other while maintaining enterprise-grade security and access control.
+This design enables autonomous agent ecosystems where agents discover and coordinate with each other while maintaining security and access control features.

--- a/docs/design/architectural-decision-reverse-proxy-vs-application-layer-gateway.md
+++ b/docs/design/architectural-decision-reverse-proxy-vs-application-layer-gateway.md
@@ -87,7 +87,7 @@ AI Agent/Coding Assistant
 
 | Aspect | Reverse Proxy (Current) | Tools Gateway | Preferable Approach |
 |--------|-------------------------|---------------|-------------------|
-| Authentication | Nginx auth_request pattern = proven, battle-tested | Gateway must implement auth validation | Equivalent |
+| Authentication | Nginx auth_request pattern = proven, well-documented | Gateway must implement auth validation | Equivalent |
 | Authorization | Fine-grained scope validation per server/tool before routing | Can implement same fine-grained scopes | Equivalent |
 | Audit Trail | Complete Nginx access logs + auth server logs + IdP logs | Gateway logs all tool calls | Equivalent |
 | Attack Surface | Direct server access blocked, only authenticated routes exposed | Single endpoint, easier to monitor but single point of failure | Equivalent |
@@ -157,7 +157,7 @@ A tools gateway requires:
 
 Both architectures have merits:
 
-- **Reverse Proxy**: Better performance, proven scalability, protocol independence, battle-tested Nginx foundation, allows Python implementation due to Nginx handling message routing
+- **Reverse Proxy**: Better performance, proven scalability, protocol independence, established Nginx foundation, allows Python implementation due to Nginx handling message routing
 - **Tools Gateway**: Better developer experience, easier enterprise adoption, simpler operations, requires Go/Rust implementation for enterprise performance requirements
 
 The choice depends on organizational priorities:
@@ -168,4 +168,4 @@ The choice depends on organizational priorities:
 - **Developer experience-first organizations** (internal tooling, enterprise IT): Consider tools gateway but must invest in Go/Rust development expertise
 - **Hybrid organizations**: Implement both patterns and let teams choose
 
-The current implementation is production-ready and protocol-independent. The reverse proxy approach provides more architectural flexibility for future protocol support while allowing the team to continue developing in Python.
+The current implementation is suitable for deployment and protocol-independent. The reverse proxy approach provides more architectural flexibility for future protocol support while allowing the team to continue developing in Python.

--- a/docs/design/database-abstraction-layer.md
+++ b/docs/design/database-abstraction-layer.md
@@ -16,7 +16,7 @@
 
 ## Architecture Overview
 
-The MCP Gateway Registry implements a **repository pattern with abstract base classes** to provide a clean separation between business logic and data storage. This design enables seamless switching between file-based storage (legacy, backwards compatible) and DocumentDB/MongoDB (recommended, production-ready) without modifying application code.
+The MCP Gateway Registry implements a **repository pattern with abstract base classes** to provide a clean separation between business logic and data storage. This design enables seamless switching between file-based storage (legacy, backwards compatible) and DocumentDB/MongoDB (recommended) without modifying application code.
 
 ### System Diagram
 
@@ -375,7 +375,7 @@ registry/
 **Purpose:** Distributed document database for production deployments
 
 **Characteristics:**
-- **Scalability**: Clustered deployment for high availability (DocumentDB) or replica sets (MongoDB)
+- **Scalability**: Clustered deployment for redundancy (DocumentDB) or replica sets (MongoDB)
 - **Query Capabilities**: Rich aggregation pipelines, complex filtering, projections
 - **Vector Search**: Native vector search (DocumentDB) or application-level (MongoDB CE)
 - **Collection Management**: Automatic index creation with proper field mappings
@@ -415,7 +415,7 @@ Provides:
 - Hybrid search (BM25 + k-NN) for semantic understanding
 - Native vector support for embeddings
 - Scales to millions of documents
-- Production-ready
+- Recommended for deployment
 
 **Limitations:**
 - Requires DocumentDB cluster or MongoDB CE instance

--- a/docs/design/storage-architecture-mongodb-documentdb.md
+++ b/docs/design/storage-architecture-mongodb-documentdb.md
@@ -298,7 +298,7 @@ AWS DocumentDB is a MongoDB-compatible managed database service optimized for cl
 
 1. **DocumentDB Cluster**
    - Managed by AWS
-   - Multi-AZ deployment for high availability
+   - Multi-AZ deployment for redundancy
    - Auto-scaling read replicas
    - Automated backups and point-in-time recovery
 
@@ -417,7 +417,7 @@ The application code is identical, but DocumentDB executes it much faster.
      master_username         = var.master_username
      master_password         = var.master_password
 
-     # High availability
+     # Redundancy
      backup_retention_period = 7
      preferred_backup_window = "03:00-04:00"
 

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -19,7 +19,7 @@ Switch between providers with simple configuration changes - no code modificatio
 - **Backward Compatible**: Works seamlessly with existing FAISS indices
 - **Easy Configuration**: Simple environment variable setup
 - **Extensible**: Easy to add new providers
-- **Production-Ready**: Terraform support for AWS deployments
+- **AWS Deployable**: Terraform support for AWS deployments
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 <div align="center">
 <img src="img/mcp_gateway_horizontal_white_logo.png" alt="MCP Gateway Logo" width="100%">
 
-**Enterprise-Ready Gateway for AI Development Tools**
+**Gateway for AI Development Tools**
 
 </div>
 
-## Enterprise-Grade MCP Server & Registry
+## MCP Server & Registry
 
 A comprehensive solution for managing, securing, and accessing Model Context Protocol (MCP) servers at scale. Built for enterprises, development teams, and autonomous AI agents.
 
@@ -29,11 +29,11 @@ A comprehensive solution for managing, securing, and accessing Model Context Pro
 
 ## Key Features
 
-### Enterprise-Ready Architecture
+### Architecture Features
 - **Reverse Proxy**: Centralized access point for all MCP servers
 - **Service Discovery**: Automatic registration and health monitoring
 - **Load Balancing**: Intelligent request distribution across server instances
-- **High Availability**: Production-ready deployment patterns
+- **Multi-Instance Support**: Deployment patterns supporting redundancy
 
 ### Advanced Security & Authentication
 - **OAuth 2.0 Integration**: Amazon Cognito, Google, GitHub, and custom providers
@@ -250,7 +250,7 @@ Accelerate development workflows with integrated tooling:
 | [Complete Setup Guide](complete-setup-guide.md)<br/>Step-by-step from scratch on AWS EC2 | [Authentication Guide](auth.md)<br/>OAuth and identity provider integration | [AI Coding Assistants Setup](ai-coding-assistants-setup.md)<br/>VS Code, Cursor, Claude Code integration |
 | [Installation Guide](installation.md)<br/>Complete setup instructions for EC2 and EKS | [Amazon Cognito Setup](cognito.md)<br/>Step-by-step IdP configuration | [API Reference](registry_api.md)<br/>Programmatic registry management |
 | [Configuration Reference](configuration.md)<br/>Environment variables and settings | [Fine-Grained Access Control](scopes.md)<br/>Permission management and security | [Dynamic Tool Discovery](dynamic-tool-discovery.md)<br/>Autonomous agent capabilities |
-| | | [Production Deployment](installation.md)<br/>Complete setup for production environments |
+| | | [Deployment Guide](installation.md)<br/>Complete setup for deployment environments |
 | | | [Troubleshooting Guide](FAQ.md)<br/>Common issues and solutions |
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -562,7 +562,7 @@ graph TB
 
 ### Key Benefits of EKS Deployment
 
-- **High Availability**: Multi-AZ pod distribution
+- **Multi-AZ Support**: Pod distribution across availability zones
 - **Auto Scaling**: Horizontal pod autoscaling based on metrics
 - **Service Mesh**: Istio integration for advanced traffic management
 - **Observability**: Native integration with CloudWatch and Prometheus
@@ -649,5 +649,5 @@ For more troubleshooting help, see [Troubleshooting Guide](troubleshooting.md).
 
 - [Authentication Setup](auth.md) - Configure identity providers
 - [AI Assistant Integration](ai-coding-assistants-setup.md) - Setup development tools
-- [Production Deployment](production-deployment.md) - High availability configuration
+- [AWS ECS Deployment](../terraform/aws-ecs/README.md) - Multi-instance configuration
 - [API Reference](registry_api.md) - Programmatic management

--- a/docs/jwt-token-vending.md
+++ b/docs/jwt-token-vending.md
@@ -13,7 +13,7 @@ In enterprise scenarios, users often need to provide programmatic access to MCP 
 
 ## A Solution with Integrated Token Vending
 
-The JWT Token Vending Service provides an enterprise-ready solution that integrates directly with the existing MCP Gateway authentication infrastructure, allowing users to generate scoped JWT tokens through a familiar web interface.
+The JWT Token Vending Service integrates directly with the existing MCP Gateway authentication infrastructure, allowing users to generate scoped JWT tokens through a familiar web interface.
 
 Here is an architecture diagram showing how the token vending service integrates with the existing system:
 
@@ -405,7 +405,7 @@ The token generation interface provides:
 - **Usage Instructions**: Clear examples of how to use the generated token
 - **Security Warnings**: Prominent warnings about token storage and sharing
 
-By implementing the JWT Token Vending Service, organizations can provide their users with a secure, user-friendly way to generate programmatic access tokens while maintaining enterprise-grade security controls and comprehensive audit capabilities. The service seamlessly integrates with existing MCP Gateway infrastructure and provides a foundation for advanced token management features.
+By implementing the JWT Token Vending Service, organizations can provide their users with a secure, user-friendly way to generate programmatic access tokens while maintaining security controls and comprehensive audit capabilities. The service seamlessly integrates with existing MCP Gateway infrastructure and provides a foundation for advanced token management features.
 
 ## Integration with Token Refresh Service
 

--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -1027,7 +1027,7 @@ telnet localhost 8080
 
 You now have a fully functional MCP Gateway & Registry running on macOS! The system provides:
 
-- **Authentication**: Enterprise-grade Keycloak identity provider
+- **Authentication**: Keycloak identity provider
 - **Registry**: Web-based interface for managing MCP servers
 - **API Gateway**: Centralized access to multiple MCP servers
 - **Agent Support**: Ready for AI coding assistants and agents

--- a/docs/registry-auth-detailed.md
+++ b/docs/registry-auth-detailed.md
@@ -27,7 +27,7 @@ The MCP Gateway Registry implements a sophisticated dual-authentication system d
 
 - 🔐 **Dual Authentication**: Support for both traditional and OAuth2 flows
 - 🎯 **RBAC System**: Fine-grained role-based access control
-- 🏢 **Enterprise Ready**: Integration with Cognito and SAML providers
+- 🏢 **IdP Integration**: Integration with Cognito and SAML providers
 - 🔒 **Secure Sessions**: Encrypted, signed session cookies
 - 🎛️ **Dynamic UI**: Permission-based interface rendering
 - 📊 **Audit Logging**: Comprehensive authentication event tracking

--- a/release-notes/DISCLAIMER.md
+++ b/release-notes/DISCLAIMER.md
@@ -1,0 +1,6 @@
+# Release Notes Disclaimer
+
+The release notes in this directory describe features and capabilities at the time of release.
+Terms like "production-ready" or "enterprise-grade" describe design intent and should not be
+construed as warranties or guarantees. Users should perform their own testing and validation
+before deploying to their environments.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -37,7 +37,7 @@ For Kubernetes deployments on Amazon EKS, we recommend using the Helm charts wit
 
 **Why not Terraform for EKS here?**
 
-The [awslabs/ai-on-eks](https://github.com/awslabs/ai-on-eks) project provides production-ready, battle-tested Terraform blueprints specifically designed for AI/ML workloads on EKS. Rather than duplicate this excellent work, we recommend:
+The [awslabs/ai-on-eks](https://github.com/awslabs/ai-on-eks) project provides Terraform blueprints specifically designed for AI/ML workloads on EKS. Rather than duplicate this excellent work, we recommend:
 
 1. **Provision EKS cluster** using ai-on-eks blueprints:
    ```bash

--- a/terraform/aws-ecs/README.md
+++ b/terraform/aws-ecs/README.md
@@ -23,7 +23,7 @@ Production-grade infrastructure for the MCP Gateway Registry using AWS ECS Farga
 
 ### Network Architecture
 
-The infrastructure is deployed within a dedicated VPC spanning two availability zones for high availability. User traffic enters through Route 53 DNS resolution, directing requests to either the Main ALB (for Registry and Auth Server) or the Keycloak ALB (for identity management). AWS Certificate Manager provisions and manages SSL/TLS certificates for secure HTTPS communication.
+The infrastructure is deployed within a dedicated VPC spanning two availability zones for redundancy. User traffic enters through Route 53 DNS resolution, directing requests to either the Main ALB (for Registry and Auth Server) or the Keycloak ALB (for identity management). AWS Certificate Manager provisions and manages SSL/TLS certificates for secure HTTPS communication.
 
 ### Application Load Balancers
 
@@ -46,7 +46,7 @@ The infrastructure is deployed within a dedicated VPC spanning two availability 
 
 The infrastructure runs on an ECS cluster with Fargate launch type, eliminating server management. Three primary service types run as containerized tasks:
 
-**Registry Tasks** provide the core MCP server registry and discovery service. An auto-scaling group manages task count based on CPU and memory utilization, with tasks deployed across both availability zones for high availability. The registry retrieves secrets from AWS Secrets Manager for secure credential management, writes logs to CloudWatch Logs for centralized monitoring, and stores server metadata in DocumentDB for persistent, distributed access with native vector search capabilities.
+**Registry Tasks** provide the core MCP server registry and discovery service. An auto-scaling group manages task count based on CPU and memory utilization, with tasks deployed across both availability zones for redundancy. The registry retrieves secrets from AWS Secrets Manager for secure credential management, writes logs to CloudWatch Logs for centralized monitoring, and stores server metadata in DocumentDB for persistent, distributed access with native vector search capabilities.
 
 **Auth Server Tasks** handle OAuth2/OIDC authentication and authorization for the entire platform. These tasks manage user sessions and token validation, integrate with Keycloak for identity federation, and auto-scale based on demand. User data and session information is stored in Aurora PostgreSQL Serverless for reliable, scalable persistence.
 
@@ -54,9 +54,9 @@ The infrastructure runs on an ECS cluster with Fargate launch type, eliminating 
 
 ### Data Layer
 
-**Amazon Aurora PostgreSQL Serverless v2** provides a fully managed, auto-scaling database with capacity ranging from 0.5 to 2 ACUs based on workload demands. The database stores user credentials, session data, and application state with automatic backups and point-in-time recovery capabilities. Deployed in a multi-AZ configuration for high availability, Aurora uses RDS Proxy for efficient connection pooling and management across ECS tasks.
+**Amazon Aurora PostgreSQL Serverless v2** provides a fully managed, auto-scaling database with capacity ranging from 0.5 to 2 ACUs based on workload demands. The database stores user credentials, session data, and application state with automatic backups and point-in-time recovery capabilities. Deployed in a multi-AZ configuration for redundancy, Aurora uses RDS Proxy for efficient connection pooling and management across ECS tasks.
 
-**Amazon DocumentDB** (MongoDB-compatible) serves as the primary data store for the MCP Gateway Registry. DocumentDB provides distributed, scalable storage for server metadata, agent registrations, scopes, and security scan results. With native HNSW vector search support, DocumentDB enables sub-100ms semantic queries for server and agent discovery. The cluster automatically scales storage and replicates data across multiple availability zones for high availability and durability.
+**Amazon DocumentDB** (MongoDB-compatible) serves as the primary data store for the MCP Gateway Registry. DocumentDB provides distributed, scalable storage for server metadata, agent registrations, scopes, and security scan results. With native HNSW vector search support, DocumentDB enables sub-100ms semantic queries for server and agent discovery. The cluster automatically scales storage and replicates data across multiple availability zones for redundancy and durability.
 
 ### Observability
 


### PR DESCRIPTION
## Summary

Refines documentation language across 24 files to focus on specific capabilities rather than broad marketing-style claims.

- Replace "production-ready" with descriptive alternatives
- Replace "enterprise-ready/grade" with feature descriptions  
- Replace "battle-tested" with "well-documented" or "established"
- Replace "high availability" with "redundancy" or architecture descriptions
- Remove SLA claims from example documentation
- Fix broken links to non-existent `production-deployment.md`
- Add release-notes/DISCLAIMER.md for historical release notes
- Rename "Production Deployment" section headers to "Deployment Options/Guide"

## Test plan

- [x] Verified no remaining instances of "production-ready" in docs (excluding release-notes)
- [x] Verified no remaining instances of "enterprise-ready/grade" in docs
- [x] Verified no remaining instances of "battle-tested" in docs
- [x] Verified no remaining instances of "high availability" guarantee language
- [x] Verified no SLA percentage claims remain
- [x] Fixed broken links to production-deployment.md

Fixes #504