### PR TITLE
fix: Nginx config would not load on startup due to the amount of variables in the file

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -1,6 +1,11 @@
 # Nginx configuration directive for handling long server names
 server_names_hash_bucket_size 128;
 
+# Variables hash configuration - needed for large number of auth_request_set variables
+# With multiple location blocks each setting 5+ variables, we need larger hash tables
+variables_hash_max_size 2048;
+variables_hash_bucket_size 128;
+
 # Lua shared dictionary for metrics collection (10MB)
 lua_shared_dict metrics_buffer 10m;
 

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -1,6 +1,11 @@
 # Nginx configuration directive for handling long server names
 server_names_hash_bucket_size 128;
 
+# Variables hash configuration - needed for large number of auth_request_set variables
+# With multiple location blocks each setting 5+ variables, we need larger hash tables
+variables_hash_max_size 2048;
+variables_hash_bucket_size 128;
+
 # Lua shared dictionary for metrics collection (10MB)
 lua_shared_dict metrics_buffer 10m;
 


### PR DESCRIPTION
*Description of changes:*
```
2026-02-19 18:42:35,089,p114,{nginx_service.py:358},ERROR,Failed to reload Nginx: 2026/02/19 18:42:35 [warn] 132#132: could not build optimal variables_hash, you should increase either variables_hash_max_size: 1024 or variables_hash_bucket_size: 64; ignoring variables_hash_bucket_size
```

When starting the registry server in Kubernetes, was unable to interact with the registry API.
Upon further investigation this was because the `{{ROOT_PATH}}` was being set to an empty string, even though the ENV VAR was correctly set.
Other variables, including `{{ANTHROPIC_API_VERSION}}` were being left uninterpolated in the final NGINX config.
Reading online it seems the amount of variables may have reached the default limits.

Willing to change the final values, was just updated to match the error output.
NGINX now correctly restarts with the config and the API routes correctly - `{{ROOT_PATH}}` is correctly interpolated

Can create an issue on request