### PR TITLE
fix: Okta M2M sync dual-write to idp_m2m_clients collection

### DIFF
--- a/registry/services/okta_m2m_sync.py
+++ b/registry/services/okta_m2m_sync.py
@@ -49,6 +49,7 @@ class OktaM2MSync:
         self.okta_domain = okta_domain.replace("https://", "").rstrip("/")
         self.okta_api_token = okta_api_token
         self.collection = db["okta_m2m_clients"]
+        self.idp_collection = db["idp_m2m_clients"]
 
         logger.info(f"Initialized Okta M2M sync for domain: {self.okta_domain}")
 
@@ -195,6 +196,27 @@ class OktaM2MSync:
                         added_count += 1
                         logger.info(f"Added new client: {client_id}")
 
+                    # Also sync to generic idp_m2m_clients collection for groups enrichment
+                    idp_doc = {
+                        "client_id": client_id,
+                        "name": app.get("label", client_id),
+                        "description": client_doc.get("description"),
+                        "groups": groups,
+                        "enabled": client_doc["enabled"],
+                        "provider": "okta",
+                        "idp_app_id": app.get("id"),
+                        "updated_at": datetime.utcnow(),
+                    }
+
+                    existing_idp = await self.idp_collection.find_one({"client_id": client_id})
+                    if existing_idp:
+                        await self.idp_collection.update_one(
+                            {"client_id": client_id}, {"$set": idp_doc}
+                        )
+                    else:
+                        idp_doc["created_at"] = datetime.utcnow()
+                        await self.idp_collection.insert_one(idp_doc)
+
                 except Exception as e:
                     error_msg = f"Failed to process app {app.get('label')}: {e}"
                     logger.error(error_msg)
@@ -274,6 +296,17 @@ class OktaM2MSync:
             True if updated, False if client not found
         """
         result = await self.collection.update_one(
+            {"client_id": client_id},
+            {
+                "$set": {
+                    "groups": groups,
+                    "updated_at": datetime.utcnow(),
+                }
+            },
+        )
+
+        # Also update in generic idp_m2m_clients collection
+        await self.idp_collection.update_one(
             {"client_id": client_id},
             {
                 "$set": {


### PR DESCRIPTION
## Summary
- Okta M2M sync now dual-writes to `idp_m2m_clients` (the collection the auth server reads for group enrichment), matching the Auth0 sync behavior
- `sync_from_okta()` upserts into `idp_m2m_clients` after each client insert/update
- `update_client_groups()` also updates `idp_m2m_clients` when groups change

Closes #758

## Context

The auth server's group enrichment (`auth_server/mongodb_groups_enrichment.py:96`) reads from `idp_m2m_clients` when a JWT token has empty groups. The Auth0 sync already dual-writes to both `auth0_m2m_clients` and `idp_m2m_clients`, but the Okta sync only wrote to `okta_m2m_clients` -- meaning Okta-synced M2M clients were never picked up for group enrichment.

## Test plan
- [x] `py_compile` passes
- [x] Full test suite: 2126 passed, 67 skipped (2 pre-existing failures in unrelated skill scanner tests)
- [ ] Verify after Okta sync, documents exist in both `okta_m2m_clients` and `idp_m2m_clients`
- [ ] Verify auth server group enrichment picks up Okta-synced M2M clients