### PR TITLE
Bug: Auth-Server admin username / password was missing from the Helm Chart

### DIFF
--- a/charts/auth-server/templates/secret.yaml
+++ b/charts/auth-server/templates/secret.yaml
@@ -66,6 +66,10 @@ data:
   REGISTRY_ROOT_PATH: {{ $registryRootPath | b64enc | quote }}
   SESSION_COOKIE_SECURE: {{ .Values.app.sessionCookieSecure | toString | b64enc | quote }}
   SESSION_COOKIE_DOMAIN: {{ printf ".%s" $domain | b64enc | quote }}
+  {{- if .Values.app.adminUser}}
+  ADMIN_USER: {{ .Values.app.adminUser | b64enc | quote }}
+  ADMIN_PASSWORD: {{ required "app.adminPassword or global.adminPassword is required" (.Values.global.adminPassword | default .Values.app.adminPassword) | b64enc | quote }}
+  {{- end }}
 {{- if not .Values.global.sharedSecretName }}
   {{/* Federation and SECRET_KEY managed per-chart in standalone deployment */}}
   {{- if $federationEnabled }}

--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -22,6 +22,11 @@ app:
   sessionCookieDomain: ""  # Auto-inferred from Host header if empty
   sessionCookieSecure: true
 
+  # Admin credentials for reload-scopes endpoint
+  # adminUser: "admin"
+  # adminPassword: REQUIRED - must be set for /internal/reload-scopes endpoint
+  # adminPassword: "your-secure-admin-password"
+
   # Federation configuration
   federationStaticTokenAuthEnabled: false #If not provided, defaults to false
   federationStaticToken: # If not provided, a random token is auto-generated

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -159,6 +159,12 @@ registry:
 auth-server:
   app:
     replicas: 2 # set to > 1 replica for high availability
+    # Admin credentials for auth-server reload-scopes endpoint
+    # adminPassword: REQUIRED for /internal/reload-scopes endpoint functionality
+    # adminUser defaults to "admin" if not specified
+    # adminUser: "admin"
+    # Uncomment and set a secure password:
+    # adminPassword: password
 
   keycloak:
     enabled: true


### PR DESCRIPTION
*Description of changes:*
This is required for at least one endpoint. This PR allows adding a username and password, which is currently only used for one internal API. Does not set a default, however if `adminUser` is set then `adminPassword` must also be set.

Unsure if this was previously part of the `.env` config docs and just missing from the Helm Chart

Can create an issue on request
