### PR TITLE
fix: nginx X-Forwarded-Port mapping and proxy buffer permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 
 # Set ownership of application files, nginx configs, and entrypoint
-RUN chown -R appuser:appuser /app /etc/nginx /var/log/nginx /run/nginx /app/docker/entrypoint.sh
+RUN chown -R appuser:appuser /app /etc/nginx /var/log/nginx /var/lib/nginx /run/nginx /app/docker/entrypoint.sh
 
 # Switch to non-root user
 USER appuser

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -115,14 +115,16 @@ COPY --from=backend-builder --chown=appuser:appuser /app/cli/examples /app/cli/e
 # Copy built frontend from frontend builder
 COPY --from=frontend-builder --chown=appuser:appuser /app/frontend/build /app/frontend/build
 
-# Create directories and set ownership in one step (faster than separate chown)
+# Create directories and set ownership
+# Note: /app files already have correct ownership via --chown on COPY commands above.
+# Only chown directories that are created here (not covered by COPY --chown).
 RUN mkdir -p /app/logs && \
     mkdir -p /etc/nginx/lua/virtual_mappings && \
     rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-available/default && \
     mkdir -p /var/lib/nginx/body /var/lib/nginx/proxy /var/lib/nginx/fastcgi /var/lib/nginx/uwsgi /var/lib/nginx/scgi && \
     mkdir -p /var/log/nginx && \
     mkdir -p /run/nginx && \
-    chown -R appuser:appuser /app /etc/nginx /var/log/nginx /run/nginx
+    chown -R appuser:appuser /app/logs /etc/nginx /var/log/nginx /var/lib/nginx /run/nginx
 
 # Expose ports for nginx (HTTP/HTTPS on high ports for non-root) and registry
 EXPOSE 8080 8443 7860

--- a/docker/Dockerfile.registry-cpu
+++ b/docker/Dockerfile.registry-cpu
@@ -102,8 +102,11 @@ RUN chmod +x /app/registry-entrypoint.sh
 # Create non-root user for security (CIS Docker Benchmark 4.1)
 RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 
-# Set ownership of application files, venv, logs, nginx configs, and entrypoint
-RUN chown -R appuser:appuser /app /app/.venv /app/logs /etc/nginx /var/log/nginx /run/nginx /app/registry-entrypoint.sh
+# Set ownership for runtime-writable directories and entrypoint
+# Note: Use targeted chown instead of chown -R /app to avoid slow recursive
+# ownership change on .venv (thousands of files that don't need write access)
+RUN chown -R appuser:appuser /app/logs /app/registry /etc/nginx /var/log/nginx /var/lib/nginx /run/nginx && \
+    chown appuser:appuser /app /app/registry-entrypoint.sh
 
 # Switch to non-root user
 USER appuser

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -24,6 +24,22 @@ map $http_x_forwarded_proto $real_scheme {
     http    http;
 }
 
+# Map to determine the real client port
+# Uses X-Forwarded-Port from ALB/load balancer if present, otherwise maps internal
+# container ports (8080/8443) to their standard external equivalents (80/443)
+# This is critical for Keycloak URL generation when running behind a reverse proxy
+map $http_x_forwarded_port $real_port {
+    default         $http_x_forwarded_port;
+    ""              $standard_port;
+}
+
+# Map internal container listen ports to standard external ports
+map $server_port $standard_port {
+    8080    80;
+    8443    443;
+    default $server_port;
+}
+
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
@@ -441,7 +457,7 @@ server {
         proxy_set_header X-Forwarded-Proto $real_scheme;
         
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -457,7 +473,7 @@ server {
         proxy_set_header X-Forwarded-Proto $real_scheme;
         
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -703,7 +719,7 @@ server {
         proxy_set_header X-Forwarded-Proto $real_scheme;
         
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -719,7 +735,7 @@ server {
         proxy_set_header X-Forwarded-Proto $real_scheme;
         
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -27,6 +27,22 @@ map $http_x_forwarded_proto $forwarded_proto {
     ""      $scheme;
 }
 
+# Map to determine the real client port
+# Uses X-Forwarded-Port from ALB/load balancer if present, otherwise maps internal
+# container ports (8080/8443) to their standard external equivalents (80/443)
+# This is critical for Keycloak URL generation when running behind a reverse proxy
+map $http_x_forwarded_port $real_port {
+    default         $http_x_forwarded_port;
+    ""              $standard_port;
+}
+
+# Map internal container listen ports to standard external ports
+map $server_port $standard_port {
+    8080    80;
+    8443    443;
+    default $server_port;
+}
+
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
@@ -491,7 +507,7 @@ server {
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
 
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
@@ -507,7 +523,7 @@ server {
         proxy_set_header X-Forwarded-Proto $forwarded_proto;
 
         # Keycloak specific headers
-        proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Port $real_port;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;


### PR DESCRIPTION
## Summary

- **X-Forwarded-Port fix**: Add `$real_port` nginx map to translate internal container ports (8080/8443) to standard external ports (80/443). Honors existing `X-Forwarded-Port` from upstream ALB when present, falls back to mapped port for direct-access deployments. Fixes Keycloak generating URLs with `:8443` which broke login on non-ALB setups.
- **Proxy buffer permissions**: Add `/var/lib/nginx` to `chown` in all registry Dockerfiles so nginx worker (appuser) can write proxy temp files. Fixes `ERR_INCOMPLETE_CHUNKED_ENCODING` for large upstream responses (e.g. 1.4MB PatternFly CSS).
- **Build optimization**: Replace `chown -R /app` with targeted chown on runtime-writable directories only, avoiding slow recursive ownership change on `.venv` (thousands of files).

## Test plan

- [x] Verified `$real_port` map produces correct port: `X-Forwarded-Port: 443` on HTTPS, `80` on HTTP
- [x] Verified Keycloak OIDC discovery issuer no longer includes `:8443`
- [x] Verified Keycloak login form action URL is correct (`https://airegistry.ddns.net/realms/...`)
- [x] Verified ALB path unaffected: when `X-Forwarded-Port` header exists from upstream, it is preserved as-is
- [ ] Verify Keycloak login page CSS renders correctly (no truncated responses)
- [ ] Verify login flow completes successfully end-to-end