### PR TITLE
fix: Bandit B104 findings across 11 files (#520)

### DIFF
--- a/agents/a2a/src/flight-booking-agent/env_settings.py
+++ b/agents/a2a/src/flight-booking-agent/env_settings.py
@@ -30,7 +30,7 @@ class EnvSettings:
         self.agent_url: str = os.getenv("AGENTCORE_RUNTIME_URL", "http://127.0.0.1:9000/")
 
         # Server configuration (fixed for A2A protocol)
-        self.host: str = "0.0.0.0"
+        self.host: str = os.getenv("AGENT_HOST", "0.0.0.0")  # nosec B104
         self.port: int = 9000
 
         logger.info(f"EnvSettings initialized: agent_name={self.agent_name}, version={self.agent_version}")

--- a/agents/a2a/src/travel-assistant-agent/env_settings.py
+++ b/agents/a2a/src/travel-assistant-agent/env_settings.py
@@ -30,7 +30,7 @@ class EnvSettings:
         self.agent_url: str = os.getenv("AGENTCORE_RUNTIME_URL", "http://127.0.0.1:9000/")
 
         # Server configuration (fixed for A2A protocol)
-        self.host: str = "0.0.0.0"
+        self.host: str = os.getenv("AGENT_HOST", "0.0.0.0")  # nosec B104
         self.port: int = 9000
 
         # Keycloak configuration for M2M authentication

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2112,8 +2112,8 @@ def parse_arguments():
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
-        help="Host for the server to listen on (default: 0.0.0.0)",
+        default=os.getenv("AUTH_SERVER_HOST", "127.0.0.1"),  # nosec B104
+        help="Host for the server to listen on (default: 127.0.0.1, override with AUTH_SERVER_HOST env var)",
     )
 
     parser.add_argument(

--- a/metrics-service/app/config.py
+++ b/metrics-service/app/config.py
@@ -12,7 +12,7 @@ class Settings:
     
     # Service settings
     METRICS_SERVICE_PORT: int = int(os.getenv("METRICS_SERVICE_PORT", "8890"))
-    METRICS_SERVICE_HOST: str = os.getenv("METRICS_SERVICE_HOST", "0.0.0.0")
+    METRICS_SERVICE_HOST: str = os.getenv("METRICS_SERVICE_HOST", "0.0.0.0")  # nosec B104
     
     # OpenTelemetry settings
     OTEL_SERVICE_NAME: str = os.getenv("OTEL_SERVICE_NAME", "mcp-metrics-service")

--- a/metrics-service/app/otel/exporters.py
+++ b/metrics-service/app/otel/exporters.py
@@ -43,7 +43,7 @@ def setup_otel():
         # Setup Prometheus exporter if enabled
         if settings.OTEL_PROMETHEUS_ENABLED:
             # Start Prometheus HTTP server
-            start_http_server(port=settings.OTEL_PROMETHEUS_PORT, addr="0.0.0.0")
+            start_http_server(port=settings.OTEL_PROMETHEUS_PORT, addr=settings.METRICS_SERVICE_HOST)  # nosec B104
 
             # Create PrometheusMetricReader (no endpoint parameter needed)
             prometheus_reader = PrometheusMetricReader()

--- a/registry/main.py
+++ b/registry/main.py
@@ -662,7 +662,7 @@ if __name__ == "__main__":
     import uvicorn
     uvicorn.run(
         "registry.main:app", 
-        host="0.0.0.0", 
+        host=os.getenv("REGISTRY_HOST", "127.0.0.1"),  # nosec B104
         port=7860, 
         reload=True,
         log_level="info",

--- a/servers/currenttime/server.py
+++ b/servers/currenttime/server.py
@@ -46,7 +46,7 @@ logger.info(f"Parsed arguments - port: {args.port}, transport: {args.transport}"
 logger.info(f"Environment variables - MCP_TRANSPORT: {os.environ.get('MCP_TRANSPORT', 'NOT SET')}, MCP_SERVER_LISTEN_PORT: {os.environ.get('MCP_SERVER_LISTEN_PORT', 'NOT SET')}")
 
 # Initialize FastMCP server
-mcp = FastMCP("CurrentTimeAPI", host="0.0.0.0", port=int(args.port))
+mcp = FastMCP("CurrentTimeAPI", host="0.0.0.0", port=int(args.port))  # nosec B104
 mcp.settings.mount_path = "/currenttime"
 
 

--- a/servers/example-server/server.py
+++ b/servers/example-server/server.py
@@ -48,7 +48,7 @@ logger.info(f"Parsed arguments - port: {args.port}, transport: {args.transport}"
 logger.info(f"Environment variables - MCP_TRANSPORT: {os.environ.get('MCP_TRANSPORT', 'NOT SET')}, MCP_SERVER_LISTEN_PORT: {os.environ.get('MCP_SERVER_LISTEN_PORT', 'NOT SET')}")
 
 # Initialize FastMCP server
-mcp = FastMCP("ExampleMCPServer", host="0.0.0.0", port=int(args.port))
+mcp = FastMCP("ExampleMCPServer", host="0.0.0.0", port=int(args.port))  # nosec B104
 mcp.settings.mount_path = "/example-server"
 
 

--- a/servers/fininfo/server.py
+++ b/servers/fininfo/server.py
@@ -572,7 +572,7 @@ def main():
     # Run the server with the specified transport from command line args
     # FastMCP 2.0 handles port and host in the run method
     logger.info(f"Starting fininfo server on port {args.port} with transport {args.transport}")
-    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port), path="/sse")
+    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port), path="/sse")  # nosec B104
 
 if __name__ == "__main__":
     main()

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -2082,7 +2082,7 @@ def main():
     logger.info(f"Server will be available at: http://localhost:{args.port}{endpoint}")
 
     # Run the server with the specified transport from command line args
