### PR TITLE
fix: simplify A2A agent discovery configuration

### DIFF
--- a/agents/a2a/.env.example
+++ b/agents/a2a/.env.example
@@ -1,27 +1,7 @@
-# Keycloak Configuration
-# Use service name 'keycloak' when running in Docker network
-# Use 'localhost' when running agents outside Docker
-KEYCLOAK_URL=http://keycloak:8080
-KEYCLOAK_REALM=mcp-gateway
-
-# MCP Registry
-# MUST use port 80 (nginx) for proper JWT authentication, not direct registry access (port 7860)
-# Use service name 'registry' when running in Docker network
-# Use 'localhost' when running agents outside Docker
+# MCP Registry URL (use Docker service name when running in Docker network)
 MCP_REGISTRY_URL=http://registry
 
-# Option 1: Direct JWT Token (takes precedence over M2M credentials)
-# Copy token from: ../../.oauth-tokens/ingress.json
-# If set, this bypasses M2M authentication and uses the token directly
+# JWT Token for registry authentication
+# Get a valid token from the registry UI or API, then paste it here.
+# The agent uses this token to call the registry's semantic search API.
 REGISTRY_JWT_TOKEN=
-
-# Option 2: M2M Client Credentials (used when REGISTRY_JWT_TOKEN is not set)
-# Travel Assistant Agent M2M Credentials
-# Get these from: ../../.oauth-tokens/agent-test-agent-m2m.json
-TRAVEL_AGENT_M2M_CLIENT_ID=agent-test-agent-m2m
-TRAVEL_AGENT_M2M_CLIENT_SECRET=your-secret-here
-
-# Flight Booking Agent M2M Credentials
-# You can use the same credentials or create separate ones
-FLIGHT_BOOKING_M2M_CLIENT_ID=agent-test-agent-m2m
-FLIGHT_BOOKING_M2M_CLIENT_SECRET=your-secret-here

--- a/agents/a2a/deploy_local.sh
+++ b/agents/a2a/deploy_local.sh
@@ -24,6 +24,17 @@ fi
 # Change to agents/a2a directory for the deployment
 cd "$A2A_DIR"
 
+# Load environment variables from .env file if it exists
+if [ -f ".env" ]; then
+    echo "Loading configuration from .env file..."
+    set -a
+    source .env
+    set +a
+else
+    echo "Warning: No .env file found in $A2A_DIR"
+    echo "Copy .env.example to .env and configure REGISTRY_JWT_TOKEN for agent discovery."
+fi
+
 # Parse command line arguments
 COMPOSE_FILE="docker-compose.local.yml"
 ARCHITECTURE=""

--- a/agents/a2a/docker-compose.arm.yml
+++ b/agents/a2a/docker-compose.arm.yml
@@ -18,13 +18,12 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AGENT_NAME=travel-assistant
       - AGENTCORE_RUNTIME_URL=http://travel-assistant-agent:9000/
