### PR TITLE
fix(security): add missing request timeouts (Bandit B113)

### DIFF
--- a/agents/a2a/test/agent_discovery_test.py
+++ b/agents/a2a/test/agent_discovery_test.py
@@ -49,7 +49,7 @@ class AgentTester:
             },
         }
 
-        response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"})
+        response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"}, timeout=60)
         return response.json()
 
     def extract_response_text(self, response):

--- a/agents/a2a/test/agent_simple_test.py
+++ b/agents/a2a/test/agent_simple_test.py
@@ -92,7 +92,7 @@ class AgentTester:
             logger.debug(f"[REQUEST] Payload:\n{json.dumps(payload, indent=2)}")
 
             start_time = time.time()
-            response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"})
+            response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"}, timeout=60)
             response_time = time.time() - start_time
 
             response_json = response.json()
@@ -204,9 +204,9 @@ class AgentTester:
 
         start_time = time.time()
         if method.upper() == "GET":
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=60)
         else:
-            response = requests.post(url, params=params)
+            response = requests.post(url, params=params, timeout=60)
         response_time = time.time() - start_time
 
         response_json = response.json()

--- a/agents/a2a/test/simple_agents_test.py
+++ b/agents/a2a/test/simple_agents_test.py
@@ -92,7 +92,7 @@ class AgentTester:
             logger.debug(f"[REQUEST] Payload:\n{json.dumps(payload, indent=2)}")
 
             start_time = time.time()
-            response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"})
+            response = requests.post(endpoint, json=payload, headers={"Content-Type": "application/json"}, timeout=60)
             response_time = time.time() - start_time
 
             response_json = response.json()
@@ -204,9 +204,9 @@ class AgentTester:
 
         start_time = time.time()
         if method.upper() == "GET":
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=60)
         else:
-            response = requests.post(url, params=params)
+            response = requests.post(url, params=params, timeout=60)
         response_time = time.time() - start_time
 
         response_json = response.json()

--- a/agents/cli_user_auth.py
+++ b/agents/cli_user_auth.py
@@ -176,7 +176,7 @@ class OAuthCallbackHandler(BaseHTTPRequestHandler):
                 'code_verifier': pkce_verifier
             }
             
-            response = requests.post(TOKEN_URL, headers=headers, data=data)
+            response = requests.post(TOKEN_URL, headers=headers, data=data, timeout=30)
             response.raise_for_status()
             
             token_data = response.json()

--- a/agents/client.py
+++ b/agents/client.py
@@ -206,7 +206,7 @@ def main():
     
     # Example: Check server health
     try:
-        health_response = requests.get(f"{args.server_url}/health")
+        health_response = requests.get(f"{args.server_url}/health", timeout=30)
         health_response.raise_for_status()
         logger.info(f"Server health: {health_response.json()}")
     except Exception as e:
@@ -270,7 +270,7 @@ def main():
     
     try:
         # Call the validate endpoint
-        validate_response = requests.post(f"{args.server_url}/validate", headers=headers)
+        validate_response = requests.post(f"{args.server_url}/validate", headers=headers, timeout=30)
         validate_response.raise_for_status()
         result = validate_response.json()
         
@@ -292,7 +292,7 @@ def main():
     
     # Example: Get auth configuration
     try:
-        config_response = requests.get(f"{args.server_url}/config")
+        config_response = requests.get(f"{args.server_url}/config", timeout=30)
         config_response.raise_for_status()
         auth_config = config_response.json()
         

--- a/cli/mcp_client.py
+++ b/cli/mcp_client.py
@@ -162,7 +162,7 @@ def _load_m2m_credentials() -> Optional[str]:
     }
 
     try:
-        response = requests.post(token_url, data=data)
+        response = requests.post(token_url, data=data, timeout=30)
         response.raise_for_status()
         token_data = response.json()
         return token_data.get('access_token')

--- a/cli/test_asor_complete.py
+++ b/cli/test_asor_complete.py
@@ -45,7 +45,7 @@ def get_token():
     }
     
     try:
-        response = requests.post(token_url, data=data)
+        response = requests.post(token_url, data=data, timeout=30)
         if response.status_code == 200:
             tokens = response.json()
             access_token = tokens.get('access_token')

