### PR TITLE
fix: add CSRF protection, path traversal prevention, and credential logging fixes

### DIFF
--- a/cli/src/utils/docsReader.ts
+++ b/cli/src/utils/docsReader.ts
@@ -16,9 +16,21 @@ export interface DocFile {
 
 function _walkDirectory(dir: string, baseDir: string, files: string[] = []): string[] {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const resolvedBase = path.resolve(baseDir);
 
   for (const entry of entries) {
+    // Validate entry name doesn't contain path traversal sequences
+    if (entry.name.includes('..') || entry.name.includes('/') || entry.name.includes('\\')) {
+      continue;
+    }
+
     const fullPath = path.join(dir, entry.name);
+
+    // Ensure resolved path is still within baseDir
+    const resolvedPath = path.resolve(fullPath);
+    if (!resolvedPath.startsWith(resolvedBase)) {
+      continue;
+    }
 
     if (entry.isDirectory()) {
       _walkDirectory(fullPath, baseDir, files);
@@ -64,14 +76,26 @@ export function getAllDocFiles(): string[] {
 
 
 export function readDocFile(filePath: string): DocFile | null {
+  // Reject path traversal sequences and absolute paths
+  if (filePath.includes('..') || path.isAbsolute(filePath)) {
+    throw new Error(`Invalid file path: ${filePath}`);
+  }
+
   const fullPath = path.join(DOCS_DIR, filePath);
 
-  if (!fs.existsSync(fullPath)) {
+  // Resolve paths and ensure result is within DOCS_DIR
+  const resolvedPath = path.resolve(fullPath);
+  const resolvedBase = path.resolve(DOCS_DIR);
+  if (!resolvedPath.startsWith(resolvedBase)) {
+    throw new Error(`Path traversal detected: ${filePath}`);
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
     return null;
   }
 
   try {
-    const content = fs.readFileSync(fullPath, 'utf-8');
+    const content = fs.readFileSync(resolvedPath, 'utf-8');
     const name = path.basename(filePath);
 
     return {

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from ..audit import set_audit_action
+from ..auth.csrf import generate_csrf_token, verify_csrf_token
 from ..auth.dependencies import enhanced_auth, nginx_proxied_auth
 from ..auth.internal import validate_internal_auth
 from ..constants import VALID_AUTH_SCHEMES
@@ -251,6 +252,7 @@ async def read_root(
             "username": user_context["username"],
             "user_context": user_context,  # Pass full user context to template
             "can_perform_action": can_perform_action,  # Helper function for permission checks
+            "csrf_token": generate_csrf_token(session) if session else "",
         },
     )
 
@@ -399,6 +401,7 @@ async def toggle_service_route(
     service_path: str,
     enabled: Annotated[str | None, Form()] = None,
     user_context: Annotated[dict, Depends(enhanced_auth)] = None,
+    _csrf: Annotated[None, Depends(verify_csrf_token)] = None,
 ):
     """Toggle a service on/off (requires toggle_service UI permission)."""
     from ..auth.dependencies import user_has_ui_permission_for_service
@@ -1248,6 +1251,7 @@ async def edit_server_form(
                 detail="You do not have access to edit this server",
             )
 
+    session_cookie = request.cookies.get(settings.session_cookie_name, "")
     return templates.TemplateResponse(
         "edit_server.html",
         {
@@ -1255,6 +1259,7 @@ async def edit_server_form(
             "server": server_info,
             "username": user_context["username"],
             "user_context": user_context,
+            "csrf_token": generate_csrf_token(session_cookie) if session_cookie else "",
         },
     )
 
@@ -1276,6 +1281,7 @@ async def edit_server_submit(
     auth_scheme: Annotated[str, Form()] = "none",
     auth_credential: Annotated[str | None, Form()] = None,
     auth_header_name: Annotated[str | None, Form()] = None,
+    _csrf: Annotated[None, Depends(verify_csrf_token)] = None,
 ):
     """Handle server edit form submission (requires modify_service UI permission)."""
     from ..auth.dependencies import user_has_ui_permission_for_service

--- a/registry/auth/csrf.py
+++ b/registry/auth/csrf.py
@@ -1,0 +1,104 @@
+"""CSRF token generation and validation utilities.
+
+Provides signed CSRF tokens bound to user sessions using itsdangerous.
+Tokens are validated against the session ID and expire based on session max age.
+"""
+
+import logging
+
+from fastapi import Form, HTTPException, Request, status
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+CSRF_SALT: str = "csrf-salt"
+
+_csrf_signer = URLSafeTimedSerializer(settings.secret_key)
+
+
+def generate_csrf_token(
+    session_id: str,
+) -> str:
+    """Generate a signed CSRF token bound to the given session ID.
+
+    Args:
+        session_id: The session cookie value to bind the token to.
+
+    Returns:
+        A signed CSRF token string.
+    """
+    token = _csrf_signer.dumps(session_id, salt=CSRF_SALT)
+    logger.debug("Generated CSRF token for session")
+    return token
+
+
+def validate_csrf_token(
+    token: str,
+    session_id: str,
+) -> bool:
+    """Validate a CSRF token against the session ID.
+
+    Args:
+        token: The CSRF token to validate.
+        session_id: The session cookie value the token should be bound to.
+
+    Returns:
+        True if the token is valid, False otherwise.
+    """
+    try:
+        data = _csrf_signer.loads(
+            token,
+            salt=CSRF_SALT,
+            max_age=settings.session_max_age_seconds,
+        )
+        if data != session_id:
+            logger.warning("CSRF token session mismatch")
+            return False
+        logger.debug("CSRF token validated successfully")
+        return True
+    except SignatureExpired:
+        logger.warning("CSRF token has expired")
+        return False
+    except BadSignature:
+        logger.warning("CSRF token has invalid signature")
+        return False
+    except Exception as e:
+        logger.error(f"Unexpected error validating CSRF token: {e}")
+        return False
+
+
+async def verify_csrf_token(
+    request: Request,
+    csrf_token: str = Form(...),
+) -> None:
+    """FastAPI dependency that validates the CSRF token from form data.
+
+    Reads the session cookie from the request and validates the submitted
+    CSRF token against it.
+
+    Args:
+        request: The incoming FastAPI request.
+        csrf_token: The CSRF token submitted via form data.
+
+    Raises:
+        HTTPException: If the CSRF token is missing, invalid, or the session
+            cookie is not present.
+    """
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if not session_id:
+        logger.warning("CSRF validation failed: no session cookie present")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF validation failed: no session",
+        )
+
+    if not validate_csrf_token(csrf_token, session_id):
+        logger.warning("CSRF validation failed: invalid token")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="CSRF validation failed: invalid token",
+        )
+
+    logger.debug("CSRF token verified via dependency")

--- a/registry/auth/routes.py
+++ b/registry/auth/routes.py
@@ -4,11 +4,12 @@ import urllib.parse
 from typing import Annotated
 
 import httpx
-from fastapi import APIRouter, Cookie, Request, status
+from fastapi import APIRouter, Cookie, Depends, Form, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from prometheus_client import Counter
 
+from .csrf import verify_csrf_token
 from ..core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -294,8 +295,9 @@ async def logout_get(
 async def logout_post(
     request: Request,
     session: Annotated[str | None, Cookie(alias=settings.session_cookie_name)] = None,
+    _csrf: Annotated[None, Depends(verify_csrf_token)] = None,
 ):
-    """Handle logout via POST request (for forms)"""
+    """Handle logout via POST request (for forms with CSRF validation)"""
     return await logout_handler(request, session)
 
 

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -64,7 +64,7 @@ class AsorFederationClient(BaseFederationClient):
         access_token_env = os.getenv("ASOR_ACCESS_TOKEN")
         if access_token_env:
             logger.info("Using pre-obtained ASOR access token from environment")
-            logger.debug(f"Token starts with: {access_token_env[:50]}...")
+            logger.debug(f"Token starts with: {access_token_env[:10]}...")
             self._access_token = access_token_env
             # Set a reasonable expiry (1 hour from now)
             self._token_expiry = datetime.now(UTC).replace(microsecond=0) + timedelta(hours=1)
@@ -185,7 +185,7 @@ class AsorFederationClient(BaseFederationClient):
             logger.error("Failed to authenticate with Workday")
             return None
 
-        logger.debug(f"Using access token for API call: {access_token[:50]}...")
+        logger.debug("Using access token for API call")
 
         # Build headers - match working test script format
         headers = {
@@ -221,9 +221,8 @@ class AsorFederationClient(BaseFederationClient):
             logger.error("Failed to authenticate with Workday")
             return []
 
-        logger.info(f"ASOR DEBUG - URL: {url}")
-        logger.info(f"ASOR DEBUG - Token (first 50 chars): {access_token[:50]}...")
-        logger.info(f"ASOR DEBUG - Endpoint: {self.endpoint}")
+        logger.debug(f"ASOR DEBUG - URL: {url}")
+        logger.debug(f"ASOR DEBUG - Endpoint: {self.endpoint}")
 
         # Build headers - match working test script format
         headers = {
@@ -232,7 +231,7 @@ class AsorFederationClient(BaseFederationClient):
             "Authorization": f"Bearer {access_token}",
         }
 
-        logger.info(f"ASOR DEBUG - Headers: {headers}")
+        logger.debug("ASOR DEBUG - Headers prepared (Authorization redacted)")
 
         # Make request
         logger.info("Listing all agents from ASOR")

--- a/registry/templates/edit_server.html
+++ b/registry/templates/edit_server.html
@@ -82,6 +82,7 @@
             </div>
         {% endif %}
         <form action="/edit{{ server.path }}" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <div class="form-group">
                 <label for="path">Path (Read-only)</label>
                 <div class="path-display">{{ server.path }}</div>

--- a/registry/templates/index.html
+++ b/registry/templates/index.html
@@ -2205,6 +2205,7 @@
                 {% endif %}
             </div>
             <form action="/logout" method="post" style="display: inline;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                 <button type="submit" class="logout-button">Logout</button>
             </form>
         </div>
@@ -2353,6 +2354,7 @@
                                 {% if can_perform_action('toggle_service', service.display_name) %}
                                     {# Add ID to form if needed, but action URL is sufficient #}
                                     <form action="/toggle{{ service.path }}" method="post" class="toggle-form">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
                                         <label class="switch">
                                             {# Change onchange to use data attributes instead #}
                                             <input type="checkbox" name="enabled" value="on"

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -262,11 +262,17 @@ def test_client_admin(
         patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
         patch("registry.api.server_routes.enhanced_auth", mock_enhanced_auth_func),
     ):
+        from registry.auth.csrf import verify_csrf_token
         from registry.main import app
+
+        # Override CSRF verification for tests
+        app.dependency_overrides[verify_csrf_token] = lambda: None
 
         # Create client with session cookie (uses the default cookie name mcp_gateway_session)
         client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
         yield client
+
+        app.dependency_overrides.pop(verify_csrf_token, None)
 
 
 @pytest.fixture
@@ -296,11 +302,17 @@ def test_client_regular(
         patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
         patch("registry.api.server_routes.enhanced_auth", mock_enhanced_auth_func),
     ):
+        from registry.auth.csrf import verify_csrf_token
         from registry.main import app
+
+        # Override CSRF verification for tests
+        app.dependency_overrides[verify_csrf_token] = lambda: None
 
         # Create client with session cookie (uses the default cookie name mcp_gateway_session)
         client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
         yield client
+
+        app.dependency_overrides.pop(verify_csrf_token, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- **CSRF Protection**: Add signed CSRF tokens (via `itsdangerous`) to all POST forms (logout, toggle service, edit server) with server-side validation dependency
- **Path Traversal Prevention**: Add input validation and path resolution checks to `_walkDirectory()` and `readDocFile()` in `cli/src/utils/docsReader.ts`
- **Credential Logging**: Sanitize token/credential logging in `asor_client.py` — remove token values from logs, redact Authorization headers, reduce token prefix exposure

Closes #600

## Changes

### CSRF Protection (Priority 1)
- New file: `registry/auth/csrf.py` — token generation/validation using `itsdangerous` with session-bound signing
- `registry/templates/index.html` — hidden `csrf_token` input in logout and toggle forms
- `registry/templates/edit_server.html` — hidden `csrf_token` input in edit form
- `registry/api/server_routes.py` — pass `csrf_token` to templates, add `verify_csrf_token` dependency to toggle/edit POST endpoints
- `registry/auth/routes.py` — add `verify_csrf_token` dependency to logout POST endpoint

### Path Traversal Prevention (Priority 2)
- `cli/src/utils/docsReader.ts` — reject `..`, `/`, `\` in directory entries; verify resolved paths stay within base directory; reject absolute paths in `readDocFile()`

### Credential Logging (Priority 3)
- `registry/services/federation/asor_client.py` — remove token value logging, redact headers, reduce token prefix from 50 to 10 chars, downgrade verbose logs to debug level

## Test plan
- [x] All unit tests pass (1366 passed, 11 skipped — 14 pre-existing faiss failures unrelated to changes)
- [x] Toggle service tests pass with CSRF dependency override
- [x] Python files pass `py_compile` checks
- [x] Pre-existing test failures confirmed on main branch (faiss_service, config defaults)