### PR TITLE
fix: point CodeBuild source to upstream repo and main branch

### DIFF
--- a/terraform/aws-ecs/codebuild.tf
+++ b/terraform/aws-ecs/codebuild.tf
@@ -330,7 +330,7 @@ resource "aws_codebuild_project" "upstream" {
 
   source {
     type            = "GITHUB"
-    location        = "https://github.com/WPrintz/mcp-gateway-registry.git"
+    location        = "https://github.com/agentic-community/mcp-gateway-registry.git"
     buildspec       = aws_s3_object.upstream_buildspec[0].content
     git_clone_depth = 1
 
@@ -339,9 +339,7 @@ resource "aws_codebuild_project" "upstream" {
     }
   }
 
-  # Build from the PR 3 branch (observability pipeline).
-  # Update to "main" after the PR is merged upstream.
-  source_version = "feat/v1.0.13-metrics-service"
+  source_version = "main"
 
   cache {
     type  = "LOCAL"


### PR DESCRIPTION
## Summary

- Updated CodeBuild GitHub source from `WPrintz/mcp-gateway-registry` fork to `agentic-community/mcp-gateway-registry`
- Changed `source_version` from stale `feat/v1.0.13-metrics-service` branch to `main`
- Removed outdated comment about updating after PR merge

Closes #491

## Test plan

- [ ] Verify `terraform plan` shows no unexpected changes beyond the source location and branch update