### PR TITLE
fix: resolve test regressions introduced in PR #676

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -549,7 +549,7 @@ async def register_service(
     auth_scheme: Annotated[str, Form()] = "none",
     auth_credential: Annotated[str | None, Form()] = None,
     auth_header_name: Annotated[str | None, Form()] = None,
-    status: Annotated[str | None, Form()] = None,
+    service_status: Annotated[str | None, Form(alias="status")] = None,
     provider_organization: Annotated[str | None, Form()] = None,
     provider_url: Annotated[str | None, Form()] = None,
     source_created_at: Annotated[str | None, Form()] = None,
@@ -656,8 +656,8 @@ async def register_service(
             )
 
     # Add lifecycle and federation fields
-    if status:
-        server_entry["status"] = status
+    if service_status:
+        server_entry["status"] = service_status
 
     # Add provider information (stored as nested AgentProvider object)
     if provider_organization or provider_url:

--- a/tests/integration/test_skill_api.py
+++ b/tests/integration/test_skill_api.py
@@ -132,7 +132,10 @@ class TestSkillModels:
             tags=["tag1", "tag2"],
         )
 
+        from uuid import uuid4
+
         info = SkillInfo(
+            id=uuid4(),
             path=skill.path,
             name=skill.name,
             description=skill.description,


### PR DESCRIPTION
## Summary

Fixes two test regressions introduced in PR #676 (commit c655d60) that are currently breaking `Registry Test Suite` CI on `main`.

## Bugs Fixed

**1. `test_skill_info_from_card` — pydantic ValidationError: `id` field required**

PR #676 added `id: UUID = Field(...)` as a required field to `SkillInfo` but did not update the test that constructs `SkillInfo` without an `id`.

Fix: add `id=uuid4()` to the `SkillInfo` instantiation in the test.

**2. `test_register_service_no_permission` — AttributeError: `'NoneType' has no attribute 'HTTP_403_FORBIDDEN'`**

PR #676 added a Form parameter named `status` to `register_service()` in `server_routes.py`. This shadows the `from fastapi import status` module-level import. When the form field is not submitted (`status=None`), any reference to `status.HTTP_403_FORBIDDEN` raises `AttributeError`.

Fix: rename the parameter to `service_status` with `Form(alias="status")` to preserve the API contract while eliminating the name collision.

## Files Changed

- `tests/integration/test_skill_api.py` — add `id=uuid4()` to test
- `registry/api/server_routes.py` — rename `status` param to `service_status`

## Testing

Both fixes are targeted at the exact lines causing CI failures. No logic changes.