### PR TITLE
feat: Support authenticated GitHub access for SKILL.md fetching (private repos)

### DIFF
--- a/frontend/src/components/GitHubConnect.tsx
+++ b/frontend/src/components/GitHubConnect.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+
+interface GitHubConnectProps {
+  onShowToast?: (message: string, type: 'success' | 'error') => void;
+  compact?: boolean;
+}
+
+interface GitHubStatus {
+  connected: boolean;
+  username?: string;
+}
+
+const GitHubIcon: React.FC<{ className?: string }> = ({ className = 'h-5 w-5' }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+  </svg>
+);
+
+const GitHubConnect: React.FC<GitHubConnectProps> = ({ onShowToast, compact = false }) => {
+  const [status, setStatus] = useState<GitHubStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [hidden, setHidden] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await axios.get('/api/github/status');
+      setStatus(response.data);
+    } catch (error: any) {
+      if (error.response?.status === 503) {
+        setHidden(true);
+      } else {
+        setStatus({ connected: false });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Check for ?github_connected=true in URL params
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('github_connected') === 'true') {
+      if (onShowToast) {
+        onShowToast('GitHub account connected successfully', 'success');
+      }
+      params.delete('github_connected');
+      const newUrl = params.toString()
+        ? `${window.location.pathname}?${params.toString()}`
+        : window.location.pathname;
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, [onShowToast]);
+
+  const handleConnect = () => {
+    window.location.href = `${axios.defaults.baseURL || ''}/api/github/connect`;
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await axios.post('/api/github/disconnect');
+      setStatus({ connected: false });
+      if (onShowToast) {
+        onShowToast('GitHub account disconnected', 'success');
+      }
+    } catch (error: any) {
+      if (onShowToast) {
+        onShowToast('Failed to disconnect GitHub account', 'error');
+      }
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  if (hidden || loading) return null;
+
+  if (status?.connected) {
+    if (compact) {
+      return (
+        <div className="flex items-center gap-2 py-1.5">
+          <div className="w-2 h-2 rounded-full bg-green-500" />
+          <span className="text-sm text-gray-600 dark:text-gray-300">
+            GitHub connected{status.username ? ` as ${status.username}` : ''}
+          </span>
+          <button
+            onClick={handleDisconnect}
+            disabled={disconnecting}
+            className="text-xs text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors ml-1"
+          >
+            {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex items-center gap-3 p-3 rounded-lg border border-green-200 dark:border-green-700 bg-green-50 dark:bg-green-900/20">
+        <div className="w-2.5 h-2.5 rounded-full bg-green-500" />
+        <GitHubIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
+        <span className="text-sm text-gray-700 dark:text-gray-200 flex-1">
+          GitHub connected{status.username ? ` as ${status.username}` : ''}
+        </span>
+        <button
+          onClick={handleDisconnect}
+          disabled={disconnecting}
+          className="text-sm text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400 transition-colors"
+        >
+          {disconnecting ? 'Disconnecting...' : 'Disconnect'}
+        </button>
+      </div>
+    );
+  }
+
+  // Not connected
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2 py-2">
+        <GitHubIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        <button
+          onClick={handleConnect}
+          className="text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-800 dark:hover:text-amber-200 transition-colors"
+        >
+          Connect GitHub
+        </button>
+        <span className="text-xs text-gray-400 dark:text-gray-500">for private repos</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+      <GitHubIcon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+      <div className="flex-1">
+        <p className="text-sm text-gray-700 dark:text-gray-200">
+          Connect your GitHub account to access private repositories
+        </p>
+      </div>
+      <button
+        onClick={handleConnect}
+        className="px-3 py-1.5 text-sm font-medium text-white bg-gray-800 dark:bg-gray-600 hover:bg-gray-700 dark:hover:bg-gray-500 rounded-md transition-colors"
+      >
+        Connect
+      </button>
+    </div>
+  );
+};
+
+export default GitHubConnect;

--- a/frontend/src/components/SemanticSearchResults.tsx
+++ b/frontend/src/components/SemanticSearchResults.tsx
@@ -23,6 +23,7 @@ import AgentDetailsModal from './AgentDetailsModal';
 import type { Server } from './ServerCard';
 import type { Agent as AgentType } from './AgentCard';
 import useEscapeKey from '../hooks/useEscapeKey';
+import GitHubConnect from './GitHubConnect';
 
 interface SemanticSearchResultsProps {
   query: string;
@@ -375,6 +376,12 @@ const SkillContentModal: React.FC<SkillContentModalProps> = ({
           ) : error ? (
             <div className="text-center py-12 text-gray-500">
               <p className="text-red-500">{error}</p>
+              <div className="mt-3 max-w-sm mx-auto">
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                  This may be a private repository. Connect your GitHub account to access it.
+                </p>
+                <GitHubConnect compact />
+              </div>
               {skill.skill_md_url && (
                 <p className="mt-2 text-sm">
                   Try visiting the{' '}

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -24,6 +24,7 @@ import {
 import { Skill } from '../types/skill';
 import StarRatingWidget from './StarRatingWidget';
 import SecurityScanModal from './SecurityScanModal';
+import GitHubConnect from './GitHubConnect';
 import useEscapeKey from '../hooks/useEscapeKey';
 
 /**
@@ -129,6 +130,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
   const [showDetails, setShowDetails] = useState(false);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [skillMdContent, setSkillMdContent] = useState<string | null>(null);
+  const [contentFetchFailed, setContentFetchFailed] = useState(false);
 
   useEscapeKey(() => setShowDetails(false), showDetails);
   const [loadingToolCheck, setLoadingToolCheck] = useState(false);
@@ -204,6 +206,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
     setShowDetails(true);
     setLoadingDetails(true);
     setSkillMdContent(null);
+    setContentFetchFailed(false);
 
     try {
       // Fetch SKILL.md content via backend proxy to avoid CORS issues
@@ -215,6 +218,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
       setSkillMdContent(response.data.content);
     } catch (error: any) {
       console.error('Failed to fetch SKILL.md content:', error);
+      setContentFetchFailed(true);
       if (onShowToast) {
         onShowToast(
           error.response?.data?.detail || 'Failed to load SKILL.md content',
@@ -731,6 +735,14 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
             ) : (
               <div className="text-center py-12 text-gray-500">
                 <p>Could not load SKILL.md content.</p>
+                {contentFetchFailed && (
+                  <div className="mt-3 max-w-sm mx-auto">
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                      This may be a private repository. Connect your GitHub account to access it.
+                    </p>
+                    <GitHubConnect compact onShowToast={onShowToast} />
+                  </div>
+                )}
                 <p className="mt-2 text-sm">
                   Try visiting the{' '}
                   <a

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -18,6 +18,7 @@ import {
   UpdateVirtualServerRequest,
 } from '../types/virtualServer';
 import VirtualServerForm from '../components/VirtualServerForm';
+import GitHubConnect from '../components/GitHubConnect';
 import axios from 'axios';
 
 
@@ -2777,6 +2778,11 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all' }) => {
                     />
                   </button>
                 </div>
+              )}
+
+              {/* GitHub Connect - only for new skills */}
+              {!editingSkill && (
+                <GitHubConnect compact onShowToast={showToast} />
               )}
 
               {/* SKILL.md URL with Parse button */}

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 
 from ..audit.context import set_audit_action
 from ..auth.csrf import verify_csrf_token_flexible
-from ..auth.dependencies import nginx_proxied_auth
+from ..auth.dependencies import get_github_token_from_request, nginx_proxied_auth
 from ..exceptions import (
     SkillAlreadyExistsError,
     SkillServiceError,
@@ -160,6 +160,7 @@ async def list_skills(
 
 @router.post("/parse-skill-md", summary="Parse SKILL.md content from URL")
 async def parse_skill_md(
+    http_request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     url: str = Query(..., description="URL to SKILL.md file"),
 ) -> dict:
@@ -168,9 +169,10 @@ async def parse_skill_md(
     Returns name, description, version, and tags from the SKILL.md file.
     Useful for auto-populating the skill registration form.
     """
+    github_token = get_github_token_from_request(http_request)
     service = get_skill_service()
     try:
-        result = await service.parse_skill_md(url)
+        result = await service.parse_skill_md(url, github_token=github_token)
         return {
             "success": True,
             "name": result.get("name"),
@@ -251,6 +253,7 @@ async def search_skills(
 
 @router.get("/{skill_path:path}/health", summary="Check skill health")
 async def check_skill_health(
+    http_request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     skill_path: str = Path(..., description="Skill path or name"),
 ) -> dict:
@@ -258,9 +261,10 @@ async def check_skill_health(
 
     Returns health status, HTTP status code, and response time.
     """
+    github_token = get_github_token_from_request(http_request)
     normalized_path = normalize_skill_path(skill_path)
     service = get_skill_service()
-    result = await service.check_skill_health(normalized_path)
+    result = await service.check_skill_health(normalized_path, github_token=github_token)
     return {
         "path": normalized_path,
         "healthy": result["healthy"],
@@ -272,6 +276,7 @@ async def check_skill_health(
 
 @router.get("/{skill_path:path}/content", summary="Get SKILL.md content")
 async def get_skill_content(
+    http_request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     skill_path: str = Path(..., description="Skill path or name"),
 ) -> dict:
@@ -314,7 +319,8 @@ async def get_skill_content(
 
         from ..utils.github_client import get_authenticated_client
 
-        async with await get_authenticated_client(str(raw_url)) as client:
+        github_token = get_github_token_from_request(http_request)
+        async with await get_authenticated_client(str(raw_url), user_token=github_token) as client:
             response = await client.get(str(raw_url), follow_redirects=True, timeout=30.0)
 
             # SSRF protection: validate final URL after redirects
@@ -535,11 +541,14 @@ async def register_skill(
         description=f"Register skill {request.name}",
     )
 
+    github_token = get_github_token_from_request(http_request)
     service = get_skill_service()
     owner = user_context.get("username")
 
     try:
-        skill = await service.register_skill(request=request, owner=owner, validate_url=True)
+        skill = await service.register_skill(
+            request=request, owner=owner, validate_url=True, github_token=github_token
+        )
         logger.info(f"Registered skill: {skill.name} by {owner}")
 
         # Perform security scan on registration (non-blocking on failure)

--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -662,6 +662,25 @@ def create_session_cookie(
     return signer.dumps(session_data)
 
 
+def get_github_token_from_request(request: Request) -> str | None:
+    """Extract GitHub OAuth token from user's session cookie.
+
+    Args:
+        request: The incoming HTTP request.
+
+    Returns:
+        GitHub token string or None if not present.
+    """
+    cookie_value = request.cookies.get(settings.session_cookie_name)
+    if not cookie_value:
+        return None
+    try:
+        session_data = signer.loads(cookie_value, max_age=settings.session_max_age_seconds)
+        return session_data.get("github_token")
+    except Exception:
+        return None
+
+
 def ui_permission_required(permission: str, service_name: str = None):
     """
     Decorator to require a specific UI permission for a route.

--- a/registry/auth/github_oauth.py
+++ b/registry/auth/github_oauth.py
@@ -1,0 +1,258 @@
+"""GitHub OAuth router for user-level GitHub SSO.
+
+Allows logged-in users to connect their GitHub account via OAuth,
+storing the access token in their session cookie for authenticated
+access to private GitHub repositories when fetching SKILL.md files.
+"""
+
+import logging
+import time
+
+import httpx
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, RedirectResponse
+from itsdangerous import BadSignature
+
+from ..core.config import settings
+from .dependencies import nginx_proxied_auth, signer
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# State token max age in seconds
+_STATE_MAX_AGE: int = 300
+
+
+@router.get("/connect", summary="Initiate GitHub OAuth connection")
+async def connect(
+    request: Request,
+    user_context: dict = Depends(nginx_proxied_auth),
+):
+    """Redirect user to GitHub OAuth authorization page.
+
+    User must already be logged in. Generates a signed state parameter
+    to prevent CSRF attacks during the OAuth flow.
+    """
+    if not settings.github_oauth_client_id:
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "GitHub OAuth not configured"},
+        )
+
+    username = user_context.get("username", "")
+    state_data = {"username": username, "timestamp": int(time.time())}
+    state = signer.dumps(state_data)
+
+    callback_url = str(request.base_url).rstrip("/") + "/api/github/callback"
+
+    github_authorize_url = (
+        f"https://github.com/login/oauth/authorize"
+        f"?client_id={settings.github_oauth_client_id}"
+        f"&redirect_uri={callback_url}"
+        f"&scope=repo"
+        f"&state={state}"
+    )
+
+    response = RedirectResponse(url=github_authorize_url)
+    response.set_cookie(
+        key="github_oauth_state",
+        value=state,
+        httponly=True,
+        max_age=_STATE_MAX_AGE,
+        samesite="lax",
+    )
+    return response
+
+
+@router.get("/callback", summary="GitHub OAuth callback")
+async def callback(
+    request: Request,
+    code: str = "",
+    state: str = "",
+):
+    """Handle GitHub OAuth callback after user authorization.
+
+    Exchanges the authorization code for an access token and stores
+    it in the user's session cookie.
+    """
+    if not code or not state:
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "Missing code or state parameter"},
+        )
+
+    # Validate state matches cookie
+    cookie_state = request.cookies.get("github_oauth_state")
+    if not cookie_state or cookie_state != state:
+        logger.warning("GitHub OAuth state mismatch")
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "Invalid state parameter"},
+        )
+
+    # Validate state is properly signed and not expired
+    try:
+        signer.loads(state, max_age=_STATE_MAX_AGE)
+    except BadSignature:
+        logger.warning("GitHub OAuth state has invalid signature")
+        return JSONResponse(
+            status_code=400,
+            content={"detail": "Invalid or expired state parameter"},
+        )
+
+    # Exchange code for access token
+    try:
+        async with httpx.AsyncClient() as client:
+            token_response = await client.post(
+                "https://github.com/login/oauth/access_token",
+                json={
+                    "client_id": settings.github_oauth_client_id,
+                    "client_secret": settings.github_oauth_client_secret,
+                    "code": code,
+                },
+                headers={"Accept": "application/json"},
+                timeout=10.0,
+            )
+            token_response.raise_for_status()
+            token_data = token_response.json()
+    except Exception:
+        logger.exception("Failed to exchange GitHub OAuth code for token")
+        return JSONResponse(
+            status_code=502,
+            content={"detail": "Failed to exchange code with GitHub"},
+        )
+
+    access_token = token_data.get("access_token")
+    if not access_token:
+        error = token_data.get("error_description", token_data.get("error", "unknown"))
+        logger.error("GitHub OAuth token exchange returned error: %s", error)
+        return JSONResponse(
+            status_code=400,
+            content={"detail": f"GitHub token exchange failed: {error}"},
+        )
+
+    # Read existing session cookie and add github_token
+    session_cookie = request.cookies.get(settings.session_cookie_name)
+    if not session_cookie:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "No active session. Please log in first."},
+        )
+
+    try:
+        session_data = signer.loads(session_cookie, max_age=settings.session_max_age_seconds)
+    except Exception:
+        logger.warning("Failed to decode session cookie during GitHub OAuth callback")
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Invalid session. Please log in again."},
+        )
+
+    # Add GitHub token to session
+    session_data["github_token"] = access_token
+    updated_cookie = signer.dumps(session_data)
+
+    response = RedirectResponse(url="/?github_connected=true")
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=updated_cookie,
+        httponly=True,
+        max_age=settings.session_max_age_seconds,
+        samesite="lax",
+    )
+    # Delete the temporary state cookie
+    response.delete_cookie(key="github_oauth_state")
+
+    logger.info(
+        "GitHub account connected for user %s",
+        session_data.get("username"),
+    )
+    return response
+
+
+@router.get("/status", summary="Check GitHub connection status")
+async def status_check(
+    request: Request,
+    user_context: dict = Depends(nginx_proxied_auth),
+):
+    """Check if the current user has a connected GitHub account.
+
+    If connected, validates the token by calling the GitHub API
+    and returns the GitHub username.
+    """
+    github_token = _get_github_token_from_session(request)
+    if not github_token:
+        return {"connected": False, "github_username": None}
+
+    # Validate token by calling GitHub API
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                "https://api.github.com/user",
+                headers={"Authorization": f"token {github_token}"},
+                timeout=10.0,
+            )
+            if resp.status_code == 200:
+                user_data = resp.json()
+                return {
+                    "connected": True,
+                    "github_username": user_data.get("login"),
+                }
+    except Exception:
+        logger.warning("Failed to validate GitHub token")
+
+    return {"connected": False, "github_username": None}
+
+
+@router.post("/disconnect", summary="Disconnect GitHub account")
+async def disconnect(
+    request: Request,
+    user_context: dict = Depends(nginx_proxied_auth),
+):
+    """Remove GitHub token from user's session."""
+    session_cookie = request.cookies.get(settings.session_cookie_name)
+    if not session_cookie:
+        return {"disconnected": True}
+
+    try:
+        session_data = signer.loads(session_cookie, max_age=settings.session_max_age_seconds)
+    except Exception:
+        return {"disconnected": True}
+
+    session_data.pop("github_token", None)
+    updated_cookie = signer.dumps(session_data)
+
+    response = JSONResponse(content={"disconnected": True})
+    response.set_cookie(
+        key=settings.session_cookie_name,
+        value=updated_cookie,
+        httponly=True,
+        max_age=settings.session_max_age_seconds,
+        samesite="lax",
+    )
+
+    logger.info(
+        "GitHub account disconnected for user %s",
+        session_data.get("username"),
+    )
+    return response
+
+
+def _get_github_token_from_session(request: Request) -> str | None:
+    """Extract GitHub OAuth token from session cookie.
+
+    Args:
+        request: The incoming HTTP request.
+
+    Returns:
+        GitHub token string or None if not present.
+    """
+    cookie_value = request.cookies.get(settings.session_cookie_name)
+    if not cookie_value:
+        return None
+    try:
+        session_data = signer.loads(cookie_value, max_age=settings.session_max_age_seconds)
+        return session_data.get("github_token")
+    except Exception:
+        return None

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -112,6 +112,8 @@ class Settings(BaseSettings):
     github_app_id: str = ""  # GitHub App ID for installation-based auth
     github_app_installation_id: str = ""  # GitHub App Installation ID
     github_app_private_key: str = ""  # GitHub App private key (PEM format)
+    github_oauth_client_id: str = ""  # GitHub OAuth App client ID for user SSO
+    github_oauth_client_secret: str = ""  # GitHub OAuth App client secret
 
     # Skill security scanning settings (AI Agent Skills)
     skill_security_scan_enabled: bool = True

--- a/registry/main.py
+++ b/registry/main.py
@@ -33,6 +33,7 @@ from registry.api.registry_routes import router as registry_router
 from registry.api.search_routes import router as search_router
 from registry.api.server_routes import router as servers_router
 from registry.api.skill_routes import router as skill_router
+from registry.auth.github_oauth import router as github_oauth_router
 from registry.api.system_routes import router as system_router
 from registry.api.system_routes import set_server_start_time
 from registry.api.virtual_server_routes import router as virtual_server_router
@@ -564,6 +565,7 @@ app.include_router(health_router, prefix="/api/health", tags=["Health Monitoring
 app.include_router(federation_export_router)
 app.include_router(peer_management_router)
 app.include_router(audit_router, prefix="/api", tags=["Audit Logs"])
+app.include_router(github_oauth_router, prefix="/api/github", tags=["GitHub OAuth"])
 
 # Register Anthropic MCP Registry API (public API for MCP servers only)
 app.include_router(registry_router, tags=["Anthropic Registry API"])

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -164,6 +164,7 @@ def _is_safe_url(
 
 async def _validate_skill_md_url(
     url: str,
+    github_token: str | None = None,
 ) -> dict[str, Any]:
     """Validate SKILL.md URL is accessible and get content hash.
 
@@ -183,7 +184,7 @@ async def _validate_skill_md_url(
         )
 
     try:
-        async with await get_authenticated_client(str(url)) as client:
+        async with await get_authenticated_client(str(url), user_token=github_token) as client:
             response = await client.get(
                 str(url), follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
@@ -214,6 +215,7 @@ async def _validate_skill_md_url(
 
 async def _parse_skill_md_content(
     url: str,
+    github_token: str | None = None,
 ) -> dict[str, Any]:
     """Parse SKILL.md content and extract metadata.
 
@@ -256,7 +258,7 @@ async def _parse_skill_md_content(
         )
 
     try:
-        async with await get_authenticated_client(raw_url_str) as client:
+        async with await get_authenticated_client(raw_url_str, user_token=github_token) as client:
             # Fetch from raw URL
             response = await client.get(
                 raw_url_str, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
@@ -402,6 +404,7 @@ async def _parse_skill_md_content(
 
 async def _check_skill_health(
     url: str,
+    github_token: str | None = None,
 ) -> dict[str, Any]:
     """Check skill health by performing HEAD request to SKILL.md URL.
 
@@ -425,7 +428,7 @@ async def _check_skill_health(
         }
 
     try:
-        async with await get_authenticated_client(str(url)) as client:
+        async with await get_authenticated_client(str(url), user_token=github_token) as client:
             response = await client.head(
                 str(url), follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
@@ -555,6 +558,7 @@ class SkillService:
         request: SkillRegistrationRequest,
         owner: str | None = None,
         validate_url: bool = True,
+        github_token: str | None = None,
     ) -> SkillCard:
         """Register a new skill.
 
@@ -581,7 +585,7 @@ class SkillService:
         content_updated_at = None
 
         if validate_url:
-            validation = await _validate_skill_md_url(raw_url)
+            validation = await _validate_skill_md_url(raw_url, github_token=github_token)
             content_version = validation["content_version"]
             content_updated_at = validation["content_updated_at"]
 
@@ -794,25 +798,29 @@ class SkillService:
     async def parse_skill_md(
         self,
         url: str,
+        github_token: str | None = None,
     ) -> dict[str, Any]:
         """Parse SKILL.md content and extract metadata.
 
         Args:
             url: URL to SKILL.md file
+            github_token: Optional user GitHub OAuth token.
 
         Returns:
             Dict with parsed metadata (name, description, version, tags)
         """
-        return await _parse_skill_md_content(url)
+        return await _parse_skill_md_content(url, github_token=github_token)
 
     async def check_skill_health(
         self,
         path: str,
+        github_token: str | None = None,
     ) -> dict[str, Any]:
         """Check skill health by performing HEAD request to SKILL.md URL.
 
         Args:
             path: Skill path
+            github_token: Optional user GitHub OAuth token.
 
         Returns:
             Dict with health status
@@ -833,7 +841,7 @@ class SkillService:
 
         # Use raw URL for health check (more reliable, returns actual content)
         url = skill.skill_md_raw_url or skill.skill_md_url
-        result = await _check_skill_health(str(url))
+        result = await _check_skill_health(str(url), github_token=github_token)
 
         # Persist health status to database
         health_status = "healthy" if result.get("healthy") else "unhealthy"

--- a/registry/utils/github_client.py
+++ b/registry/utils/github_client.py
@@ -161,17 +161,24 @@ async def _get_cached_installation_token() -> str:
     return token
 
 
-async def get_github_auth_headers() -> dict[str, str]:
+async def get_github_auth_headers(user_token: str | None = None) -> dict[str, str]:
     """Get authentication headers for GitHub API requests.
 
     Authentication priority:
-    1. GitHub App (if app_id, installation_id, and private_key are set)
-    2. Personal Access Token (if github_pat is set)
-    3. Empty dict (unauthenticated fallback)
+    1. User OAuth token (if provided via SSO)
+    2. GitHub App (if app_id, installation_id, and private_key are set)
+    3. Personal Access Token (if github_pat is set)
+    4. Empty dict (unauthenticated fallback)
+
+    Args:
+        user_token: Optional user OAuth token from GitHub SSO.
 
     Returns:
         Dictionary of HTTP headers for authentication.
     """
+    if user_token:
+        logger.debug("Using user OAuth token for GitHub authentication")
+        return {"Authorization": f"token {user_token}"}
     if _has_github_app_credentials():
         try:
             token = await _get_cached_installation_token()
@@ -192,13 +199,17 @@ async def get_github_auth_headers() -> dict[str, str]:
     return {}
 
 
-async def get_authenticated_client(url: str) -> httpx.AsyncClient:
+async def get_authenticated_client(
+    url: str,
+    user_token: str | None = None,
+) -> httpx.AsyncClient:
     """Create an httpx.AsyncClient with GitHub auth headers if the URL is a GitHub domain.
 
     For non-GitHub URLs, returns a plain client with no extra headers.
 
     Args:
         url: The target URL to configure authentication for.
+        user_token: Optional user OAuth token from GitHub SSO.
 
     Returns:
         Configured httpx.AsyncClient instance. Caller is responsible for closing it.
@@ -206,7 +217,7 @@ async def get_authenticated_client(url: str) -> httpx.AsyncClient:
     headers: dict[str, str] = {}
 
     if _is_github_url(url):
-        headers = await get_github_auth_headers()
+        headers = await get_github_auth_headers(user_token=user_token)
         if headers:
             logger.debug("Created authenticated GitHub client for %s", url)
         else:

--- a/tests/unit/auth/test_github_oauth.py
+++ b/tests/unit/auth/test_github_oauth.py
@@ -1,0 +1,320 @@
+"""Tests for registry.auth.github_oauth - GitHub OAuth router endpoints."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.auth.dependencies import signer
+from registry.auth.github_oauth import router
+from registry.core.config import settings
+
+
+def _make_session_cookie(
+    username: str = "testuser",
+    auth_method: str = "oauth2",
+    github_token: str | None = None,
+) -> str:
+    """Create a signed session cookie for testing."""
+    data = {"username": username, "auth_method": auth_method, "provider": "keycloak"}
+    if github_token:
+        data["github_token"] = github_token
+    return signer.dumps(data)
+
+
+def _build_app() -> FastAPI:
+    """Build a minimal FastAPI app with the GitHub OAuth router."""
+    app = FastAPI()
+    app.include_router(router, prefix="/api/github")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# /api/github/connect tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+    """Tests for GET /api/github/connect endpoint."""
+
+    @patch("registry.auth.github_oauth.settings")
+    @patch("registry.auth.github_oauth.nginx_proxied_auth")
+    def test_connect_redirects_to_github(self, mock_auth, mock_settings):
+        """Should redirect to GitHub OAuth authorize URL when configured."""
+        mock_settings.github_oauth_client_id = "test-client-id"
+        mock_auth.return_value = {"username": "testuser"}
+        app = _build_app()
+        app.dependency_overrides[
+            __import__("registry.auth.dependencies", fromlist=["nginx_proxied_auth"]).nginx_proxied_auth
+        ] = lambda: {"username": "testuser"}
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/github/connect", follow_redirects=False)
+
+        assert response.status_code == 307
+        location = response.headers["location"]
+        assert "github.com/login/oauth/authorize" in location
+        assert "client_id=test-client-id" in location
+        assert "scope=repo" in location
+
+    @patch("registry.auth.github_oauth.settings")
+    def test_connect_returns_503_when_not_configured(self, mock_settings):
+        """Should return 503 when GitHub OAuth client ID is empty."""
+        mock_settings.github_oauth_client_id = ""
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.get("/api/github/connect")
+
+        assert response.status_code == 503
+        assert "not configured" in response.json()["detail"]
+
+    def test_connect_requires_auth(self):
+        """Should return 401 when no session cookie is provided."""
+        app = _build_app()
+        # Do NOT override the auth dependency, so the real one runs
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/github/connect")
+
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /api/github/callback tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallback:
+    """Tests for GET /api/github/callback endpoint."""
+
+    @patch("registry.auth.github_oauth.httpx.AsyncClient")
+    @patch("registry.auth.github_oauth.settings")
+    def test_callback_exchanges_code_for_token(self, mock_settings, mock_client_cls):
+        """Should exchange code for token and update session with github_token."""
+        mock_settings.github_oauth_client_id = "test-client-id"
+        mock_settings.github_oauth_client_secret = "test-secret"
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+
+        # Create signed state
+        state_data = {"username": "testuser", "timestamp": int(time.time())}
+        state = signer.dumps(state_data)
+
+        # Mock GitHub token exchange response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "gho_user_token_123"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_http_client = AsyncMock()
+        mock_http_client.post = AsyncMock(return_value=mock_response)
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_http_client
+
+        session_cookie = _make_session_cookie()
+
+        app = _build_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get(
+                f"/api/github/callback?code=test_code&state={state}",
+                cookies={
+                    "github_oauth_state": state,
+                    settings.session_cookie_name: session_cookie,
+                },
+                follow_redirects=False,
+            )
+
+        # Should redirect after successful token exchange
+        assert response.status_code == 307
+        assert "github_connected=true" in response.headers.get("location", "")
+
+        # Verify updated session cookie contains github_token
+        updated_cookie = response.cookies.get(settings.session_cookie_name)
+        if updated_cookie:
+            session_data = signer.loads(updated_cookie)
+            assert session_data.get("github_token") == "gho_user_token_123"
+
+    def test_callback_rejects_invalid_state(self):
+        """Should return 400 when state parameter doesn't match cookie."""
+        state = signer.dumps({"username": "testuser", "timestamp": int(time.time())})
+        wrong_state = signer.dumps({"username": "hacker", "timestamp": int(time.time())})
+
+        app = _build_app()
+        with TestClient(app) as client:
+            response = client.get(
+                f"/api/github/callback?code=test_code&state={state}",
+                cookies={"github_oauth_state": wrong_state},
+            )
+
+        assert response.status_code == 400
+        assert "state" in response.json()["detail"].lower()
+
+    def test_callback_rejects_missing_code(self):
+        """Should return 400 when code parameter is missing."""
+        app = _build_app()
+        with TestClient(app) as client:
+            response = client.get("/api/github/callback?state=some_state")
+
+        assert response.status_code == 400
+        assert "Missing" in response.json()["detail"]
+
+    def test_callback_rejects_missing_state(self):
+        """Should return 400 when state parameter is missing."""
+        app = _build_app()
+        with TestClient(app) as client:
+            response = client.get("/api/github/callback?code=some_code")
+
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /api/github/status tests
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    """Tests for GET /api/github/status endpoint."""
+
+    @patch("registry.auth.github_oauth.httpx.AsyncClient")
+    @patch("registry.auth.github_oauth.settings")
+    def test_status_connected(self, mock_settings, mock_client_cls):
+        """Should return connected=True with username when token is valid."""
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+        mock_settings.github_oauth_client_id = "test-client-id"
+
+        # Mock GitHub user API response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"login": "octocat"}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+        mock_http_client.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_http_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_http_client
+
+        session_cookie = _make_session_cookie(github_token="gho_valid_token")
+
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/github/status",
+                cookies={settings.session_cookie_name: session_cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connected"] is True
+        assert data["github_username"] == "octocat"
+
+    @patch("registry.auth.github_oauth.settings")
+    def test_status_disconnected(self, mock_settings):
+        """Should return connected=False when no github_token in session."""
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+
+        session_cookie = _make_session_cookie()  # No github_token
+
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/github/status",
+                cookies={settings.session_cookie_name: session_cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connected"] is False
+
+    @patch("registry.auth.github_oauth.settings")
+    def test_status_no_session_returns_disconnected(self, mock_settings):
+        """Should return connected=False when no session cookie."""
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.get("/api/github/status")
+
+        assert response.status_code == 200
+        assert response.json()["connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# /api/github/disconnect tests
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnect:
+    """Tests for POST /api/github/disconnect endpoint."""
+
+    @patch("registry.auth.github_oauth.settings")
+    def test_disconnect_removes_token(self, mock_settings):
+        """Should remove github_token from session and return disconnected=True."""
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+
+        session_cookie = _make_session_cookie(github_token="gho_to_remove")
+
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/github/disconnect",
+                cookies={settings.session_cookie_name: session_cookie},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["disconnected"] is True
+
+        # Verify github_token is removed from session cookie
+        updated_cookie = response.cookies.get(settings.session_cookie_name)
+        if updated_cookie:
+            session_data = signer.loads(updated_cookie)
+            assert "github_token" not in session_data
+
+    @patch("registry.auth.github_oauth.settings")
+    def test_disconnect_without_session(self, mock_settings):
+        """Should return disconnected=True even without session."""
+        mock_settings.session_cookie_name = settings.session_cookie_name
+        mock_settings.session_max_age_seconds = settings.session_max_age_seconds
+
+        app = _build_app()
+
+        from registry.auth.dependencies import nginx_proxied_auth
+
+        app.dependency_overrides[nginx_proxied_auth] = lambda: {"username": "testuser"}
+
+        with TestClient(app) as client:
+            response = client.post("/api/github/disconnect")
+
+        assert response.status_code == 200
+        assert response.json()["disconnected"] is True

--- a/tests/unit/utils/test_github_client.py
+++ b/tests/unit/utils/test_github_client.py
@@ -221,6 +221,84 @@ class TestGetGithubAuthHeaders:
         headers = await get_github_auth_headers()
         assert headers == {}
 
+    @pytest.mark.asyncio
+    @patch("registry.utils.github_client.settings")
+    async def test_user_token_takes_priority_over_pat(self, mock_settings):
+        """User OAuth token should take priority over PAT."""
+        mock_settings.github_pat = "ghp_server_pat"
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+
+        headers = await get_github_auth_headers(user_token="gho_user_token")
+        assert headers == {"Authorization": "token gho_user_token"}
+
+    @pytest.mark.asyncio
+    @patch("registry.utils.github_client._get_cached_installation_token", new_callable=AsyncMock)
+    @patch("registry.utils.github_client.settings")
+    async def test_user_token_takes_priority_over_app(self, mock_settings, mock_get_token):
+        """User OAuth token should take priority over GitHub App credentials."""
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = "-----BEGIN RSA PRIVATE KEY-----"
+        mock_settings.github_pat = ""
+
+        mock_get_token.return_value = "ghs_app_token"
+
+        headers = await get_github_auth_headers(user_token="gho_user_token")
+        assert headers == {"Authorization": "token gho_user_token"}
+        # Should not call the app token fetch at all
+        mock_get_token.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_github_auth_headers_with_user_token(self):
+        """User token should produce proper Authorization header."""
+        headers = await get_github_auth_headers(user_token="gho_abc123")
+        assert headers == {"Authorization": "token gho_abc123"}
+
+
+# ---------------------------------------------------------------------------
+# User token with get_authenticated_client
+# ---------------------------------------------------------------------------
+
+
+class TestUserTokenWithClient:
+    """Tests for user_token parameter in get_authenticated_client."""
+
+    @pytest.mark.asyncio
+    @patch("registry.utils.github_client.get_github_auth_headers", new_callable=AsyncMock)
+    async def test_user_token_passed_to_auth_headers(self, mock_auth_headers):
+        """User token should be forwarded to get_github_auth_headers."""
+        mock_auth_headers.return_value = {"Authorization": "token gho_user"}
+
+        client = await get_authenticated_client(
+            "https://raw.githubusercontent.com/org/repo/main/SKILL.md",
+            user_token="gho_user",
+        )
+
+        try:
+            assert client.headers.get("authorization") == "token gho_user"
+        finally:
+            await client.aclose()
+
+        mock_auth_headers.assert_awaited_once_with(user_token="gho_user")
+
+    @pytest.mark.asyncio
+    @patch("registry.utils.github_client.get_github_auth_headers", new_callable=AsyncMock)
+    async def test_user_token_not_applied_to_non_github_urls(self, mock_auth_headers):
+        """User token should not be applied to non-GitHub URLs."""
+        client = await get_authenticated_client(
+            "https://gitlab.com/org/repo/SKILL.md",
+            user_token="gho_user_token",
+        )
+
+        try:
+            assert "authorization" not in client.headers
+        finally:
+            await client.aclose()
+
+        mock_auth_headers.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # Token caching tests
@@ -381,7 +459,7 @@ class TestSkillServiceGitHubIntegration:
         result = await _validate_skill_md_url(url)
 
         assert result["valid"] is True
-        mock_get_client.assert_awaited_once_with(url)
+        mock_get_client.assert_awaited_once_with(url, user_token=None)
 
     @pytest.mark.asyncio
     @patch("registry.services.skill_service._is_safe_url", return_value=True)
@@ -407,7 +485,7 @@ class TestSkillServiceGitHubIntegration:
         result = await _validate_skill_md_url(url)
 
         assert result["valid"] is True
-        mock_get_client.assert_awaited_once_with(url)
+        mock_get_client.assert_awaited_once_with(url, user_token=None)
 
     @pytest.mark.asyncio
     @patch("registry.services.skill_service._is_safe_url", return_value=True)
@@ -434,7 +512,7 @@ class TestSkillServiceGitHubIntegration:
         result = await _check_skill_health(url)
 
         assert result["healthy"] is True
-        mock_get_client.assert_awaited_once_with(url)
+        mock_get_client.assert_awaited_once_with(url, user_token=None)
 
     @pytest.mark.asyncio
     @patch("registry.services.skill_service._is_safe_url", return_value=True)
@@ -471,7 +549,8 @@ class TestSkillServiceGitHubIntegration:
 
         assert result["name"] == "Test Skill"
         mock_get_client.assert_awaited_once_with(
-            "https://raw.githubusercontent.com/org/repo/main/SKILL.md"
+            "https://raw.githubusercontent.com/org/repo/main/SKILL.md",
+            user_token=None,
         )
 
 
@@ -488,8 +567,10 @@ class TestSkillRoutesGitHubIntegration:
     @patch("registry.api.skill_routes._user_can_access_skill", return_value=True)
     @patch("registry.utils.github_client.get_authenticated_client", new_callable=AsyncMock)
     @patch("registry.api.skill_routes.get_skill_service")
+    @patch("registry.api.skill_routes.get_github_token_from_request", return_value=None)
     async def test_get_skill_content_uses_auth_for_github(
         self,
+        mock_get_token,
         mock_get_service,
         mock_get_client,
         mock_access,
@@ -522,13 +603,16 @@ class TestSkillRoutesGitHubIntegration:
         mock_client.__aexit__ = AsyncMock(return_value=False)
         mock_get_client.return_value = mock_client
 
+        mock_request = MagicMock()
         user_context = {"username": "testuser", "is_admin": False}
         result = await get_skill_content(
+            http_request=mock_request,
             user_context=user_context,
             skill_path="my-skill",
         )
 
         assert result["content"] == "# My Skill Content"
         mock_get_client.assert_awaited_once_with(
-            "https://raw.githubusercontent.com/org/repo/main/SKILL.md"
+            "https://raw.githubusercontent.com/org/repo/main/SKILL.md",
+            user_token=None,
         )


### PR DESCRIPTION
## Summary

Closes #660

Adds authenticated GitHub access for fetching SKILL.md files from private repositories, with both server-level and user-level authentication.

### Tier 1: Server-level credentials (admin-configured)
- **PAT**: Set `GITHUB_PAT` env var for simple token-based auth
- **GitHub App**: Set `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` for JWT-based installation token auth with automatic caching

### Tier 2: User-level GitHub OAuth SSO
- Users authenticate via enterprise IdP (Cognito/Keycloak/Entra) as before
- Users optionally link their GitHub account via OAuth for private repo access
- Frontend "Connect GitHub" button in skill registration and content viewer
- OAuth token stored in signed session cookie

### Auth priority chain
User OAuth token > Server GitHub App > Server PAT > unauthenticated

### Changes

| File | Change |
|------|--------|
| `registry/core/config.py` | 6 new settings (PAT, App, OAuth client) |
| `registry/utils/github_client.py` | GitHub URL detection, auth headers, token caching, user_token support |
| `registry/auth/github_oauth.py` | **New** - OAuth router: connect, callback, status, disconnect |
| `registry/auth/dependencies.py` | `get_github_token_from_request()` helper |
| `registry/services/skill_service.py` | 3 call sites + service methods accept github_token |
| `registry/api/skill_routes.py` | 4 endpoints extract and pass user's GitHub token |
| `registry/main.py` | Mount GitHub OAuth router at /api/github |
| `frontend/src/components/GitHubConnect.tsx` | **New** - GitHub connect/disconnect component |
| `frontend/src/pages/Dashboard.tsx` | GitHubConnect in skill registration modal |
| `frontend/src/components/SkillCard.tsx` | GitHubConnect on private repo fetch failure |
| `frontend/src/components/SemanticSearchResults.tsx` | GitHubConnect on content fetch failure |
| `tests/unit/auth/test_github_oauth.py` | **New** - 12 OAuth endpoint tests |
| `tests/unit/utils/test_github_client.py` | 39 total tests (user_token priority, etc.) |

### Configuration

```bash
# Server-level: PAT (quick win)
export GITHUB_PAT=ghp_your_token_here

# Server-level: GitHub App (recommended for enterprise)
export GITHUB_APP_ID=12345
export GITHUB_APP_INSTALLATION_ID=67890
export GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n..."

# User-level: GitHub OAuth SSO (recommended)
export GITHUB_OAUTH_CLIENT_ID=your_oauth_app_client_id
export GITHUB_OAUTH_CLIENT_SECRET=your_oauth_app_client_secret
```

## Test plan

- [x] 39 github_client unit tests passing
- [x] 12 GitHub OAuth endpoint tests passing
- [x] All existing skill-related tests pass
- [x] Full unit test suite: 1743 passed, 0 new failures
- [ ] Manual test: GitHub OAuth connect flow
- [ ] Manual test: private repo SKILL.md fetch after connecting
- [ ] Manual test: disconnect flow