### PR TITLE
fix: replace execSync with execFileSync to prevent shell injection

### DIFF
--- a/cli/src/agent/tools.ts
+++ b/cli/src/agent/tools.ts
@@ -130,13 +130,17 @@ export async function executeMappedTool(
   }
 
   if (invocation.type === "shell") {
-    const { execSync } = await import("child_process");
+    const { execFileSync } = await import("child_process");
     const command = String(invocation.input.command || "").trim();
     if (!command) {
       return {output: "Missing command field", isError: true};
     }
+    // Split command into executable and arguments to avoid shell injection
+    const parts = command.split(/\s+/);
+    const executable = parts[0];
+    const args = parts.slice(1);
     try {
-      const output = execSync(command, {encoding: "utf-8", maxBuffer: 10 * 1024 * 1024});
+      const output = execFileSync(executable, args, {encoding: "utf-8", maxBuffer: 10 * 1024 * 1024, timeout: 30000});
       return {output};
     } catch (error) {
       const errorMessage = (error as Error).message || String(error);


### PR DESCRIPTION
## Summary

Replace `execSync` with `execFileSync` in the `shell_command` agent tool to prevent command injection via prompt injection attacks.

Fixes #654

## Problem

The `shell_command` tool passes LLM-provided command strings directly to `execSync()`, which invokes a shell. Shell metacharacters (`;`, `|`, `$()`, backticks) in the command string are interpreted, enabling arbitrary command execution (CWE-78).

## Solution

- Replace `execSync` with `execFileSync` (no shell invocation)
- Split command into executable + arguments explicitly
- Add 30-second timeout to prevent runaway processes

## Changes

| File | Change |
|------|--------|
| `cli/src/agent/tools.ts` | `execSync(command)` → `execFileSync(executable, args)` with timeout |

## Testing

- `execFileSync` is a drop-in replacement for simple commands
- Shell operators (pipes, redirects) will no longer work — this is intentional (prevents injection)
- Added 30s timeout as defense-in-depth
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*