-      # Keycloak M2M authentication for agent discovery
-      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-mcp-gateway}
-      - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
-      - M2M_CLIENT_ID=${TRAVEL_AGENT_M2M_CLIENT_ID:-agent-test-agent-m2m}
-      - M2M_CLIENT_SECRET=${TRAVEL_AGENT_M2M_CLIENT_SECRET}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
       - MCP_REGISTRY_URL=${MCP_REGISTRY_URL:-http://registry}
+      - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
+      - M2M_CLIENT_ID=${TRAVEL_AGENT_M2M_CLIENT_ID:-}
+      - M2M_CLIENT_SECRET=${TRAVEL_AGENT_M2M_CLIENT_SECRET:-}
     volumes:
       - travel_assistant_data:/app/data
     healthcheck:
@@ -53,13 +52,12 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AGENT_NAME=flight-booking
       - AGENTCORE_RUNTIME_URL=http://flight-booking-agent:9000/
-      # Keycloak M2M authentication for agent discovery
-      - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-mcp-gateway}
-      - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
-      - M2M_CLIENT_ID=${FLIGHT_BOOKING_M2M_CLIENT_ID:-agent-test-agent-m2m}
-      - M2M_CLIENT_SECRET=${FLIGHT_BOOKING_M2M_CLIENT_SECRET}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
       - MCP_REGISTRY_URL=${MCP_REGISTRY_URL:-http://registry}
+      - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
+      - M2M_CLIENT_ID=${FLIGHT_BOOKING_M2M_CLIENT_ID:-}
+      - M2M_CLIENT_SECRET=${FLIGHT_BOOKING_M2M_CLIENT_SECRET:-}
     volumes:
       - flight_booking_data:/app/data
     healthcheck:

--- a/agents/a2a/docker-compose.local.yml
+++ b/agents/a2a/docker-compose.local.yml
@@ -18,12 +18,12 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AGENT_NAME=travel-assistant
       - AGENTCORE_RUNTIME_URL=http://travel-assistant-agent:9000/
-      - KEYCLOAK_URL=${KEYCLOAK_URL}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM}
-      - MCP_REGISTRY_URL=${MCP_REGISTRY_URL}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
+      - MCP_REGISTRY_URL=${MCP_REGISTRY_URL:-http://registry}
       - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
-      - M2M_CLIENT_ID=${TRAVEL_AGENT_M2M_CLIENT_ID}
-      - M2M_CLIENT_SECRET=${TRAVEL_AGENT_M2M_CLIENT_SECRET}
+      - M2M_CLIENT_ID=${TRAVEL_AGENT_M2M_CLIENT_ID:-}
+      - M2M_CLIENT_SECRET=${TRAVEL_AGENT_M2M_CLIENT_SECRET:-}
     volumes:
       - travel_assistant_data:/app/data
     healthcheck:
@@ -52,12 +52,12 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AGENT_NAME=flight-booking
       - AGENTCORE_RUNTIME_URL=http://flight-booking-agent:9000/
-      - KEYCLOAK_URL=${KEYCLOAK_URL}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM}
-      - MCP_REGISTRY_URL=${MCP_REGISTRY_URL}
+      - KEYCLOAK_URL=${KEYCLOAK_URL:-}
+      - KEYCLOAK_REALM=${KEYCLOAK_REALM:-}
+      - MCP_REGISTRY_URL=${MCP_REGISTRY_URL:-http://registry}
       - REGISTRY_JWT_TOKEN=${REGISTRY_JWT_TOKEN:-}
-      - M2M_CLIENT_ID=${FLIGHT_BOOKING_M2M_CLIENT_ID}
-      - M2M_CLIENT_SECRET=${FLIGHT_BOOKING_M2M_CLIENT_SECRET}
+      - M2M_CLIENT_ID=${FLIGHT_BOOKING_M2M_CLIENT_ID:-}
+      - M2M_CLIENT_SECRET=${FLIGHT_BOOKING_M2M_CLIENT_SECRET:-}
     volumes:
       - flight_booking_data:/app/data
     healthcheck:


### PR DESCRIPTION
## Summary

- Simplified `.env.example` to only require `MCP_REGISTRY_URL` and `REGISTRY_JWT_TOKEN` (removed Keycloak/M2M references)
- Fixed `deploy_local.sh` to explicitly source `.env` file before docker-compose, ensuring container env vars match what is in `.env`
- Added empty defaults (`:-`) for Keycloak/M2M vars in both docker-compose files so they do not error when missing
- Added `AgentDiscoveryTests` class to `simple_agents_test.py` that exercises the full discovery flow: Travel Assistant discovers Flight Booking Agent via registry semantic search and delegates a booking request
- Rewrote the Agent-to-Agent Discovery section in README for clarity

## Test plan

- [x] Deployed agents locally with `deploy_local.sh` and verified `.env` values are picked up by containers
- [x] Verified full discovery flow via container logs: Travel Assistant -> discover_remote_agents -> registry semantic search (found 3 agents) -> invoke_remote_agent -> Flight Booking Agent processed request
- [x] All tests pass including new discovery test: `uv run python agents/a2a/test/simple_agents_test.py --endpoint local`