### PR TITLE
Add Strale (remote MCP server + A2A agent example)

### DIFF
--- a/cli/examples/strale-a2a-agent-config.json
+++ b/cli/examples/strale-a2a-agent-config.json
@@ -1,0 +1,123 @@
+{
+  "protocolVersion": "1.0",
+  "name": "Strale",
+  "description": "Trust and quality infrastructure for AI agents. 250+ quality-scored capabilities for validation, compliance, enrichment, and Web3 — each with dual-profile quality scores and audit trails.",
+  "url": "https://api.strale.io/a2a",
+  "path": "/strale",
+  "version": "0.2.3",
+  "capabilities": {
+    "streaming": false
+  },
+  "defaultInputModes": ["text/plain", "application/json"],
+  "defaultOutputModes": ["application/json"],
+  "tags": [
+    "compliance",
+    "validation",
+    "company-data",
+    "sanctions",
+    "kyb",
+    "web3",
+    "trust",
+    "enrichment"
+  ],
+  "visibility": "public",
+  "status": "active",
+  "trustLevel": "community",
+  "license": "MIT",
+  "isEnabled": true,
+  "provider": {
+    "organization": "Strale",
+    "url": "https://strale.dev"
+  },
+  "securitySchemes": {
+    "bearer_auth": {
+      "type": "http",
+      "scheme": "bearer",
+      "description": "Strale API key (starts with sk_live_). Get one at https://strale.dev/signup."
+    }
+  },
+  "security": [{"bearer_auth": []}],
+  "preferredTransport": "JSONRPC",
+  "metadata": {
+    "agent_card_url": "https://api.strale.io/.well-known/agent-card.json",
+    "capabilities_count": 250,
+    "solutions_count": 88,
+    "free_tier_available": true,
+    "countries_covered": 27,
+    "quality_scoring": "Dual-profile SQS 0-100"
+  },
+  "skills": [
+    {
+      "id": "validate_iban",
+      "name": "Validate IBAN",
+      "description": "Validate international bank account numbers with checksum verification, bank identification, and country detection.",
+      "tags": ["validation", "finance", "iban", "free"],
+      "examples": ["Validate IBAN DE89370400440532013000"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "company_lookup",
+      "name": "Company Lookup",
+      "description": "Look up company registration data from official registries across 27 countries.",
+      "tags": ["company-data", "kyb", "registry"],
+      "examples": ["Look up Swedish company 5591674668", "Find UK company Revolut"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "sanctions_screening",
+      "name": "Sanctions Screening",
+      "description": "Screen individuals and entities against OFAC, EU, UN, and UK sanctions lists.",
+      "tags": ["compliance", "sanctions", "aml"],
+      "examples": ["Screen Acme Corp for sanctions"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "pep_check",
+      "name": "PEP Check",
+      "description": "Screen individuals against Politically Exposed Persons databases.",
+      "tags": ["compliance", "pep", "kyc"],
+      "examples": ["Check if Anders Andersson is a PEP"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "validate_vat",
+      "name": "Validate VAT",
+      "description": "Validate European VAT numbers via VIES with company name and address lookup.",
+      "tags": ["validation", "tax", "vat"],
+      "examples": ["Validate VAT number SE556703748501"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "web_extract",
+      "name": "Web Data Extraction",
+      "description": "Extract structured data from web pages, convert URLs to markdown, take screenshots.",
+      "tags": ["extraction", "web", "scraping"],
+      "examples": ["Convert https://example.com to markdown"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "domain_intelligence",
+      "name": "Domain Intelligence",
+      "description": "WHOIS lookup, DNS records, SSL certificate analysis, domain reputation scoring.",
+      "tags": ["domain", "security", "dns"],
+      "examples": ["Check domain reputation for example.com"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    },
+    {
+      "id": "web3_risk",
+      "name": "Web3 Risk Analysis",
+      "description": "Wallet risk scoring, token honeypot detection, DeFi protocol intelligence, ENS resolution.",
+      "tags": ["web3", "defi", "risk", "blockchain"],
+      "examples": ["Score wallet risk for 0x1234...", "Check if token contract is a honeypot"],
+      "inputModes": ["text/plain"],
+      "outputModes": ["application/json"]
+    }
+  ]
+}

--- a/cli/examples/strale-a2a-agent-config.json
+++ b/cli/examples/strale-a2a-agent-config.json
@@ -1,7 +1,7 @@
 {
   "protocolVersion": "1.0",
   "name": "Strale",
-  "description": "Trust and quality infrastructure for AI agents. 250+ quality-scored capabilities for validation, compliance, enrichment, and Web3 — each with dual-profile quality scores and audit trails.",
+  "description": "Catalog of data capabilities for AI agents: IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence.",
   "url": "https://api.strale.io/a2a",
   "path": "/strale",
   "version": "0.2.3",
@@ -17,12 +17,10 @@
     "sanctions",
     "kyb",
     "web3",
-    "trust",
     "enrichment"
   ],
   "visibility": "public",
   "status": "active",
-  "trustLevel": "community",
   "license": "MIT",
   "isEnabled": true,
   "provider": {

--- a/cli/examples/strale-gateway-config.json
+++ b/cli/examples/strale-gateway-config.json
@@ -1,0 +1,197 @@
+{
+  "server_name": "Strale",
+  "description": "Trust and quality infrastructure for AI agents. 250+ quality-scored capabilities for IBAN validation, company registry lookups across 27 countries, sanctions and PEP screening, web scraping, lead enrichment, and Web3 risk analysis. Each capability is continuously tested with a dual-profile quality score and returns structured JSON with data provenance and audit trails. Free tier available — 5 capabilities work without an API key.",
+  "path": "/strale",
+  "proxy_pass_url": "https://api.strale.io/mcp",
+  "supported_transports": ["streamable-http"],
+  "tags": [
+    "validation",
+    "compliance",
+    "enrichment",
+    "kyb",
+    "sanctions",
+    "web3",
+    "trust",
+    "audit-trail",
+    "iban",
+    "vat",
+    "domain",
+    "email",
+    "company-data",
+    "quality-scored"
+  ],
+  "auth_scheme": "bearer",
+  "headers": [{"Authorization": "Bearer $STRALE_API_KEY"}],
+  "num_tools": 8,
+  "is_python": false,
+  "license": "MIT",
+  "version": "v0.2.3",
+  "status": "active",
+  "visibility": "public",
+  "provider_organization": "Strale",
+  "provider_url": "https://strale.dev",
+  "metadata": {
+    "capabilities_count": 250,
+    "solutions_count": 88,
+    "free_tier": "email-validate, iban-validate, dns-lookup, url-to-markdown, json-repair",
+    "pricing": "EUR 0.02 to EUR 1.00 per call, prepaid wallet",
+    "trial_credits": "EUR 2.00 on signup, no card required",
+    "quality_scoring": "Dual-profile SQS 0-100 (Quality Profile + Reliability Profile)",
+    "countries_covered": 27,
+    "transport": "Streamable HTTP (JSON-RPC)"
+  },
+  "tool_list": [
+    {
+      "name": "strale_search",
+      "parsed_description": {
+        "main": "Search 250+ capabilities and bundled solutions by keyword or category. Covers compliance, validation, company registries, domain intelligence, Web3, and more. Free — no API key needed.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search keyword (e.g., 'sanctions', 'IBAN', 'company data')"
+          },
+          "category": {
+            "type": "string",
+            "description": "Filter by category: compliance, validation, data-extraction, developer-tools, web3, security"
+          },
+          "offset": {
+            "type": "number",
+            "description": "Number of results to skip for pagination"
+          }
+        },
+        "required": ["query"]
+      }
+    },
+    {
+      "name": "strale_execute",
+      "parsed_description": {
+        "main": "Run any of 250+ capabilities by slug. Validate IBANs, look up companies, screen against sanctions lists, extract data from URLs, and more. Returns structured JSON with quality score and data provenance.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Capability slug from strale_search results (e.g., 'iban-validate', 'swedish-company-data')"
+          },
+          "inputs": {
+            "type": "object",
+            "description": "Input parameters matching the capability's required fields"
+          },
+          "max_price_cents": {
+            "type": "number",
+            "description": "Maximum price in EUR cents. Default: 200. Execution fails if capability costs more."
+          }
+        },
+        "required": ["slug", "inputs"]
+      }
+    },
+    {
+      "name": "strale_trust_profile",
+      "parsed_description": {
+        "main": "Check if a capability is reliable before calling it. Returns SQS quality score (0-100), Quality grade, Reliability grade, execution guidance, and 30-day test history.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "slug": {
+            "type": "string",
+            "description": "Capability or solution slug"
+          },
+          "type": {
+            "type": "string",
+            "description": "Whether this is a 'capability' or 'solution'. Default: 'capability'."
+          }
+        },
+        "required": ["slug"]
+      }
+    },
+    {
+      "name": "strale_balance",
+      "parsed_description": {
+        "main": "Check current wallet balance in EUR. Requires an API key.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "strale_ping",
+      "parsed_description": {
+        "main": "Health check. Returns server status, tool count, and capability count.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "strale_getting_started",
+      "parsed_description": {
+        "main": "Returns 5 free capabilities with example inputs, plus setup steps for full access to 250+ paid capabilities.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "strale_methodology",
+      "parsed_description": {
+        "main": "Explains Strale's dual-profile quality scoring model, the SQS matrix, execution guidance, test infrastructure, and current limitations.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "strale_transaction",
+      "parsed_description": {
+        "main": "Retrieve a past execution record by transaction ID. Returns inputs, outputs, latency, price, provenance, and success/failure status.",
+        "args": null,
+        "returns": null,
+        "raises": null
+      },
+      "schema": {
+        "type": "object",
+        "properties": {
+          "transaction_id": {
+            "type": "string",
+            "description": "Transaction ID from a strale_execute call"
+          }
+        },
+        "required": ["transaction_id"]
+      }
+    }
+  ]
+}

--- a/cli/examples/strale-gateway-config.json
+++ b/cli/examples/strale-gateway-config.json
@@ -1,6 +1,6 @@
 {
   "server_name": "Strale",
-  "description": "Trust and quality infrastructure for AI agents. 250+ quality-scored capabilities for IBAN validation, company registry lookups across 27 countries, sanctions and PEP screening, web scraping, lead enrichment, and Web3 risk analysis. Each capability is continuously tested with a dual-profile quality score and returns structured JSON with data provenance and audit trails. Free tier available — 5 capabilities work without an API key.",
+  "description": "Catalog of data capabilities for AI agents: IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence. Free tier covers email-validate, iban-validate, dns-lookup, url-to-markdown, and json-repair without an API key.",
   "path": "/strale",
   "proxy_pass_url": "https://api.strale.io/mcp",
   "supported_transports": ["streamable-http"],
@@ -11,14 +11,13 @@
     "kyb",
     "sanctions",
     "web3",
-    "trust",
     "audit-trail",
     "iban",
     "vat",
     "domain",
     "email",
     "company-data",
-    "quality-scored"
+    "validation"
   ],
   "auth_scheme": "bearer",
   "headers": [{"Authorization": "Bearer $STRALE_API_KEY"}],
@@ -44,7 +43,7 @@
     {
       "name": "strale_search",
       "parsed_description": {
-        "main": "Search 250+ capabilities and bundled solutions by keyword or category. Covers compliance, validation, company registries, domain intelligence, Web3, and more. Free — no API key needed.",
+        "main": "Browse the capability catalog by keyword or category. Covers compliance, validation, company registries, domain intelligence, and Web3. Free — no API key needed.",
         "args": null,
         "returns": null,
         "raises": null
@@ -71,7 +70,7 @@
     {
       "name": "strale_execute",
       "parsed_description": {
-        "main": "Run any of 250+ capabilities by slug. Validate IBANs, look up companies, screen against sanctions lists, extract data from URLs, and more. Returns structured JSON with quality score and data provenance.",
+        "main": "Run any capability by slug. Validate IBANs, look up companies, screen against sanctions lists, extract data from URLs, and more. Returns structured JSON with provenance.",
         "args": null,
         "returns": null,
         "raises": null
@@ -149,7 +148,7 @@
     {
       "name": "strale_getting_started",
       "parsed_description": {
-        "main": "Returns 5 free capabilities with example inputs, plus setup steps for full access to 250+ paid capabilities.",
+        "main": "Returns the 5 free capabilities with example inputs, plus setup steps for full catalog access.",
         "args": null,
         "returns": null,
         "raises": null

--- a/docs/strale.md
+++ b/docs/strale.md
@@ -1,0 +1,115 @@
+# Strale Integration
+
+Strale is trust and quality infrastructure for AI agents. It provides 250+ quality-scored data capabilities — IBAN validation, company registry lookups across 27 countries, sanctions screening, web scraping, lead enrichment, Web3 risk analysis — each continuously tested and assigned a dual-profile quality score (0-100). Every execution returns structured JSON with data provenance and a compliance-ready audit trail.
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────────────┐     ┌──────────────────┐
+│              │     │                      │     │                  │
+│   AI Agent   │────▶│  MCP Gateway Registry│────▶│  Strale MCP      │
+│              │     │                      │     │  api.strale.io   │
+└──────────────┘     └──────────────────────┘     └──────────────────┘
+                            │                            │
+                            │ A2A                        │ 250+ capabilities
+                            ▼                            ▼
+                     ┌──────────────┐            ┌──────────────────┐
+                     │ Strale A2A   │            │ Company regs,    │
+                     │ Agent        │            │ sanctions lists, │
+                     │ /a2a         │            │ VIES, DNS, etc.  │
+                     └──────────────┘            └──────────────────┘
+```
+
+Strale is available through two protocols:
+- **MCP Server** at `https://api.strale.io/mcp` (Streamable HTTP transport)
+- **A2A Agent** at `https://api.strale.io/a2a` (JSON-RPC, `message/send` and `tasks/get`)
+
+## Prerequisites
+
+1. **Strale API key** — Sign up at [strale.dev/signup](https://strale.dev/signup). New accounts get EUR 2.00 in free trial credits, no card required.
+2. A running MCP Gateway Registry instance.
+
+## Register as MCP Server
+
+```bash
+# Using the CLI
+./cli/service_mgmt.sh add examples/strale-gateway-config.json
+
+# Or via the Python API
+uv run python api/registry_management.py add-server --config examples/strale-gateway-config.json
+```
+
+Set the `STRALE_API_KEY` environment variable so the gateway can pass the Bearer token:
+
+```bash
+export STRALE_API_KEY=sk_live_your_key_here
+```
+
+## Register as A2A Agent
+
+```bash
+uv run python cli/agent_mgmt.py register examples/strale-a2a-agent-config.json
+```
+
+## Verify the MCP Server
+
+Test a free capability (no API key needed):
+
+```bash
+# Search for capabilities
+curl -X POST http://localhost:3000/strale/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "strale_search", "arguments": {"query": "IBAN"}}, "id": 1}'
+
+# Execute a free capability
+curl -X POST http://localhost:3000/strale/mcp \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $STRALE_API_KEY" \
+  -d '{"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "strale_execute", "arguments": {"slug": "iban-validate", "inputs": {"iban": "DE89370400440532013000"}}}, "id": 2}'
+```
+
+## Verify the A2A Agent
+
+```bash
+curl -X POST http://localhost:3000/strale/a2a \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $STRALE_API_KEY" \
+  -d '{"jsonrpc": "2.0", "method": "message/send", "params": {"message": {"role": "user", "parts": [{"type": "text", "text": "Validate IBAN DE89370400440532013000"}]}}, "id": 1}'
+```
+
+## Available Tools (MCP)
+
+| Tool | Auth Required | Description |
+|------|:---:|---|
+| `strale_ping` | No | Health check |
+| `strale_getting_started` | No | Free capabilities with example inputs |
+| `strale_search` | No | Search 250+ capabilities by keyword |
+| `strale_execute` | Partial | Run any capability. 5 free-tier slugs work without auth. |
+| `strale_trust_profile` | No | Quality score and execution guidance |
+| `strale_methodology` | No | Quality scoring methodology |
+| `strale_balance` | Yes | Check wallet balance |
+| `strale_transaction` | Partial | Retrieve past execution records |
+
+## Free Tier
+
+These capabilities work without an API key (10 calls/day per IP):
+
+- `email-validate` — verify email deliverability
+- `iban-validate` — validate international bank account numbers
+- `dns-lookup` — DNS records for any domain
+- `url-to-markdown` — convert any URL to clean markdown
+- `json-repair` — fix malformed JSON
+
+## Semantic Search Tags
+
+The Strale server is tagged for discovery via the gateway's semantic search:
+
+`validation`, `compliance`, `enrichment`, `kyb`, `sanctions`, `web3`, `trust`, `audit-trail`, `iban`, `vat`, `domain`, `email`, `company-data`, `quality-scored`
+
+## Links
+
+- [Documentation](https://strale.dev/docs)
+- [Capability catalog](https://api.strale.io/v1/capabilities)
+- [Quality methodology](https://strale.dev/trust/methodology)
+- [MCP server on npm](https://www.npmjs.com/package/strale-mcp)
+- [Agent Card](https://api.strale.io/.well-known/agent-card.json)

--- a/docs/strale.md
+++ b/docs/strale.md
@@ -1,6 +1,6 @@
 # Strale Integration
 
-Strale is trust and quality infrastructure for AI agents. It provides 250+ quality-scored data capabilities — IBAN validation, company registry lookups across 27 countries, sanctions screening, web scraping, lead enrichment, Web3 risk analysis — each continuously tested and assigned a dual-profile quality score (0-100). Every execution returns structured JSON with data provenance and a compliance-ready audit trail.
+Strale exposes a catalog of data capabilities for AI agents — IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence. Every execution returns structured JSON with provenance.
 
 ## Architecture
 
@@ -11,7 +11,7 @@ Strale is trust and quality infrastructure for AI agents. It provides 250+ quali
 │              │     │                      │     │  api.strale.io   │
 └──────────────┘     └──────────────────────┘     └──────────────────┘
                             │                            │
-                            │ A2A                        │ 250+ capabilities
+                            │ A2A                        │ capability catalog 
                             ▼                            ▼
                      ┌──────────────┐            ┌──────────────────┐
                      │ Strale A2A   │            │ Company regs,    │
@@ -83,9 +83,9 @@ curl -X POST http://localhost:3000/strale/a2a \
 |------|:---:|---|
 | `strale_ping` | No | Health check |
 | `strale_getting_started` | No | Free capabilities with example inputs |
-| `strale_search` | No | Search 250+ capabilities by keyword |
+| `strale_search` | No | Browse the capability catalog by keyword |
 | `strale_execute` | Partial | Run any capability. 5 free-tier slugs work without auth. |
-| `strale_trust_profile` | No | Quality score and execution guidance |
+| `strale_trust_profile` | No | Strale Quality Score and execution guidance |
 | `strale_methodology` | No | Quality scoring methodology |
 | `strale_balance` | Yes | Check wallet balance |
 | `strale_transaction` | Partial | Retrieve past execution records |
@@ -104,7 +104,7 @@ These capabilities work without an API key (10 calls/day per IP):
 
 The Strale server is tagged for discovery via the gateway's semantic search:
 
-`validation`, `compliance`, `enrichment`, `kyb`, `sanctions`, `web3`, `trust`, `audit-trail`, `iban`, `vat`, `domain`, `email`, `company-data`, `quality-scored`
+`validation`, `compliance`, `kyb`, `sanctions`, `web3`, `iban`, `vat`, `domain`, `email`, `company-data`
 
 ## Links
 


### PR DESCRIPTION
Adds Strale as an example remote MCP server and A2A agent integration.

**MCP Server** (`cli/examples/strale-gateway-config.json`):
- Streamable HTTP at `https://api.strale.io/mcp`
- 8 meta-tools (search, execute, balance, ping, getting_started, methodology, transaction, trust_profile)
- Bearer token auth (free tier covers 5 capabilities without an API key)

**A2A Agent** (`cli/examples/strale-a2a-agent-config.json`):
- JSON-RPC at `https://api.strale.io/a2a`
- 8 skills covering IBAN validation, company lookup, sanctions screening, web extraction, document parsing, etc.

**Integration guide** (`docs/strale.md`):
- Registration steps for both MCP and A2A
- Verification commands
- Virtual server composition example

Strale exposes a catalog of data capabilities for AI agents — IBAN/VAT/LEI validation, company registry lookups across 27 countries, sanctions and PEP screening, web extraction, document parsing, and Web3 wallet/token intelligence. Every execution returns structured JSON with provenance.