### PR TITLE
fix: Replace try-except-pass with proper error handling (Bandit B110) (#521)

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1173,8 +1173,8 @@ class RegistryClient:
                 try:
                     error_detail = response.json()
                     logger.error(f"Validation error details: {json.dumps(error_detail, indent=2)}")
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.warning(f"Could not parse 422 error response as JSON: {e}")
             raise
         return response
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1028,9 +1028,9 @@ class SimplifiedCognitoValidator:
             if unverified_claims.get("iss") == JWT_ISSUER:
                 logger.debug("Token appears to be self-signed, validating...")
                 return self.validate_self_signed_token(access_token)
-        except Exception:
+        except Exception as e:
             # Not our token or malformed, continue to Cognito validation
-            pass
+            logger.debug(f"Token is not self-signed or malformed, falling back to Cognito: {e}")
 
         # Try JWT validation with Cognito
         try:

--- a/cli/test_asor_complete.py
+++ b/cli/test_asor_complete.py
@@ -103,8 +103,8 @@ def test_agent_definition_crud(token):
                 print("   " + "="*50)
                 print(json.dumps(agent, indent=2))
                 print("   " + "="*50)
-        except:
-            pass
+        except Exception as e:
+            print(f"⚠️ Failed to parse agent list response: {e}")
     else:
         print(f"❌ Failed: {status} - {response[:200]}")
 

--- a/credentials-provider/token_refresher.py
+++ b/credentials-provider/token_refresher.py
@@ -778,8 +778,8 @@ def _generate_vscode_config(
         if 'temp_path' in locals():
             try:
                 os.unlink(temp_path)
-            except:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to clean up temp file: {e}")
         return False
 
 
@@ -855,8 +855,8 @@ def _generate_roocode_config(
         if 'temp_path' in locals():
             try:
                 os.unlink(temp_path)
-            except:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to clean up temp file: {e}")
         return False
 
 
@@ -1105,8 +1105,8 @@ Examples:
                         logger.error(f"Another token refresher instance is already running (PID: {existing_pid})")
                         logger.error("Use --no-kill flag to prevent automatic killing, or stop the existing instance first")
                         sys.exit(1)
-                except:
-                    pass  # Invalid PID file, continue
+                except Exception as e:
+                    logger.debug(f"Invalid PID file, continuing: {e}")
         else:
             # Kill existing instance if found
             killed = _kill_existing_instance()

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -223,8 +223,8 @@ class HealthMonitoringService:
         for conn in connections:
             try:
                 close_tasks.append(conn.close())
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Error closing WebSocket connection during shutdown: {e}")
                 
         if close_tasks:
             await asyncio.gather(*close_tasks, return_exceptions=True)

--- a/registry/utils/entra_manager.py
+++ b/registry/utils/entra_manager.py
@@ -345,8 +345,8 @@ async def _add_service_principal_to_group(
         try:
             error_detail = response.json()
             logger.debug(f"Error details: {error_detail}")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Could not parse error response from Entra: {e}")
         return
 
     logger.warning(

--- a/scripts/manage-documentdb.py
+++ b/scripts/manage-documentdb.py
@@ -207,8 +207,8 @@ async def list_collections(
                 size_bytes = stats.get("size", 0)
                 size_mb = size_bytes / (1024 * 1024)
                 print(f"  Size: {size_mb:.2f} MB")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Could not retrieve collection stats for {coll_name}: {e}")
 
         print("\n" + "=" * 100)
 


### PR DESCRIPTION
*Issue: #521 (sub-issue of #519)*

### Summary

Running `bandit -r . -t B110` reported 9 unaddressed B110 (`try_except_pass`) findings across Python files where exceptions are silently swallowed with `try/except/pass`. This PR resolves all 9 findings by adding proper error handling with appropriate log levels while preserving existing behavior.

### Changes

**Category 1 — Warning-level logging (3 files):**

- `api/registry_client.py`: Log warning when 422 error response body can't be parsed as JSON
- `registry/utils/entra_manager.py`: Log warning when Entra error response can't be parsed
- `scripts/manage-documentdb.py`: Log warning when `collStats` command fails for a collection

**Category 2 — Debug-level logging (3 files):**

- `auth_server/server.py`: Log debug when token isn't self-signed (expected fallback to Cognito)
- `credentials-provider/token_refresher.py`: Log debug for temp file cleanup failures (2 occurrences) and invalid PID file (1 occurrence)
- `registry/health/service.py`: Log debug when WebSocket connection can't be closed during shutdown

**Category 3 — Print-based logging (1 file):**

- `cli/test_asor_complete.py`: Replace bare `except: pass` with `except Exception as e: print(...)` to match existing print-based output style in test script

#### Update (post-rebase)
Rebased on current main. B104 changes (previously included) have been dropped as they were already merged via PR #534. This PR now contains only the B110 fixes across 7 files.


### Verification

- `bandit -r . -t B110` reports 0 findings across all 7 affected files
- No bare `except:` clauses remain
- No behavioral changes — all exception handling paths preserved
- Log levels chosen based on operational relevance: `warning` for actionable failures, `debug` for expected fallback/cleanup paths