-    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port))
+    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port))  # nosec B104
 
 
 if __name__ == "__main__":

--- a/servers/realserverfaketools/server.py
+++ b/servers/realserverfaketools/server.py
@@ -605,7 +605,7 @@ def main():
     logger.info(f"Server will be available at: http://localhost:{args.port}{endpoint}")
     
     # Run the server with the specified transport from command line args
-    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port))
+    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port))  # nosec B104
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue: #520 (sub-issue of #519)*

## Summary

Running `bandit -r . -t B104` reported 11 unaddressed B104 (hardcoded_bind_all_interfaces) findings across Python files that bind to `0.0.0.0`. This PR resolves all 11 findings using a three-category approach while preserving all container runtime behavior.

## Changes

**Category 1 — Already configurable (1 file):**
- `metrics-service/app/config.py`: Add `# nosec B104` to the existing `os.getenv` line

**Category 2 — Make configurable via env var (4 files):**
- `auth_server/server.py`: `--host` default → `os.getenv("AUTH_SERVER_HOST", "127.0.0.1")`
- `registry/main.py`: host → `os.getenv("REGISTRY_HOST", "127.0.0.1")`
- `agents/a2a/src/flight-booking-agent/env_settings.py`: host → `os.getenv("AGENT_HOST", "0.0.0.0")`
- `agents/a2a/src/travel-assistant-agent/env_settings.py`: same as above

**Category 3 — Container-only, add suppression comment (6 files):**
- `metrics-service/app/otel/exporters.py`: Replace hardcoded `addr="0.0.0.0"` with `settings.METRICS_SERVICE_HOST`
- `servers/currenttime/server.py`, `servers/example-server/server.py`, `servers/fininfo/server.py`, `servers/mcpgw/server.py`, `servers/realserverfaketools/server.py`: Add `# nosec B104`

## Verification

- `bandit -r agents auth_server metrics-service registry servers -t B104` reports **0 findings**
- Docker entrypoints (`auth-entrypoint.sh`, `registry-entrypoint.sh`) pass `--host 0.0.0.0` explicitly, bypassing Python defaults — container behavior unchanged
- `docker-compose.yml` still sets `METRICS_SERVICE_HOST=0.0.0.0` — metrics service unchanged
- Agent default stays `0.0.0.0` since agents are always containerized
