### PR TITLE
Fix registry and MCP gateway stability regressions

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1887,12 +1887,14 @@ async def generate_user_token(request: GenerateTokenRequest):
             f"groups={user_groups}, scopes={requested_scopes}"
         )
 
-        # For OAuth users, generate a self-signed JWT with their identity and groups
-        # This token is issued by our auth server and can be verified using SECRET_KEY
-        if auth_method == "oauth2":
+        # For OAuth and network-trusted users, generate a self-signed JWT with
+        # their identity and groups. This avoids unnecessary IdP token exchange
+        # for trusted internal-auth flows.
+        # This token is issued by our auth server and can be verified using SECRET_KEY.
+        if auth_method in ("oauth2", "network-trusted"):
             logger.info(
-                f"Generating self-signed JWT for OAuth user '{hash_username(username)}' "
-                f"with groups: {user_groups}"
+                f"Generating self-signed JWT for user '{hash_username(username)}' "
+                f"(auth_method={auth_method}) with groups: {user_groups}"
             )
 
             current_time = int(time.time())
@@ -1908,7 +1910,7 @@ async def generate_user_token(request: GenerateTokenRequest):
                 "groups": user_groups,
                 "scope": " ".join(requested_scopes) if requested_scopes else "",
                 "token_use": "access",
-                "auth_method": "oauth2",
+                "auth_method": auth_method,
                 "provider": provider,
                 "iat": current_time,
                 "exp": current_time + expires_in,

