### PR TITLE
fix(security): configure Bandit B101 skip for test files

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,5 @@
+[bandit]
+# Exclude test directories and virtual environment from Bandit scans
+# B101 (assert_used) only appears in test code; excluding test dirs resolves it
+# For pyproject.toml config (used by pre-commit), see [tool.bandit] in pyproject.toml
+exclude = ./tests,./agents/a2a/test,./metrics-service/tests,./.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,13 @@ title = "MCP Registry Coverage Report"
 # Local-only project - never resolve from PyPI
 package = false
 
+# Bandit Configuration
+# B101 (assert_used): exclude test directories where assert is expected
+# Requires: bandit -c pyproject.toml -r .
+# See: https://bandit.readthedocs.io/en/latest/plugins/b101_assert_used.html
+[tool.bandit]
+exclude_dirs = ["tests", "*/test/*", "*/tests/*", ".venv"]
+
 # Ruff Configuration
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## **Issue:** #524 

## **Summary:**

Configure Bandit to suppress B101 (assert_used) findings in test code. All assert occurrences are in test files where they are expected and appropriate. Verified 0 assert statements in all production code (`registry/`, `auth_server/`, `agents/`, `metrics-service/`, `cli/`, `servers/`, `scripts/`).

## Changes

| File | Change |
|---|---|
| `.bandit` (new) | Exclude test directories and `.venv` from Bandit scans. Auto-detected by `bandit -r .` |
| `pyproject.toml` | Add `[tool.bandit]` with `exclude_dirs` for test directories and `.venv`. Used by pre-commit via `-c pyproject.toml` |

## How It Works

Two complementary configs serve different invocation patterns:

1. **`.bandit`** - Auto-detected when running `bandit -r .` (no `-c` flag needed). Excludes: `./tests`, `./agents/a2a/test`, `./metrics-service/tests`, `./.venv`

2. **`pyproject.toml` `[tool.bandit]`** - Directory-based exclusion using `exclude_dirs`: `tests`, `*/test/*`, `*/tests/*`, `.venv`. Used by the pre-commit hook which already passes `-c pyproject.toml`

Both configs exclude test directories entirely (not just B101), which covers test files, fixtures, helpers, conftest, and any other test scaffolding that uses assert statements.

## Verification

```bash
# Auto-detected config (no -c flag needed)
uv run bandit -r . -t B101
# Result: 0 findings

# pyproject.toml config (used by pre-commit)
uv run bandit -c pyproject.toml -r . -t B101
# Result: 0 findings
```

## Test Plan

- [x] Verified 0 assert statements in all production code (`registry/`, `auth_server/`, `agents/`, `metrics-service/`, `cli/`, `servers/`, `scripts/`) -- no replacements needed
- [x] `uv run bandit -r . -t B101` reports 0 B101 findings (auto-detected `.bandit` config)
- [x] `uv run bandit -c pyproject.toml -r . -t B101` reports 0 findings (pyproject.toml config)
- [x] `.venv` excluded from both configs to avoid dependency noise
- [x] Other Bandit checks still active on production code
- [x] Pre-commit hook unchanged (already uses `-c pyproject.toml`)
- [x] CI workflow unchanged (already scans `registry/` only)

Closes #524

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
