### PR TITLE
bug: Handle duplicate inserts into the audit events DB

### DIFF
--- a/registry/repositories/audit_repository.py
+++ b/registry/repositories/audit_repository.py
@@ -235,7 +235,8 @@ class DocumentDBAuditRepository(AuditRepositoryBase):
             record: The audit record to insert (RegistryApiAccessRecord or MCPServerAccessRecord)
 
         Returns:
-            True if inserted successfully, False otherwise
+            True if inserted successfully or if the record already exists (duplicate request_id),
+            False if an unexpected error occurs
         """
         logger.debug(
             f"DocumentDB WRITE: Inserting audit event with request_id={record.request_id}"
@@ -255,7 +256,7 @@ class DocumentDBAuditRepository(AuditRepositoryBase):
                 f"DocumentDB WRITE: Inserted audit event request_id={record.request_id}"
             )
             return True
-        except DuplicateKeyError as e:
+        except DuplicateKeyError:
             logger.debug(
                 f"DocumentDB WRITE: Skipped duplicate audit event for request_id={record.request_id}. "
                 f"This occurs when the same request_id is processed twice (auth validation + endpoint execution). "

--- a/tests/unit/audit/test_audit_repository.py
+++ b/tests/unit/audit/test_audit_repository.py
@@ -5,6 +5,7 @@ Validates: Requirements 6.1, 6.2
 """
 
 from datetime import datetime, timezone
+from pymongo.errors import DuplicateKeyError
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -34,19 +35,19 @@ class TestFind:
         mock_cursor.sort = MagicMock(return_value=mock_cursor)
         mock_cursor.skip = MagicMock(return_value=mock_cursor)
         mock_cursor.limit = MagicMock(return_value=mock_cursor)
-        
+
         test_docs = [{"request_id": "req-1"}, {"request_id": "req-2"}]
         async def async_iter():
             for doc in test_docs:
                 yield doc
         mock_cursor.__aiter__ = lambda self: async_iter()
         mock_collection.find = MagicMock(return_value=mock_cursor)
-        
+
         with patch.object(DocumentDBAuditRepository, '_get_collection', new_callable=AsyncMock, return_value=mock_collection):
             repo = DocumentDBAuditRepository()
             repo._collection = mock_collection
             results = await repo.find({})
-            
+
             assert len(results) == 2
 
     async def test_applies_pagination(self):
@@ -56,18 +57,18 @@ class TestFind:
         mock_cursor.sort = MagicMock(return_value=mock_cursor)
         mock_cursor.skip = MagicMock(return_value=mock_cursor)
         mock_cursor.limit = MagicMock(return_value=mock_cursor)
-        
+
         async def async_iter():
             return
             yield
         mock_cursor.__aiter__ = lambda self: async_iter()
         mock_collection.find = MagicMock(return_value=mock_cursor)
-        
+
         with patch.object(DocumentDBAuditRepository, '_get_collection', new_callable=AsyncMock, return_value=mock_collection):
             repo = DocumentDBAuditRepository()
             repo._collection = mock_collection
             await repo.find({}, limit=25, offset=50)
-            
+
             mock_cursor.skip.assert_called_once_with(50)
             mock_cursor.limit.assert_called_once_with(25)
 
@@ -79,13 +80,13 @@ class TestInsert:
         """insert() writes the audit record to MongoDB."""
         mock_collection = AsyncMock()
         mock_collection.insert_one.return_value = MagicMock(inserted_id="new_id")
-        
+
         with patch.object(DocumentDBAuditRepository, '_get_collection', return_value=mock_collection):
             repo = DocumentDBAuditRepository()
             repo._collection = mock_collection
-            
+
             result = await repo.insert(make_test_record())
-            
+
             assert result is True
             mock_collection.insert_one.assert_called_once()
 
@@ -93,11 +94,24 @@ class TestInsert:
         """insert() returns False when an error occurs."""
         mock_collection = AsyncMock()
         mock_collection.insert_one.side_effect = Exception("Database error")
-        
+
         with patch.object(DocumentDBAuditRepository, '_get_collection', return_value=mock_collection):
             repo = DocumentDBAuditRepository()
             repo._collection = mock_collection
-            
+
             result = await repo.insert(make_test_record())
-            
+
             assert result is False
+
+    async def test_returns_true_on_duplicate_key(self):
+        """insert() returns True when a duplicate audit event already exists."""
+        mock_collection = AsyncMock()
+        mock_collection.insert_one.side_effect = DuplicateKeyError("duplicate key error")
+
+        with patch.object(DocumentDBAuditRepository, '_get_collection', return_value=mock_collection):
+            repo = DocumentDBAuditRepository()
+            repo._collection = mock_collection
+
+            result = await repo.insert(make_test_record())
+
+            assert result is True


### PR DESCRIPTION
### **Description of changes:**
When the auth-server receives a request it inserts the request ID into the DB as an audit event.
Many of the registry APIs also insert the same data into the DB with the same ID, which emits an error each time, since the nginx request ID is identical in both cases.

This change returns true on audit events that already exist in the DB, rather than emitting an error on each API call, which can make debugging harder than it should be.

### **Alternatives with more code changes**
The code could be changed to `upsert` or update the audit DB entry, since it needs to go through validation and onto the registry API anyway.
Or we could remove the audit logic from one or more parts of the code

Can create an issue on request