### PR TITLE
fix: agent enable/disable 500 after container restart

### DIFF
--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -313,6 +313,23 @@ class AgentService:
             logger.error(f"Failed to delete agent at path '{path}': {e}", exc_info=True)
             raise ValueError(f"Failed to delete agent: {e}")
 
+    async def _ensure_agent_loaded(
+        self,
+        path: str,
+    ) -> None:
+        """Load agent from DB into in-memory dict if not already present.
+
+        Raises:
+            ValueError: If agent not found in DB either
+        """
+        if path in self.registered_agents:
+            return
+        agent = await self._repo.get(path)
+        if agent is None:
+            raise ValueError(f"Agent not found at path: {path}")
+        self.registered_agents[path] = agent
+        logger.info(f"Loaded agent '{agent.name}' ({path}) from database into memory")
+
     async def enable_agent(
         self,
         path: str,
@@ -326,8 +343,7 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        if path not in self.registered_agents:
-            raise ValueError(f"Agent not found at path: {path}")
+        await self._ensure_agent_loaded(path)
 
         if path in self.agent_state["enabled"]:
             logger.info(f"Agent '{path}' is already enabled")
@@ -355,8 +371,7 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        if path not in self.registered_agents:
-            raise ValueError(f"Agent not found at path: {path}")
+        await self._ensure_agent_loaded(path)
 
         if path in self.agent_state["disabled"]:
             logger.info(f"Agent '{path}' is already disabled")


### PR DESCRIPTION
Fixes #618

## Summary

`AgentService.enable_agent()` and `disable_agent()` fail with HTTP 500 after a container restart (or in multi-container deployments) because they check `self.registered_agents` (an in-memory dict) and raise `ValueError` if the agent path is not present.

The agent data exists in the database but the toggle methods never attempt to load it.

## Changes

**`registry/services/agent_service.py`:**
- Add `_ensure_agent_loaded()` helper that checks the in-memory dict first, then falls back to a database lookup via `self._repo.get(path)`
- Replace inline `if path not in self.registered_agents` checks in `enable_agent()` and `disable_agent()` with `await self._ensure_agent_loaded(path)`

## Test plan

- [x] All agent service unit tests pass (38 passed)
- [x] `py_compile` passes
- [x] Verified in production ECS deployment (agents toggle correctly after container cycle)