### PR TITLE
fix: pin litellm to 1.82.4 to avoid compromised 1.82.8 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "motor>=3.3.0",
     "pymongo>=4.6.0",
     "dnspython>=2.4.0",
-    "litellm>=1.50.0",
+    "litellm==1.82.4",
     "cryptography>=46.0.3",
     "prometheus-client>=0.20.0",
 ]


### PR DESCRIPTION
## Summary

- Pin `litellm` from `>=1.50.0` to `==1.82.4` to prevent dependency resolution to the compromised `1.82.8` release
- Reference: https://github.com/BerriAI/litellm/issues/24512

**No released version of this repository contains or uses the infected litellm 1.82.8. The latest release v1.0.17 uses litellm 1.82.4. This change is being made out of an abundance of caution.**

### Verified container versions

| Release Tag | litellm Version |
|---|---|
| v1.0.16 | 1.82.0 |
| v1.0.17 | 1.82.4 |

## Test plan

- [ ] Verify `uv lock` resolves to litellm 1.82.4
- [ ] Verify registry container builds successfully
- [ ] Verify embeddings functionality works with pinned version