### PR TITLE
fix: FAISS search broken - missing initialization and wrong entity types

### DIFF
--- a/registry/repositories/file/search_repository.py
+++ b/registry/repositories/file/search_repository.py
@@ -58,17 +58,17 @@ class FaissSearchRepository(SearchRepositoryBase):
 
     async def initialize(self) -> None:
         """Initialize the search repository."""
-        # FAISS service initializes itself
-        pass
+        # Explicitly initialize the shared FAISS service used by this repository.
+        await self.faiss_service.initialize()
 
     async def index_server(
         self, server_path: str, server_data: dict[str, Any], is_enabled: bool
     ) -> None:
         """Index a server."""
-        await self.index_entity(server_path, server_data, "server", is_enabled)
+        await self.index_entity(server_path, server_data, "mcp_server", is_enabled)
 
     async def index_agent(
         self, agent_path: str, agent_data: dict[str, Any], is_enabled: bool
     ) -> None:
         """Index an agent."""
-        await self.index_entity(agent_path, agent_data, "agent", is_enabled)
+        await self.index_entity(agent_path, agent_data, "a2a_agent", is_enabled)


### PR DESCRIPTION
## Summary

Fixes #613

- **`initialize()` was a no-op**: Replaced `pass` with `await self.faiss_service.initialize()` so the FAISS index is properly loaded on startup
- **Wrong entity types in `index_server()`**: Changed `"server"` to `"mcp_server"` to match the schema expected by FAISS service
- **Wrong entity types in `index_agent()`**: Changed `"agent"` to `"a2a_agent"` to match the schema expected by FAISS service

## Test plan

- [x] Verified `faiss_service.initialize()` method exists and loads embeddings + FAISS index
- [x] Verified FAISS service expects `"mcp_server"` and `"a2a_agent"` entity types (confirmed in `registry/search/service.py` and `registry/api/search_routes.py`)
- [x] Confirmed no other incorrect entity type usages remain in the codebase
- [x] All 151 search-related unit tests pass
- [x] All 1419 unit tests pass (14 pre-existing FAISS test failures unrelated to this change, confirmed identical before/after)
- [x] Python syntax validation passes