### PR TITLE
fix: decouple is_admin from server wildcard access

### DIFF
--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -315,6 +315,9 @@ async def user_has_wildcard_access(user_scopes: list[str]) -> bool:
     A user has wildcard access if any of their scopes includes server: '*'.
     This is determined dynamically from the scopes configuration, not hardcoded group names.
 
+    Note: This function checks server access only. It is NOT used to determine
+    admin status. See _user_is_admin() for admin determination.
+
     Args:
         user_scopes: List of user's scopes
 
@@ -325,6 +328,54 @@ async def user_has_wildcard_access(user_scopes: list[str]) -> bool:
         servers = await get_servers_for_scope(scope)
         if "*" in servers:
             logger.debug(f"User scope '{scope}' grants wildcard access to all servers")
+            return True
+
+    return False
+
+
+# Prefixes for mutating (management) UI-Scopes actions.
+# Any action starting with these prefixes is a management action.
+# A user with any such action for "all" resources is considered an admin.
+# Read-only prefixes (list_, get_, health_check_) are NOT included.
+#
+# SECURITY BOUNDARY: Changes to this tuple affect who is considered an admin.
+# Reference: scripts/registry-admins.json for the complete admin permissions set.
+_ADMIN_ACTION_PREFIXES: tuple[str, ...] = (
+    "register_",
+    "modify_",
+    "toggle_",
+    "delete_",
+    "publish_",
+    "create_",
+)
+
+
+def _user_is_admin(
+    ui_permissions: dict[str, list[str]],
+) -> bool:
+    """Check if user has admin privileges based on UI-Scopes management actions.
+
+    Admin status is determined by whether the user has any mutating
+    (write/delete) UI-Scopes action with wildcard ("all") access.
+    This decouples admin status from server: '*' wildcard access, allowing
+    consumer roles to access all servers without gaining admin privileges.
+
+    Mutating actions are identified by prefix: register_, modify_, toggle_,
+    delete_, publish_, create_. Read-only actions (list_, get_, health_check_)
+    do not grant admin status.
+
+    See GitHub issue #663 for the motivation behind this design.
+
+    Args:
+        ui_permissions: Dict mapping UI actions to lists of allowed resources.
+            Example: {'list_service': ['all'], 'register_service': ['all']}
+
+    Returns:
+        True if user has admin-level management permissions, False otherwise.
+    """
+    for action, resources in ui_permissions.items():
+        if action.startswith(_ADMIN_ACTION_PREFIXES) and "all" in resources:
+            logger.debug(f"Admin check: action '{action}' with 'all' grants admin status")
             return True
 
     return False
@@ -474,7 +525,7 @@ async def enhanced_auth(
         "accessible_agents": accessible_agents,
         "ui_permissions": ui_permissions,
         "can_modify_servers": can_modify,
-        "is_admin": await user_has_wildcard_access(scopes),
+        "is_admin": _user_is_admin(ui_permissions),
     }
 
     # Set user context on request state for audit logging middleware
