### PR TITLE
fix: format KMS key policy and add role pattern comments

### DIFF
--- a/terraform/aws-ecs/documentdb.tf
+++ b/terraform/aws-ecs/documentdb.tf
@@ -152,9 +152,12 @@ resource "aws_kms_key" "documentdb" {
             "aws:PrincipalAccount" = data.aws_caller_identity.current.account_id
           }
           StringLike = {
-            "aws:PrincipalArn" = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*task-exec*",
-               "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mcp-gateway-v2-*"
-             ]
+            "aws:PrincipalArn" = [
+              # ECS task execution roles (e.g., mcp-gateway-task-exec-role)
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*task-exec*",
+              # ECS task roles for v2 deployments (e.g., mcp-gateway-v2-registry-task-role)
+              "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mcp-gateway-v2-*",
+            ]
           }
         }
       },


### PR DESCRIPTION
## Summary

- Run `terraform fmt` on `documentdb.tf` to fix inconsistent indentation in the KMS key policy array
- Add inline comments explaining which ECS roles each `StringLike` pattern matches

Follow-up from PR #749 review. Cosmetic only -- no functional change to the Terraform plan.