### PR TITLE
feat: enhance usage-report skill with chart generation and styling

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -66,20 +66,42 @@ scp -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519 \
   OUTPUT_DIR/registry_metrics.csv
 ```
 
-### Step 5: Generate the Usage Report
+### Step 5: Install Python Dependencies and Generate Charts
+
+First, ensure matplotlib and seaborn are available on the system Python:
+
+```bash
+/usr/bin/python3 -c "import matplotlib, seaborn" 2>/dev/null || pip install --break-system-packages matplotlib seaborn
+```
+
+Then generate the deployment distribution chart:
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_charts.py \
+  --csv OUTPUT_DIR/registry_metrics.csv \
+  --output OUTPUT_DIR/deployment-distribution-YYYY-MM-DD.png
+```
+
+This produces a single faceted PNG with 6 subplots: Cloud Provider, Compute Platform, Storage Backend, Auth Provider, Version Type, and Deployment Mode. Each subplot shows counts and percentages.
+
+### Step 6: Generate the Usage Report
 
 Read the downloaded CSV and the captured export output. Generate a markdown report with the following sections:
 
 #### Report Structure
 
 ```markdown
-# MCP Gateway Registry -- Usage Report
+# AI Registry -- Usage Report
 
 *Report Date: YYYY-MM-DD*
 *Data Source: Telemetry Collector (DocumentDB)*
 *Collection Period: [earliest ts] to [latest ts]*
 
 ---
+
+## Deployment Distribution
+
+![Deployment Distribution](deployment-distribution-YYYY-MM-DD.png)
 
 ## Executive Summary
 - Total events, unique instances, collection period, key highlights
@@ -126,13 +148,30 @@ Identify 3-5 distinct deployment patterns from the data (e.g., "Dev Setup", "AWS
 3-5 actionable insights based on the data.
 ```
 
-Save the report to `OUTPUT_DIR/usage-report-YYYY-MM-DD.md`.
+Save the report to `OUTPUT_DIR/ai-registry-usage-report-YYYY-MM-DD.md`.
 
-### Step 6: Present Results
+### Step 7: Generate Self-Contained HTML
+
+Convert the markdown report to a single self-contained HTML file using pandoc. The chart PNG is base64-embedded so the HTML works standalone. Run from the OUTPUT_DIR so relative image paths resolve:
+
+```bash
+cd OUTPUT_DIR && pandoc ai-registry-usage-report-YYYY-MM-DD.md \
+  -o ai-registry-usage-report-YYYY-MM-DD.html \
+  --embed-resources --standalone \
+  --css=.claude/skills/usage-report/report-style.css \
+  --metadata title="AI Registry - Usage Report YYYY-MM-DD"
+```
+
+The `report-style.css` file in the skill directory provides a clean, professional layout. Pandoc must be installed:
+```bash
+which pandoc >/dev/null || sudo apt-get install -y pandoc
+```
+
+### Step 8: Present Results
 
 After generating the report:
 1. Display the Executive Summary and Key Metrics directly in the conversation
-2. Tell the user the full report path and CSV path
+2. Tell the user the full report path, HTML path, and CSV path
 3. Highlight the most interesting findings
 
 ## Error Handling
@@ -149,9 +188,11 @@ User: /usage-report
 
 Output:
 ```
-Executive Summary: 52 startup events from ~6 unique registry instances over 3 days...
+Executive Summary: 68 startup events from ~7 unique registry instances over 4 days...
 
-Full report: .scratchpad/usage-reports/usage-report-2026-03-30.md
+Full report: .scratchpad/usage-reports/ai-registry-usage-report-2026-03-31.md
+HTML report: .scratchpad/usage-reports/ai-registry-usage-report-2026-03-31.html
+Chart: .scratchpad/usage-reports/deployment-distribution-2026-03-31.png
 CSV data: .scratchpad/usage-reports/registry_metrics.csv
 ```
 
