### PR TITLE
fix: resolve ECS Service Connect dual-stack DNS failures in registry entrypoint

### DIFF
--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -629,6 +629,12 @@ module "ecs_service_registry" {
         {
           name  = "METRICS_SERVICE_URL"
           value = var.enable_observability ? "http://metrics-service:8890" : ""
+        },
+        # Service Connect namespace for FQDN alias injection in entrypoint.
+        # Enables Python health checker to resolve both short names and FQDNs.
+        {
+          name  = "SERVICE_CONNECT_NAMESPACE"
+          value = aws_service_discovery_private_dns_namespace.mcp.name
         }
       ]
 


### PR DESCRIPTION
## Summary

Fixes two DNS resolution failures caused by ECS Service Connect dual-stack (IPv4 + IPv6) virtual IP injection. These affect any ECS Terraform deployment with `enable_observability = true`.

Closes #547. Related: #491, #496.

## Changes

**`docker/registry-entrypoint.sh`** (2 new blocks + 1 config change):

1. **Resolve `METRICS_SERVICE_URL` to IPv4 before nginx starts.** Lua cosockets use the nginx `resolver` directive (VPC DNS), which cannot resolve Service Connect hostnames. `getent ahostsv4` pins the hostname to its IPv4 Service Connect VIP (e.g., `127.255.0.6`), bypassing DNS entirely.

2. **Inject FQDN aliases into `/etc/hosts`.** Service Connect only registers short names (`auth-server`), but servers may be registered with Cloud Map FQDNs (`auth-server.mcp-gateway.local`). Appends `{ip} {name}.{namespace}` entries so both formats resolve. Gated on `SERVICE_CONNECT_NAMESPACE` env var -- only runs in ECS Terraform deployments.

3. **Raise nginx `error_log` to `warn` level.** The default `error` level suppresses Lua timer messages, silently hiding the metrics flush failure.

**`terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf`**:

4. **Pass `SERVICE_CONNECT_NAMESPACE`** env var to the registry container, sourced from the Cloud Map namespace name.

## Deployment scenarios

| Deployment | SERVICE_CONNECT_NAMESPACE set? | 127.255.0.x in /etc/hosts? | Effect |
|---|---|---|---|
| Docker Compose (local dev) | No | No | Skipped entirely |
| Kubernetes/Helm | No | No | Skipped entirely |
| ECS without Service Connect | No | No | Skipped entirely |
| ECS with Service Connect (TF) | Yes (we set it) | Yes | Adds FQDN aliases -- intended behavior |
| CloudFormation ECS | No (unless added) | Yes | Skipped (env var not set) |

## Note for maintainers

This PR was tested using a fork branch build. The `codebuild.tf` in this branch temporarily points to `WPrintz/mcp-gateway-registry` for image builds. **Do not merge `codebuild.tf` changes from this branch** -- only `docker/registry-entrypoint.sh` and `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` are intended for merge. See #491 for the existing issue tracking the fork reference in `codebuild.tf`.

## Test plan

- [x] `bash -n docker/registry-entrypoint.sh` -- syntax valid
- [x] `terraform validate` -- passed
- [x] Deployed to ECS Fargate (us-east-1) and verified:
  - Lua flush_metrics connects to IPv4 VIP -- zero DNS errors
  - Health checker resolves FQDN aliases -- internal servers marked healthy
  - Metrics flowing end-to-end: nginx -> metrics-service -> ADOT -> AMP -> Grafana
- [x] No changes affect Docker Compose, Kubernetes, or non-Service-Connect ECS deployments