### PR TITLE
fix: eliminate health status race condition for enabled services (#612)

### DIFF
--- a/registry/api/registry_routes.py
+++ b/registry/api/registry_routes.py
@@ -84,13 +84,19 @@ async def list_servers(
     filtered_servers = []
 
     for path, server_info in all_servers.items():
-        # Add health status and enabled state for transformation
-        health_data = health_service._get_service_health_data(path, server_info)
+        # Fetch enabled status before health check to avoid race condition (Issue #612)
+        is_enabled = await server_service.is_service_enabled(path)
+
+        # Add health status with current enabled state
+        health_data = health_service._get_service_health_data(
+            path,
+            {**server_info, "is_enabled": is_enabled},
+        )
 
         server_info_with_status = server_info.copy()
         server_info_with_status["health_status"] = health_data["status"]
         server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-        server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+        server_info_with_status["is_enabled"] = is_enabled
 
         filtered_servers.append(server_info_with_status)
 
@@ -173,13 +179,19 @@ async def list_server_versions(
             )
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
 
+    # Fetch enabled status before health check to avoid race condition (Issue #612)
+    is_enabled = await server_service.is_service_enabled(path)
+
     # Add health and status info using the correct path
-    health_data = health_service._get_service_health_data(path, server_info)
+    health_data = health_service._get_service_health_data(
+        path,
+        {**server_info, "is_enabled": is_enabled},
+    )
 
     server_info_with_status = server_info.copy()
     server_info_with_status["health_status"] = health_data["status"]
     server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-    server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+    server_info_with_status["is_enabled"] = is_enabled
 
     # Since we only have one version, return a list with one item
     server_list = transform_to_server_list([server_info_with_status])
@@ -268,13 +280,19 @@ async def get_server_version(
             detail=f"Version {decoded_version} not found",
         )
 
+    # Fetch enabled status before health check to avoid race condition (Issue #612)
+    is_enabled = await server_service.is_service_enabled(path)
+
     # Add health and status info
-    health_data = health_service._get_service_health_data(path, server_info)
+    health_data = health_service._get_service_health_data(
+        path,
+        {**server_info, "is_enabled": is_enabled},
+    )
 
     server_info_with_status = server_info.copy()
     server_info_with_status["health_status"] = health_data["status"]
     server_info_with_status["last_checked_iso"] = health_data["last_checked_iso"]
-    server_info_with_status["is_enabled"] = await server_service.is_service_enabled(path)
+    server_info_with_status["is_enabled"] = is_enabled
 
     # Transform to Anthropic format
     server_response = transform_to_server_response(

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -204,10 +204,16 @@ async def read_root(
         # Include description and tags in search
         searchable_text = f"{server_name.lower()} {server_info.get('description', '').lower()} {' '.join(server_info.get('tags', []))}"
         if not search_query or search_query in searchable_text:
+            # Fetch enabled status before health check to avoid race condition (Issue #612)
+            is_enabled = await server_service.is_service_enabled(path)
+
             # Get real health status from health service
             from ..health.service import health_service
 
-            health_data = health_service._get_service_health_data(path, server_info)
+            health_data = health_service._get_service_health_data(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
             # Normalize health status to enum values only (strip error messages)
             raw_status = health_data["status"]
@@ -233,7 +239,7 @@ async def read_root(
                     "path": path,
                     "description": server_info.get("description", ""),
                     "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-                    "is_enabled": await server_service.is_service_enabled(path),
+                    "is_enabled": is_enabled,
                     "tags": server_info.get("tags", []),
                     "num_tools": server_info.get("num_tools", 0),
                     "license": server_info.get("license", "N/A"),
@@ -309,10 +315,16 @@ async def get_servers_json(
         # Include description and tags in search
         searchable_text = f"{server_name.lower()} {server_info.get('description', '').lower()} {' '.join(server_info.get('tags', []))}"
         if not search_query or search_query in searchable_text:
+            # Fetch enabled status before health check to avoid race condition (Issue #612)
+            is_enabled = await server_service.is_service_enabled(path)
+
             # Get real health status from health service
             from ..health.service import health_service
 
-            health_data = health_service._get_service_health_data(path, server_info)
+            health_data = health_service._get_service_health_data(
+                path,
+                {**server_info, "is_enabled": is_enabled},
+            )
 
             # Normalize health status to enum values only (strip error messages)
             raw_status = health_data["status"]
@@ -367,7 +379,7 @@ async def get_servers_json(
                     "path": path,
                     "description": server_info.get("description", ""),
                     "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-                    "is_enabled": await server_service.is_service_enabled(path),
+                    "is_enabled": is_enabled,
                     "tags": server_info.get("tags", []),
                     "num_tools": server_info.get("num_tools", 0),
                     "license": server_info.get("license", "N/A"),
@@ -1900,15 +1912,21 @@ async def internal_list_services(
     for service_path, server_info in all_servers.items():
         from ..health.service import health_service
 
+        # Fetch enabled status before health check to avoid race condition (Issue #612)
+        is_enabled = await server_service.is_service_enabled(service_path)
+
         # Get real health status from health service
-        health_data = health_service._get_service_health_data(service_path)
+        health_data = health_service._get_service_health_data(
+            service_path,
+            {**server_info, "is_enabled": is_enabled},
+        )
 
         service_data = {
             "server_name": server_info.get("server_name", "Unknown"),
             "path": service_path,
             "description": server_info.get("description", ""),
             "proxy_pass_url": server_info.get("proxy_pass_url", ""),
-            "is_enabled": await server_service.is_service_enabled(service_path),
+            "is_enabled": is_enabled,
             "tags": server_info.get("tags", []),
             "num_tools": server_info.get("num_tools", 0),
             "license": server_info.get("license", "N/A"),

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -637,6 +637,51 @@ def test_health_service_get_service_health_data_disabled(health_service, mock_se
     assert health_data["status"] == "disabled"
 
 
+@pytest.mark.unit
+def test_health_service_enabled_status_consistency(health_service):
+    """Test that health data correctly reflects enabled status from server_info (Issue #612)."""
+    service_path = "/test-server"
+
+    # Test Case 1: Enabled service should NOT return "disabled" status
+    server_info_enabled = {
+        "server_name": "test-server",
+        "is_enabled": True,
+        "num_tools": 5,
+    }
+    health_data = health_service._get_service_health_data_fast(
+        service_path, server_info_enabled
+    )
+
+    # Should NOT return "disabled" status for enabled service
+    assert health_data["status"] != "disabled"
+    assert health_data["status"] in ["healthy", "unhealthy", "unknown", "checking"]
+
+    # Test Case 2: Disabled service should return "disabled" status
+    server_info_disabled = {
+        "server_name": "test-server",
+        "is_enabled": False,
+        "num_tools": 5,
+    }
+    health_data = health_service._get_service_health_data_fast(
+        service_path, server_info_disabled
+    )
+
+    # Should return "disabled" status
+    assert health_data["status"] == "disabled"
+
+    # Test Case 3: Missing is_enabled defaults to False (disabled)
+    server_info_missing = {
+        "server_name": "test-server",
+        "num_tools": 5,
+    }
+    health_data = health_service._get_service_health_data_fast(
+        service_path, server_info_missing
+    )
+
+    # Should default to disabled when is_enabled is missing
+    assert health_data["status"] == "disabled"
+
+
 # =============================================================================
 # ADDITIONAL TESTS FOR MISSING COVERAGE
 # =============================================================================


### PR DESCRIPTION
 *Issue #612                                                                                                                                                                                                                               
   
  *Description of changes:*                                                                                                                                                                                                                                   
                  
  Fix race condition where health status was misreported for enabled services. The issue occurred because enabled status was fetched after calling the health service, causing the health service to see stale or missing enabled state and incorrectly report
   "disabled" status.

  ## Changes
  - Fetch enabled status once before health check in all affected endpoints
  - Pass enabled status to health service via enriched server_info dict
  - Apply fix to 6 endpoints: 3 in registry_routes.py, 3 in server_routes.py
  - Add unit test to verify enabled status consistency

  This ensures health status accurately reflects the current enabled state without race conditions.

  ## Testing
  All tests pass:
  ```bash
  uv run pytest tests/unit/health/ tests/unit/api/ -v --no-cov
  # Result: 304 passed, 7 skipped ✅

  ---
  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

  **Key changes:**
  1. ✅ Filled in `*Issue #, if available:* #612`
  2. ✅ Moved your description under `*Description of changes:*`
  3. ✅ Added testing section
  4. ✅ Kept the contribution confirmation at the bottom