### PR TITLE
support basic-auth as a credential mechanism

### DIFF
--- a/cli/mcp_security_scanner.py
+++ b/cli/mcp_security_scanner.py
@@ -110,21 +110,31 @@ def _run_mcp_scanner(
         server_url,
     ]
 
-    # Add headers if provided - parse JSON and extract bearer token
+    # Add authentication headers if provided
     if headers:
         logger.info("Adding custom headers for scanning")
         try:
             headers_dict = json.loads(headers)
-            # Check for X-Authorization header with Bearer token
-            auth_header = headers_dict.get("X-Authorization", "")
-            if auth_header.startswith("Bearer "):
-                bearer_token = auth_header.replace("Bearer ", "")
-                cmd.extend(["--bearer-token", bearer_token])
+
+            # Check for Bearer token in X-Authorization header
+            x_auth = headers_dict.get("X-Authorization", "")
+            auth_header = headers_dict.get("Authorization", "")
+
+            if x_auth.startswith("Bearer "):
+                cmd.extend(["--bearer-token", x_auth.replace("Bearer ", "")])
                 logger.info("Using bearer token authentication")
+            elif auth_header.startswith("Bearer "):
+                cmd.extend(["--bearer-token", auth_header.replace("Bearer ", "")])
+                logger.info("Using bearer token authentication from Authorization header")
+            elif auth_header.startswith("Basic "):
+                cmd.extend(["--header", f"Authorization: {auth_header}"])
+                logger.info("Using basic auth authentication")
             else:
-                logger.warning(
-                    "Headers provided but no Bearer token found in X-Authorization header"
-                )
+                # Pass all headers as --header flags
+                for name, value in headers_dict.items():
+                    cmd.extend(["--header", f"{name}: {value}"])
+                    logger.info(f"Passing custom header: {name}")
+
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse headers JSON: {e}")
             raise ValueError(f"Invalid headers JSON: {headers}") from e
@@ -515,8 +525,11 @@ Example usage:
     # Scan with LLM only, passing API key directly
     uv run cli/mcp_security_scanner.py --server-url https://example.com/mcp --analyzers llm --api-key sk-...
 
-    # Scan with custom headers (e.g., authentication)
-    uv run cli/mcp_security_scanner.py --server-url https://example.com/mcp --headers '{"X-Authorization": "Bearer token123"}'
+    # Scan with Bearer token authentication
+    uv run cli/mcp_security_scanner.py --server-url https://example.com/mcp --headers '{"Authorization": "Bearer token123"}'
+
+    # Scan with Basic Auth authentication
+    uv run cli/mcp_security_scanner.py --server-url https://example.com/mcp --headers '{"Authorization": "Basic YWRtaW46cGFzc3dvcmQ="}'
 
     # Output as JSON
     uv run cli/mcp_security_scanner.py --server-url https://example.com/mcp --json
@@ -548,7 +561,7 @@ Example usage:
 
     parser.add_argument(
         "--headers",
-        help='JSON string of headers to include in requests (e.g., \'{"X-Authorization": "token"}\')',
+        help='JSON string of headers for auth (e.g., \'{"Authorization": "Basic YWRtaW46cGFzc3dvcmQ="}\' or \'{"Authorization": "Bearer token123"}\')',
     )
 
     args = parser.parse_args()