--- a/registry/api/registry_routes.py
+++ b/registry/api/registry_routes.py
@@ -85,12 +85,16 @@ async def list_servers(
 
     for path, server_info in all_servers.items():
         # Add health status and enabled state for transformation
-        health_data = health_service._get_service_health_data(path, server_info)
+        is_enabled = await server_service.is_service_enabled(path)
+        health_data = health_service._get_service_health_data(
+            path,
+            {**server_info, "is_enabled": is_enabled},
+        )
 
         server_info_with_status = server_info.copy()
         server_info_with_status["health_status"] = health_data["status"]
         server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-        server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+        server_info_with_status["is_enabled"] = is_enabled
 
         filtered_servers.append(server_info_with_status)
 
@@ -174,12 +178,16 @@ async def list_server_versions(
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
 
     # Add health and status info using the correct path
-    health_data = health_service._get_service_health_data(path, server_info)
+    is_enabled = await server_service.is_service_enabled(path)
+    health_data = health_service._get_service_health_data(
+        path,
+        {**server_info, "is_enabled": is_enabled},
+    )
 
     server_info_with_status = server_info.copy()
     server_info_with_status["health_status"] = health_data["status"]
     server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-    server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+    server_info_with_status["is_enabled"] = is_enabled
 
     # Since we only have one version, return a list with one item
     server_list = transform_to_server_list([server_info_with_status])
@@ -269,12 +277,16 @@ async def get_server_version(
         )
 
     # Add health and status info
-    health_data = health_service._get_service_health_data(path, server_info)
+    is_enabled = await server_service.is_service_enabled(path)
+    health_data = health_service._get_service_health_data(
+        path,
+        {**server_info, "is_enabled": is_enabled},
+    )
 
     server_info_with_status = server_info.copy()
     server_info_with_status["health_status"] = health_data["status"]
     server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-    server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+    server_info_with_status["is_enabled"] = is_enabled
 
     # Transform to Anthropic format
     server_response = transform_to_server_response(

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -207,7 +207,11 @@ async def read_root(
             # Get real health status from health service
             from ..health.service import health_service
 
-            health_data = health_service._get_service_health_data(path, server_info)
+            is_enabled = await server_service.is_service_enabled(path)
+            health_data = health_service._get_service_health_data(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
             # Normalize health status to enum values only (strip error messages)
             raw_status = health_data["status"]
@@ -233,7 +237,7 @@ async def read_root(
                     "path": path,
                     "description": server_info.get("description", ""),
                     "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-                    "is_enabled": await server_service.is_service_enabled(path),
+                    "is_enabled": is_enabled,
                     "tags": server_info.get("tags", []),
                     "num_tools": server_info.get("num_tools", 0),
                     "license": server_info.get("license", "N/A"),
@@ -312,7 +316,11 @@ async def get_servers_json(
             # Get real health status from health service
             from ..health.service import health_service
 
-            health_data = health_service._get_service_health_data(path, server_info)
+            is_enabled = await server_service.is_service_enabled(path)
+            health_data = health_service._get_service_health_data(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
             # Normalize health status to enum values only (strip error messages)
             raw_status = health_data["status"]
@@ -367,7 +375,7 @@ async def get_servers_json(
                     "path": path,
                     "description": server_info.get("description", ""),
                     "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-                    "is_enabled": await server_service.is_service_enabled(path),
+                    "is_enabled": is_enabled,
                     "tags": server_info.get("tags", []),
                     "num_tools": server_info.get("num_tools", 0),
                     "license": server_info.get("license", "N/A"),
@@ -1901,14 +1909,18 @@ async def internal_list_services(
         from ..health.service import health_service
 
         # Get real health status from health service
-        health_data = health_service._get_service_health_data(service_path)
+        is_enabled = await server_service.is_service_enabled(service_path)
+        health_data = health_service._get_service_health_data(
+            service_path,
+            {**server_info, "is_enabled": is_enabled},
+        )
 
         service_data = {
             "server_name": server_info.get("server_name", "Unknown"),
             "path": service_path,
             "description": server_info.get("description", ""),
             "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-            "is_enabled": await server_service.is_service_enabled(service_path),
+            "is_enabled": is_enabled,
             "tags": server_info.get("tags", []),
             "num_tools": server_info.get("num_tools", 0),
             "license": server_info.get("license", "N/A"),

--- a/registry/auth/internal.py
+++ b/registry/auth/internal.py
@@ -12,7 +12,15 @@ import os
 import time
 
 import jwt as pyjwt
-from fastapi import HTTPException, Request, status
+
+try:
+    # Runtime import is required so FastAPI sees a concrete Request type for dependency injection.
+    from fastapi import Request
+except Exception:  # pragma: no cover - only used in non-FastAPI runtimes
+    try:
+        from starlette.requests import Request
+    except Exception:  # pragma: no cover
+        Request = object  # type: ignore[assignment]
 
 # Configure logging
 logging.basicConfig(
@@ -26,6 +34,18 @@ logger = logging.getLogger(__name__)
 _INTERNAL_JWT_ISSUER: str = "mcp-auth-server"
 _INTERNAL_JWT_AUDIENCE: str = "mcp-registry"
 _INTERNAL_JWT_TTL_SECONDS: int = 60
+
+
+def _http_exception(status_code: int, detail: str, headers: dict[str, str] | None = None):
+    """
+    Raise a FastAPI HTTPException lazily.
+
+    This keeps `generate_internal_token()` usable in lightweight runtimes
+    (for example the mcpgw MCP server) that do not install FastAPI.
+    """
+    from fastapi import HTTPException
+
+    raise HTTPException(status_code=status_code, detail=detail, headers=headers)
 
 
 def generate_internal_token(
@@ -84,8 +104,8 @@ async def validate_internal_auth(request: Request) -> str:
     auth_header = request.headers.get("Authorization")
 
     if not auth_header:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _http_exception(
+            status_code=401,
             detail="Missing authorization header",
             headers={"WWW-Authenticate": "Bearer"},
         )
@@ -96,8 +116,8 @@ async def validate_internal_auth(request: Request) -> str:
     if auth_header.startswith("Basic "):
         return _validate_basic_auth_deprecated(auth_header)
 
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
+    _http_exception(
+        status_code=401,
         detail="Unsupported authentication scheme",
     )
 
@@ -109,8 +129,8 @@ def _validate_bearer_token(auth_header: str) -> str:
     secret_key = os.environ.get("SECRET_KEY")
     if not secret_key:
         logger.error("SECRET_KEY not set, cannot validate internal JWT")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        _http_exception(
+            status_code=500,
             detail="Internal server configuration error",
         )
 
@@ -140,14 +160,14 @@ def _validate_bearer_token(auth_header: str) -> str:
 
     except pyjwt.ExpiredSignatureError:
         logger.warning("Expired JWT token for internal request")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _http_exception(
+            status_code=401,
             detail="Token has expired",
         )
     except (pyjwt.InvalidTokenError, ValueError) as e:
         logger.warning(f"JWT validation failed for internal request: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _http_exception(
+            status_code=401,
             detail="Invalid token",
         )
 
@@ -167,8 +187,8 @@ def _validate_basic_auth_deprecated(auth_header: str) -> str:
         username, password = decoded_credentials.split(":", 1)
     except (IndexError, ValueError, Exception) as e:
         logger.warning(f"Failed to decode Basic Auth credentials: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _http_exception(
+            status_code=401,
             detail="Invalid authentication format",
             headers={"WWW-Authenticate": "Basic"},
         )
@@ -178,15 +198,15 @@ def _validate_basic_auth_deprecated(auth_header: str) -> str:
 
     if not admin_password:
         logger.error("ADMIN_PASSWORD not set and Basic Auth attempted on internal endpoint")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        _http_exception(
+            status_code=500,
             detail="Internal server configuration error",
         )
 
     if username != admin_user or password != admin_password:
         logger.warning(f"Failed admin authentication attempt from {username}")
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
+        _http_exception(
+            status_code=401,
             detail="Invalid admin credentials",
             headers={"WWW-Authenticate": "Basic"},
         )

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -292,7 +292,11 @@ class HealthMonitoringService:
             # Single service update - get data efficiently
             server_info = await server_service.get_server_info(service_path)
             if server_info:
-                health_data = self._get_service_health_data_fast(service_path, server_info)
+                is_enabled = await server_service.is_service_enabled(service_path)
+                health_data = self._get_service_health_data_fast(
+                    service_path,
+                    {**server_info, "is_enabled": is_enabled},
+                )
                 await self.websocket_manager.broadcast_update(service_path, health_data)
         else:
             # Full update - use cached data
@@ -313,7 +317,11 @@ class HealthMonitoringService:
 
         data = {}
         for path, server_info in all_servers.items():
-            data[path] = self._get_service_health_data_fast(path, server_info)
+            is_enabled = await server_service.is_service_enabled(path)
+            data[path] = self._get_service_health_data_fast(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
         self._cached_health_data = data
         self._cache_timestamp = current_time
@@ -1158,7 +1166,11 @@ class HealthMonitoringService:
 
         data = {}
         for path, server_info in all_servers.items():
-            data[path] = self._get_service_health_data_fast(path, server_info)
+            is_enabled = await server_service.is_service_enabled(path)
+            data[path] = self._get_service_health_data_fast(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
         return data
 
@@ -1272,13 +1284,32 @@ class HealthMonitoringService:
 
     def _get_service_health_data(self, service_path: str, server_info: dict = None) -> dict:
         """Get health data for a specific service - legacy method, use _get_service_health_data_fast for better performance."""
-        return self._get_service_health_data_fast(service_path, server_info or {})
+        if not server_info:
+            last_checked_dt = self.server_last_check_time.get(service_path)
+            last_checked_iso = last_checked_dt.isoformat() if last_checked_dt else None
+            return {
+                "status": self.server_health_status.get(service_path, HealthStatus.UNKNOWN),
+                "last_checked_iso": last_checked_iso,
+                "num_tools": 0,
+            }
+
+        return self._get_service_health_data_fast(service_path, server_info)
 
     def _get_service_health_data_fast(self, service_path: str, server_info: dict) -> dict:
         """Get health data for a specific service - optimized version."""
 
+        if "is_enabled" not in server_info:
+            last_checked_dt = self.server_last_check_time.get(service_path)
+            last_checked_iso = last_checked_dt.isoformat() if last_checked_dt else None
+            num_tools = server_info.get("num_tools", 0) if server_info else 0
+            return {
+                "status": self.server_health_status.get(service_path, HealthStatus.UNKNOWN),
+                "last_checked_iso": last_checked_iso,
+                "num_tools": num_tools,
+            }
+
         # Quick enabled check from server_info
-        is_enabled = server_info.get("is_enabled", False)
+        is_enabled = bool(server_info.get("is_enabled"))
 
         if not is_enabled:
             status = "disabled"

--- a/registry/repositories/file/search_repository.py
+++ b/registry/repositories/file/search_repository.py
@@ -58,17 +58,17 @@ class FaissSearchRepository(SearchRepositoryBase):
 
     async def initialize(self) -> None:
         """Initialize the search repository."""
-        # FAISS service initializes itself
-        pass
+        # Explicitly initialize the shared FAISS service used by this repository.
+        await self.faiss_service.initialize()
 
     async def index_server(
         self, server_path: str, server_data: dict[str, Any], is_enabled: bool
     ) -> None:
         """Index a server."""
-        await self.index_entity(server_path, server_data, "server", is_enabled)
+        await self.index_entity(server_path, server_data, "mcp_server", is_enabled)
 
     async def index_agent(
         self, agent_path: str, agent_data: dict[str, Any], is_enabled: bool
     ) -> None:
         """Index an agent."""
-        await self.index_entity(agent_path, agent_data, "agent", is_enabled)
+        await self.index_entity(agent_path, agent_data, "a2a_agent", is_enabled)

--- a/registry/servers/currenttime.json
+++ b/registry/servers/currenttime.json
@@ -2,7 +2,7 @@
   "server_name": "Current Time API",
   "description": "A simple API that returns the current server time in various formats.",
   "path": "/currenttime/",
-  "proxy_pass_url": "http://currenttime-server:8000/",
+  "proxy_pass_url": "http://currenttime-server:8000/mcp",
   "auth_scheme": "none",
   "tags": ["time", "utility", "api"],
   "num_tools": 1,

--- a/registry/servers/realserverfaketools.json
+++ b/registry/servers/realserverfaketools.json
@@ -2,7 +2,7 @@
   "server_name": "Real Server Fake Tools",
   "description": "A collection of fake tools with interesting names that take different parameter types",
   "path": "/realserverfaketools/",
-  "proxy_pass_url": "http://realserverfaketools-server:8002/",  
+  "proxy_pass_url": "http://realserverfaketools-server:8002/mcp",  
   "supported_transports": ["streamable-http"],
   "auth_scheme": "none",
   "tags": ["demo", "fake", "tools", "testing"],

--- a/registry/services/federation/anthropic_client.py
+++ b/registry/services/federation/anthropic_client.py
@@ -88,7 +88,25 @@ class AnthropicFederationClient(BaseFederationClient):
         Returns:
             List of server data dictionaries
         """
-        servers = []
+        servers: list[dict[str, Any]] = []
+
+        # Empty list means "import all" from Anthropic catalog.
+        if not server_configs:
+            logger.info("No explicit Anthropic server list provided, fetching full server catalog")
+            catalog_servers = self._fetch_all_catalog_servers()
+
+            for server_entry in catalog_servers:
+                server = server_entry.get("server", {})
+                server_name = server.get("name")
+                if not server_name:
+                    continue
+
+                transformed = self._transform_server_response(server_entry, server_name, None)
+                if transformed:
+                    servers.append(transformed)
+
+            logger.info(f"Successfully fetched {len(servers)} servers from Anthropic catalog")
+            return servers
 
         for config in server_configs:
             server_data = self.fetch_server(config.name, config)
@@ -99,6 +117,54 @@ class AnthropicFederationClient(BaseFederationClient):
 
         logger.info(f"Successfully fetched {len(servers)}/{len(server_configs)} servers")
         return servers
+
+    def _fetch_all_catalog_servers(self) -> list[dict[str, Any]]:
+        """
+        Fetch all server entries from Anthropic registry using cursor pagination.
+
+        Returns:
+            List of unique server entries from the catalog.
+        """
+        all_servers: list[dict[str, Any]] = []
+        seen_names: set[str] = set()
+        cursor: str | None = None
+        page = 0
+        max_pages = 1000
+
+        while page < max_pages:
+            page += 1
+            url = f"{self.endpoint}/{self.api_version}/servers"
+            if cursor:
+                url = f"{url}?cursor={quote(cursor, safe='')}"
+
+            response = self._make_request(url, headers={"Content-Type": "application/json"})
+            if not response:
+                logger.warning(f"Failed to fetch Anthropic catalog page {page}, stopping pagination")
+                break
+
+            servers = response.get("servers", [])
+            metadata = response.get("metadata", {})
+
+            for entry in servers:
+                server = entry.get("server", {}) if isinstance(entry, dict) else {}
+                server_name = server.get("name")
+                if not server_name or server_name in seen_names:
+                    continue
+                seen_names.add(server_name)
+                all_servers.append(entry)
+
+            next_cursor = metadata.get("nextCursor")
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+        if page >= max_pages:
+            logger.warning(
+                f"Reached pagination safety limit ({max_pages}) while fetching Anthropic catalog"
+            )
+
+        logger.info(f"Fetched {len(all_servers)} unique servers from Anthropic catalog")
+        return all_servers
 
     def _transform_server_response(
         self,

--- a/registry/services/federation_reconciliation.py
+++ b/registry/services/federation_reconciliation.py
@@ -121,7 +121,9 @@ async def reconcile_anthropic_servers(
     # Step 1: Get expected paths from config
     expected_paths = _config_server_names_to_paths(config)
 
-    # If anthropic is disabled entirely, all anthropic servers are stale
+    # If anthropic is disabled entirely, all anthropic servers are stale.
+    # If anthropic is enabled with an empty server list, this is "full catalog"
+    # mode and we should not remove anything based on config-path diff.
     if not config.anthropic.enabled:
         expected_paths = set()
 
@@ -138,6 +140,20 @@ async def reconcile_anthropic_servers(
         f"Reconciliation: {len(actual_paths)} servers found "
         f"in mcp_servers_default with source='anthropic'"
     )
+
+    # In full-catalog mode we cannot infer stale servers from config, so skip removal.
+    if config.anthropic.enabled and not config.anthropic.servers:
+        logger.info(
+            "Reconciliation: Anthropic full-catalog mode detected "
+            "(empty server list), skipping stale-server removals"
+        )
+        return {
+            "removed": [],
+            "removed_count": 0,
+            "expected_count": len(expected_paths),
+            "actual_count": len(actual_paths),
+            "dry_run": dry_run,
+        }
 
     # Step 3: Compute stale servers (in DB but not in config)
     stale_paths = actual_paths - expected_paths

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -1,19 +1,42 @@
-"""MCP Gateway Interaction Server (mcpgw).
-
-This MCP server provides tools to interact with the MCP Gateway Registry API.
-It acts as a thin protocol adapter, translating MCP tool calls into registry HTTP requests.
-
-All tools require bearer token authentication via the Authorization header.
+"""
+This server provides tools to interact with the MCP Gateway Registry API.
 """
 
+import argparse
+import asyncio  # Added for locking
+import base64
+import json
 import logging
 import os
-from typing import Any
+import re
 
-import httpx
-from fastmcp import Context, FastMCP
+# Import embeddings client from registry
+import sys
+from pathlib import Path  # Added Path
+from typing import Any, ClassVar
 
-from models import AgentInfo, RegistryStats, ServerInfo, SkillInfo, ToolSearchResult
+import faiss  # Added
+import httpx  # Use httpx for async requests
+import numpy as np  # Added
+import yaml  # Added for scopes.yml parsing
+from dotenv import load_dotenv
+from fastmcp import Context, FastMCP  # Updated import for FastMCP 2.0
+from fastmcp.server.dependencies import get_http_request  # New dependency function for HTTP access
+from pydantic import BaseModel, Field
+from sklearn.metrics.pairwise import cosine_similarity  # Added
+
+# Add registry to path - works in both Docker and local dev
+registry_path_docker = Path("/app/registry")
+registry_path_local = Path(__file__).parent.parent.parent / "registry"
+
+if registry_path_docker.exists():
+    sys.path.insert(0, str(registry_path_docker))
+elif registry_path_local.exists():
+    sys.path.insert(0, str(registry_path_local))
+else:
+    raise ImportError("Cannot find registry module. Ensure registry directory is accessible.")
+
+from embeddings import EmbeddingsClient, create_embeddings_client
 
 # Configure logging
 logging.basicConfig(
@@ -22,448 +45,2372 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Get registry URL from environment (used inside Docker containers)
-# This is the internal registry URL that mcpgw uses to communicate with the registry
-# Example: http://registry:7860 (Docker), http://registry.namespace.svc.cluster.local:8000 (K8s)
-REGISTRY_URL = os.getenv("REGISTRY_BASE_URL", "http://localhost")
+_QUERY_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "from",
+    "that",
+    "this",
+    "into",
+    "about",
+    "find",
+    "tool",
+    "tools",
+    "use",
+    "using",
+    "help",
+    "get",
+    "list",
+    "show",
+}
 
-# Input validation constants
-MAX_QUERY_LENGTH: int = 500
-MIN_TOP_N: int = 1
-MAX_TOP_N: int = 100
+_HIGH_SIGNAL_QUERY_TOKENS = {
+    "github",
+    "git",
+    "repo",
+    "repos",
+    "repository",
+    "repositories",
+    "issue",
+    "issues",
+    "pull",
+    "request",
+    "commit",
+    "branch",
+}
 
-logger.info(f"Registry URL: {REGISTRY_URL}")
+load_dotenv()  # Load environment variables from .env file
+
+# Get Registry URL from environment variable (keep this one)
+REGISTRY_BASE_URL = os.environ.get(
+    "REGISTRY_BASE_URL", "http://localhost:7860"
+)  # Default to localhost
+
+if not REGISTRY_BASE_URL:
+    raise ValueError("REGISTRY_BASE_URL environment variable is not set.")
+
+# Global variable to cache loaded scopes
+_scopes_config = None
+
+
+def _get_internal_auth_headers() -> dict[str, str]:
+    """
+    Get authorization headers for internal API calls.
+
+    Preferred: short-lived JWT signed with SECRET_KEY.
+    Fallback: Basic auth using REGISTRY_USERNAME / REGISTRY_PASSWORD.
+    """
+    try:
+        from registry.auth.internal import generate_internal_token
+
+        token = generate_internal_token(subject="mcpgw-server", purpose="internal-api")
+        return {"Authorization": f"Bearer {token}"}
+    except Exception as jwt_error:
+        username = os.getenv("REGISTRY_USERNAME")
+        password = os.getenv("REGISTRY_PASSWORD")
+        if username and password:
+            basic_token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode(
+                "utf-8"
+            )
+            logger.warning(
+                "Falling back to Basic auth for internal API calls because JWT setup failed: %s",
+                jwt_error,
+            )
+            return {"Authorization": f"Basic {basic_token}"}
+
+        raise RuntimeError(
+            "Unable to build internal auth headers. Configure SECRET_KEY for JWT "
+            "or REGISTRY_USERNAME/REGISTRY_PASSWORD for Basic auth fallback."
+        ) from jwt_error
+
+
+# --- Scopes Management Helper Functions ---
+async def load_scopes_config() -> dict[str, Any]:
+    """
+    Load and parse the scopes.yml configuration file.
+
+    Returns:
+        Dict containing the parsed scopes configuration
+    """
+    global _scopes_config
+
+    if _scopes_config is not None:
+        return _scopes_config
+
+    try:
+        # Look for scopes.yml in the auth_server directory
+        # First try the docker container path, then fallback to local development path
+        scopes_path = Path("/app/auth_server/scopes.yml")
+        if not scopes_path.exists():
+            scopes_path = Path(__file__).parent.parent / "auth_server" / "scopes.yml"
+
+        if not scopes_path.exists():
+            logger.warning(f"Scopes file not found at {scopes_path}")
+            return {}
+
+        with open(scopes_path) as f:
+            _scopes_config = yaml.safe_load(f)
+
+        logger.info(f"Successfully loaded scopes configuration from {scopes_path}")
+        return _scopes_config
+
+    except Exception as e:
+        logger.error(f"Failed to load scopes configuration: {e}")
+        return {}
+
+
+def extract_user_scopes_from_headers(headers: dict[str, str]) -> list[str]:
+    """
+    Extract user scopes from HTTP headers.
+
+    Args:
+        headers: Dictionary of HTTP headers
+
+    Returns:
+        List of scopes the user has access to
+    """
+    scopes = []
+
+    # Check for scopes in various header formats
+    scope_headers = ["x-scopes", "x-user-scopes", "scopes"]
+
+    for header_name in scope_headers:
+        header_value = headers.get(header_name) or headers.get(header_name.lower())
+        if header_value:
+            # Scopes might be comma-separated or space-separated
+            if "," in header_value:
+                scopes.extend([s.strip() for s in header_value.split(",")])
+            else:
+                scopes.extend([s.strip() for s in header_value.split()])
+            break
+
+    logger.info(f"Extracted scopes from headers: {scopes}")
+    return scopes
+
+
+def get_default_user_scopes_from_env() -> list[str]:
+    """
+    Optional fallback scopes for integrations that do not forward scope headers.
+
+    Expected format:
+      - Comma-separated: "scope-a,scope-b"
+      - Space-separated: "scope-a scope-b"
+    """
+    raw = os.getenv("MCPGW_DEFAULT_SCOPES", "").strip()
+    if not raw:
+        return []
+
+    if "," in raw:
+        scopes = [scope.strip() for scope in raw.split(",") if scope.strip()]
+    else:
+        scopes = [scope.strip() for scope in raw.split() if scope.strip()]
+
+    logger.info(f"Using MCPGW_DEFAULT_SCOPES fallback: {scopes}")
+    return scopes
+
+
+def _tool_allowed_for_scope(configured_tools: Any, tool_name: str) -> bool:
+    """Check tool permission with support for wildcard entries."""
+    if configured_tools == "*":
+        return True
+    if isinstance(configured_tools, list):
+        return "*" in configured_tools or tool_name in configured_tools
+    return False
+
+
+def _normalize_service_name_for_matching(service_name: str) -> str:
+    """
+    Normalize service identifiers for semantic/lexical matching.
+
+    Example:
+    - io.github.Owner/repo-name -> repo name
+    - owner/repo-name -> repo name
+    """
+    if not service_name:
+        return ""
+
+    normalized = service_name.strip()
+    lowered = normalized.lower()
+
+    if lowered.startswith(("io.github.", "com.github.", "org.github.")):
+        if "/" in normalized:
+            normalized = normalized.split("/", 1)[1]
+        else:
+            normalized = normalized.split(".")[-1]
+
+    if "/" in normalized:
+        normalized = normalized.split("/", 1)[1]
+
+    return re.sub(r"[^a-z0-9]+", " ", normalized.lower()).strip()
+
+
+def _query_tokens(text: str) -> set[str]:
+    """Build normalized query tokens for lightweight lexical boosting."""
+    tokens = set()
+    for token in re.findall(r"[a-z0-9]+", (text or "").lower()):
+        if len(token) < 3:
+            continue
+        if token in _QUERY_STOPWORDS:
+            continue
+        tokens.add(token)
+    return tokens
+
+
+def _lexical_tool_signal(
+    query_tokens: set[str],
+    raw_service_name: str,
+    normalized_service_name: str,
+    tool_name: str,
+    description: str,
+) -> float:
+    """
+    Compute lexical relevance signal for a candidate tool.
+    """
+    if not query_tokens:
+        return 0.0
+
+    service_tokens = _query_tokens(normalized_service_name)
+    tool_tokens = _query_tokens(tool_name.replace("_", " ").replace("-", " "))
+    desc_tokens = _query_tokens(description)
+
+    score = 0.0
+    score += 1.4 * len(query_tokens & tool_tokens)
+    score += 1.0 * len(query_tokens & desc_tokens)
+    score += 0.4 * len(query_tokens & service_tokens)
+
+    query_has_github = "github" in query_tokens
+    explicit_github_tokens = tool_tokens | desc_tokens
+    namespace_like = raw_service_name.lower().startswith(("io.github.", "com.github.", "org.github."))
+    if query_has_github and namespace_like and "github" not in explicit_github_tokens:
+        # Avoid over-ranking all io.github.* package namespaces for generic "github" queries.
+        score -= 0.8
+
+    return score
+
+
+def check_tool_access(
+    server_name: str, tool_name: str, user_scopes: list[str], scopes_config: dict[str, Any]
+) -> bool:
+    """
+    Check if a user has access to a specific tool based on their scopes.
+
+    Args:
+        server_name: Name of the server (e.g., 'mcpgw', 'fininfo')
+        tool_name: Name of the tool
+        user_scopes: List of scopes the user has
+        scopes_config: Parsed scopes configuration
+
+    Returns:
+        True if user has access, False otherwise
+    """
+    if not scopes_config or not user_scopes:
+        logger.warning(
+            f"Access denied: {server_name}.{tool_name} - no scopes config or user scopes"
+        )
+        return False
+
+    logger.info(f"Checking access for {server_name}.{tool_name} with user scopes: {user_scopes}")
+    logger.info(f"Available scope keys in config: {list(scopes_config.keys())}")
+
+    # Check direct scope access
+    for user_scope in user_scopes:
+        logger.info(f"Checking user scope: {user_scope}")
+        if user_scope in scopes_config:
+            scope_data = scopes_config[user_scope]
+            logger.info(f"Found scope data for {user_scope}: {type(scope_data)}")
+            if isinstance(scope_data, list):
+                # This is a server scope (like mcp-servers-unrestricted/read)
+                for server_config in scope_data:
+                    logger.info(
+                        f"Checking server config: {server_config.get('server')} vs {server_name}"
+                    )
+                    # Normalize server names by stripping trailing slashes for comparison
+                    config_server_name = server_config.get("server", "").rstrip("/")
+                    normalized_server_name = server_name.rstrip("/")
+                    server_matches = config_server_name in ("*", normalized_server_name)
+                    if server_matches:
+                        tools = server_config.get("tools", [])
+                        logger.info(f"Available tools for {server_name}: {tools}")
+                        if _tool_allowed_for_scope(tools, tool_name):
+                            logger.info(
+                                f"Access granted: {server_name}.{tool_name} via scope {user_scope}"
+                            )
+                            return True
+
+    # Check group mappings for additional access
+    group_mappings = scopes_config.get("group_mappings", {})
+    logger.debug(f"Checking group mappings: {group_mappings}")
+    for group, mapped_scopes in group_mappings.items():
+        if group in user_scopes:
+            logger.debug(f"User is in group {group}, checking mapped scopes: {mapped_scopes}")
+            # User is in this group, check the mapped scopes
+            for mapped_scope in mapped_scopes:
+                if mapped_scope in scopes_config:
+                    scope_data = scopes_config[mapped_scope]
+                    if isinstance(scope_data, list):
+                        for server_config in scope_data:
+                            # Normalize server names by stripping trailing slashes for comparison
+                            config_server_name = server_config.get("server", "").rstrip("/")
+                            normalized_server_name = server_name.rstrip("/")
+                            server_matches = config_server_name in ("*", normalized_server_name)
+                            if server_matches:
+                                tools = server_config.get("tools", [])
+                                if _tool_allowed_for_scope(tools, tool_name):
+                                    logger.info(
+                                        f"Access granted: {server_name}.{tool_name} via group {group} -> {mapped_scope}"
+                                    )
+                                    return True
+
+    logger.warning(f"Access denied: {server_name}.{tool_name} for scopes {user_scopes}")
+    return False
+
+
+# --- Authentication Context Helper Functions ---
+async def extract_auth_context(ctx: Context) -> dict[str, Any]:
+    """
+    Extract authentication context from the MCP Context.
+    FastMCP 2.0 version with improved HTTP header access.
+
+    Args:
+        ctx: FastMCP Context object
+
+    Returns:
+        Dict containing authentication information
+    """
+    try:
+        # Basic context information we can reliably access
+        auth_context = {
+            "request_id": ctx.request_id,
+            "client_id": ctx.client_id,
+            "session_available": ctx.session is not None,
+            "request_context_available": ctx.request_context is not None,
+        }
+
+        # Try to get HTTP request information using FastMCP 2.0 dependency system
+        try:
+            http_request = get_http_request()
+            if http_request:
+                auth_context["http_request_available"] = True
+
+                # Access HTTP headers directly
+                headers = dict(http_request.headers)
+                auth_headers = {}
+
+                # Extract auth-related headers
+                for key, value in headers.items():
+                    key_lower = key.lower()
+                    if key_lower in [
+                        "authorization",
+                        "x-user-pool-id",
+                        "x-client-id",
+                        "x-region",
+                        "x-scopes",
+                        "x-user",
+                        "x-username",
+                        "x-auth-method",
+                        "cookie",
+                    ]:
+                        if key_lower == "authorization":
+                            # Don't log full auth token, just indicate presence
+                            auth_headers[key] = (
+                                "Bearer Token Present"
+                                if value.startswith("Bearer ")
+                                else "Auth Header Present"
+                            )
+                        elif key_lower == "cookie" and "mcp_gateway_session=" in value:
+                            # Extract session cookie safely
+                            import re
+
+                            match = re.search(r"mcp_gateway_session=([^;]+)", value)
+                            if match:
+                                cookie_value = match.group(1)
+                                auth_headers["session_cookie"] = (
+                                    cookie_value[:20] + "..."
+                                    if len(cookie_value) > 20
+                                    else cookie_value
+                                )
+                        else:
+                            auth_headers[key] = str(value)[:100]  # Truncate long values
+
+                if auth_headers:
+                    auth_context["auth_headers"] = auth_headers
+                else:
+                    auth_context["auth_headers"] = "No auth headers found"
+
+                # Additional HTTP request info
+                auth_context["http_info"] = {
+                    "method": http_request.method,
+                    "url": str(http_request.url),
+                    "client_host": http_request.client.host if http_request.client else "Unknown",
+                    "user_agent": headers.get("user-agent", "Unknown"),
+                }
+            else:
+                auth_context["http_request_available"] = False
+                auth_context["auth_headers"] = "No HTTP request context"
+
+        except RuntimeError as e:
+            # get_http_request() raises RuntimeError when not in HTTP context
+            auth_context["http_request_available"] = False
+            auth_context["auth_headers"] = f"Not in HTTP context: {str(e)}"
+        except Exception as http_error:
+            logger.debug(f"Could not access HTTP request: {http_error}")
+            auth_context["http_request_available"] = False
+            auth_context["auth_headers"] = f"HTTP access error: {str(http_error)}"
+
+        # Try to inspect the session for transport-level information (fallback)
+        session_info = {}
+        try:
+            session = ctx.session
+            if session:
+                session_info["session_type"] = type(session).__name__
+
+                # Check if session has transport
+                if hasattr(session, "transport"):
+                    transport = session.transport
+                    if transport:
+                        session_info["transport_type"] = type(transport).__name__
+
+                        # Try to access any available transport attributes
+                        transport_attrs = [
+                            attr for attr in dir(transport) if not attr.startswith("_")
+                        ]
+                        session_info["transport_attributes"] = transport_attrs[
+                            :10
+                        ]  # Limit to avoid spam
+
+        except Exception as session_error:
+            logger.debug(f"Could not access session info: {session_error}")
+            session_info["error"] = str(session_error)
+
+        auth_context["session_info"] = session_info
+
+        # Try to access request context metadata
+        request_info = {}
+        try:
+            request_context = ctx.request_context
+            if request_context:
+                request_info["request_context_type"] = type(request_context).__name__
+
+                if hasattr(request_context, "meta") and request_context.meta:
+                    meta = request_context.meta
+                    meta_info = {}
+
+                    # Check for standard meta attributes
+                    for attr in ["client_id", "user_pool_id", "region", "progressToken"]:
+                        if hasattr(meta, attr):
+                            value = getattr(meta, attr)
+                            meta_info[attr] = str(value) if value is not None else None
+
+                    request_info["meta"] = meta_info
+
+        except Exception as request_error:
+            logger.debug(f"Could not access request context info: {request_error}")
+            request_info["error"] = str(request_error)
+
+        auth_context["request_info"] = request_info
+
+        return auth_context
+
+    except Exception as e:
+        logger.error(f"Failed to extract auth context: {e}")
+        return {
+            "error": f"Failed to extract auth context: {str(e)}",
+            "request_id": getattr(ctx, "request_id", "unknown"),
+            "client_id": getattr(ctx, "client_id", None),
+        }
+
+
+async def log_auth_context(tool_name: str, ctx: Context) -> dict[str, Any]:
+    """
+    Log authentication context for a tool call and return the context.
+
+    Args:
+        tool_name: Name of the tool being called
+        ctx: FastMCP Context object
+
+    Returns:
+        Dict containing the auth context
+    """
+    auth_context = await extract_auth_context(ctx)
+
+    # Log the context for debugging via MCP logging
+    await ctx.info(f"🔐 Auth Context for {tool_name}:")
+    await ctx.info(f"   Request ID: {auth_context.get('request_id', 'Unknown')}")
+    await ctx.info(f"   Client ID: {auth_context.get('client_id', 'Not present')}")
+    await ctx.info(f"   Session Available: {auth_context.get('session_available', False)}")
+
+    # Log auth headers if found
+    auth_headers = auth_context.get("auth_headers", {})
+    if auth_headers:
+        await ctx.info("   Auth Headers Found:")
+        for key, value in auth_headers.items():
+            await ctx.info(f"     {key}: {value}")
+    else:
+        await ctx.info("   No auth headers detected")
+
+    # Log session info if available
+    session_info = auth_context.get("session_info", {})
+    if session_info.get("session_type"):
+        await ctx.info(f"   Session Type: {session_info['session_type']}")
+        if session_info.get("transport_type"):
+            await ctx.info(f"   Transport Type: {session_info['transport_type']}")
+
+    # Log request info if available
+    request_info = auth_context.get("request_info", {})
+    if request_info.get("meta"):
+        await ctx.info(f"   Request Meta: {request_info['meta']}")
+
+    # Also log to server logs for debugging
+    logger.info(f"AUTH_CONTEXT for {tool_name}: {json.dumps(auth_context, indent=2, default=str)}")
+
+    return auth_context
+
+
+async def validate_session_cookie_with_auth_server(
+    session_cookie: str, auth_server_url: str = "http://localhost:8888"
+) -> dict[str, Any]:
+    """
+    Validate a session cookie with the auth server and return user context.
+
+    Args:
+        session_cookie: The session cookie value
+        auth_server_url: URL of the auth server
+
+    Returns:
+        Dict containing user context information including username, groups, scopes, etc.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # Call the auth server to validate the session cookie
+            response = await client.post(
+                f"{auth_server_url}/validate",
+                headers={
+                    "Cookie": f"mcp_gateway_session={session_cookie}",
+                    "Content-Type": "application/json",
+                },
+                json={"action": "validate_session"},  # Indicate we want session validation
+            )
+
+            if response.status_code == 200:
+                user_context = response.json()
+                logger.info(
+                    f"Session validation successful for user: {user_context.get('username', 'unknown')}"
+                )
+                return user_context
+            else:
+                logger.warning(f"Session validation failed: HTTP {response.status_code}")
+                return {"valid": False, "error": f"HTTP {response.status_code}"}
+
+    except Exception as e:
+        logger.error(f"Error validating session cookie: {e}")
+        return {"valid": False, "error": str(e)}
+
+
+async def extract_user_scopes_from_auth_context(auth_context: dict[str, Any]) -> list[str]:
+    """
+    Extract user scopes from the authentication context.
+
+    Args:
+        auth_context: Authentication context from extract_auth_context()
+
+    Returns:
+        List of user scopes
+    """
+    # Try to get scopes from auth headers (set by nginx from auth server)
+    auth_headers = auth_context.get("auth_headers", {})
+    if isinstance(auth_headers, dict) and "x-scopes" in auth_headers:
+        scopes_header = auth_headers["x-scopes"]
+        if scopes_header and scopes_header.strip():
+            # Scopes are space-separated in the header
+            scopes = scopes_header.split()
+            logger.info(f"Extracted scopes from auth headers: {scopes}")
+            return scopes
+
+    logger.warning("No scopes found in auth context")
+    return []
+
+
+async def validate_user_access_to_tool(
+    ctx: Context, tool_name: str, server_name: str = "mcpgw", action: str = "execute"
+) -> bool:
+    """
+    Validate if the authenticated user has access to execute a specific tool.
+
+    Args:
+        ctx: FastMCP Context object
+        tool_name: Name of the tool being accessed
+        server_name: Name of the server (default: "mcpgw")
+        action: Action being performed ("read" or "execute")
+
+    Returns:
+        True if access is granted, False otherwise
+
+    Raises:
+        Exception: If access is denied
+    """
+    # Extract authentication context
+    auth_context = await extract_auth_context(ctx)
+
+    # Get user info
+    auth_headers = auth_context.get("auth_headers", {})
+    username = auth_headers.get("x-user", "unknown") or auth_headers.get("x-username", "unknown")
+
+    # Extract scopes
+    user_scopes = await extract_user_scopes_from_auth_context(auth_context)
+
+    if not user_scopes:
+        logger.error(
+            f"FGAC: Access denied for user '{username}' to tool '{tool_name}' - no scopes available"
+        )
+        raise Exception("Access denied: No scopes configured for user")
+
+    logger.info(
+        f"FGAC: Validating access for user '{username}' to tool '{tool_name}' on server '{server_name}' with action '{action}'"
+    )
+    logger.info(f"FGAC: User scopes: {user_scopes}")
+
+    # Check for server-specific scopes that allow this action
+    required_scope_patterns = [
+        f"mcp-servers-unrestricted/{action}",  # Unrestricted access for this action
+        f"mcp-servers-restricted/{action}",  # Restricted access for this action
+    ]
+
+    for scope in user_scopes:
+        if scope in required_scope_patterns:
+            logger.info(
+                f"FGAC: Access granted - user '{username}' has scope '{scope}' for tool '{tool_name}'"
+            )
+            return True
+
+    # If no matching scope found, deny access
+    logger.error(
+        f"FGAC: Access denied for user '{username}' to tool '{tool_name}' - insufficient permissions"
+    )
+    logger.error(f"FGAC: Required one of: {required_scope_patterns}")
+    logger.error(f"FGAC: User has: {user_scopes}")
+
+    raise Exception(
+        f"Access denied: Insufficient permissions to execute '{tool_name}'. Required scopes: {required_scope_patterns}"
+    )
+
+
+async def check_user_permission_for_tool(
+    auth_context: dict[str, Any], tool_name: str, action: str = "execute"
+) -> bool:
+    """
+    DEPRECATED: Legacy function for backward compatibility.
+    Use validate_user_access_to_tool() instead for proper FGAC.
+    """
+    logger.warning(
+        "Using deprecated check_user_permission_for_tool - consider upgrading to validate_user_access_to_tool"
+    )
+
+    if not auth_context.get("valid", False):
+        logger.warning(f"Access denied for {tool_name}: Invalid auth context")
+        return False
+
+    username = auth_context.get("username", "unknown")
+    scopes = auth_context.get("scopes", [])
+    groups = auth_context.get("groups", [])
+
+    # Example permission logic - you can customize this based on your needs
+
+    # Admin users can access everything
+    if "mcp-registry-admin" in groups:
+        logger.info(f"Access granted for {tool_name}: Admin user {username}")
+        return True
+
+    # Check for specific tool permissions in scopes
+    # You could implement more sophisticated scope checking here
+    tool_permission = f"mcp-tools/{tool_name}/{action}"
+    if tool_permission in scopes:
+        logger.info(f"Access granted for {tool_name}: User {username} has scope {tool_permission}")
+        return True
+
+    # Check for wildcard permissions
+    wildcard_permission = f"mcp-tools/*/{action}"
+    if wildcard_permission in scopes:
+        logger.info(f"Access granted for {tool_name}: User {username} has wildcard scope")
+        return True
+
+    # Deny access by default
+    logger.warning(
+        f"Access denied for {tool_name}: User {username} lacks required permissions. Available scopes: {scopes}"
+    )
+    return False
+
+
+# --- FAISS and Embeddings Integration for mcpgw --- START
+_faiss_data_lock = asyncio.Lock()
+_embedding_model_mcpgw: EmbeddingsClient | None = None
+_faiss_index_mcpgw: faiss.Index | None = None
+_faiss_metadata_mcpgw: dict[str, Any] | None = (
+    None  # This will store the content of service_index_metadata.json
+)
+_last_faiss_index_mtime: float | None = None
+_last_faiss_metadata_mtime: float | None = None
+_last_faiss_check_time: float | None = None  # Track when we last checked for file updates
+_faiss_check_interval: float = 5.0  # Only check for file updates every 5 seconds
+
+# Determine base path for mcpgw server to find registry's server data
+# When running in Docker, server.py is at /app/server.py and registry files are at /app/registry/servers/
+_registry_server_data_path = Path(__file__).resolve().parent / "registry" / "servers"
+FAISS_INDEX_PATH_MCPGW = _registry_server_data_path / "service_index.faiss"
+FAISS_METADATA_PATH_MCPGW = _registry_server_data_path / "service_index_metadata.json"
+EMBEDDING_DIMENSION_MCPGW = 384  # Should match the one used in main registry
+
+
+async def load_faiss_data_for_mcpgw():
+    """Loads the FAISS index, metadata, and embedding model for the mcpgw server.
+    Reloads data if underlying files have changed since last load.
+    """
+    global _embedding_model_mcpgw, _faiss_index_mcpgw, _faiss_metadata_mcpgw
+    global _last_faiss_index_mtime, _last_faiss_metadata_mtime
+
+    async with _faiss_data_lock:
+        # Load embedding model if not already loaded (model doesn't change on disk typically)
+        if _embedding_model_mcpgw is None:
+            try:
+                # Get embeddings configuration from environment
+                embeddings_provider = os.environ.get("EMBEDDINGS_PROVIDER", "sentence-transformers")
+                embeddings_model_name = os.environ.get("EMBEDDINGS_MODEL_NAME", "all-MiniLM-L6-v2")
+                embeddings_api_key = os.environ.get("EMBEDDINGS_API_KEY")
+                embeddings_api_base = os.environ.get("EMBEDDINGS_API_BASE")
+                embeddings_aws_region = os.environ.get("EMBEDDINGS_AWS_REGION", "us-east-1")
+                embeddings_model_dimensions = int(
+                    os.environ.get("EMBEDDINGS_MODEL_DIMENSIONS", "384")
+                )
+
+                logger.info(
+                    f"MCPGW: Loading embeddings model with provider: {embeddings_provider}, model: {embeddings_model_name}"
+                )
+
+                # Compute model directory for sentence-transformers
+                embeddings_model_dir = (
+                    _registry_server_data_path.parent / "models" / embeddings_model_name
+                    if embeddings_provider == "sentence-transformers"
+                    else None
+                )
+
+                # Create embeddings client using the factory function
+                _embedding_model_mcpgw = await asyncio.to_thread(
+                    create_embeddings_client,
+                    provider=embeddings_provider,
+                    model_name=embeddings_model_name,
+                    model_dir=embeddings_model_dir,
+                    cache_dir=_registry_server_data_path.parent / ".cache"
+                    if embeddings_provider == "sentence-transformers"
+                    else None,
+                    api_key=embeddings_api_key if embeddings_provider == "litellm" else None,
+                    api_base=embeddings_api_base if embeddings_provider == "litellm" else None,
+                    aws_region=embeddings_aws_region if embeddings_provider == "litellm" else None,
+                    embedding_dimension=embeddings_model_dimensions,
+                )
+
+                logger.info(
+                    f"MCPGW: Embeddings client loaded successfully. Provider: {embeddings_provider}, Model: {embeddings_model_name}"
+                )
+            except Exception as e:
+                logger.error(f"MCPGW: Failed to load embeddings client: {e}", exc_info=True)
+                return  # Cannot proceed without the model for subsequent logic
+
+        # Check FAISS index file
+        index_file_changed = False
+        if FAISS_INDEX_PATH_MCPGW.exists():
+            try:
+                current_index_mtime = await asyncio.to_thread(
+                    os.path.getmtime, FAISS_INDEX_PATH_MCPGW
+                )
+                if (
+                    _faiss_index_mcpgw is None
+                    or _last_faiss_index_mtime is None
+                    or current_index_mtime > _last_faiss_index_mtime
+                ):
+                    logger.info(
+                        f"MCPGW: FAISS index file {FAISS_INDEX_PATH_MCPGW} has changed or not loaded. Reloading..."
+                    )
+                    _faiss_index_mcpgw = await asyncio.to_thread(
+                        faiss.read_index, str(FAISS_INDEX_PATH_MCPGW)
+                    )
+                    _last_faiss_index_mtime = current_index_mtime
+                    index_file_changed = True  # Mark that it was reloaded
+                    logger.info(
+                        f"MCPGW: FAISS index loaded. Total vectors: {_faiss_index_mcpgw.ntotal}"
+                    )
+                    if _faiss_index_mcpgw.d != EMBEDDING_DIMENSION_MCPGW:
+                        logger.warning(
+                            f"MCPGW: Loaded FAISS index dimension ({_faiss_index_mcpgw.d}) differs from expected ({EMBEDDING_DIMENSION_MCPGW}). Search might be compromised."
+                        )
+                else:
+                    logger.debug("MCPGW: FAISS index file unchanged since last load.")
+            except Exception as e:
+                logger.error(f"MCPGW: Failed to load or check FAISS index: {e}", exc_info=True)
+                _faiss_index_mcpgw = None  # Ensure it's None on error
+        else:
+            logger.warning(f"MCPGW: FAISS index file {FAISS_INDEX_PATH_MCPGW} does not exist.")
+            _faiss_index_mcpgw = None
+            _last_faiss_index_mtime = None
+
+        # Check FAISS metadata file
+        metadata_file_changed = False
+        if FAISS_METADATA_PATH_MCPGW.exists():
+            try:
+                logger.info(
+                    f"MCPGW: Checking FAISS metadata file {FAISS_METADATA_PATH_MCPGW} for changes..."
+                )
+                current_metadata_mtime = await asyncio.to_thread(
+                    os.path.getmtime, FAISS_METADATA_PATH_MCPGW
+                )
+                if (
+                    _faiss_metadata_mcpgw is None
+                    or _last_faiss_metadata_mtime is None
+                    or current_metadata_mtime > _last_faiss_metadata_mtime
+                    or index_file_changed
+                ):
+                    logger.info(
+                        f"MCPGW: FAISS metadata file {FAISS_METADATA_PATH_MCPGW} has changed, not loaded, or index changed. Reloading..."
+                    )
+                    with open(FAISS_METADATA_PATH_MCPGW) as f:
+                        content = await asyncio.to_thread(f.read)
+                        _faiss_metadata_mcpgw = await asyncio.to_thread(json.loads, content)
+                    _last_faiss_metadata_mtime = current_metadata_mtime
+                    metadata_file_changed = True
+                    logger.info(
+                        f"MCPGW: FAISS metadata loaded. Paths: {len(_faiss_metadata_mcpgw.get('metadata', {})) if _faiss_metadata_mcpgw else 'N/A'}"
+                    )
+                    logger.info(
+                        f"MCPGW: FAISS metadata _faiss_metadata_mcpgw {_faiss_metadata_mcpgw.get('metadata')}"
+                    )
+                else:
+                    logger.debug("MCPGW: FAISS metadata file unchanged since last load.")
+            except Exception as e:
+                logger.error(f"MCPGW: Failed to load or check FAISS metadata: {e}", exc_info=True)
+                _faiss_metadata_mcpgw = None  # Ensure it's None on error
+        else:
+            logger.warning(
+                f"MCPGW: FAISS metadata file {FAISS_METADATA_PATH_MCPGW} does not exist."
+            )
+            _faiss_metadata_mcpgw = None
+            _last_faiss_metadata_mtime = None
+
+
+# Call it once at startup, but allow lazy loading if it fails initially
+# This direct call might be problematic if server.py is imported elsewhere before app runs.
+# A better approach would be a startup event if FastMCP supports it.
+# For now, it will attempt to load on first tool call if still None.
+# asyncio.create_task(load_faiss_data_for_mcpgw()) # Consider FastMCP startup hook
+
+# --- FAISS and Sentence Transformer Integration for mcpgw --- END
+
+
+class Constants(BaseModel):
+    # Using ClassVar to define class-level constants
+    DESCRIPTION: ClassVar[str] = "MCP Gateway Registry Interaction Server (mcpgw)"
+    DEFAULT_MCP_TRANSPORT: ClassVar[str] = "streamable-http"
+    DEFAULT_MCP_SEVER_LISTEN_PORT: ClassVar[str] = "8003"  # Default to a different port
+    REQUEST_TIMEOUT: ClassVar[float] = 15.0  # Timeout for HTTP requests
+
+    # Disable instance creation - optional but recommended for constants
+    class Config:
+        frozen = True  # Make instances immutable
+
+
+def parse_arguments():
+    """Parse command line arguments with defaults matching environment variables."""
+    parser = argparse.ArgumentParser(description=Constants.DESCRIPTION)
+
+    parser.add_argument(
+        "--port",
+        type=str,
+        default=os.environ.get("MCP_SERVER_LISTEN_PORT", Constants.DEFAULT_MCP_SEVER_LISTEN_PORT),
+        help=f"Port for the MCP server to listen on (default: {Constants.DEFAULT_MCP_SEVER_LISTEN_PORT})",
+    )
+
+    parser.add_argument(
+        "--transport",
+        type=str,
+        default=os.environ.get("MCP_TRANSPORT", Constants.DEFAULT_MCP_TRANSPORT),
+        choices=["streamable-http"],
+        help=f"Transport type for the MCP server (default: {Constants.DEFAULT_MCP_TRANSPORT})",
+    )
+
+    return parser.parse_args()
+
+
+# Parse arguments at module level to make them available
+args = parse_arguments()
+
+# Log parsed arguments for debugging
+logger.info(f"Parsed arguments - port: {args.port}, transport: {args.transport}")
+logger.info(
+    f"Environment variables - MCP_TRANSPORT: {os.environ.get('MCP_TRANSPORT', 'NOT SET')}, MCP_SERVER_LISTEN_PORT: {os.environ.get('MCP_SERVER_LISTEN_PORT', 'NOT SET')}"
+)
 
 # Initialize FastMCP server
-mcp = FastMCP("mcpgw")
+mcp = FastMCP("MCPGateway")
 
 
-def _validate_top_n(top_n: int) -> int:
-    """Validate top_n parameter is within acceptable bounds.
-
-    Args:
-        top_n: Number of results to return
-
-    Returns:
-        Validated top_n value
-
-    Raises:
-        ValueError: If top_n is out of bounds
+# --- Helper function for making requests to the registry ---
+async def _call_registry_api(
+    method: str, endpoint: str, ctx: Context = None, **kwargs
+) -> dict[str, Any]:
     """
-    if not isinstance(top_n, int) or top_n < MIN_TOP_N or top_n > MAX_TOP_N:
-        raise ValueError(
-            f"top_n must be an integer between {MIN_TOP_N} and {MAX_TOP_N}"
-        )
-    return top_n
-
-
-def _validate_query(query: str) -> str:
-    """Validate query parameter.
+    Helper function to make async requests to the registry API with auth passthrough.
 
     Args:
-        query: Search query string
+        method: HTTP method (GET, POST, etc.)
+        endpoint: API endpoint path
+        ctx: FastMCP Context to extract auth headers from
+        **kwargs: Additional arguments to pass to the HTTP request
 
     Returns:
-        Validated and trimmed query
-
-    Raises:
-        ValueError: If query is empty or too long
+        Dict[str, Any]: JSON response from the API
     """
-    if not query or not query.strip():
-        raise ValueError("Query cannot be empty")
+    url = f"{REGISTRY_BASE_URL.rstrip('/')}{endpoint}"
 
-    if len(query) > MAX_QUERY_LENGTH:
-        raise ValueError(
-            f"Query exceeds maximum length of {MAX_QUERY_LENGTH} characters"
-        )
+    # Extract auth headers to pass through to registry
+    auth_headers = {}
+    if ctx:
+        try:
+            http_request = get_http_request()
+            if http_request:
+                # Extract auth-related headers to pass through
+                for key, value in http_request.headers.items():
+                    key_lower = key.lower()
+                    if key_lower in [
+                        "authorization",
+                        "x-user-pool-id",
+                        "x-client-id",
+                        "x-region",
+                        "x-scopes",
+                        "x-user",
+                        "x-username",
+                        "x-auth-method",
+                        "cookie",
+                    ]:
+                        auth_headers[key] = value
 
-    return query.strip()
+                if auth_headers:
+                    logger.info(
+                        f"Passing through auth headers to registry: {list(auth_headers.keys())}"
+                    )
+                else:
+                    logger.info("No auth headers found to pass through")
+            else:
+                logger.info("No HTTP request context available for auth passthrough")
+        except RuntimeError:
+            # Not in HTTP context, no auth headers to pass through
+            logger.info("Not in HTTP context, no auth headers to pass through")
+        except Exception as e:
+            logger.warning(f"Could not extract auth headers for passthrough: {e}")
+
+    # Merge auth headers with any existing headers in kwargs
+    if "headers" in kwargs:
+        kwargs["headers"].update(auth_headers)
+    else:
+        kwargs["headers"] = auth_headers
+
+    # Add internal service auth headers
+    internal_auth = _get_internal_auth_headers()
+    if "headers" in kwargs:
+        kwargs["headers"].update(internal_auth)
+    else:
+        kwargs["headers"] = internal_auth
+
+    async with httpx.AsyncClient(timeout=Constants.REQUEST_TIMEOUT) as client:
+        try:
+            logger.info(f"Calling Registry API: {method} {url}")  # Log the actual call
+            response = await client.request(method, url, **kwargs)
+            response.raise_for_status()  # Raise HTTPStatusError for bad responses (4xx or 5xx)
+
+            # Handle cases where response might be empty (e.g., 204 No Content)
+            if response.status_code == 204:
+                return {
+                    "status": "success",
+                    "message": "Operation successful, no content returned.",
+                }
+            return response.json()
+
+        except httpx.HTTPStatusError as e:
+            # Handle HTTP errors
+            error_detail = "No specific error detail provided."
+            try:
+                error_detail = e.response.json().get("detail", error_detail)
+            except Exception as json_error:
+                # Log that we couldn't get detailed error from JSON, but continue with existing error info
+                logger.debug(f"MCPGW: Could not extract detailed error from response: {json_error}")
+            raise Exception(
+                f"Registry API Error ({e.response.status_code}): {error_detail} for {method} {url}"
+            ) from e
+        except httpx.RequestError as e:
+            # Network or connection error during the API call
+            raise Exception(
+                f"Registry API Request Error: Failed to connect or communicate with {url}. Details: {e}"
+            ) from e
+        except Exception as e:  # Catch other potential errors during API call
+            raise Exception(
+                f"An unexpected error occurred while calling the Registry API at {url}: {e}"
+            ) from e
 
 
-def _extract_bearer_token(ctx: Context | None) -> str:
-    """Extract bearer token from FastMCP context via Starlette Request.
+# --- MCP Tools ---
 
-    Supports both standard Authorization header and MCP Gateway's X-Authorization header.
 
-    Args:
-        ctx: FastMCP context containing request information
+@mcp.tool()
+async def debug_auth_context(ctx: Context = None) -> dict[str, Any]:
+    """
+    Debug tool to explore what authentication context is available.
+    This tool helps understand what auth information can be accessed through the MCP Context.
 
     Returns:
-        Bearer token string
-
-    Raises:
-        ValueError: If token cannot be extracted or is missing
+        Dict[str, Any]: Detailed debug information about available auth context
     """
     if not ctx:
-        raise ValueError("Authentication required: Context is None")
+        return {"error": "No context available"}
 
-    try:
-        # Access the Starlette Request object from request_context
-        if hasattr(ctx, "request_context") and ctx.request_context:
-            request = ctx.request_context.request
-            if request and hasattr(request, "headers"):
-                # Try standard Authorization header first (case-insensitive)
-                auth_header = request.headers.get("authorization")
+    debug_info = {
+        "context_type": type(ctx).__name__,
+        "available_attributes": sorted([attr for attr in dir(ctx) if not attr.startswith("_")]),
+        "context_properties": {},
+    }
 
-                # If not found, try MCP Gateway's X-Authorization header
-                if not auth_header:
-                    auth_header = request.headers.get("x-authorization")
-
-                if auth_header and auth_header.lower().startswith("bearer "):
-                    token = auth_header.split(" ", 1)[1]
-                    logger.debug(f"Successfully extracted token (length: {len(token)})")
-                    return token
-
-                raise ValueError(
-                    "Authorization or X-Authorization header not found or not a Bearer token"
-                )
+    # Try to access each property safely
+    for prop in ["client_id", "request_id", "session", "request_context", "fastmcp"]:
+        try:
+            value = getattr(ctx, prop, "NOT_AVAILABLE")
+            if value == "NOT_AVAILABLE":
+                debug_info["context_properties"][prop] = "NOT_AVAILABLE"
+            elif value is None:
+                debug_info["context_properties"][prop] = "None"
             else:
-                raise ValueError(
-                    "Request object or headers not found in request_context"
-                )
-        else:
-            raise ValueError("request_context not available in Context")
+                debug_info["context_properties"][prop] = {
+                    "type": type(value).__name__,
+                    "available": True,
+                }
 
-    except ValueError:
-        raise
-    except Exception as e:
-        logger.error(f"Failed to extract token: {e}", exc_info=True)
-        raise ValueError(f"Failed to extract bearer token: {e}") from e
+                # For session, explore further
+                if prop == "session" and value:
+                    session_attrs = [attr for attr in dir(value) if not attr.startswith("_")]
+                    debug_info["context_properties"][prop]["attributes"] = session_attrs[:20]
+
+                    # Check for transport
+                    if hasattr(value, "transport") and value.transport:
+                        transport = value.transport
+                        transport_attrs = [
+                            attr for attr in dir(transport) if not attr.startswith("_")
+                        ]
+                        debug_info["context_properties"][prop]["transport"] = {
+                            "type": type(transport).__name__,
+                            "attributes": transport_attrs[:20],
+                        }
+
+                # For request_context, explore further
+                if prop == "request_context" and value:
+                    rc_attrs = [attr for attr in dir(value) if not attr.startswith("_")]
+                    debug_info["context_properties"][prop]["attributes"] = rc_attrs[:20]
+
+                    if hasattr(value, "meta") and value.meta:
+                        meta = value.meta
+                        meta_attrs = [attr for attr in dir(meta) if not attr.startswith("_")]
+                        debug_info["context_properties"][prop]["meta"] = {
+                            "type": type(meta).__name__,
+                            "attributes": meta_attrs[:20],
+                        }
+
+        except Exception as e:
+            debug_info["context_properties"][prop] = f"ERROR: {str(e)}"
+
+    # Log the full auth context
+    auth_context = await log_auth_context("debug_auth_context", ctx)
+    debug_info["extracted_auth_context"] = auth_context
+
+    return debug_info
 
 
 @mcp.tool()
-async def list_services(ctx: Context | None = None) -> dict[str, Any]:
+async def get_http_headers(ctx: Context = None) -> dict[str, Any]:
     """
-    List all MCP servers registered in the gateway.
+    FastMCP 2.0 tool to access HTTP headers directly using the new dependency system.
+    This tool demonstrates how to get HTTP request information including auth headers.
 
     Returns:
-        Dictionary containing services, total_count, enabled_count, and status
+        Dict[str, Any]: HTTP request information including headers
     """
-    logger.info("list_services called")
+    if not ctx:
+        return {"error": "No context available"}
+
+    result = {
+        "fastmcp_version": "2.0",
+        "tool_name": "get_http_headers",
+        "timestamp": str(asyncio.get_event_loop().time()),
+    }
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        # Use FastMCP 2.0's dependency function to get HTTP request
+        http_request = get_http_request()
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(
-                f"{REGISTRY_URL}/api/servers", headers=headers
+        if http_request:
+            # Extract all headers
+            all_headers = dict(http_request.headers)
+
+            # Separate auth-related headers for easy viewing
+            auth_headers = {}
+            other_headers = {}
+
+            for key, value in all_headers.items():
+                key_lower = key.lower()
+                if key_lower in [
+                    "authorization",
+                    "x-user-pool-id",
+                    "x-client-id",
+                    "x-region",
+                    "cookie",
+                    "x-api-key",
+                ]:
+                    if key_lower == "authorization":
+                        # Show type of auth but not full token
+                        if value.startswith("Bearer "):
+                            auth_headers[key] = f"Bearer <TOKEN_HIDDEN> (length: {len(value)})"
+                        else:
+                            auth_headers[key] = f"<AUTH_HIDDEN> (length: {len(value)})"
+                    elif key_lower == "cookie":
+                        # Show cookie names but hide values
+                        cookies = [c.split("=")[0] for c in value.split(";")]
+                        auth_headers[key] = f"Cookies: {', '.join(cookies)}"
+                    else:
+                        auth_headers[key] = value
+                else:
+                    other_headers[key] = value
+
+            result.update(
+                {
+                    "http_request_available": True,
+                    "method": http_request.method,
+                    "url": str(http_request.url),
+                    "path": http_request.url.path,
+                    "query_params": dict(http_request.query_params),
+                    "client_info": {
+                        "host": http_request.client.host if http_request.client else "Unknown",
+                        "port": http_request.client.port if http_request.client else "Unknown",
+                    },
+                    "auth_headers": auth_headers,
+                    "other_headers": other_headers,
+                    "total_headers_count": len(all_headers),
+                }
             )
-            response.raise_for_status()
-            data = response.json()
 
-        # Parse response
-        if isinstance(data, dict) and "servers" in data:
-            servers = data["servers"]
-        elif isinstance(data, list):
-            servers = data
+            # Log the auth headers for server-side debugging
+            await ctx.info(
+                f"🔐 HTTP Headers Debug - Auth Headers Found: {list(auth_headers.keys())}"
+            )
+            if auth_headers:
+                for key, value in auth_headers.items():
+                    await ctx.info(f"   {key}: {value}")
+            else:
+                await ctx.info("   No auth-related headers found")
+
         else:
-            servers = []
+            result.update(
+                {"http_request_available": False, "error": "No HTTP request context available"}
+            )
+            await ctx.warning(
+                "No HTTP request context available - may be running in non-HTTP transport mode"
+            )
 
-        # Validate and convert to ServerInfo models
-        services = []
-        for s in servers:
-            try:
-                services.append(ServerInfo(**s).model_dump())
-            except Exception as e:
-                logger.warning(f"Failed to parse server {s.get('path', 'unknown')}: {e}")
-        enabled_count = sum(1 for s in services if s.get("enabled"))
+    except RuntimeError as e:
+        # This happens when not in HTTP context (e.g., stdio transport)
+        result.update(
+            {
+                "http_request_available": False,
+                "error": f"Not in HTTP context: {str(e)}",
+                "transport_mode": "Likely STDIO or other non-HTTP transport",
+            }
+        )
+        await ctx.info(f"Not in HTTP context - this is expected for STDIO transport: {e}")
 
-        return {
-            "services": services,
-            "total_count": len(services),
-            "enabled_count": enabled_count,
-            "status": "success",
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error: {e}")
-        return {
-            "services": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error: {e.response.status_code}")
-        return {
-            "services": [],
-            "total_count": 0,
-            "error": f"Registry API error: {e.response.status_code}",
-            "status": "failed",
-        }
     except Exception as e:
-        logger.error(f"Failed to list services: {e}")
-        return {
-            "services": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
+        result.update(
+            {"http_request_available": False, "error": f"Error accessing HTTP request: {str(e)}"}
+        )
+        await ctx.error(f"Error accessing HTTP request: {e}")
+        logger.error(f"Error in get_http_headers: {e}", exc_info=True)
+
+    return result
+
+
+async def print_all_http_headers(ctx: Context = None) -> str:
+    """
+    Helper function to print out all HTTP request headers in a formatted string.
+    This function can be called internally by other tools to display HTTP headers.
+
+    Args:
+        ctx: FastMCP Context object
+
+    Returns:
+        str: Formatted string containing all HTTP headers
+    """
+    if not ctx:
+        return "Error: No context available"
+
+    output = []
+    output.append("=== HTTP Request Headers ===")
+    output.append("Server: mcpgw")
+    output.append(f"Timestamp: {asyncio.get_event_loop().time()}")
+    output.append("")
+
+    try:
+        # Use FastMCP 2.0's dependency function to get HTTP request
+        http_request = get_http_request()
+
+        if http_request:
+            # Extract all headers
+            all_headers = dict(http_request.headers)
+
+            output.append(f"Total Headers: {len(all_headers)}")
+            output.append(f"HTTP Method: {http_request.method}")
+            output.append(f"URL: {http_request.url}")
+            output.append(f"Path: {http_request.url.path}")
+            output.append("")
+            output.append("Headers:")
+            output.append("-" * 50)
+
+            # Sort headers for consistent output
+            for key in sorted(all_headers.keys()):
+                value = all_headers[key]
+                # Mask sensitive headers
+                if key.lower() in ["authorization", "cookie"]:
+                    if key.lower() == "authorization":
+                        if value.startswith("Bearer "):
+                            masked_value = f"Bearer <TOKEN_MASKED> (length: {len(value)})"
+                        else:
+                            masked_value = f"<AUTH_MASKED> (length: {len(value)})"
+                    else:  # cookie
+                        cookie_names = [c.split("=")[0] for c in value.split(";")]
+                        masked_value = f"<COOKIES_MASKED>: {', '.join(cookie_names)}"
+                    output.append(f"{key}: {masked_value}")
+                else:
+                    output.append(f"{key}: {value}")
+
+            # Log to context as well
+            await ctx.info(f"📋 Printed all HTTP headers - Total: {len(all_headers)}")
+
+        else:
+            output.append("No HTTP request context available")
+            output.append("This may occur when using STDIO transport")
+            await ctx.warning("No HTTP request context available")
+
+    except RuntimeError as e:
+        output.append(f"Not in HTTP context: {str(e)}")
+        output.append("This is expected for STDIO transport")
+        await ctx.info(f"Not in HTTP context - this is expected for STDIO transport: {e}")
+
+    except Exception as e:
+        output.append(f"Error accessing HTTP request: {str(e)}")
+        await ctx.error(f"Error accessing HTTP request: {e}")
+        logger.error(f"Error in print_all_http_headers: {e}", exc_info=True)
+
+    return "\n".join(output)
 
 
 @mcp.tool()
-async def list_agents(ctx: Context | None = None) -> dict[str, Any]:
+async def toggle_service(
+    service_path: str = Field(
+        ...,
+        description="The unique path identifier for the service (e.g., '/fininfo'). Must start with '/'.",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
     """
-    List all agents registered in the gateway.
+    Toggles the enabled/disabled state of a registered MCP server in the gateway.
+
+    Args:
+        service_path: The unique path identifier for the service (e.g., '/fininfo'). Must start with '/'.
 
     Returns:
-        Dictionary containing agents, total_count, and status
+        Dict[str, Any]: Response from the registry API indicating success or failure.
+
+    Raises:
+        Exception: If the API call fails.
     """
-    logger.info("list_agents called")
-
-    try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
-
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(f"{REGISTRY_URL}/api/agents", headers=headers)
-            response.raise_for_status()
-            data = response.json()
-
-        agents = data.get("agents", []) if isinstance(data, dict) else data
-        agent_list = [AgentInfo(**a).model_dump() for a in agents]
-
-        return {
-            "agents": agent_list,
-            "total_count": len(agent_list),
-            "status": "success",
-        }
-
-    except ValueError as e:
-        logger.error(f"Validation error: {e}")
-        return {
-            "agents": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error: {e.response.status_code}")
-        return {
-            "agents": [],
-            "total_count": 0,
-            "error": f"Registry API error: {e.response.status_code}",
-            "status": "failed",
-        }
-    except Exception as e:
-        logger.error(f"Failed to list agents: {e}")
-        return {
-            "agents": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
+    endpoint = "/api/internal/toggle"
+    form_data = {"service_path": service_path}
+    # Send as form data instead of JSON
+    return await _call_registry_api("POST", endpoint, ctx, data=form_data)
 
 
 @mcp.tool()
-async def list_skills(ctx: Context | None = None) -> dict[str, Any]:
+async def register_service(
+    server_name: str = Field(..., description="Display name for the server."),
+    path: str = Field(
+        ...,
+        description="Unique URL path prefix for the server (e.g., '/my-service'). Must start with '/'.",
+    ),
+    proxy_pass_url: str = Field(
+        ...,
+        description="The internal URL where the actual MCP server is running (e.g., 'http://localhost:8001').",
+    ),
+    description: str | None = Field("", description="Description of the server."),
+    tags: list[str] | None = Field(None, description="Optional list of tags for categorization."),
+    num_tools: int | None = Field(0, description="Number of tools provided by the server."),
+    license: str | None = Field("N/A", description="License information for the server."),
+    auth_provider: str | None = Field(
+        None, description="Authentication provider (e.g., 'bedrock-agentcore', 'oauth')."
+    ),
+    auth_scheme: str | None = Field(
+        None, description="Authentication scheme (e.g., 'bearer', 'api_key', 'none')."
+    ),
+    supported_transports: list[str] | None = Field(
+        None, description="List of supported transports (e.g., ['streamable-http'])."
+    ),
+    headers: list[dict[str, str]] | None = Field(
+        None, description="List of header dictionaries to include in requests."
+    ),
+    tool_list: list[dict[str, Any]] | None = Field(
+        None, description="List of tools with their schemas."
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
     """
-    List all skills registered in the gateway.
+    Registers a new MCP server with the gateway.
+
+    Args:
+        server_name: Display name for the server.
+        path: Unique URL path prefix for the server (e.g., '/my-service'). Must start with '/'.
+        proxy_pass_url: The internal URL where the actual MCP server is running (e.g., 'http://localhost:8001').
+        description: Description of the server.
+        tags: Optional list of tags for categorization.
+        num_tools: Number of tools provided by the server.
+        license: License information for the server.
 
     Returns:
-        Dictionary containing skills, total_count, and status
+        Dict[str, Any]: Response from the registry API, likely including the registered server details.
+
+    Raises:
+        Exception: If the API call fails.
     """
-    logger.info("list_skills called")
+    endpoint = "/api/internal/register"
+
+    # Convert tags list to comma-separated string if it's a list
+    tags_str = ",".join(tags) if isinstance(tags, list) and tags is not None else tags
+
+    # Create form data to send to the API
+    form_data = {
+        "name": server_name,  # Use 'name' as expected by the registry API
+        "path": path,
+        "proxy_pass_url": proxy_pass_url,
+        "description": description if description is not None else "",
+        "tags": tags_str if tags_str is not None else "",
+        "num_tools": num_tools,
+        "license_str": license,  # The registry API uses license_str field name
+    }
+
+    # Add optional fields if provided
+    if auth_provider is not None:
+        form_data["auth_provider"] = auth_provider
+    if auth_scheme is not None:
+        form_data["auth_scheme"] = auth_scheme
+    if supported_transports is not None:
+        # Convert list to JSON string for form data
+        form_data["supported_transports"] = (
+            json.dumps(supported_transports)
+            if isinstance(supported_transports, list)
+            else supported_transports
+        )
+    if headers is not None:
+        # Convert list to JSON string for form data
+        form_data["headers"] = json.dumps(headers) if isinstance(headers, list) else headers
+    if tool_list is not None:
+        # Convert list to JSON string for form data
+        form_data["tool_list_json"] = (
+            json.dumps(tool_list) if isinstance(tool_list, list) else tool_list
+        )
+
+    # Remove None values
+    form_data = {k: v for k, v in form_data.items() if v is not None}
+
+    # Send as form data instead of JSON
+    return await _call_registry_api("POST", endpoint, ctx, data=form_data)
+
+
+@mcp.tool()
+async def list_services(
+    include_tool_list: bool = Field(
+        False,
+        description="If true, include per-service tool metadata in the response. Default false for faster, smaller responses.",
+    ),
+    include_tool_schemas: bool = Field(
+        False,
+        description="If true (and include_tool_list is true), include full tool schema payloads. Default false to return compact tool metadata.",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """
+    Lists all registered MCP services in the gateway.
+
+    By default this returns a compact response without full tool schemas, which keeps
+    ChatGPT connector calls fast and avoids oversized payloads.
+
+    Returns:
+        A dictionary containing:
+        - services: List of service information.
+        - total_count: Total number of services.
+
+    Example:
+        services_info = await list_services()
+        for service in services_info["services"]:
+            print(f"Service: {service['server_name']} at {service['path']}")
+    """
+    logger.info("MCPGW: list_services tool called")
+
+    # Call the registry's internal list endpoint
+    endpoint = "/api/internal/list"
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        result = await _call_registry_api("GET", endpoint, ctx)
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(f"{REGISTRY_URL}/api/skills", headers=headers)
-            response.raise_for_status()
-            data = response.json()
+        if isinstance(result, dict) and "services" in result:
+            raw_services = result.get("services", [])
+            compact_services = []
 
-        skills = data.get("skills", []) if isinstance(data, dict) else data
-        skill_list = [SkillInfo(**s).model_dump() for s in skills]
+            for service in raw_services:
+                if not isinstance(service, dict):
+                    continue
 
-        return {
-            "skills": skill_list,
-            "total_count": len(skill_list),
-            "status": "success",
-        }
+                service_item = dict(service)
+                tool_list = service_item.get("tool_list", [])
+                service_item["tool_count"] = (
+                    len(tool_list)
+                    if isinstance(tool_list, list)
+                    else service_item.get("num_tools", 0)
+                )
 
-    except ValueError as e:
-        logger.error(f"Validation error: {e}")
-        return {
-            "skills": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error: {e.response.status_code}")
-        return {
-            "skills": [],
-            "total_count": 0,
-            "error": f"Registry API error: {e.response.status_code}",
-            "status": "failed",
-        }
+                if include_tool_list:
+                    if include_tool_schemas:
+                        service_item["tool_list"] = tool_list
+                    else:
+                        compact_tool_list = []
+                        if isinstance(tool_list, list):
+                            for tool in tool_list:
+                                if not isinstance(tool, dict):
+                                    continue
+                                compact_tool_list.append(
+                                    {
+                                        "name": tool.get("name"),
+                                        "description": (
+                                            (tool.get("parsed_description") or {}).get("main")
+                                            or "No description available."
+                                        ),
+                                    }
+                                )
+                        service_item["tool_list"] = compact_tool_list
+                else:
+                    service_item.pop("tool_list", None)
+
+                compact_services.append(service_item)
+
+            response_mode = (
+                "full"
+                if include_tool_list and include_tool_schemas
+                else "with_tools" if include_tool_list else "compact"
+            )
+            logger.info(
+                "MCPGW: Successfully retrieved %s services (mode=%s)",
+                result.get("total_count", len(raw_services)),
+                response_mode,
+            )
+            return {
+                "services": compact_services,
+                "total_count": result.get("total_count", len(compact_services)),
+                "response_mode": response_mode,
+            }
+        else:
+            logger.warning(
+                f"MCPGW: Unexpected response format from registry list endpoint: {result}"
+            )
+            return {
+                "services": [],
+                "total_count": 0,
+                "error": "Unexpected response format from registry",
+            }
+
     except Exception as e:
-        logger.error(f"Failed to list skills: {e}")
-        return {
-            "skills": [],
-            "total_count": 0,
-            "error": str(e),
-            "status": "failed",
-        }
+        logger.error(f"MCPGW: Failed to list services: {e}")
+        return {"services": [], "total_count": 0, "error": f"Failed to retrieve services: {str(e)}"}
+
+
+@mcp.tool()
+async def remove_service(
+    service_path: str = Field(
+        ...,
+        description="The unique path identifier for the service to remove (e.g., '/fininfo'). Must start with '/'.",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """
+    Removes a registered MCP server from the gateway.
+
+    Args:
+        service_path: The unique path identifier for the service to remove (e.g., '/fininfo'). Must start with '/'.
+
+    Returns:
+        Dict[str, Any]: Response from the registry API indicating success or failure of the removal.
+
+    Raises:
+        Exception: If the API call fails or the server is not found.
+    """
+    endpoint = "/api/internal/remove"
+
+    # Create form data to send to the API
+    form_data = {"service_path": service_path}
+
+    # Send as form data instead of JSON
+    return await _call_registry_api("POST", endpoint, ctx, data=form_data)
+
+
+@mcp.tool()
+async def refresh_service(
+    service_path: str = Field(
+        ...,
+        description="The unique path identifier for the service (e.g., '/fininfo'). Must start with '/'.",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """
+    Triggers a refresh of the tool list for a specific registered MCP server.
+    The registry will re-connect to the target server to get its latest tools.
+
+    Args:
+        service_path: The unique path identifier for the service (e.g., '/fininfo'). Must start with '/'.
+
+    Returns:
+        Dict[str, Any]: Response from the registry API indicating the result of the refresh attempt.
+
+    Raises:
+        Exception: If the API call fails.
+    """
+    endpoint = f"/api/refresh/{service_path.lstrip('/')}"
+
+    return await _call_registry_api("POST", endpoint, ctx)
+
+
+@mcp.tool()
+async def healthcheck(ctx: Context = None) -> dict[str, Any]:
+    """
+    Retrieves health status information from all registered MCP servers via the registry's internal API.
+
+    Returns:
+        Dict[str, Any]: Health status information for all registered servers, including:
+            - status: 'healthy' or 'disabled'
+            - last_checked_iso: ISO timestamp of when the server was last checked
+            - num_tools: Number of tools provided by the server
+
+    Raises:
+        Exception: If the API call fails or data cannot be retrieved
+    """
+    try:
+        import httpx
+
+        headers = _get_internal_auth_headers()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        # Call registry's internal health check endpoint
+        registry_base_url = os.getenv("REGISTRY_BASE_URL", "http://registry:7860")
+        healthcheck_url = f"{registry_base_url}/api/internal/healthcheck"
+
+        logger.info(f"Calling internal health check endpoint: {healthcheck_url}")
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(healthcheck_url, headers=headers)
+
+            if response.status_code == 200:
+                health_data = response.json()
+                logger.info(f"Retrieved health status data for {len(health_data)} servers")
+                return health_data
+            else:
+                logger.error(
+                    f"Health check API returned status {response.status_code}: {response.text}"
+                )
+                raise Exception(f"Health check API call failed with status {response.status_code}")
+
+    except Exception as e:
+        logger.error(f"Error retrieving health status: {e}")
+        raise Exception(f"Failed to retrieve health status: {str(e)}")
 
 
 @mcp.tool()
 async def intelligent_tool_finder(
-    query: str,
-    top_n: int = 5,
-    ctx: Context | None = None,
-) -> dict[str, Any]:
+    natural_language_query: str | None = Field(
+        None,
+        description="Your query in natural language describing the task you want to perform. Optional if tags are provided.",
+    ),
+    tags: list[str] | None = Field(
+        None,
+        description="List of tags to filter tools by using AND logic. IMPORTANT: AI agents should ONLY use this if the user explicitly provides specific tags. DO NOT infer tags - incorrect tags will exclude valid results.",
+    ),
+    top_k_services: int = Field(
+        120,
+        description="Number of top services to consider from initial FAISS search (ignored if only tags provided). Higher default improves discovery in larger registries.",
+    ),
+    top_n_tools: int = Field(1, description="Number of best matching tools to return."),
+    ctx: Context = None,
+) -> list[dict[str, Any]]:
     """
-    Search for tools using natural language semantic search.
+    Finds the most relevant MCP tool(s) across all registered and enabled services
+    based on a natural language query and/or tag filtering, using semantic search on the registry's FAISS index.
+
+    IMPORTANT FOR AI AGENTS:
+    - Only fill in the 'tags' parameter if the user explicitly provides specific tags to filter by
+    - DO NOT infer or guess tags from the natural language query
+    - Tags act as a strict filter - incorrect tags will exclude valid results
+    - When tags are provided with a query, results must match BOTH the semantic search AND all tags
+    - If unsure about tags, use natural_language_query alone for best results
 
     Args:
-        query: Natural language description of what you want to do
-        top_n: Number of results to return (default: 5, max: 100)
+        natural_language_query: The user's natural language query. Optional if tags are provided.
+        tags: List of tags to filter by using AND logic. All tags must match a server's tags for its tools to be included.
+              CAUTION: Only use this parameter if explicitly provided by the user. Incorrect tags will filter out valid results.
+        top_k_services: How many top-matching services to analyze for tools from FAISS search (ignored if only tags provided).
+        top_n_tools: How many best tools to return from the combined list.
 
     Returns:
-        Dictionary containing results, query, total_results, and status
+        A list of dictionaries, each describing a recommended tool, its parent service, and similarity score (if semantic search used).
+
+    Examples:
+        # Semantic search only (RECOMMENDED for AI agents unless user specifies tags)
+        tools = await intelligent_tool_finder(natural_language_query="find files", top_n_tools=5)
+
+        # Semantic search + tag filtering (ONLY use when user explicitly provides tags)
+        tools = await intelligent_tool_finder(
+            natural_language_query="find files",
+            tags=["file-system", "search"],  # User explicitly said: "use tags file-system and search"
+            top_n_tools=5
+        )
+
+        # Pure tag-based filtering (ONLY when user provides tags without a query)
+        tools = await intelligent_tool_finder(tags=["database", "analytics"], top_n_tools=10)
     """
-    logger.info(f"intelligent_tool_finder called: query={query}, top_n={top_n}")
+    # Load scopes configuration and extract user scopes from headers
+    scopes_config = await load_scopes_config()
+    user_scopes = []
 
-    try:
-        # Validate inputs
-        query = _validate_query(query)
-        top_n = _validate_top_n(top_n)
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+    if ctx:
+        try:
+            http_request = get_http_request()
+            if http_request:
+                headers = dict(http_request.headers)
+                user_scopes = extract_user_scopes_from_headers(headers)
+            else:
+                logger.warning("No HTTP request context available for scope extraction")
+        except RuntimeError:
+            logger.warning("Not in HTTP context, no scopes to extract")
+        except Exception as e:
+            logger.warning(f"Could not extract scopes from headers: {e}")
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                f"{REGISTRY_URL}/api/search/semantic",
-                headers=headers,
-                json={"query": query, "entity_type": "tool", "top_k": top_n},
+    if not user_scopes:
+        fallback_scopes = get_default_user_scopes_from_env()
+        if fallback_scopes:
+            user_scopes = fallback_scopes
+            logger.warning(
+                "No user scopes found in request headers; using MCPGW_DEFAULT_SCOPES fallback"
             )
-            response.raise_for_status()
-            data = response.json()
+        else:
+            logger.warning("No user scopes found - user may not have access to any tools")
+            return []
 
-        # Extract servers array from response
-        servers = data.get("servers", []) if isinstance(data, dict) else []
+    # Input validation - at least one of query or tags must be provided
+    if not natural_language_query and not tags:
+        raise Exception("At least one of 'natural_language_query' or 'tags' must be provided")
 
-        # Flatten matching_tools from all servers into ToolSearchResult objects
-        result_list = []
-        for server in servers:
-            server_path = server.get("path", "")
-            server_name = server.get("server_name", "")
-            for tool in server.get("matching_tools", []):
-                result_list.append(
-                    ToolSearchResult(
-                        tool_name=tool.get("tool_name", ""),
-                        server_name=server_name,
-                        description=tool.get("description"),
-                        score=tool.get("relevance_score"),
-                        path=server_path,
-                    ).model_dump()
+    # Normalize tags for case-insensitive matching
+    normalized_tags = [tag.lower().strip() for tag in tags] if tags else []
+    if normalized_tags:
+        logger.info(f"MCPGW: Filtering by tags: {normalized_tags}")
+    query_tokens = _query_tokens(natural_language_query or "")
+
+    global _embedding_model_mcpgw, _faiss_index_mcpgw, _faiss_metadata_mcpgw, _last_faiss_check_time
+    import time
+
+    # Check for FAISS data updates, but only if enough time has passed since last check
+    current_time = time.time()
+    should_check_for_updates = (
+        _embedding_model_mcpgw is None
+        or _faiss_index_mcpgw is None
+        or _faiss_metadata_mcpgw is None
+        or _last_faiss_check_time is None
+        or (current_time - _last_faiss_check_time) >= _faiss_check_interval
+    )
+
+    if should_check_for_updates:
+        await load_faiss_data_for_mcpgw()
+        _last_faiss_check_time = current_time
+
+    if _embedding_model_mcpgw is None:
+        raise Exception(
+            "MCPGW: Sentence embedding model is not available. Cannot perform intelligent search."
+        )
+    if _faiss_index_mcpgw is None:
+        raise Exception("MCPGW: FAISS index is not available. Cannot perform intelligent search.")
+    if _faiss_metadata_mcpgw is None or "metadata" not in _faiss_metadata_mcpgw:
+        raise Exception(
+            "MCPGW: FAISS metadata is not available or in unexpected format. Cannot perform intelligent search."
+        )
+
+    registry_faiss_metadata = _faiss_metadata_mcpgw[
+        "metadata"
+    ]  # This is {service_path: {id, text, full_server_info}}
+
+    # Determine which services to process based on whether we're doing semantic search
+    services_to_process = []
+    use_semantic_ranking = False
+
+    if natural_language_query:
+        use_semantic_ranking = True
+        # 1. Embed the natural language query
+        try:
+            query_embedding = await asyncio.to_thread(
+                _embedding_model_mcpgw.encode, [natural_language_query]
+            )
+            query_embedding_np = np.array(query_embedding, dtype=np.float32)
+        except Exception as e:
+            logger.error(f"MCPGW: Error encoding natural language query: {e}", exc_info=True)
+            raise Exception(f"MCPGW: Error encoding query: {e}")
+
+        # 2. Search FAISS for top_k_services
+        # The FAISS index in registry/main.py stores SERVICE embeddings.
+        try:
+            logger.info(
+                f"MCPGW: Searching FAISS index for top {top_k_services} services matching query."
+            )
+            distances, faiss_ids = await asyncio.to_thread(
+                _faiss_index_mcpgw.search, query_embedding_np, top_k_services
+            )
+        except Exception as e:
+            logger.error(f"MCPGW: Error searching FAISS index: {e}", exc_info=True)
+            raise Exception(f"MCPGW: Error searching FAISS index: {e}")
+
+        # Create a reverse map from FAISS internal ID to service_path for quick lookup
+        id_to_service_path_map = {}
+        for Svc_path, meta_item in registry_faiss_metadata.items():
+            if "id" in meta_item:
+                id_to_service_path_map[meta_item["id"]] = Svc_path
+            else:
+                logger.warning(
+                    f"MCPGW: Metadata for service {Svc_path} missing 'id' field. Skipping."
                 )
 
-        return {
-            "results": result_list,
-            "query": query,
-            "total_results": len(result_list),
-            "status": "success",
-        }
+        # Extract service paths from FAISS results
+        for i in range(len(faiss_ids[0])):
+            faiss_id = faiss_ids[0][i]
+            if faiss_id == -1:  # FAISS uses -1 for no more results or if k > ntotal
+                continue
+            service_path = id_to_service_path_map.get(faiss_id)
+            if service_path:
+                services_to_process.append(service_path)
+                logger.debug(f"MCPGW: Found service_path {service_path} for FAISS ID {faiss_id}")
+            else:
+                logger.warning(
+                    f"MCPGW: Could not find service_path for FAISS ID {faiss_id}. Skipping."
+                )
 
-    except ValueError as e:
-        logger.error(f"Validation error: {e}")
-        return {
-            "results": [],
-            "query": query,
-            "total_results": 0,
-            "error": str(e),
-            "status": "failed",
-        }
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error: {e.response.status_code}")
-        return {
-            "results": [],
-            "query": query,
-            "total_results": 0,
-            "error": f"Registry API error: {e.response.status_code}",
-            "status": "failed",
-        }
-    except Exception as e:
-        logger.error(f"Failed to search tools: {e}")
-        return {
-            "results": [],
-            "query": query,
-            "total_results": 0,
-            "error": str(e),
-            "status": "failed",
-        }
+        # Add lexical service matches to reduce misses when semantic service embeddings are noisy.
+        if query_tokens:
+            lexical_service_scores = []
+            for lexical_service_path, meta_item in registry_faiss_metadata.items():
+                full_server_info = meta_item.get("full_server_info", {})
+                service_name = full_server_info.get("server_name", "")
+                service_desc = full_server_info.get("description", "")
+                tags_value = full_server_info.get("tags", [])
+                tags_text = (
+                    " ".join(str(tag) for tag in tags_value)
+                    if isinstance(tags_value, list)
+                    else str(tags_value)
+                )
+                tool_value = full_server_info.get("tool_list", [])
+                tool_text_parts = []
+                if isinstance(tool_value, list):
+                    for tool_item in tool_value[:40]:
+                        if not isinstance(tool_item, dict):
+                            continue
+                        tool_name = str(tool_item.get("name", ""))
+                        tool_desc = str(
+                            (tool_item.get("parsed_description") or {}).get("main", "")
+                        )
+                        if tool_name or tool_desc:
+                            tool_text_parts.append(f"{tool_name} {tool_desc}")
+                tool_text = " ".join(tool_text_parts)
+
+                service_search_text = " ".join(
+                    [
+                        _normalize_service_name_for_matching(service_name),
+                        str(service_desc),
+                        tags_text,
+                        tool_text,
+                    ]
+                )
+                lexical_hits = len(query_tokens & _query_tokens(service_search_text))
+                if lexical_hits > 0:
+                    lexical_service_scores.append((lexical_hits, lexical_service_path))
+
+            lexical_service_scores.sort(key=lambda item: item[0], reverse=True)
+            max_lexical_services = min(max(top_k_services // 2, 20), 200)
+            lexical_added = 0
+            for _lexical_hits, lexical_service_path in lexical_service_scores:
+                if lexical_service_path in services_to_process:
+                    continue
+                services_to_process.append(lexical_service_path)
+                lexical_added += 1
+                if lexical_added >= max_lexical_services:
+                    break
+
+            if lexical_added:
+                logger.info(
+                    "MCPGW: Added %s lexical service candidates for query token overlap",
+                    lexical_added,
+                )
+
+        logger.info(
+            f"MCPGW: Processing {len(services_to_process)} services from FAISS search results."
+        )
+    else:
+        # Tags-only mode: process all services
+        services_to_process = list(registry_faiss_metadata.keys())
+        logger.info(f"MCPGW: Tags-only mode - processing all {len(services_to_process)} services")
+
+    candidate_tools = []
+    tools_before_scope_filter = 0
+
+    # 3. Filter and Collect Tools from services
+    for service_path in services_to_process:
+        service_metadata = registry_faiss_metadata.get(service_path)
+        if not service_metadata or "full_server_info" not in service_metadata:
+            logger.warning(
+                f"MCPGW: Metadata or full_server_info not found for service path {service_path}. Skipping."
+            )
+            continue
+        else:
+            logger.debug(
+                f"MCPGW: Found metadata for service path {service_path}, service_metadata: {service_metadata}"
+            )
+        full_server_info = service_metadata["full_server_info"]
+
+        if not full_server_info.get("is_enabled", False):
+            logger.info(f"MCPGW: Service {service_path} is disabled. Skipping its tools.")
+            continue
+
+        # Apply tag filtering if tags are specified
+        if normalized_tags:
+            server_tags = full_server_info.get("tags", "")
+            if isinstance(server_tags, str):
+                server_tags_list = [
+                    tag.strip().lower() for tag in server_tags.split(",") if tag.strip()
+                ]
+            else:
+                server_tags_list = (
+                    [str(tag).lower().strip() for tag in server_tags] if server_tags else []
+                )
+
+            # Check if all required tags are present (AND logic)
+            if not all(tag in server_tags_list for tag in normalized_tags):
+                logger.info(
+                    f"MCPGW: Service {service_path} does not match required tags {normalized_tags}, has tags {server_tags_list}. Skipping."
+                )
+                continue
+            else:
+                logger.info(
+                    f"MCPGW: Service {service_path} matches required tags {normalized_tags}"
+                )
+        logger.info(
+            f"MCPGW: Processing service {service_path} with full_server_info: {full_server_info}"
+        )
+        service_name = full_server_info.get("server_name", "Unknown Service")
+        service_name_for_matching = _normalize_service_name_for_matching(service_name)
+        tool_list = full_server_info.get("tool_list", [])
+        supported_transports = full_server_info.get("supported_transports", ["streamable-http"])
+        auth_provider = full_server_info.get("auth_provider", None)
+        logger.info(
+            f"MCPGW: Found {len(tool_list)} tools for service {service_name} at path {service_path}, supported_transports: {supported_transports}"
+        )
+        for tool_info in tool_list:
+            tool_name = tool_info.get("name", "Unknown Tool")
+            parsed_desc = tool_info.get("parsed_description", {})
+            main_desc = parsed_desc.get("main", "No description.")
+
+            tools_before_scope_filter += 1
+
+            # Check if user has access to this tool based on scopes
+            # Map service_path to server name for scope checking
+            server_name = service_path.lstrip("/") if service_path.startswith("/") else service_path
+            logger.info(
+                f"MCPGW: Checking access for user to tool {server_name}.{tool_name} with scopes {user_scopes}"
+            )
+            if not check_tool_access(server_name, tool_name, user_scopes, scopes_config):
+                logger.warning(
+                    f"User does not have access to tool {server_name}.{tool_name}, skipping"
+                )
+                continue
+
+            # Create descriptive text for this specific tool
+            tool_text_for_embedding = (
+                f"Service: {service_name_for_matching}. Tool: {tool_name}. Description: {main_desc}"
+            )
+            lexical_signal = _lexical_tool_signal(
+                query_tokens=query_tokens,
+                raw_service_name=service_name,
+                normalized_service_name=service_name_for_matching,
+                tool_name=tool_name,
+                description=main_desc,
+            )
+
+            candidate_tools.append(
+                {
+                    "text_for_embedding": tool_text_for_embedding,
+                    "tool_name": tool_name,
+                    "tool_parsed_description": parsed_desc,
+                    "tool_schema": tool_info.get("schema", {}),
+                    "service_path": service_path,
+                    "service_name": service_name,
+                    "service_name_for_matching": service_name_for_matching,
+                    "supported_transports": supported_transports,
+                    "auth_provider": auth_provider,
+                    "lexical_signal": lexical_signal,
+                }
+            )
+
+    logger.info(
+        f"MCPGW: Scope filtering results - {tools_before_scope_filter} tools found, {len(candidate_tools)} accessible after filtering"
+    )
+
+    if not candidate_tools:
+        logger.info(
+            "MCPGW: No accessible tools found in the top services from FAISS search after scope filtering."
+        )
+        return []
+
+    # Apply semantic ranking if we have a natural language query
+    if use_semantic_ranking:
+        # 4. Embed all candidate tool descriptions
+        logger.info(
+            f"MCPGW: Embedding {len(candidate_tools)} candidate tools (after scope filtering) for secondary ranking."
+        )
+        try:
+            tool_texts = [tool["text_for_embedding"] for tool in candidate_tools]
+            tool_embeddings = await asyncio.to_thread(_embedding_model_mcpgw.encode, tool_texts)
+            tool_embeddings_np = np.array(tool_embeddings, dtype=np.float32)
+        except Exception as e:
+            logger.error(f"MCPGW: Error encoding tool descriptions: {e}", exc_info=True)
+            raise Exception(f"MCPGW: Error encoding tool descriptions: {e}")
+
+        # 5. Calculate cosine similarity between query and each tool embedding
+        similarities = cosine_similarity(query_embedding_np, tool_embeddings_np)[
+            0
+        ]  # Get the first row (query vs all tools)
+
+        # 6. Add similarity score to each tool and sort
+        ranked_tools = []
+        for i, tool_data in enumerate(candidate_tools):
+            semantic_score = float(similarities[i])
+            lexical_signal = float(tool_data.get("lexical_signal", 0.0))
+            overall_score = semantic_score + (0.20 * lexical_signal)
+            ranked_tools.append(
+                {
+                    **tool_data,
+                    "semantic_similarity_score": semantic_score,
+                    "overall_similarity_score": overall_score,
+                }
+            )
+
+        ranked_tools.sort(key=lambda x: x["overall_similarity_score"], reverse=True)
+
+        # If the query contains high-signal repo workflow terms, require lexical evidence
+        # so namespace artifacts (e.g., io.github.*) do not dominate rankings.
+        high_signal_tokens = query_tokens & _HIGH_SIGNAL_QUERY_TOKENS
+        if high_signal_tokens:
+            lexical_matches = [
+                tool for tool in ranked_tools if float(tool.get("lexical_signal", 0.0)) > 0.0
+            ]
+            if lexical_matches:
+                ranked_tools = lexical_matches
+                logger.info(
+                    "MCPGW: Applied high-signal lexical filter for tokens %s; %s tools remain",
+                    sorted(high_signal_tokens),
+                    len(ranked_tools),
+                )
+            else:
+                logger.warning(
+                    "MCPGW: No lexical matches found for high-signal tokens %s",
+                    sorted(high_signal_tokens),
+                )
+                return []
+    else:
+        # Tags-only mode: no semantic ranking, just use the tools as-is
+        ranked_tools = candidate_tools
+        logger.info(
+            f"MCPGW: Tags-only mode - {len(ranked_tools)} tools found without semantic ranking"
+        )
+
+    # 7. Select top N tools
+    final_results = ranked_tools[:top_n_tools]
+    logger.info(f"MCPGW: Top {len(final_results)} tools found after scope filtering and ranking")
+
+    # Log which tools were returned for debugging
+    for i, tool in enumerate(final_results):
+        if "overall_similarity_score" in tool:
+            logger.info(
+                f"  {i + 1}. {tool['service_name']}.{tool['tool_name']} (similarity: {tool['overall_similarity_score']:.3f})"
+            )
+        else:
+            logger.info(f"  {i + 1}. {tool['service_name']}.{tool['tool_name']} (tags-only mode)")
+
+    # Remove the temporary 'text_for_embedding' field from results
+    for res in final_results:
+        del res["text_for_embedding"]
+        res.pop("service_name_for_matching", None)
+        res.pop("lexical_signal", None)
+        res.pop("semantic_similarity_score", None)
+    logger.info(
+        f"intelligent_tool_finder, final_results: {json.dumps(final_results, indent=2, default=str)}"
+    )
+    return final_results
 
 
 @mcp.tool()
-async def healthcheck(ctx: Context | None = None) -> dict[str, Any]:
+async def add_server_to_scopes_groups(
+    server_name: str = Field(
+        ...,
+        description="Name of the server to add to groups (e.g., 'example-server'). Should not include leading slash.",
+    ),
+    group_names: list[str] = Field(
+        ...,
+        description="List of scopes group names to add the server to (e.g., ['mcp-servers-restricted/read', 'mcp-servers-restricted/execute']).",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
     """
-    Get registry health status and statistics.
+    Add a server and all its known tools/methods to specific scopes groups.
+
+    This tool retrieves the server's tools from the last health check and adds
+    them to the specified groups in scopes.yml using the same format as other servers.
+
+    Args:
+        server_name: Name of the server (without leading slash)
+        group_names: List of group names to add the server to
 
     Returns:
-        Dictionary containing health stats and status
+        Dict with success status and details about the operation
     """
-    logger.info("healthcheck called")
+    logger.info(
+        f"add_server_to_scopes_groups called with server_name={server_name}, group_names={group_names}"
+    )
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        # Prepare the request data
+        form_data = {
+            "server_name": server_name,
+            "group_names": ",".join(group_names),  # Convert list to comma-separated string
+        }
 
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(
-                f"{REGISTRY_URL}/api/servers/health", headers=headers
+        headers = _get_internal_auth_headers()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        # Make request to internal API
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{REGISTRY_BASE_URL}/api/internal/add-to-groups",
+                data=form_data,
+                headers=headers,
+                timeout=30.0,
             )
-            response.raise_for_status()
-            data = response.json()
 
-        stats = RegistryStats(**data)
-        return {**stats.model_dump(), "status": "success"}
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Successfully added server {server_name} to groups {group_names}")
+            return {
+                "success": True,
+                "message": result.get("message", "Server successfully added to groups"),
+                "server_name": server_name,
+                "groups": group_names,
+                "server_path": result.get("server_path"),
+            }
+        else:
+            error_detail = f"HTTP {response.status_code}: {response.text}"
+            logger.error(f"Failed to add server {server_name} to groups: {error_detail}")
+            return {"success": False, "error": error_detail, "status_code": response.status_code}
 
-    except ValueError as e:
-        logger.error(f"Validation error: {e}")
-        return {
-            "health_status": "error",
-            "error": str(e),
-            "status": "failed",
-        }
-    except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error: {e.response.status_code}")
-        return {
-            "health_status": "error",
-            "error": f"Registry API error: {e.response.status_code}",
-            "status": "failed",
-        }
     except Exception as e:
-        logger.error(f"Failed to get health status: {e}")
-        return {
-            "health_status": "error",
-            "error": str(e),
-            "status": "failed",
+        error_msg = f"Error adding server {server_name} to groups {group_names}: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
+@mcp.tool()
+async def remove_server_from_scopes_groups(
+    server_name: str = Field(
+        ...,
+        description="Name of the server to remove from groups (e.g., 'example-server'). Should not include leading slash.",
+    ),
+    group_names: list[str] = Field(
+        ...,
+        description="List of scopes group names to remove the server from (e.g., ['mcp-servers-restricted/read', 'mcp-servers-restricted/execute']).",
+    ),
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """
+    Remove a server from specific scopes groups.
+
+    This tool removes the server from the specified groups in scopes.yml.
+    Useful for revoking access or moving servers between access levels.
+
+    Args:
+        server_name: Name of the server (without leading slash)
+        group_names: List of group names to remove the server from
+
+    Returns:
+        Dict with success status and details about the operation
+    """
+    logger.info(
+        f"remove_server_from_scopes_groups called with server_name={server_name}, group_names={group_names}"
+    )
+
+    try:
+        # Prepare the request data
+        form_data = {
+            "server_name": server_name,
+            "group_names": ",".join(group_names),  # Convert list to comma-separated string
         }
+
+        headers = _get_internal_auth_headers()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        # Make request to internal API
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{REGISTRY_BASE_URL}/api/internal/remove-from-groups",
+                data=form_data,
+                headers=headers,
+                timeout=30.0,
+            )
+
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Successfully removed server {server_name} from groups {group_names}")
+            return {
+                "success": True,
+                "message": result.get("message", "Server successfully removed from groups"),
+                "server_name": server_name,
+                "groups": group_names,
+                "server_path": result.get("server_path"),
+            }
+        else:
+            error_detail = f"HTTP {response.status_code}: {response.text}"
+            logger.error(f"Failed to remove server {server_name} from groups: {error_detail}")
+            return {"success": False, "error": error_detail, "status_code": response.status_code}
+
+    except Exception as e:
+        error_msg = f"Error removing server {server_name} from groups {group_names}: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
+@mcp.tool()
+async def create_group(
+    group_name: str = Field(
+        ..., description="Name of the group to create (e.g., 'mcp-servers-finance/read')"
+    ),
+    description: str | None = Field("", description="Optional description for the group"),
+    ctx: Context = None,
+) -> dict[str, Any]:
+    """
+    Create a new group in both Keycloak and scopes.yml.
+
+    This tool creates a new access control group that can be used to manage
+    server permissions. The group is automatically created in both Keycloak
+    (for authentication) and scopes.yml (for authorization).
+
+    Args:
+        group_name: Name of the group (e.g., 'mcp-servers-finance/read')
+        description: Optional description of the group's purpose
+
+    Returns:
+        Dict with success status and creation details
+
+    Example:
+        create_group(
+            group_name="mcp-servers-finance/read",
+            description="Finance team read access"
+        )
+    """
+    logger.info(f"create_group called with group_name={group_name}")
+
+    try:
+        # Prepare the request data
+        form_data = {"group_name": group_name, "description": description}
+
+        headers = _get_internal_auth_headers()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        # Make request to internal API
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{REGISTRY_BASE_URL}/api/internal/create-group",
+                data=form_data,
+                headers=headers,
+                timeout=30.0,
+            )
+
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Successfully created group {group_name}")
+            return {
+                "success": True,
+                "message": result.get("message", "Group successfully created"),
+                "group_name": group_name,
+                "created_in_keycloak": result.get("created_in_keycloak", False),
+                "created_in_scopes": result.get("created_in_scopes", False),
+            }
+        else:
+            error_detail = f"HTTP {response.status_code}: {response.text}"
+            logger.error(f"Failed to create group {group_name}: {error_detail}")
+            return {"success": False, "error": error_detail, "status_code": response.status_code}
+
+    except Exception as e:
+        error_msg = f"Error creating group {group_name}: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
+@mcp.tool()
+async def delete_group(
+    group_name: str = Field(..., description="Name of the group to delete"), ctx: Context = None
+) -> dict[str, Any]:
+    """
+    Delete a group from both Keycloak and scopes.yml.
+
+    This tool removes an access control group from the system. It deletes the
+    group from both Keycloak and scopes.yml, and removes it from group_mappings.
+    System groups cannot be deleted.
+
+    Args:
+        group_name: Name of the group to delete
+
+    Returns:
+        Dict with success status and deletion details
+
+    Example:
+        delete_group(group_name="mcp-servers-finance/read")
+    """
+    logger.info(f"delete_group called with group_name={group_name}")
+
+    try:
+        # Prepare the request data
+        form_data = {"group_name": group_name}
+
+        headers = _get_internal_auth_headers()
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        # Make request to internal API
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{REGISTRY_BASE_URL}/api/internal/delete-group",
+                data=form_data,
+                headers=headers,
+                timeout=30.0,
+            )
+
+        if response.status_code == 200:
+            result = response.json()
+            logger.info(f"Successfully deleted group {group_name}")
+            return {
+                "success": True,
+                "message": result.get("message", "Group successfully deleted"),
+                "group_name": group_name,
+                "deleted_from_keycloak": result.get("deleted_from_keycloak", False),
+                "deleted_from_scopes": result.get("deleted_from_scopes", False),
+            }
+        else:
+            error_detail = f"HTTP {response.status_code}: {response.text}"
+            logger.error(f"Failed to delete group {group_name}: {error_detail}")
+            return {"success": False, "error": error_detail, "status_code": response.status_code}
+
+    except Exception as e:
+        error_msg = f"Error deleting group {group_name}: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
+@mcp.tool()
+async def list_groups(ctx: Context = None) -> dict[str, Any]:
+    """
+    List all groups from Keycloak and scopes.yml with synchronization status.
+
+    This tool provides a comprehensive view of all access control groups in the
+    system, showing which groups exist in Keycloak, scopes.yml, or both. It also
+    identifies groups that are out of sync between the two systems.
+
+    Returns:
+        Dict containing:
+        - keycloak_groups: List of groups in Keycloak
+        - scopes_groups: Dict of groups in scopes.yml with server counts
+        - synchronized: List of groups in both systems
+        - keycloak_only: List of groups only in Keycloak
+        - scopes_only: List of groups only in scopes.yml
+        - summary: Statistics about group counts
+
+    Example:
+        list_groups()
+    """
+    logger.info("list_groups called")
+
+    try:
+        headers = _get_internal_auth_headers()
+
+        # Make request to internal API
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{REGISTRY_BASE_URL}/api/internal/list-groups", headers=headers, timeout=30.0
+            )
+
+        if response.status_code == 200:
+            result = response.json()
+            logger.info("Successfully listed groups")
+
+            # Add success flag
+            result["success"] = True
+
+            # Calculate summary stats
+            result["summary"] = {
+                "total_keycloak": len(result.get("keycloak_groups", [])),
+                "total_scopes": len(result.get("scopes_groups", {})),
+                "synchronized_count": len(result.get("synchronized", [])),
+                "keycloak_only_count": len(result.get("keycloak_only", [])),
+                "scopes_only_count": len(result.get("scopes_only", [])),
+            }
+
+            return result
+        else:
+            error_detail = f"HTTP {response.status_code}: {response.text}"
+            logger.error(f"Failed to list groups: {error_detail}")
+            return {"success": False, "error": error_detail, "status_code": response.status_code}
+
+    except Exception as e:
+        error_msg = f"Error listing groups: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
+# --- Main Execution ---
+
+
+def main():
+    # Log transport and endpoint information
+    endpoint = "/mcp"  # streamable-http always uses /mcp endpoint
+    logger.info(f"Starting MCPGateway server on port {args.port} with transport {args.transport}")
+    logger.info(f"Server will be available at: http://localhost:{args.port}{endpoint}")
+
+    # Run the server with the specified transport from command line args
+    mcp.run(transport=args.transport, host="0.0.0.0", port=int(args.port))  # nosec B104
 
 
 if __name__ == "__main__":
-    import os
-
-    logger.info("Starting mcpgw server")
-
-    # Use HTTP transport if PORT is set (Docker container), otherwise stdio
-    port = os.environ.get("PORT")
-    if port:
-        # Use configurable host with secure default (127.0.0.1)
-        # Set HOST=0.0.0.0 in environment for Docker deployments
-        host = os.environ.get("HOST", "127.0.0.1")
-        logger.info(f"Running in HTTP mode on {host}:{port}")
-        mcp.run(transport="streamable-http", host=host, port=int(port))
-    else:
-        logger.info("Running in stdio mode")
-        mcp.run(transport="stdio")
+    main()

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -282,6 +282,7 @@ async def test_health_service_broadcast_health_update_specific_service(
 
     with patch("registry.services.server_service.server_service") as mock_server_service:
         mock_server_service.get_server_info = AsyncMock(return_value=mock_server_info)
+        mock_server_service.is_service_enabled = AsyncMock(return_value=True)
 
         # Add a mock connection
         mock_ws = AsyncMock(spec=WebSocket)
@@ -304,6 +305,7 @@ async def test_health_service_get_cached_health_data(health_service):
         mock_server_service.get_all_servers = AsyncMock(
             return_value={"/test-server": {"server_name": "test", "proxy_pass_url": "http://test"}}
         )
+        mock_server_service.is_service_enabled = AsyncMock(return_value=True)
 
         data = await health_service._get_cached_health_data()
 
@@ -574,20 +576,26 @@ async def test_health_service_update_tools_background(health_service, mock_serve
     mock_server_info_copy["tool_list"] = []
     mock_server_info_copy["num_tools"] = 0
 
-    with patch("registry.core.mcp_client.mcp_client_service") as mock_mcp:
-        mock_mcp.get_mcp_connection_result = AsyncMock(
-            return_value={
-                "tools": [{"name": "test_tool", "description": "Test"}],
-                "server_info": {"name": "test-server", "version": "1.0.0"},
-            }
-        )
+    import sys
+    import types
 
+    mock_mcp = MagicMock()
+    mock_mcp.get_mcp_connection_result = AsyncMock(
+        return_value={
+            "tools": [{"name": "test_tool", "description": "Test"}],
+            "server_info": {"name": "test-server", "version": "1.0.0"},
+        }
+    )
+    fake_mcp_module = types.ModuleType("registry.core.mcp_client")
+    fake_mcp_module.mcp_client_service = mock_mcp
+
+    with patch.dict(sys.modules, {"registry.core.mcp_client": fake_mcp_module}):
         with patch("registry.services.server_service.server_service") as mock_server_service:
             # First call returns server info without tools, second call returns it with tools
             mock_server_service.get_server_info = AsyncMock(return_value=mock_server_info_copy)
             mock_server_service.update_server = AsyncMock()
 
-            with patch("registry.utils.scopes_manager.update_server_scopes", new=AsyncMock()):
+            with patch("registry.services.scope_service.update_server_scopes", new=AsyncMock()):
                 # Add small sleep to allow background coroutine to run
                 await health_service._update_tools_background(service_path, proxy_url)
                 await asyncio.sleep(0.01)
@@ -604,6 +612,7 @@ async def test_health_service_get_all_health_status(health_service, mock_server_
         mock_server_service.get_all_servers = AsyncMock(
             return_value={"/test-server": mock_server_info}
         )
+        mock_server_service.is_service_enabled = AsyncMock(return_value=True)
 
         all_status = await health_service.get_all_health_status()
 

--- a/tests/unit/services/federation/test_anthropic_client.py
+++ b/tests/unit/services/federation/test_anthropic_client.py
@@ -1,0 +1,95 @@
+"""Unit tests for Anthropic federation client."""
+
+from unittest.mock import patch
+
+from registry.schemas.federation_schema import AnthropicServerConfig
+from registry.services.federation.anthropic_client import AnthropicFederationClient
+
+
+class TestAnthropicFederationClientFetchAllServers:
+    """Test fetch_all_servers behavior."""
+
+    def test_fetch_all_servers_with_explicit_config_list(self):
+        """Explicit config list should fetch only requested servers."""
+        client = AnthropicFederationClient(endpoint="https://registry.modelcontextprotocol.io")
+        configs = [
+            AnthropicServerConfig(name="io.example/server-a"),
+            AnthropicServerConfig(name="io.example/server-b"),
+        ]
+
+        with patch.object(
+            client,
+            "fetch_server",
+            side_effect=[
+                {"server_name": "io.example/server-a", "path": "/io.example-server-a"},
+                {"server_name": "io.example/server-b", "path": "/io.example-server-b"},
+            ],
+        ) as mock_fetch_server:
+            result = client.fetch_all_servers(configs)
+
+        assert len(result) == 2
+        assert result[0]["path"] == "/io.example-server-a"
+        assert result[1]["path"] == "/io.example-server-b"
+        assert mock_fetch_server.call_count == 2
+
+    def test_fetch_all_servers_with_empty_list_fetches_full_catalog(self):
+        """Empty config list should fetch paginated catalog and transform entries."""
+        client = AnthropicFederationClient(endpoint="https://registry.modelcontextprotocol.io")
+
+        page_one = {
+            "servers": [
+                {
+                    "server": {
+                        "name": "io.example/server-a",
+                        "description": "A",
+                        "version": "1.0.0",
+                        "remotes": [{"type": "streamable-http", "url": "https://a.example/mcp"}],
+                    },
+                    "_meta": {},
+                },
+                {
+                    "server": {
+                        "name": "io.example/server-b",
+                        "description": "B",
+                        "version": "1.0.0",
+                        "remotes": [{"type": "streamable-http", "url": "https://b.example/mcp"}],
+                    },
+                    "_meta": {},
+                },
+            ],
+            "metadata": {"nextCursor": "io.example/server-b:1.0.0", "count": 2},
+        }
+        page_two = {
+            "servers": [
+                {
+                    "server": {
+                        "name": "io.example/server-c",
+                        "description": "C",
+                        "version": "1.0.0",
+                        "remotes": [{"type": "streamable-http", "url": "https://c.example/mcp"}],
+                    },
+                    "_meta": {},
+                },
+                # Duplicate from page one should be de-duplicated.
+                {
+                    "server": {
+                        "name": "io.example/server-b",
+                        "description": "B",
+                        "version": "1.0.0",
+                        "remotes": [{"type": "streamable-http", "url": "https://b.example/mcp"}],
+                    },
+                    "_meta": {},
+                },
+            ],
+            "metadata": {"count": 2},
+        }
+
+        with patch.object(client, "_make_request", side_effect=[page_one, page_two]) as mock_request:
+            result = client.fetch_all_servers([])
+
+        assert len(result) == 3
+        paths = {item["path"] for item in result}
+        assert "/io.example-server-a" in paths
+        assert "/io.example-server-b" in paths
+        assert "/io.example-server-c" in paths
+        assert mock_request.call_count == 2

--- a/tests/unit/services/test_federation_reconciliation.py
+++ b/tests/unit/services/test_federation_reconciliation.py
@@ -1,0 +1,86 @@
+"""Unit tests for federation reconciliation behavior."""
+
+import asyncio
+
+from registry.schemas.federation_schema import AnthropicFederationConfig, FederationConfig
+from registry.services.federation_reconciliation import reconcile_anthropic_servers
+
+
+class _DummyServerRepo:
+    def __init__(self, servers_by_path):
+        self._servers_by_path = servers_by_path
+
+    async def list_by_source(self, source):
+        if source == "anthropic":
+            return self._servers_by_path
+        return {}
+
+    async def list_all(self):
+        return self._servers_by_path
+
+
+class _DummyServerService:
+    def __init__(self):
+        self.removed_paths = []
+
+    async def remove_server(self, path):
+        self.removed_paths.append(path)
+        return True
+
+
+def test_reconciliation_skips_removal_in_full_catalog_mode():
+    """Enabled Anthropic + empty config list should not remove synced servers."""
+    config = FederationConfig(
+        anthropic=AnthropicFederationConfig(
+            enabled=True,
+            endpoint="https://registry.modelcontextprotocol.io",
+            servers=[],
+        )
+    )
+    repo = _DummyServerRepo(
+        {
+            "/com.example-one": {"server_name": "com.example/one", "source": "anthropic"},
+            "/com.example-two": {"server_name": "com.example/two", "source": "anthropic"},
+        }
+    )
+    service = _DummyServerService()
+
+    result = asyncio.run(
+        reconcile_anthropic_servers(
+            config=config,
+            server_service=service,
+            server_repo=repo,
+        )
+    )
+
+    assert result["removed_count"] == 0
+    assert service.removed_paths == []
+
+
+def test_reconciliation_removes_all_when_anthropic_disabled():
+    """Disabled Anthropic should remove stale anthropic servers."""
+    config = FederationConfig(
+        anthropic=AnthropicFederationConfig(
+            enabled=False,
+            endpoint="https://registry.modelcontextprotocol.io",
+            servers=[],
+        )
+    )
+    repo = _DummyServerRepo(
+        {
+            "/com.example-one": {"server_name": "com.example/one", "source": "anthropic"},
+            "/com.example-two": {"server_name": "com.example/two", "source": "anthropic"},
+        }
+    )
+    service = _DummyServerService()
+
+    result = asyncio.run(
+        reconcile_anthropic_servers(
+            config=config,
+            server_service=service,
+            server_repo=repo,
+        )
+    )
+
+    assert result["removed_count"] == 2
+    assert set(service.removed_paths) == {"/com.example-one", "/com.example-two"}


### PR DESCRIPTION
## Summary
This PR includes only code-level fixes needed to restore broken behavior observed in downstream usage. It intentionally excludes deployment-specific compose/routing changes.

## Included Fixes
- fix network-trusted JWT generation for `/api/tokens/generate`
- fix health-status resolution for enabled services across registry APIs
- fix FAISS repository initialization and entity-type indexing (`mcp_server` / `a2a_agent`)
- add Anthropic full-catalog sync support when server list is empty (`servers=[]`)
- prevent stale-removal during Anthropic full-catalog reconciliation mode
- fix default demo server MCP proxy endpoints (`/mcp`)
- include mcpgw auth/discovery/catalog stabilization updates
- add federation unit tests for Anthropic client + reconciliation
- fix health unit tests to match async enabled-state checks and decouple from `mcp` import availability

## Not Included
- `docker-compose*.yml` changes
- host/routing/environment-specific deployment changes

## Validation
- Python syntax checks passed for all touched Python modules via `python3 -m py_compile`.
- Focused federation tests pass:
  - `tests/unit/services/federation/test_anthropic_client.py`
  - `tests/unit/services/test_federation_reconciliation.py`
- Targeted unit suite pass (current branch):
  - `tests/auth_server/unit/test_server.py`
  - `tests/unit/api/test_server_routes.py`
  - `tests/unit/search/test_faiss_service.py`
  - `tests/unit/health/test_health_service.py`
  - Result: `236 passed, 5 skipped`

## Related
- Tracks issue #609
- Supersedes broad sync PR #607 with a focused code-fix scope.
