### PR TITLE
feat: add macOS setup and teardown Claude skill

### DIFF
--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -42,6 +42,14 @@ Or reference it remotely if you have not installed this repo:
 
 ---
 
+## CRITICAL: First action is ALWAYS Step 0
+
+**DO NOT run any Bash commands. DO NOT check prerequisites. DO NOT read any files.**
+**The very first action when this skill is invoked MUST be using `AskUserQuestion` to complete Step 0.**
+**Nothing else happens until the user has answered all three Step 0 questions.**
+
+---
+
 ## Step tracking
 
 Throughout the entire execution, Claude must maintain an internal step log. After every phase completes (success, skip, or failure), append an entry to this log. Display the full log as a formatted table in the Final Summary phase.
@@ -50,9 +58,9 @@ Step log format: `{ phase, name, status (DONE / SKIPPED / FAILED), notes }`
 
 ---
 
-## Step 0: Determine Mode
+## Step 0: Determine Mode — MUST BE FIRST, NO EXCEPTIONS
 
-**Before doing anything else**, use `AskUserQuestion` to ask:
+**STOP. Do not run any commands. Use `AskUserQuestion` right now to ask all three questions below before taking any other action.**
 
 **Question 1 — Operation:**
 ```


### PR DESCRIPTION
## Summary

Implements a Claude Code skill (`/macos-setup`) that automates the complete MCP Gateway & Registry setup and teardown on macOS, addressing #581.

The skill is placed at `.claude/skills/macos-setup/SKILL.md`, following the existing convention used by the other skills in this repo (`pr-review`, `new-feature-design`, `release-notes`). This differs from the `skills/quickstart-for-macbook/` path suggested in the issue — happy to also add a copy there if remote-URL accessibility is needed.

## What the skill does

**`/macos-setup setup`** — 13 guided phases:

| Phase | Action |
|-------|--------|
| 1 | Prerequisites check (Docker Desktop, Python 3.12+, uv, jq, git) |
| 2 | Collects mandatory config: Keycloak admin + DB passwords (re-prompts if empty) |
| 3 | Creates `.env` from template with auto-generated `SECRET_KEY` |
| 4 | Python virtual environment via `uv sync` |
| 5 | Downloads `sentence-transformers/all-MiniLM-L6-v2` (~90MB) |
| 6 | Creates Docker volume mount directories under `~/mcp-gateway/` |
| 7 | Starts Keycloak + DB, polls until ready (max 3 min) |
| 8 | Disables macOS HTTPS requirement on Keycloak master realm |
| 9 | Runs `init-keycloak.sh`, creates `mcp-gateway` realm, fixes SSL on new realm |
| 10 | Retrieves client secrets, updates `.env` |
| 11 | Creates `test-agent` and `ai-coding-assistant` service accounts |
| 12 | Starts all services via `./build_and_run.sh --prebuilt` |
| 13 | Health checks + summary with URLs, credential locations, quick-test commands |

**`/macos-setup teardown`** — scope-controlled removal with optional cleanup of model files, Docker images, and system prune. Requires a final irreversible-action confirmation before touching anything.

## Design decisions

- **Progressive disclosure**: every phase announces what it will do, asks for confirmation via `AskUserQuestion`, then executes — no silent changes
- **Mandatory credentials**: Keycloak passwords are validated (min 8 chars), never displayed in output, re-prompted if empty
- **macOS-specific handling**: `sed -i ''` syntax, Python-based `.env` updates for special characters, dynamic container name detection
- **Fault-tolerant**: detects partial setups, shows logs on failures, explains recovery steps
- Follows every step from `docs/macos-setup-guide.md` including the two-phase SSL fix (master realm, then mcp-gateway realm post-init)

Closes #581