### PR TITLE
Packaging as a python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ directory = "htmlcov"
 title = "MCP Registry Coverage Report"
 
 [tool.uv]
+# Local-only project - never resolve from PyPI
 package = false
 
 # Bandit Configuration


### PR DESCRIPTION
*Description of changes:*

Modified the pyproject.toml file so that the mcp-registry can be used as a python package. Tested installing this locally. 

