### PR TITLE
Fix telemetry registry_id being None on first startup

### DIFF
--- a/registry/core/telemetry.py
+++ b/registry/core/telemetry.py
@@ -124,11 +124,14 @@ def _compute_signature(body: bytes) -> str:
     ).hexdigest()
 
 
-async def _get_registry_id() -> str | None:
-    """Get the registry ID from the registry card.
+async def _get_registry_id() -> str:
+    """Get the registry ID for telemetry events.
+
+    Tries the registry card UUID first. Falls back to the persistent
+    telemetry instance_id if the card hasn't been created yet.
 
     Returns:
-        Registry card UUID string, or None if not initialized.
+        Registry card UUID or telemetry instance_id (never None).
     """
     try:
         from registry.repositories.factory import get_registry_card_repository
@@ -138,9 +141,11 @@ async def _get_registry_id() -> str | None:
         if card and card.id:
             return str(card.id)
     except Exception as e:
-        logger.warning(f"[telemetry] Failed to get registry ID: {e}")
+        logger.warning(f"[telemetry] Failed to get registry card ID: {e}")
 
-    return None
+    # Fallback: use the persistent telemetry instance_id
+    logger.debug("[telemetry] Registry card not found, using telemetry instance_id")
+    return await _get_or_create_instance_id()
 
 
 def _is_telemetry_enabled() -> bool:

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -17,6 +17,7 @@ from registry.core.telemetry import (
     _build_heartbeat_payload,
     _build_startup_payload,
     _get_or_create_instance_id,
+    _get_registry_id,
     _initialize_telemetry_collection,
     _is_opt_in_enabled,
     _is_telemetry_enabled,
@@ -74,6 +75,85 @@ class TestTelemetryEnabled:
         assert _is_opt_in_enabled() is False
 
 
+class TestGetRegistryIdFallback:
+    """Tests for _get_registry_id fallback to instance_id."""
+
+    @pytest.mark.asyncio
+    async def test_returns_card_id_when_available(self):
+        """Registry card UUID takes precedence over instance_id."""
+        mock_card = MagicMock()
+        mock_card.id = "card-uuid-1234"
+
+        mock_repo = MagicMock()
+        mock_repo.get = AsyncMock(return_value=mock_card)
+
+        with patch(
+            "registry.repositories.factory.get_registry_card_repository",
+            return_value=mock_repo,
+        ):
+            result = await _get_registry_id()
+            assert result == "card-uuid-1234"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_instance_id_when_no_card(self):
+        """Falls back to telemetry instance_id when card is None."""
+        mock_repo = MagicMock()
+        mock_repo.get = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "registry.repositories.factory.get_registry_card_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "registry.core.telemetry._get_or_create_instance_id",
+                new_callable=AsyncMock,
+                return_value="instance-uuid-5678",
+            ),
+        ):
+            result = await _get_registry_id()
+            assert result == "instance-uuid-5678"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_on_exception(self):
+        """Falls back to instance_id when card repo throws."""
+        with (
+            patch(
+                "registry.repositories.factory.get_registry_card_repository",
+                side_effect=Exception("DB error"),
+            ),
+            patch(
+                "registry.core.telemetry._get_or_create_instance_id",
+                new_callable=AsyncMock,
+                return_value="instance-uuid-fallback",
+            ),
+        ):
+            result = await _get_registry_id()
+            assert result == "instance-uuid-fallback"
+
+    @pytest.mark.asyncio
+    async def test_never_returns_none(self):
+        """Verify _get_registry_id never returns None."""
+        mock_repo = MagicMock()
+        mock_repo.get = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "registry.repositories.factory.get_registry_card_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "registry.core.telemetry._get_or_create_instance_id",
+                new_callable=AsyncMock,
+                return_value="some-uuid",
+            ),
+        ):
+            result = await _get_registry_id()
+            assert result is not None
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+
 class TestPayloadBuilding:
     """Tests for payload construction."""
 
@@ -121,6 +201,11 @@ class TestPayloadBuilding:
                 "registry.repositories.stats_repository.get_search_counts",
                 new_callable=AsyncMock,
                 return_value={"total": 0, "last_24h": 0, "last_1h": 0},
+            ),
+            patch(
+                "registry.core.telemetry._get_registry_id",
+                new_callable=AsyncMock,
+                return_value="test-registry-id",
             ),
         ):
             mock_settings.deployment_mode.value = "with-gateway"


### PR DESCRIPTION
## Summary

- `_get_registry_id()` now falls back to `_get_or_create_instance_id()` when the registry card hasn't been created yet, ensuring every telemetry event has a non-null, persistent `registry_id`
- The fallback function already existed but was never wired into the payload builders (dead code since initial telemetry implementation)
- Added 4 unit tests for the fallback behavior and fixed an existing test that needed the new mock

Closes #713

## Test plan

- [x] All 32 telemetry unit tests pass
- [x] Full test suite: 1924 passed, 67 skipped
- [x] `py_compile` passes for both modified files
- [ ] Deploy to dev and verify startup events have non-null registry_id