@@ -609,7 +660,7 @@ async def nginx_proxied_auth(
             # Check modification permissions
             can_modify = user_can_modify_servers(groups, scopes)
 
-            is_admin = await user_has_wildcard_access(scopes)
+            is_admin = _user_is_admin(ui_permissions)
 
         user_context = {
             "username": username,

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -21,6 +21,7 @@ from fastapi import HTTPException, Request
 from itsdangerous import SignatureExpired, URLSafeTimedSerializer
 
 from registry.auth.dependencies import (
+    _user_is_admin,
     api_auth,
     create_session_cookie,
     enhanced_auth,
@@ -1350,3 +1351,146 @@ class TestNetworkTrustedAuthMethod:
         assert "mcp-registry-admin" in context["groups"]
         assert "mcp-servers-unrestricted/read" in context["scopes"]
         assert "mcp-servers-unrestricted/execute" in context["scopes"]
+
+
+# =============================================================================
+# TEST: _user_is_admin (issue #663)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.auth
+class TestUserIsAdmin:
+    """Tests for _user_is_admin function.
+
+    Verifies that admin status is derived from mutating UI-Scopes actions
+    (register_, modify_, toggle_, delete_, publish_, create_) with 'all'
+    resources, NOT from server: '*' wildcard access.
+
+    See GitHub issue #663.
+    """
+
+    @pytest.mark.parametrize("action", [
+        "register_service",
+        "modify_service",
+        "toggle_service",
+        "delete_service",
+        "publish_agent",
+        "modify_agent",
+        "delete_agent",
+        "create_virtual_server",
+        "modify_virtual_server",
+        "delete_virtual_server",
+    ])
+    def test_admin_with_mutating_action_all(self, action: str):
+        """User with any mutating action for [all] is admin."""
+        # Arrange
+        ui_permissions = {action: ["all"], "list_service": ["all"]}
+
+        # Act
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is True
+
+    def test_not_admin_with_only_read_actions(self):
+        """Consumer with only read-only permissions is not admin (issue #663 core fix)."""
+        # Arrange
+        ui_permissions = {
+            "list_service": ["all"],
+            "health_check_service": ["all"],
+            "list_agents": ["all"],
+            "get_agent": ["all"],
+            "list_virtual_server": ["all"],
+        }
+
+        # Act
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is False
+
+    def test_not_admin_with_specific_server_modify(self):
+        """User with modify_service for specific servers only is not admin."""
+        # Arrange
+        ui_permissions = {"modify_service": ["server1", "server2"]}
+
+        # Act
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is False
+
+    def test_not_admin_empty_permissions(self):
+        """User with no UI permissions is not admin."""
+        # Arrange / Act
+        result = _user_is_admin({})
+
+        # Assert
+        assert result is False
+
+    def test_full_admin_permissions_match_registry_admins_json(self):
+        """Full admin role (matching scripts/registry-admins.json) is admin."""
+        # Arrange
+        ui_permissions = {
+            "list_agents": ["all"],
+            "get_agent": ["all"],
+            "publish_agent": ["all"],
+            "modify_agent": ["all"],
+            "delete_agent": ["all"],
+            "list_service": ["all"],
+            "register_service": ["all"],
+            "health_check_service": ["all"],
+            "toggle_service": ["all"],
+            "modify_service": ["all"],
+            "delete_service": ["all"],
+            "list_virtual_server": ["all"],
+            "create_virtual_server": ["all"],
+            "modify_virtual_server": ["all"],
+            "delete_virtual_server": ["all"],
+        }
+
+        # Act
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is True
+
+    def test_consumer_with_wildcard_server_not_admin(self):
+        """Issue #663: server: '*' in scopes should NOT trigger is_admin.
+
+        A consumer role with server: '*' but only read-only UI-Scopes
+        must not be treated as admin.
+        """
+        # Arrange - consumer has only read-only UI-Scopes
+        ui_permissions = {
+            "list_service": ["all"],
+            "health_check_service": ["all"],
+            "list_agents": ["all"],
+            "get_agent": ["all"],
+        }
+
+        # Act - even though the user's scopes contain server: '*',
+        # _user_is_admin only checks ui_permissions, not server access
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is False
+
+    @pytest.mark.parametrize("action", [
+        "list_service",
+        "get_agent",
+        "health_check_service",
+        "list_agents",
+        "list_virtual_server",
+    ])
+    def test_read_only_actions_never_grant_admin(self, action: str):
+        """Read-only actions with 'all' do not grant admin status."""
+        # Arrange
+        ui_permissions = {action: ["all"]}
+
+        # Act
+        result = _user_is_admin(ui_permissions)
+
+        # Assert
+        assert result is False


### PR DESCRIPTION
## Summary

- Fixes `server: '*'` in scopes incorrectly triggering `is_admin=True`, which granted unintended admin privileges (audit log access, agent deletion, peer management) to consumer/reader roles
- Adds `_user_is_admin()` function that derives admin status from mutating UI-Scopes actions (register_, modify_, toggle_, delete_, publish_, create_) instead of server wildcard patterns
- Existing admin roles are unaffected since they already have mutating UI-Scopes like `register_service: [all]`

Closes #663

## Changes

**`registry/auth/dependencies.py`:**
- Added `_ADMIN_ACTION_PREFIXES` tuple defining mutating action prefixes
- Added `_user_is_admin(ui_permissions)` function that checks for mutating actions with `all` resources
- Updated `enhanced_auth()` and `nginx_proxied_auth()` to use `_user_is_admin()` instead of `user_has_wildcard_access()` for `is_admin` determination

**`tests/unit/auth/test_dependencies.py`:**
- Added `TestUserIsAdmin` class with 20 test cases covering:
  - All 10 mutating actions grant admin (parametrized)
  - Read-only actions do NOT grant admin (parametrized)
  - Consumer role with `server: '*'` is NOT admin (core bug fix)
  - Full admin permissions matching `scripts/registry-admins.json`
  - Empty permissions and specific-server-only modify edge cases

## Design

See `.scratchpad/issue-663/lld.md` for the full low-level design document.

## Test plan

- [x] All 20 new `TestUserIsAdmin` tests pass
- [x] Full test suite: 1944 passed, 67 skipped (1 pre-existing flaky failure in audit model tests, unrelated)
- [ ] Manual verification: admin roles still show admin badge in UI
- [ ] Manual verification: consumer roles with `server: '*'` do NOT show admin badge