### PR TITLE
Feature: Allow Helm Chart to not deploy the keycloak-ingress-patch

### DIFF
--- a/charts/mcp-gateway-registry-stack/templates/keycloak-ingress-patch.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/keycloak-ingress-patch.yaml
@@ -1,7 +1,7 @@
 # This template patches the Keycloak ingress hostname to use the global domain
 # Only deployed when the auth provider is keycloak (not entra)
-{{- if .Values.global.ingress.enabled }}
 {{- if eq .Values.global.authProvider.type "keycloak" }}
+{{- if .Values.keycloakIngress.enabled }}
 {{- $routingMode := .Values.global.ingress.routingMode | default "subdomain" }}
 {{- $pathPrefix := .Values.global.ingress.paths.keycloak | default "/keycloak" }}
 apiVersion: networking.k8s.io/v1

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -34,7 +34,6 @@ global:
 
   # Common ingress settings
   ingress:
-    enabled: true
     inboundCidrs: # optional comma separated list of allowed inbound CIDR ranges
     className: alb
     tls: true
@@ -138,6 +137,11 @@ keycloak-configure:
     realm: mcp-gateway
     adminUser: user
   # authServer.externalUrl will be templated in the subchart using global.domain
+
+# Keycloak ingress for mcp-gateway-registry
+# Whether to create an ingress for Keycloak with this Chart (only applicable when keycloak.create: true)
+keycloakIngress:
+  enabled: true
 
 # Mongodb configuration job
 mongodb-configure:


### PR DESCRIPTION
*Description of changes:*
All other ingresses that can be deployed can be disabled, adding variables to allow this for the patch also.
Useful when cluster has a service-mesh controlling this functionality (e.g istio as mentioned in the documentation)

