### PR TITLE
fix: persist agent enabled state to repository on toggle

### DIFF
--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -337,6 +337,7 @@ class AgentService:
             self.agent_state["disabled"].remove(path)
         self.agent_state["enabled"].append(path)
 
+        await self._repo.set_state(path, True)
         await self._persist_state()
 
         agent_name = self.registered_agents[path].name
@@ -366,6 +367,7 @@ class AgentService:
             self.agent_state["enabled"].remove(path)
         self.agent_state["disabled"].append(path)
 
+        await self._repo.set_state(path, False)
         await self._persist_state()
 
         agent_name = self.registered_agents[path].name

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -774,6 +774,7 @@ class TestEnableDisableAgent:
         # Assert
         assert "/test-agent" in agent_service.agent_state["enabled"]
         assert "/test-agent" not in agent_service.agent_state["disabled"]
+        mock_agent_repository.set_state.assert_called_with("/test-agent", True)
 
     @pytest.mark.asyncio
     async def test_enable_already_enabled_agent(
@@ -827,6 +828,7 @@ class TestEnableDisableAgent:
         # Assert
         assert "/test-agent" in agent_service.agent_state["disabled"]
         assert "/test-agent" not in agent_service.agent_state["enabled"]
+        mock_agent_repository.set_state.assert_called_with("/test-agent", False)
 
     @pytest.mark.asyncio
     async def test_disable_already_disabled_agent(


### PR DESCRIPTION
Fixes #619

## Summary

`AgentService.enable_agent()` and `disable_agent()` update an in-memory state dict and call `save_state()`, which is a no-op in the DocumentDB backend. After a container restart, `get_state()` reads `is_enabled=False` from the database and all agents revert to disabled.

The other services (`ServerService`, `SkillService`, `VirtualServerService`) all call `self._repo.set_state(path, enabled)` directly, which correctly persists to DocumentDB. Only `AgentService` was missing this call.

## Changes

**`registry/services/agent_service.py`:**
- Add `await self._repo.set_state(path, True)` in `enable_agent()` before `_persist_state()`
- Add `await self._repo.set_state(path, False)` in `disable_agent()` before `_persist_state()`

**`tests/unit/services/test_agent_service.py`:**
- Add `set_state` assertions to `test_enable_agent` and `test_disable_agent`

## Test plan

- [x] All agent service unit tests pass (38 passed)
- [x] `py_compile` passes
- [ ] Deploy and verify: enable agent, restart container, confirm agent remains enabled