--- a/credentials-provider/agentcore-auth/generate_access_token.py
+++ b/credentials-provider/agentcore-auth/generate_access_token.py
@@ -124,7 +124,7 @@ def _get_cognito_token(
             "scope": "invoke:gateway",
         }
         # Send as JSON for Auth0
-        response_method = lambda: requests.post(url, headers=headers, json=data)
+        response_method = lambda: requests.post(url, headers=headers, json=data, timeout=30)
     else:
         # Cognito format
         url = f"{cognito_domain_url.rstrip('/')}/oauth2/token"
@@ -135,7 +135,7 @@ def _get_cognito_token(
             "client_secret": client_secret,
         }
         # Send as form data for Cognito
-        response_method = lambda: requests.post(url, headers=headers, data=data)
+        response_method = lambda: requests.post(url, headers=headers, data=data, timeout=30)
 
     try:
         # Make the request
@@ -332,7 +332,8 @@ def generate_access_token(
             logger.info(f"Token generation completed successfully! Egress token saved to {saved_path}")
 
         except Exception as e:
-            logger.error(f"Failed to generate token for {server_name or f'config_{config['index']}'}: {e}")
+            config_label = server_name or f"config_{config['index']}"
+            logger.error(f"Failed to generate token for {config_label}: {e}")
             if not generate_all:
                 raise
 

--- a/credentials-provider/keycloak/generate_tokens.py
+++ b/credentials-provider/keycloak/generate_tokens.py
@@ -100,7 +100,7 @@ class TokenGenerator:
         }
 
         try:
-            response = requests.post(token_url, data=data, headers=headers)
+            response = requests.post(token_url, data=data, headers=headers, timeout=30)
             response.raise_for_status()
 
             token_data = response.json()


### PR DESCRIPTION
*Issue #518 (sub-issue of #519)*

*Description of changes:*

Add explicit `timeout` parameters to 16 HTTP requests across 9 files flagged by Bandit B113 (`request_without_timeout`). Requests without timeouts can hang indefinitely if the remote server is unresponsive, leading to resource exhaustion or application hangs.

Production code: `timeout=30`. Test files: `timeout=60` (slower environments).

| File | Occurrences | Timeout |
|------|-------------|---------|
| `agents/a2a/test/agent_discovery_test.py` | 1 | 60s |
| `agents/a2a/test/agent_simple_test.py` | 3 | 60s |
| `agents/a2a/test/simple_agents_test.py` | 3 | 60s |
| `agents/cli_user_auth.py` | 1 | 30s |
| `agents/client.py` | 3 | 30s |
| `cli/mcp_client.py` | 1 | 30s |
| `cli/test_asor_complete.py` | 1 | 30s |
| `credentials-provider/agentcore-auth/generate_access_token.py` | 2 | 30s |
| `credentials-provider/keycloak/generate_tokens.py` | 1 | 30s |

Additionally fixed a pre-existing `SyntaxError` in `credentials-provider/agentcore-auth/generate_access_token.py`:
- Nested f-string with dict bracket access incompatible with Python < 3.12 (extracted to local variable)

## Validation

### Bandit B113 scan (targeted files)

```
$ uv run bandit -t B113 <all 9 files>

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 2379
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
        Total issues (by confidence):
                Undefined: 0
                Low: 0
                Medium: 0
                High: 0
Files skipped (0):
```

### Full unit test suite

```
$ uv run pytest tests/unit/ -v
===== 17 failed, 1326 passed, 11 skipped, 12 warnings in 152.44s (0:02:32) =====
```

All 17 failures are **pre-existing on `main`** and unrelated to this change:

- **3 config tests** (`test_config.py`): Local `.env` sets `EMBEDDINGS_PROVIDER=litellm` which overrides the `sentence-transformers` default the tests expect. Tests don't isolate from environment variables -- passes in clean CI.
- **14 FAISS tests** (`test_faiss_service.py`): FAISS index dimension mismatch caused by the same LiteLLM override producing different embedding dimensions than the expected 384-dim `sentence-transformers` default.

No new failures introduced by this PR.

Closes #518

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