--- a/docs/ai-coding-assistants-setup.md
+++ b/docs/ai-coding-assistants-setup.md
@@ -377,13 +377,14 @@ When MCP servers require their own authentication (API keys, bearer tokens, etc.
 
 ### Supported Authentication Schemes
 
-The registry supports three backend authentication schemes:
+The registry supports four backend authentication schemes:
 
 | Scheme | Description | Example Header |
 |--------|-------------|----------------|
 | `none` | No backend authentication required | N/A |
 | `bearer` | Bearer token authentication | `Authorization: Bearer <token>` |
 | `api_key` | API key with custom header | `CONTEXT7_API_KEY: <key>` or `X-API-Key: <key>` |
+| `basic` | HTTP Basic authentication | `Authorization: Basic <base64-encoded credentials>` |
 
 ### Example Configurations
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -398,6 +398,22 @@ When an MCP server requires authentication, you can provide the credentials duri
 | `none` | No authentication required | Public MCP servers |
 | `bearer` | Bearer token in `Authorization` header | OAuth2-protected services |
 | `api_key` | API key with custom header name | Services requiring API keys (e.g., `X-API-Key`, `CONTEXT7_API_KEY`) |
+| `basic` | HTTP Basic Auth in `Authorization` header | Username/password-protected MCP servers |
+
+### Basic Auth Details
+
+For MCP servers protected by HTTP Basic Authentication, the registry stores the base64-encoded `username:password` string. The credential value should be the base64 encoding of `username:password` (e.g., `YWRtaW46cGFzc3dvcmQ=` for `admin:password`).
+
+Generate the base64 credential:
+```bash
+echo -n "admin:password" | base64
+# Output: YWRtaW46cGFzc3dvcmQ=
+```
+
+When the registry communicates with the server (health checks, security scans, tool discovery), it sends:
+```
+Authorization: Basic YWRtaW46cGFzc3dvcmQ=
+```
 
 ### Credential Encryption
 
@@ -426,9 +442,11 @@ ENCRYPTION_KEY=your-base64-encoded-fernet-key-here
    - `none` - No authentication
    - `bearer` - Bearer token
    - `api_key` - API key
-4. If `bearer` or `api_key`:
-   - Enter the **credential** (API key or bearer token)
+   - `basic` - HTTP Basic Auth
+4. If `bearer`, `api_key`, or `basic`:
+   - Enter the **credential** (API key, bearer token, or base64-encoded `user:pass`)
    - For `api_key`: Specify the **header name** (e.g., `CONTEXT7_API_KEY`, `X-API-Key`)
+   - For `basic`: Enter the base64-encoded `username:password` (e.g., `YWRtaW46cGFzc3dvcmQ=`)
 5. Click **Register**
 
 ![Server Registration with Authentication Scheme](img/auth-scheme.gif)
@@ -462,6 +480,20 @@ curl -X POST https://registry.example.com/api/servers/register \
   -F "auth_credential=ctx7sk-6dd75bd4-80ef-486e-99ef-b5493df4e578" \
   -F "auth_header_name=CONTEXT7_API_KEY" \
   -F "description=Context7 LLM context service"
+```
+
+**Register server with Basic Auth:**
+
+```bash
+# Generate base64 credential: echo -n "admin:password" | base64
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "server_name=My Basic Auth Server" \
+  -F "path=/basic-auth-server" \
+  -F "proxy_pass_url=http://basic-auth-mcp-server:8080/" \
+  -F "auth_scheme=basic" \
+  -F "auth_credential=YWRtaW46cGFzc3dvcmQ=" \
+  -F "description=An MCP server with Basic Auth"
 ```
 
 **Response:**
@@ -530,10 +562,23 @@ curl -X PUT https://registry.example.com/api/servers/context7/credentials \
   }'
 ```
 
+**Set or update Basic Auth credentials:**
+
+```bash
+# echo -n "admin:password" | base64 => YWRtaW46cGFzc3dvcmQ=
+curl -X PATCH https://registry.example.com/api/servers/basic-auth-server/auth-credential \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "auth_scheme": "basic",
+    "auth_credential": "YWRtaW46cGFzc3dvcmQ="
+  }'
+```
+
 **Switch to bearer token:**
 
 ```bash
-curl -X PUT https://registry.example.com/api/servers/my-server/credentials \
+curl -X PATCH https://registry.example.com/api/servers/my-server/auth-credential \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -619,6 +664,7 @@ When the health check service performs periodic checks, it:
 3. Includes the appropriate header in the MCP initialize request:
    - Bearer: `Authorization: Bearer <decrypted_token>`
    - API Key: `<auth_header_name>: <decrypted_key>`
+   - Basic: `Authorization: Basic <decrypted_base64_credential>`
 
 **Example health check with auth:**
 
@@ -630,6 +676,8 @@ if server.auth_scheme == "bearer":
 elif server.auth_scheme == "api_key":
     header_name = server.auth_header_name or "X-API-Key"
     headers[header_name] = decrypt_credential(server.auth_credential_encrypted)
+elif server.auth_scheme == "basic":
+    headers["Authorization"] = f"Basic {decrypt_credential(server.auth_credential_encrypted)}"
 
 # MCP initialize request with auth headers
 response = await mcp_client.initialize(url=server.proxy_pass_url, headers=headers)
@@ -652,8 +700,37 @@ When AI coding assistants connect to a server through the gateway:
 3. Gateway retrieves and decrypts server credential
 4. Gateway proxies the request with the server's auth header
 
-**Example MCP client configuration:**
+#### 4. Security Scanning
 
+When a security scan is triggered (on registration or via rescan), the registry:
+
+1. Retrieves the server's stored credentials (if any)
+2. Decrypts and builds the appropriate `Authorization` header
+3. Passes it to the `mcp-scanner` tool via `--header` or `--bearer-token` flags
+
+This means servers registered with `basic`, `bearer`, or `api_key` auth schemes are scanned automatically with the correct credentials. No manual header passing is needed for rescans.
+
+**Manual CLI scan with Basic Auth:**
+
+```bash
+# Scan a Basic Auth server directly via CLI
+uv run cli/mcp_security_scanner.py \
+  --server-url http://basic-auth-mcp-server:8080/mcp \
+  --headers '{"Authorization": "Basic YWRtaW46cGFzc3dvcmQ="}'
+```
+
+**Trigger rescan via API (uses stored credentials automatically):**
+
+```bash
+curl -X POST https://registry.example.com/api/servers/basic-auth-server/rescan \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+#### 5. Client Connections
+
+**Example MCP client configurations:**
+
+Connecting to a server with API key auth via the gateway:
 ```json
 {
   "mcpServers": {
@@ -669,6 +746,59 @@ When AI coding assistants connect to a server through the gateway:
   }
 }
 ```
+
+Connecting directly to a Basic Auth-protected MCP server (without the gateway):
+```json
+{
+  "mcpServers": {
+    "basic-auth-server": {
+      "type": "streamable-http",
+      "url": "http://basic-auth-mcp-server:8080/mcp",
+      "disabled": false,
+      "headers": {
+        "Authorization": "Basic YWRtaW46cGFzc3dvcmQ="
+      }
+    }
+  }
+}
+```
+
+Connecting to a Basic Auth server through the gateway (gateway handles server auth):
+```json
+{
+  "mcpServers": {
+    "basic-auth-server": {
+      "type": "streamable-http",
+      "url": "https://mcpgateway.ddns.net/basic-auth-server/mcp",
+      "disabled": false,
+      "headers": {
+        "X-Authorization": "Bearer <user_gateway_token>"
+      }
+    }
+  }
+}
+```
+
+When connecting through the gateway, the client only needs the gateway JWT token. The gateway retrieves the server's stored Basic Auth credentials and injects them into the proxied request automatically.
+
+Connecting to a Basic Auth server through the gateway (client sends credentials):
+```json
+{
+  "mcpServers": {
+    "basic-auth-server": {
+      "type": "streamable-http",
+      "url": "https://mcpgateway.ddns.net/basic-auth-server/mcp",
+      "disabled": false,
+      "headers": {
+        "X-Authorization": "Bearer <user_gateway_token>",
+        "Authorization": "Basic YWRtaW46cGFzc3dvcmQ="
+      }
+    }
+  }
+}
+```
+
+When connecting through the gateway without the credentials stored in the gateway, the client needs both the gateway JWT token and mcp server credentials.
 
 ### Security Considerations
 
@@ -716,7 +846,22 @@ curl -H "Authorization: Bearer $TOKEN" \
   https://registry.example.com/api/servers
 
 # Check auth scheme is valid
-# Valid values: none, bearer, api_key
+# Valid values: none, bearer, api_key, basic
+```
+
+**Security Scan Fails with "Authentication failed":**
+
+This means the scanner could not authenticate to the MCP server. Ensure credentials are set:
+```bash
+# 1. Set credentials on the server (example for Basic Auth)
+curl -X PATCH https://registry.example.com/api/servers/my-server/auth-credential \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_scheme": "basic", "auth_credential": "YWRtaW46cGFzc3dvcmQ="}'
+
+# 2. Trigger rescan (will now use stored credentials)
+curl -X POST https://registry.example.com/api/servers/my-server/rescan \
+  -H "Authorization: Bearer $TOKEN"
 ```
 
 **Health Check Shows "auth-expired":**

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -122,6 +122,8 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
         } else if (server.auth_scheme === 'api_key') {
           const headerName = server.auth_header_name || 'X-API-Key';
           headers[headerName] = '[YOUR_API_KEY]';
+        } else if (server.auth_scheme === 'basic') {
+          headers['Authorization'] = 'Basic [YOUR_BASE64_CREDENTIALS]';
         }
       }
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2522,13 +2522,14 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                       <option value="none">None</option>
                       <option value="bearer">Bearer Token</option>
                       <option value="api_key">API Key</option>
+                      <option value="basic">Basic Auth</option>
                     </select>
                   </div>
 
                   {editForm.auth_scheme !== 'none' && (
                     <div>
                       <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
-                        {editForm.auth_scheme === 'bearer' ? 'Bearer Token' : 'API Key'}
+                        {editForm.auth_scheme === 'bearer' ? 'Bearer Token' : editForm.auth_scheme === 'basic' ? 'Basic Credential' : 'API Key'}
                       </label>
                       <input
                         type="password"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -605,20 +605,21 @@ const RegisterPage: React.FC = () => {
             <option value="none">None</option>
             <option value="bearer">Bearer Token</option>
             <option value="api_key">API Key</option>
+            <option value="basic">Basic Auth</option>
           </select>
         </div>
 
         {serverForm.auth_scheme !== 'none' && (
           <div>
             <label className={labelClass}>
-              {serverForm.auth_scheme === 'bearer' ? 'Bearer Token' : 'API Key'} *
+              {serverForm.auth_scheme === 'bearer' ? 'Bearer Token' : serverForm.auth_scheme === 'basic' ? 'Basic Credential' : 'API Key'} *
             </label>
             <input
               type="password"
               className={inputClass}
               value={serverForm.auth_credential}
               onChange={(e) => setServerForm(prev => ({ ...prev, auth_credential: e.target.value }))}
-              placeholder={serverForm.auth_scheme === 'bearer' ? 'Enter bearer token' : 'Enter API key'}
+              placeholder={serverForm.auth_scheme === 'bearer' ? 'Enter bearer token' : serverForm.auth_scheme === 'basic' ? 'Enter base64-encoded username:password' : 'Enter API key'}
             />
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
               This credential is stored securely and never displayed after saving.

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -33,6 +33,51 @@ class RatingRequest(BaseModel):
 templates = Jinja2Templates(directory=settings.templates_dir)
 
 
+def _build_scan_headers_from_server_info(server_info: dict) -> str | None:
+    """Build JSON headers string from a server's stored auth credentials.
+
+    Decrypts the server's auth_credential_encrypted and constructs the
+    appropriate Authorization header so the security scanner can authenticate.
+
+    Args:
+        server_info: Server metadata dictionary
+
+    Returns:
+        JSON string like '{"Authorization": "Basic ..."}', or None if no auth
+    """
+    auth_scheme = server_info.get("auth_scheme", "none")
+    encrypted_credential = server_info.get("auth_credential_encrypted")
+
+    if auth_scheme == "none" or not encrypted_credential:
+        return None
+
+    from ..utils.credential_encryption import decrypt_credential
+
+    credential = decrypt_credential(encrypted_credential)
+    if not credential:
+        logger.warning(
+            f"Could not decrypt credential for '{server_info.get('path', 'unknown')}'. "
+            "Security scan will proceed without auth."
+        )
+        return None
+
+    header_name = server_info.get("auth_header_name", "Authorization")
+
+    if auth_scheme == "bearer":
+        headers = {header_name: f"Bearer {credential}"}
+    elif auth_scheme == "basic":
+        headers = {header_name: f"Basic {credential}"}
+    elif auth_scheme == "api_key":
+        header_name = server_info.get("auth_header_name", "X-API-Key")
+        headers = {header_name: credential}
+    else:
+        logger.warning(f"Unknown auth_scheme '{auth_scheme}' for scanner headers")
+        return None
+
+    logger.info(f"Built {auth_scheme} auth header for security scan")
+    return json.dumps(headers)
+
+
 async def _perform_security_scan_on_registration(
     path: str,
     proxy_pass_url: str,
@@ -66,6 +111,9 @@ async def _perform_security_scan_on_registration(
         headers_json = None
         if headers_list:
             headers_json = json.dumps(headers_list)
+        elif not headers_json:
+            # Fall back to stored server credentials
+            headers_json = _build_scan_headers_from_server_info(server_entry)
 
         # Run the security scan
         scan_result = await security_scanner_service.scan_server(
@@ -3676,8 +3724,8 @@ async def rescan_server(
     if not path.startswith("/"):
         path = "/" + path
 
-    # Check if server exists
-    server_info = await server_service.get_server_info(path)
+    # Check if server exists (include credentials so scanner can authenticate)
+    server_info = await server_service.get_server_info(path, include_credentials=True)
     if not server_info:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -3698,13 +3746,16 @@ async def rescan_server(
     )
 
     try:
+        # Build auth headers from stored server credentials (if any)
+        headers_json = _build_scan_headers_from_server_info(server_info)
+
         # Trigger security scan
         scan_result = await security_scanner_service.scan_server(
             server_url=server_url,
             server_path=path,
             analyzers=None,
             api_key=None,
-            headers=None,
+            headers=headers_json,
             timeout=None,
             mcp_endpoint=server_info.get("mcp_endpoint"),
         )

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -3760,6 +3760,18 @@ async def rescan_server(
             mcp_endpoint=server_info.get("mcp_endpoint"),
         )
 
+        # If scan passed, remove 'security-pending' tag
+        if scan_result.is_safe and not scan_result.scan_failed:
+            # Re-fetch without credentials (for tag update)
+            current_info = await server_service.get_server_info(path)
+            if current_info:
+                current_tags = current_info.get("tags", [])
+                if "security-pending" in current_tags:
+                    current_tags.remove("security-pending")
+                    current_info["tags"] = current_tags
+                    await server_service.update_server(path, current_info)
+                    logger.info(f"Removed 'security-pending' tag from {path} after successful rescan")
+
         # Return the scan result data
         return {
             "server_url": scan_result.server_url,

--- a/registry/api/wellknown_routes.py
+++ b/registry/api/wellknown_routes.py
@@ -169,6 +169,8 @@ def _get_authentication_info(server_info: dict) -> dict:
     elif auth_scheme == "api_key":
         header_name = server_info.get("auth_header_name", "X-API-Key")
         return {"type": "api-key", "required": True, "header": header_name}
+    elif auth_scheme == "basic":
+        return {"type": "http-basic", "required": True}
     else:
         return {"type": "none", "required": False}
 

--- a/registry/constants.py
+++ b/registry/constants.py
@@ -44,12 +44,14 @@ class AuthScheme(str, Enum):
     NONE = "none"
     BEARER = "bearer"
     API_KEY = "api_key"
+    BASIC = "basic"
 
 
 # Auth header defaults
 DEFAULT_API_KEY_HEADER: str = "X-API-Key"
 DEFAULT_BEARER_HEADER: str = "Authorization"
-VALID_AUTH_SCHEMES: list = ["none", "bearer", "api_key"]
+DEFAULT_BASIC_HEADER: str = "Authorization"
+VALID_AUTH_SCHEMES: list = ["none", "bearer", "api_key", "basic"]
 
 
 class RegistryConstants(BaseModel):

--- a/registry/core/mcp_client.py
+++ b/registry/core/mcp_client.py
@@ -117,6 +117,10 @@ def _build_headers_for_server(server_info: dict = None) -> dict[str, str]:
                     header_name = server_info.get("auth_header_name", "X-API-Key")
                     headers[header_name] = credential
                     logger.debug(f"Added API key header '{header_name}' for MCP client")
+                elif auth_scheme == "basic":
+                    header_name = server_info.get("auth_header_name", "Authorization")
+                    headers[header_name] = f"Basic {credential}"
+                    logger.debug("Added Basic auth header for MCP client")
             else:
                 logger.warning(
                     f"Could not decrypt credential for "

--- a/registry/core/schemas.py
+++ b/registry/core/schemas.py
@@ -112,7 +112,7 @@ class ServerInfo(BaseModel):
     # Backend authentication (replaces legacy auth_type)
     auth_scheme: str = Field(
         default="none",
-        description="Authentication scheme for backend server: none, bearer, api_key",
+        description="Authentication scheme for backend server: none, bearer, api_key, basic",
     )
     auth_credential_encrypted: str | None = Field(
         default=None,
@@ -213,7 +213,7 @@ class ServiceRegistrationRequest(BaseModel):
         default_factory=list, description="Groups with access when visibility is group-restricted"
     )
     auth_scheme: str = Field(
-        default="none", description="Authentication scheme: none, bearer, api_key"
+        default="none", description="Authentication scheme: none, bearer, api_key, basic"
     )
     auth_credential: str | None = Field(
         default=None,
@@ -227,7 +227,7 @@ class ServiceRegistrationRequest(BaseModel):
 class AuthCredentialUpdateRequest(BaseModel):
     """Request model for updating server auth credentials via PATCH."""
 
-    auth_scheme: str = Field(..., description="Authentication scheme: none, bearer, api_key")
+    auth_scheme: str = Field(..., description="Authentication scheme: none, bearer, api_key, basic")
     auth_credential: str | None = Field(
         default=None, description="New credential (required if auth_scheme is not 'none')"
     )

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -516,6 +516,10 @@ class HealthMonitoringService:
                     header_name = server_info.get("auth_header_name", "X-API-Key")
                     headers[header_name] = credential
                     logger.debug(f"Added API key header '{header_name}' for health check")
+                elif auth_scheme == "basic":
+                    header_name = server_info.get("auth_header_name", "Authorization")
+                    headers[header_name] = f"Basic {credential}"
+                    logger.debug("Added Basic auth header for health check")
             else:
                 logger.warning(
                     f"Could not decrypt credential for "

--- a/registry/services/demo_servers_init.py
+++ b/registry/services/demo_servers_init.py
@@ -37,7 +37,7 @@ def _load_server_config(config_path: str) -> dict[str, Any]:
     if not full_path.exists():
         raise FileNotFoundError(f"Server config not found: {full_path}")
 
-    with open(full_path, "r") as f:
+    with open(full_path) as f:
         return json.load(f)
 
 

--- a/registry/services/security_scanner.py
+++ b/registry/services/security_scanner.py
@@ -27,15 +27,20 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 OUTPUT_DIR = PROJECT_ROOT / "security_scans"
 
 
-def _extract_bearer_token_from_headers(headers: str) -> str | None:
+def _extract_scanner_auth_args(headers: str) -> list[str]:
     """
-    Extract bearer token from headers JSON string.
+    Extract authentication arguments for mcp-scanner from headers JSON string.
+
+    Supports:
+    - Bearer token via X-Authorization header
+    - Basic Auth via Authorization header
+    - Arbitrary headers passed through via --header flags
 
     Args:
         headers: JSON string containing headers
 
     Returns:
-        Bearer token if found, None otherwise
+        List of CLI arguments to append to the mcp-scanner command
 
     Raises:
         ValueError: If headers JSON is invalid
@@ -43,18 +48,42 @@ def _extract_bearer_token_from_headers(headers: str) -> str | None:
     logger.info("Adding custom headers for scanning")
     try:
         headers_dict = json.loads(headers)
-        # Check for X-Authorization header with Bearer token
-        auth_header = headers_dict.get("X-Authorization", "")
-        if auth_header.startswith("Bearer "):
-            bearer_token = auth_header.replace("Bearer ", "")
-            logger.info("Using bearer token authentication")
-            return bearer_token
-        else:
-            logger.warning("Headers provided but no Bearer token found in X-Authorization header")
-            return None
     except json.JSONDecodeError as e:
         logger.error(f"Failed to parse headers JSON: {e}")
         raise ValueError(f"Invalid headers JSON: {headers}") from e
+
+    args: list[str] = []
+
+    # Check for Bearer token in X-Authorization header
+    x_auth = headers_dict.get("X-Authorization", "")
+    if x_auth.startswith("Bearer "):
+        bearer_token = x_auth.replace("Bearer ", "")
+        args.extend(["--bearer-token", bearer_token])
+        logger.info("Using bearer token authentication")
+        return args
+
+    # Check for Authorization header (Basic Auth or Bearer)
+    auth_header = headers_dict.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        bearer_token = auth_header.replace("Bearer ", "")
+        args.extend(["--bearer-token", bearer_token])
+        logger.info("Using bearer token authentication from Authorization header")
+        return args
+
+    if auth_header.startswith("Basic "):
+        args.extend(["--header", f"Authorization: {auth_header}"])
+        logger.info("Using basic auth authentication")
+        return args
+
+    # Pass any remaining headers as --header flags
+    for name, value in headers_dict.items():
+        args.extend(["--header", f"{name}: {value}"])
+        logger.info(f"Passing custom header: {name}")
+
+    if not args:
+        logger.warning("Headers provided but no recognized authentication found")
+
+    return args
 
 
 def _parse_scanner_json_output(stdout: str) -> list:
@@ -365,11 +394,10 @@ class SecurityScannerService:
             server_url,
         ]
 
-        # Add headers if provided - parse JSON and extract bearer token
+        # Add authentication headers if provided
         if headers:
-            bearer_token = _extract_bearer_token_from_headers(headers)
-            if bearer_token:
-                cmd.extend(["--bearer-token", bearer_token])
+            auth_args = _extract_scanner_auth_args(headers)
+            cmd.extend(auth_args)
 
         # Set environment variable for API key if provided
         env = os.environ.copy()

--- a/registry/templates/edit_server.html
+++ b/registry/templates/edit_server.html
@@ -151,6 +151,11 @@
                         headerContainer.style.display = 'block';
                         credLabel.textContent = 'API Key';
                         credInput.placeholder = 'Enter new API key (leave blank to keep existing)';
+                    } else if (scheme === 'basic') {
+                        credContainer.style.display = 'block';
+                        headerContainer.style.display = 'none';
+                        credLabel.textContent = 'Basic Credential';
+                        credInput.placeholder = 'Enter new base64-encoded username:password (leave blank to keep existing)';
                     }
                 }
             </script>
@@ -163,10 +168,11 @@
                     <option value="none" {% if not server.auth_scheme or server.auth_scheme == 'none' %}selected{% endif %}>None</option>
                     <option value="bearer" {% if server.auth_scheme == 'bearer' %}selected{% endif %}>Bearer Token</option>
                     <option value="api_key" {% if server.auth_scheme == 'api_key' %}selected{% endif %}>API Key</option>
+                    <option value="basic" {% if server.auth_scheme == 'basic' %}selected{% endif %}>Basic Auth</option>
                 </select>
             </div>
             <div class="form-group" id="auth-credential-container" style="{% if not server.auth_scheme or server.auth_scheme == 'none' %}display: none;{% endif %}">
-                <label for="auth_credential" id="auth-credential-label">{% if server.auth_scheme == 'bearer' %}Bearer Token{% elif server.auth_scheme == 'api_key' %}API Key{% else %}Credential{% endif %}</label>
+                <label for="auth_credential" id="auth-credential-label">{% if server.auth_scheme == 'bearer' %}Bearer Token{% elif server.auth_scheme == 'api_key' %}API Key{% elif server.auth_scheme == 'basic' %}Basic Credential{% else %}Credential{% endif %}</label>
                 <input type="password" id="auth_credential" name="auth_credential" placeholder="Leave blank to keep existing credential">
                 <small style="color: #666;">Only fill in to update the credential. Leave blank to keep the current one.</small>
             </div>

--- a/registry/templates/index.html
+++ b/registry/templates/index.html
@@ -1298,6 +1298,11 @@
                 headerContainer.style.display = 'block';
                 credLabel.textContent = 'API Key';
                 credInput.placeholder = 'Enter API key';
+            } else if (scheme === 'basic') {
+                credContainer.style.display = 'block';
+                headerContainer.style.display = 'none';
+                credLabel.textContent = 'Basic Credential';
+                credInput.placeholder = 'Enter base64-encoded username:password';
             }
         }
 
@@ -2499,6 +2504,7 @@
                             <option value="none" selected>None</option>
                             <option value="bearer">Bearer Token</option>
                             <option value="api_key">API Key</option>
+                            <option value="basic">Basic Auth</option>
                         </select>
                     </div>
                     <div class="form-group" id="reg-auth-credential-container" style="display: none;">

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -12,7 +12,6 @@ from typing import Any
 
 import httpx
 from fastmcp import Context, FastMCP
-
 from models import AgentInfo, RegistryStats, ServerInfo, SkillInfo, ToolSearchResult
 
 # Configure logging

--- a/tests/unit/core/test_mcp_client.py
+++ b/tests/unit/core/test_mcp_client.py
@@ -205,6 +205,42 @@ def test_build_headers_for_server_empty_headers():
     assert "Content-Type" in headers
 
 
+@pytest.mark.unit
+def test_build_headers_for_server_basic_auth():
+    """Test building headers with basic auth injects Authorization: Basic header."""
+    server_info = {
+        "auth_scheme": "basic",
+        "auth_credential_encrypted": "encrypted_cred",
+    }
+
+    with patch(
+        "registry.utils.credential_encryption.decrypt_credential",
+        return_value="dXNlcjpwYXNz",
+    ):
+        headers = _build_headers_for_server(server_info)
+
+    assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+
+@pytest.mark.unit
+def test_build_headers_for_server_basic_auth_custom_header():
+    """Test building headers with basic auth and a custom header name."""
+    server_info = {
+        "auth_scheme": "basic",
+        "auth_credential_encrypted": "encrypted_cred",
+        "auth_header_name": "X-Custom-Auth",
+    }
+
+    with patch(
+        "registry.utils.credential_encryption.decrypt_credential",
+        return_value="dXNlcjpwYXNz",
+    ):
+        headers = _build_headers_for_server(server_info)
+
+    assert headers["X-Custom-Auth"] == "Basic dXNlcjpwYXNz"
+    assert "Authorization" not in headers
+
+
 # =============================================================================
 # DETECT_SERVER_TRANSPORT TESTS
 # =============================================================================

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -1175,6 +1175,25 @@ def test_health_service_build_headers_for_server_invalid_headers(health_service)
 
 
 @pytest.mark.unit
+def test_health_service_build_headers_for_server_basic_auth(health_service):
+    """Test building headers with basic auth injects Authorization: Basic header."""
+    server_info = {
+        "server_name": "test-server",
+        "proxy_pass_url": "http://localhost:8000/mcp",
+        "auth_scheme": "basic",
+        "auth_credential_encrypted": "encrypted_cred",
+    }
+
+    with patch(
+        "registry.utils.credential_encryption.decrypt_credential",
+        return_value="dXNlcjpwYXNz",
+    ):
+        headers = health_service._build_headers_for_server(server_info)
+
+    assert headers["Authorization"] == "Basic dXNlcjpwYXNz"
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_health_service_initialize_mcp_session_no_server_session_id(health_service):
     """Test initializing MCP session when server doesn't return session ID."""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Servers can now be registered using `Basic b64(username:password)` to give access to backend MCP servers using basic auth. You can also register the server with no credentials so that it is required to pass them from the client using the `Authorization: Basic b64(username:password)` header alongside the `X-Authorization: Bearer JWT` JWT token to authenticate to the gateway
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
