### PR TITLE
fix: make Nginx DNS resolver configurable via environment variable

### DIFF
--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -1073,9 +1074,13 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
 
         # Common proxy settings
         common_settings = f"""
-        # Use IPv4 resolver (disable IPv6)
-        resolver 8.8.8.8 8.8.4.4 valid=10s;
-        resolver_timeout 5s;
+        # DNS resolver for dynamic proxy_pass upstreams.
+        # Default: 8.8.8.8 8.8.4.4 (public DNS).
+        # Override with NGINX_DNS_RESOLVER env var for environments where
+        # backend servers use internal hostnames (e.g., Kubernetes
+        # cluster-local names like *.svc.cluster.local need kube-dns).
+        resolver {os.environ.get("NGINX_DNS_RESOLVER", "8.8.8.8 8.8.4.4")} valid=10s;
+        resolver_timeout {os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")}s;
 
         # Authenticate request - pass entire request to auth server
         auth_request /validate;


### PR DESCRIPTION
## Problem

The Nginx config generated by `nginx_service.py` hardcodes the DNS resolver to `8.8.8.8 8.8.4.4` ([line 1077](https://github.com/agentic-community/mcp-gateway-registry/blob/main/registry/core/nginx_service.py#L1077)). This causes **502 Bad Gateway** errors when backend MCP servers are registered with cluster-internal hostnames (e.g., `*.svc.cluster.local`) in Kubernetes environments, since Google public DNS cannot resolve cluster-local names.

Discovered during a GKE deployment where MCP servers were registered with in-cluster service URLs. The only workaround was to exec into the registry pod and sed the generated Nginx config after every restart.

## Solution

Two new environment variables with backward-compatible defaults:

| Variable | Default | Description |
|----------|---------|-------------|
| `NGINX_DNS_RESOLVER` | `8.8.8.8 8.8.4.4` | DNS resolver address(es) for Nginx proxy_pass |
| `NGINX_DNS_RESOLVER_TIMEOUT` | `5` | Resolver timeout in seconds |

### Kubernetes example
```yaml
env:
  - name: NGINX_DNS_RESOLVER
    value: "10.96.0.10"  # kube-dns ClusterIP
```

### Docker Compose example
```yaml
environment:
  NGINX_DNS_RESOLVER: "127.0.0.11"  # Docker embedded DNS
```

## Changes

- `registry/core/nginx_service.py`: Replace hardcoded resolver with `os.environ.get()`
- Adds missing `import os` (module already used `os.environ` in ~10 places without importing it)

## Backward Compatibility

Fully backward-compatible — without the env vars, behavior is identical to current.