### PR TITLE
Fix: preserve ans_metadata and other fields on agent edit

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -1225,6 +1225,11 @@ async def update_agent(
             registered_at=existing_agent.registered_at,
             is_enabled=existing_agent.is_enabled,
             num_stars=existing_agent.num_stars,
+            ans_metadata=existing_agent.ans_metadata,
+            health_status=existing_agent.health_status,
+            last_health_check=existing_agent.last_health_check,
+            rating_details=existing_agent.rating_details,
+            sync_metadata=existing_agent.sync_metadata,
             **update_optional_kwargs,
         )
 


### PR DESCRIPTION
## Summary

Closes #751

The `update_agent` endpoint constructs a new `AgentCard` from request fields but was not carrying over `ans_metadata`, `health_status`, `last_health_check`, `rating_details`, or `sync_metadata` from the existing agent. This caused the ANS verified badge to be lost whenever an agent was edited through the UI.

## Changes

- Preserve `ans_metadata` from existing agent during edit (fixes badge loss)
- Preserve `health_status` and `last_health_check` (prevents status reset)
- Preserve `rating_details` (prevents rating loss)
- Preserve `sync_metadata` (prevents federation metadata loss)

## Test plan

- [ ] Link ANS to an agent, verify badge appears
- [ ] Edit the agent (change description), verify ANS badge is still present
- [ ] Verify health status and ratings survive agent edit
- [ ] Run tests: `uv run pytest tests/ -n 8`