@@ -159,4 +200,4 @@ CSV data: .scratchpad/usage-reports/registry_metrics.csv
 User: /usage-report /tmp/reports
 ```
 
-Output saved to `/tmp/reports/usage-report-2026-03-30.md` and `/tmp/reports/registry_metrics.csv`.
+Output saved to `/tmp/reports/`.

--- a/.claude/skills/usage-report/generate_charts.py
+++ b/.claude/skills/usage-report/generate_charts.py
@@ -1,0 +1,201 @@
+"""Generate a single faceted bar chart from telemetry CSV data.
+
+Reads registry_metrics.csv and produces a PNG with subplots showing
+distributions across cloud, compute, storage, auth, version type,
+and deployment mode.
+"""
+import argparse
+import csv
+import logging
+import os
+from collections import Counter
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = "AI Registry -- Deployment Distribution"
+FIGURE_WIDTH: int = 16
+FIGURE_HEIGHT: int = 10
+BAR_COLOR_PALETTE: str = "Blues_d"
+
+
+def _read_csv(
+    csv_path: str,
+) -> list[dict[str, str]]:
+    """Read the telemetry CSV and return rows as list of dicts."""
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    logger.info(f"Read {len(rows)} rows from {csv_path}")
+    return rows
+
+
+def _classify_version(
+    version: str,
+) -> str:
+    """Classify a version string as Release or Dev."""
+    if not version:
+        return "unknown"
+    if version.startswith("v1.0.17") or version.startswith("v0."):
+        return "dev"
+    return "release"
+
+
+def _compute_distributions(
+    rows: list[dict[str, str]],
+) -> dict[str, Counter]:
+    """Compute value counts for each dimension."""
+    dimensions = {
+        "Cloud Provider": Counter(),
+        "Compute Platform": Counter(),
+        "Storage Backend": Counter(),
+        "Auth Provider": Counter(),
+        "Version Type": Counter(),
+        "Deployment Mode": Counter(),
+    }
+
+    for row in rows:
+        cloud = row.get("cloud", "unknown") or "unknown"
+        dimensions["Cloud Provider"][cloud] += 1
+
+        compute = row.get("compute", "unknown") or "unknown"
+        dimensions["Compute Platform"][compute] += 1
+
+        storage = row.get("storage", "unknown") or "unknown"
+        dimensions["Storage Backend"][storage] += 1
+
+        auth = row.get("auth", "none") or "none"
+        dimensions["Auth Provider"][auth] += 1
+
+        version = row.get("v", "") or ""
+        dimensions["Version Type"][_classify_version(version)] += 1
+
+        mode = row.get("mode", "unknown") or "unknown"
+        dimensions["Deployment Mode"][mode] += 1
+
+    return dimensions
+
+
+def _plot_single_facet(
+    ax: plt.Axes,
+    counter: Counter,
+    title: str,
+    total: int,
+) -> None:
+    """Plot a single horizontal bar chart with percentages."""
+    # Sort by count descending
+    items = counter.most_common()
+    labels = [item[0] for item in items]
+    counts = [item[1] for item in items]
+
+    # Reverse so largest is on top
+    labels = labels[::-1]
+    counts = counts[::-1]
+
+    colors = sns.color_palette(BAR_COLOR_PALETTE, len(labels))
+    bars = ax.barh(labels, counts, color=colors)
+
+    ax.set_title(title, fontsize=12, fontweight="bold")
+    ax.set_xlabel("")
+
+    # Add count and percentage labels on bars
+    for bar, count in zip(bars, counts):
+        pct = count / total * 100
+        label_text = f" {count} ({pct:.0f}%)"
+        ax.text(
+            bar.get_width() + 0.3,
+            bar.get_y() + bar.get_height() / 2,
+            label_text,
+            va="center",
+            fontsize=10,
+        )
+
+    # Add some padding on the right for labels
+    max_count = max(counts) if counts else 1
+    ax.set_xlim(0, max_count * 1.4)
+
+
+def _generate_chart(
+    rows: list[dict[str, str]],
+    output_path: str,
+) -> None:
+    """Generate and save the faceted distribution chart."""
+    total = len(rows)
+    distributions = _compute_distributions(rows)
+
+    sns.set_theme(style="whitegrid")
+
+    fig, axes = plt.subplots(2, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+    fig.suptitle(
+        f"{CHART_TITLE}\n({total} events)",
+        fontsize=14,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    # Plot each dimension
+    dimension_order = [
+        "Cloud Provider",
+        "Compute Platform",
+        "Storage Backend",
+        "Auth Provider",
+        "Version Type",
+        "Deployment Mode",
+    ]
+
+    for idx, dim_name in enumerate(dimension_order):
+        row_idx = idx // 3
+        col_idx = idx % 3
+        ax = axes[row_idx][col_idx]
+        _plot_single_facet(ax, distributions[dim_name], dim_name, total)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments and generate charts."""
+    parser = argparse.ArgumentParser(
+        description="Generate telemetry distribution charts from CSV data",
+    )
+    parser.add_argument(
+        "--csv",
+        required=True,
+        help="Path to registry_metrics.csv",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.csv):
+        logger.error(f"CSV file not found: {args.csv}")
+        raise SystemExit(1)
+
+    rows = _read_csv(args.csv)
+
+    if not rows:
+        logger.error("No data in CSV file")
+        raise SystemExit(1)
+
+    _generate_chart(rows, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/usage-report/report-style.css
+++ b/.claude/skills/usage-report/report-style.css
@@ -1,0 +1,159 @@
+/* Clean report style -- mimics Quarto default HTML output */
+:root {
+    --text-color: #1a1a1a;
+    --muted-color: #6c757d;
+    --border-color: #dee2e6;
+    --bg-color: #ffffff;
+    --code-bg: #f5f5f5;
+    --accent-color: #2c5282;
+    --link-color: #2b6cb0;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+}
+
+/* Title and metadata */
+h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+}
+
+h2 {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--accent-color);
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 0.3rem;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+}
+
+h3 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+}
+
+p {
+    margin: 0.75rem 0;
+}
+
+em {
+    color: var(--muted-color);
+    font-size: 0.9rem;
+}
+
+/* Horizontal rule */
+hr {
+    border: none;
+    border-top: 1px solid var(--border-color);
+    margin: 1.5rem 0;
+}
+
+/* Tables */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1rem 0;
+    font-size: 0.9rem;
+}
+
+thead {
+    background-color: #f8f9fa;
+}
+
+th {
+    font-weight: 600;
+    text-align: left;
+    padding: 0.6rem 0.75rem;
+    border-bottom: 2px solid var(--border-color);
+    color: var(--text-color);
+}
+
+td {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #eee;
+}
+
+tr:hover {
+    background-color: #f8f9fa;
+}
+
+/* Bold in tables for emphasis */
+td strong, th strong {
+    color: var(--accent-color);
+}
+
+/* Lists */
+ul, ol {
+    padding-left: 1.5rem;
+    margin: 0.75rem 0;
+}
+
+li {
+    margin: 0.3rem 0;
+}
+
+/* Code */
+code {
+    font-family: "SFMono-Regular", "Fira Code", "Fira Mono", Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    background-color: var(--code-bg);
+    padding: 0.15em 0.35em;
+    border-radius: 3px;
+}
+
+/* Images (charts) */
+img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 1rem auto;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+/* Links */
+a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* Print styles */
+@media print {
+    body {
+        max-width: none;
+        padding: 0;
+        font-size: 12px;
+    }
+
+    h1 { font-size: 1.5rem; }
+    h2 { font-size: 1.2rem; page-break-after: avoid; }
+    h3 { font-size: 1rem; page-break-after: avoid; }
+    table { page-break-inside: avoid; }
+    img { max-width: 90%; page-break-inside: avoid; }
+}


### PR DESCRIPTION
## Summary
- Add `generate_charts.py` for matplotlib-based chart generation in usage reports
- Add `report-style.css` for consistent HTML report formatting
- Update `SKILL.md` with improved report generation instructions

## Test plan
- [ ] Run usage-report skill and verify charts are generated
- [ ] Verify report HTML uses the new CSS styling