### PR TITLE
fix: AgentCard streaming AttributeError and agent visibility consistency

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -290,7 +290,7 @@ def _filter_agents_by_access(
             accessible.append(agent)
             continue
 
-        if agent.visibility == "internal":
+        if agent.visibility == "private":
             if agent.registered_by == username:
                 accessible.append(agent)
             continue
@@ -384,7 +384,7 @@ async def register_agent(
             provider=provider_obj,
             security_schemes=request.security_schemes or {},
             skills=request.skills or [],
-            streaming=request.streaming,
+            capabilities={"streaming": request.streaming} if request.streaming else {},
             tags=tag_list,
             license=request.license,
             visibility=request.visibility,
@@ -909,7 +909,7 @@ async def update_agent(
             provider=request.provider,
             security_schemes=request.security_schemes or {},
             skills=request.skills or [],
-            streaming=request.streaming,
+            capabilities={"streaming": request.streaming} if request.streaming else {},
             tags=tag_list,
             license=request.license,
             visibility=request.visibility,
@@ -1114,6 +1114,12 @@ async def discover_agents_by_skills(
 
         relevance_score = 0.6 * skill_match_score + 0.2 * tag_match_score + 0.2 * trust_boost
 
+        # Extract streaming capability from agent capabilities dict
+        streaming = agent.capabilities.get("streaming", False) if agent.capabilities else False
+
+        # Extract provider organization name (provider is AgentProvider object)
+        provider_name = agent.provider.organization if agent.provider else None
+
         agent_info = AgentInfo(
             name=agent.name,
             description=agent.description,
@@ -1124,8 +1130,8 @@ async def discover_agents_by_skills(
             num_skills=len(agent.skills),
             num_stars=agent.num_stars,
             is_enabled=True,
-            provider=agent.provider,
-            streaming=agent.streaming,
+            provider=provider_name,
+            streaming=streaming,
             trust_level=agent.trust_level,
         )
 

--- a/registry/api/federation_export_routes.py
+++ b/registry/api/federation_export_routes.py
@@ -195,8 +195,8 @@ def _filter_by_visibility(
         # Default to "public" if visibility not specified (backwards compatibility)
         visibility = _get_item_attr(item, "visibility", "public")
 
-        # Never export internal items
-        if visibility == "internal":
+        # Never export internal/private items
+        if visibility in ("internal", "private"):
             continue
 
         # Always export public items
@@ -655,7 +655,7 @@ async def export_security_scans(
         # Check visibility
         visibility = server_data.get("visibility", "public")
 
-        if visibility == "internal":
+        if visibility in ("internal", "private"):
             continue
 
         if visibility == "public":

--- a/registry/api/search_routes.py
+++ b/registry/api/search_routes.py
@@ -303,7 +303,7 @@ async def _user_can_access_agent(agent_path: str, user_context: dict) -> bool:
     if agent_card.visibility == "public":
         return True
 
-    if agent_card.visibility == "internal":
+    if agent_card.visibility == "private":
         return agent_card.registered_by == user_context.get("username")
 
     if agent_card.visibility == "group-restricted":

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -487,8 +487,8 @@ class AgentCard(BaseModel):
 
     # Access control
     visibility: str = Field(
-        "internal",
-        description="public, group-restricted, or internal (default for security)",
+        "private",
+        description="public, group-restricted, or private (default for security)",
     )
     allowed_groups: list[str] = Field(
         default_factory=list,
@@ -554,7 +554,7 @@ class AgentCard(BaseModel):
         v: str,
     ) -> str:
         """Validate visibility value."""
-        valid_values = ["public", "group-restricted", "internal"]
+        valid_values = ["public", "group-restricted", "private"]
         if v not in valid_values:
             raise ValueError(f"Visibility must be one of: {', '.join(valid_values)}")
         return v
@@ -760,8 +760,8 @@ class AgentRegistrationRequest(BaseModel):
         description="License information",
     )
     visibility: str = Field(
-        default="internal",
-        description="Visibility: public, group-restricted, or internal (default)",
+        default="private",
+        description="Visibility: public, group-restricted, or private (default)",
     )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/tests/integration/test_search_integration.py
+++ b/tests/integration/test_search_integration.py
@@ -359,7 +359,7 @@ def search_test_agents() -> list[dict[str, Any]]:
         path="/agents/internal-agent",
         tags=["internal"],
         skills=[],
-        visibility="internal",
+        visibility="private",
         registered_by="testuser",
     )
 

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -190,12 +190,12 @@ def sample_agent_card() -> AgentCard:
 
 @pytest.fixture
 def sample_internal_agent_card() -> AgentCard:
-    """Create an internal agent card for testing."""
+    """Create a private agent card for testing."""
     return AgentCardFactory(
         name="internal-agent",
         path="/agents/internal-agent",
         url="http://localhost:9000/internal-agent",
-        visibility="internal",
+        visibility="private",
         registered_by="testuser",
         is_enabled=True,
     )
@@ -382,10 +382,10 @@ class TestFilterAgentsByAccess:
         assert len(result) == 1
 
     def test_filter_agents_internal_not_visible_to_others(self, mock_limited_user_context):
-        """Test internal agents not visible to other users."""
+        """Test private agents not visible to other users."""
         # Arrange
         internal_agent = AgentCardFactory(
-            visibility="internal",
+            visibility="private",
             registered_by="differentuser",
             path="/agents/internal-agent",
         )
@@ -623,7 +623,7 @@ class TestListAgents:
         """Test filtering agents by visibility."""
         # Arrange
         public_agent = AgentCardFactory(visibility="public", path="/agents/public")
-        internal_agent = AgentCardFactory(visibility="internal", path="/agents/internal")
+        internal_agent = AgentCardFactory(visibility="private", path="/agents/internal")
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(

--- a/tests/unit/api/test_federation_export_routes.py
+++ b/tests/unit/api/test_federation_export_routes.py
@@ -901,6 +901,7 @@ class TestHelperFunctions:
                 "path": "/restricted",
             },
             {"visibility": "internal", "path": "/internal"},
+            {"visibility": "private", "path": "/private"},
         ]
 
         filtered = federation_export_routes._filter_by_visibility(items, [])
@@ -1275,6 +1276,8 @@ class TestChainPrevention:
             },
             # Local internal
             {"path": "/local-internal", "visibility": "internal"},
+            # Local private (agent visibility)
+            {"path": "/local-private", "visibility": "private"},
             # Federated public
             {
                 "path": "/peer-a/public",

--- a/tests/unit/api/test_search_routes.py
+++ b/tests/unit/api/test_search_routes.py
@@ -673,7 +673,7 @@ class TestUserCanAccessAgent:
     async def test_admin_user_can_access_any_agent(self, mock_agent_service):
         """Test admin user can access any agent."""
         # Arrange
-        mock_agent = AgentCardFactory(visibility="internal")
+        mock_agent = AgentCardFactory(visibility="private")
         mock_agent_service.get_agent_info = AsyncMock(return_value=mock_agent)
         user_context = {"is_admin": True}
 
@@ -750,9 +750,9 @@ class TestUserCanAccessAgent:
 
     @pytest.mark.asyncio
     async def test_internal_agent_accessible_to_owner(self, mock_agent_service):
-        """Test internal agent is accessible to owner."""
+        """Test private agent is accessible to owner."""
         # Arrange
-        mock_agent = AgentCardFactory(visibility="internal", registered_by="testuser")
+        mock_agent = AgentCardFactory(visibility="private", registered_by="testuser")
         mock_agent_service.get_agent_info = AsyncMock(return_value=mock_agent)
         user_context = {
             "is_admin": False,
@@ -768,9 +768,9 @@ class TestUserCanAccessAgent:
 
     @pytest.mark.asyncio
     async def test_internal_agent_not_accessible_to_others(self, mock_agent_service):
-        """Test internal agent is not accessible to non-owners."""
+        """Test private agent is not accessible to non-owners."""
         # Arrange
-        mock_agent = AgentCardFactory(visibility="internal", registered_by="owner")
+        mock_agent = AgentCardFactory(visibility="private", registered_by="owner")
         mock_agent_service.get_agent_info = AsyncMock(return_value=mock_agent)
         user_context = {
             "is_admin": False,

--- a/tests/unit/schemas/test_peer_federation_schema.py
+++ b/tests/unit/schemas/test_peer_federation_schema.py
@@ -912,7 +912,7 @@ class TestBackwardCompatibility:
             description="Test description",
             url="https://example.com",
             path="/test-agent",
-            visibility="internal",
+            visibility="private",
             trust_level="verified",
             skills=[
                 Skill(


### PR DESCRIPTION
Fixes #616

## Summary

- **Streaming AttributeError:** `discover_agents_by_skills` crashed with 500 on every skill-based discovery that found matching agents. `AgentCard` stores streaming in the `capabilities` dict per A2A spec, not as a top-level attribute. The partial fix in `4812e21` covered `list_agents` but missed `discover_agents_by_skills`.
- **Visibility consistency:** Agent visibility used `"internal"` in some places and `"private"` in others. Aligned to `"private"` across Pydantic models, validators, route filters, and federation export.

## Changes

**Streaming fix** (`registry/api/agent_routes.py`):
- Read streaming from `agent.capabilities.get("streaming", False)` instead of `agent.streaming`
- Extract `agent.provider.organization` instead of passing `AgentProvider` object
- Map `request.streaming` into `capabilities` dict during registration and update (was silently dropped by Pydantic)

**Visibility consistency** (4 files):
- `agent_routes.py`: `_filter_agents_by_access` checks `"private"` instead of `"internal"`
- `search_routes.py`: `_user_can_access_agent` checks `"private"` instead of `"internal"`
- `agent_models.py`: Default visibility, description, and validator updated to `"private"`
- `federation_export_routes.py`: Filter both `"internal"` (servers) and `"private"` (agents)

**Tests updated** (5 files):
- All `AgentCard` factory calls updated from `visibility="internal"` to `"private"`
- Federation export tests extended to cover `"private"` filtering

## Test plan

- [x] All affected unit tests pass (278 passed)
- [x] `py_compile` passes on all changed source files
- [x] Verified in production deployment (Grafana error rate at 0%)