### PR TITLE
feat: add executive summary comparison and timeseries chart to usage report skill

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -84,17 +84,43 @@ Then generate the deployment distribution chart:
 
 This produces a single faceted PNG with 6 subplots: Cloud Provider, Compute Platform, Storage Backend, Auth Provider, Version Type, and Deployment Mode. Each subplot shows counts and percentages.
 
+### Step 5b: Generate Timeseries Chart
+
+Generate a timeseries chart showing unique registry installs per cloud provider over time. This reads ALL CSV files in the output directory to build a complete historical view:
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_timeseries_chart.py \
+  --csv-dir OUTPUT_DIR \
+  --output OUTPUT_DIR/registry-installs-timeseries-YYYY-MM-DD.png
+```
+
+This produces a PNG with two subplots:
+- **Cumulative Unique Registry Installs** -- running total of unique registry_ids per cloud provider
+- **Daily Active Registry Installs** -- unique registry_ids seen each day per cloud provider
+
 ### Step 6: Run Telemetry Analysis
 
 Run the analysis script to compute all distributions, instance timelines, and metrics. This produces two files:
-- `tables-YYYY-MM-DD.md` -- pre-formatted markdown tables ready to embed in the report
-- `metrics-YYYY-MM-DD.json` -- raw computed metrics as JSON
+- `tables-YYYY-MM-DD.md` -- pre-formatted markdown tables ready to embed in the report (with executive summary comparison at the top)
+- `metrics-YYYY-MM-DD.json` -- raw computed metrics as JSON (includes `per_cloud_unique_installs`)
+
+The script automatically finds the most recent previous `metrics-*.json` file in the output directory and generates an executive summary with deltas at the top of the tables file. You can also specify a previous metrics file explicitly:
 
 ```bash
 /usr/bin/python3 .claude/skills/usage-report/analyze_telemetry.py \
   --csv OUTPUT_DIR/registry_metrics.csv \
   --output-dir OUTPUT_DIR \
   --date YYYY-MM-DD
+```
+
+Or with an explicit previous metrics file:
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/analyze_telemetry.py \
+  --csv OUTPUT_DIR/registry_metrics.csv \
+  --output-dir OUTPUT_DIR \
+  --date YYYY-MM-DD \
+  --previous-metrics OUTPUT_DIR/metrics-PREVIOUS-DATE.json
 ```
 
 ### Step 7: Generate the Usage Report
@@ -120,12 +146,18 @@ Read the generated `tables-YYYY-MM-DD.md` and include its tables directly in the
 
 ---
 
+## Executive Summary
+- Comparison with previous report (auto-detected from most recent metrics JSON)
+- Deltas for total events, unique instances, heartbeat events, null registry_id count
+- Per-cloud-provider unique registry installs comparison table
+
 ## Deployment Distribution
 
 ![Deployment Distribution](deployment-distribution-YYYY-MM-DD.png)
 
-## Executive Summary
-- Total events, unique instances, collection period, key highlights
+## Registry Installs Timeseries
+
+![Registry Installs Timeseries](registry-installs-timeseries-YYYY-MM-DD.png)
 
 ## Key Metrics
 | Metric | Value |
@@ -191,9 +223,9 @@ which pandoc >/dev/null || sudo apt-get install -y pandoc
 ### Step 9: Present Results
 
 After generating the report:
-1. Display the Executive Summary and Key Metrics directly in the conversation
-2. Tell the user the full report path, HTML path, and CSV path
-3. Highlight the most interesting findings
+1. Display the Executive Summary (with comparison deltas) and Key Metrics directly in the conversation
+2. Tell the user the full report path, HTML path, CSV path, and chart paths
+3. Highlight the most interesting findings and notable changes from the previous report
 
 ## Error Handling
 
@@ -210,10 +242,13 @@ User: /usage-report
 Output:
 ```
 Executive Summary: 68 startup events from ~7 unique registry instances over 4 days...
+Compared to previous report (2026-03-30): +12 events (+21%), +2 new instances (+40%)
 
 Full report: .scratchpad/usage-reports/ai-registry-usage-report-2026-03-31.md
 HTML report: .scratchpad/usage-reports/ai-registry-usage-report-2026-03-31.html
-Chart: .scratchpad/usage-reports/deployment-distribution-2026-03-31.png
+Charts:
+  - .scratchpad/usage-reports/deployment-distribution-2026-03-31.png
+  - .scratchpad/usage-reports/registry-installs-timeseries-2026-03-31.png
 CSV data: .scratchpad/usage-reports/registry_metrics.csv
 ```
 

--- a/.claude/skills/usage-report/analyze_telemetry.py
+++ b/.claude/skills/usage-report/analyze_telemetry.py
@@ -4,9 +4,13 @@ Reads registry_metrics.csv, computes all distributions, instance
 timelines, search stats, and version adoption. Writes a JSON file
 with raw metrics and a markdown file with pre-formatted tables
 ready to embed in the usage report.
+
+Supports comparison with a previous metrics JSON to produce an
+executive summary with deltas at the top of the report.
 """
 import argparse
 import csv
+import glob
 import json
 import logging
 import os
@@ -100,6 +104,177 @@ def _md_distribution_table(
         lines.append(f"| {value} | {count} | {pct} |")
 
     lines.append("")
+    return "\n".join(lines)
+
+
+def _find_previous_metrics(
+    output_dir: str,
+    current_date: str,
+) -> str | None:
+    """Find the most recent metrics JSON file before the current date.
+
+    Scans the output directory for metrics-YYYY-MM-DD.json files and
+    returns the path to the most recent one that predates current_date.
+    """
+    pattern = os.path.join(output_dir, "metrics-*.json")
+    candidates = glob.glob(pattern)
+
+    # Extract date from filename and filter
+    valid = []
+    for path in candidates:
+        basename = os.path.basename(path)
+        # Extract date portion: metrics-YYYY-MM-DD.json
+        date_part = basename.replace("metrics-", "").replace(".json", "")
+        if len(date_part) == 10 and date_part < current_date:
+            valid.append((date_part, path))
+
+    if not valid:
+        logger.info("No previous metrics file found for comparison")
+        return None
+
+    valid.sort(key=lambda x: x[0], reverse=True)
+    selected = valid[0]
+    logger.info(f"Found previous metrics: {selected[1]} (date: {selected[0]})")
+    return selected[1]
+
+
+def _load_previous_metrics(
+    path: str,
+) -> dict | None:
+    """Load a previous metrics JSON file."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        logger.info(f"Loaded previous metrics from {path}")
+        return data
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Failed to load previous metrics: {e}")
+        return None
+
+
+def _compute_delta(
+    current: int | float,
+    previous: int | float,
+) -> str:
+    """Compute a delta string like '+5 (+25%)' or '-3 (-10%)'."""
+    diff = current - previous
+    if previous == 0:
+        if diff == 0:
+            return "no change"
+        return f"+{diff}" if diff > 0 else f"{diff}"
+
+    pct = diff / previous * 100
+    sign = "+" if diff > 0 else ""
+    return f"{sign}{diff} ({sign}{pct:.0f}%)"
+
+
+def _compute_per_cloud_unique_installs(
+    rows: list[dict[str, str]],
+) -> dict[str, int]:
+    """Compute unique registry_id count per cloud provider."""
+    cloud_ids = defaultdict(set)
+    for row in rows:
+        rid = row.get("registry_id", "").strip()
+        if not rid:
+            continue
+        cloud = row.get("cloud") or "unknown"
+        cloud_ids[cloud].add(rid)
+
+    return {cloud: len(ids) for cloud, ids in sorted(cloud_ids.items())}
+
+
+def _build_exec_summary_md(
+    current_metrics: dict,
+    previous_metrics: dict | None,
+    current_cloud_installs: dict[str, int],
+    previous_cloud_installs: dict[str, int] | None,
+) -> str:
+    """Build the executive summary markdown section with comparison."""
+    lines = []
+    lines.append("## Executive Summary")
+    lines.append("")
+
+    curr = current_metrics
+    lines.append(
+        f"This report covers **{curr['total_events']} events** "
+        f"from **{curr['identified_instances']} unique identified registry instances** "
+        f"over the period {curr['earliest_ts'][:10]} to {curr['latest_ts'][:10]}."
+    )
+    lines.append("")
+
+    if previous_metrics is None:
+        lines.append("*No previous report available for comparison.*")
+        lines.append("")
+        # Still show per-cloud installs
+        lines.append("### Unique Registry Installs by Cloud Provider")
+        lines.append("")
+        lines.append("| Cloud Provider | Unique Installs |")
+        lines.append("|----------------|-----------------|")
+        for cloud, count in current_cloud_installs.items():
+            lines.append(f"| {cloud} | {count} |")
+        lines.append("")
+        return "\n".join(lines)
+
+    prev = previous_metrics.get("key_metrics", {})
+    prev_date = previous_metrics.get("report_date", "unknown")
+
+    lines.append(f"### Comparison with Previous Report ({prev_date})")
+    lines.append("")
+    lines.append("| Metric | Previous | Current | Change |")
+    lines.append("|--------|----------|---------|--------|")
+
+    # Key metric comparisons
+    comparisons = [
+        ("Total Events", "total_events"),
+        ("Startup Events", "startup_events"),
+        ("Heartbeat Events", "heartbeat_events"),
+        ("Unique Instances (identified)", "identified_instances"),
+        ("Events with null registry_id", "null_registry_id_count"),
+    ]
+    for label, key in comparisons:
+        prev_val = prev.get(key, 0)
+        curr_val = curr.get(key, 0)
+        delta = _compute_delta(curr_val, prev_val)
+        lines.append(f"| {label} | {prev_val} | {curr_val} | {delta} |")
+
+    lines.append("")
+
+    # Per-cloud unique installs comparison
+    lines.append("### Unique Registry Installs by Cloud Provider")
+    lines.append("")
+    if previous_cloud_installs:
+        lines.append("| Cloud Provider | Previous | Current | Change |")
+        lines.append("|----------------|----------|---------|--------|")
+        all_clouds = sorted(
+            set(list(current_cloud_installs.keys()) + list(previous_cloud_installs.keys()))
+        )
+        for cloud in all_clouds:
+            prev_count = previous_cloud_installs.get(cloud, 0)
+            curr_count = current_cloud_installs.get(cloud, 0)
+            delta = _compute_delta(curr_count, prev_count)
+            lines.append(f"| {cloud} | {prev_count} | {curr_count} | {delta} |")
+    else:
+        lines.append("| Cloud Provider | Unique Installs |")
+        lines.append("|----------------|-----------------|")
+        for cloud, count in current_cloud_installs.items():
+            lines.append(f"| {cloud} | {count} |")
+    lines.append("")
+
+    # Distribution shift highlights
+    prev_dists = previous_metrics.get("distributions", {})
+    curr_cloud = current_cloud_installs
+    prev_cloud_dist = prev_dists.get("cloud", {})
+
+    # Highlight new cloud providers
+    prev_clouds = set(prev_cloud_dist.keys()) if prev_cloud_dist else set()
+    curr_clouds = set(current_cloud_installs.keys())
+    new_clouds = curr_clouds - prev_clouds
+    if new_clouds:
+        lines.append(
+            f"**New cloud providers**: {', '.join(sorted(new_clouds))}"
+        )
+        lines.append("")
+
     return "\n".join(lines)
 
 
@@ -207,6 +382,11 @@ def _compute_instance_table(
             _safe_int(e.get("search_queries_total", "")) for e in events
         )
 
+        # Sum total search queries across all events
+        total_search = sum(
+            _safe_int(e.get("search_queries_total", "")) for e in events
+        )
+
         first_ts = events[0].get("ts", "")[:10]
         latest_ts = events[-1].get("ts", "")[:10]
 
@@ -226,6 +406,7 @@ def _compute_instance_table(
             "max_agents": max_agents,
             "max_skills": max_skills,
             "max_search_queries": max_search,
+            "total_search_queries": total_search,
             "first_seen": first_ts,
             "latest_seen": latest_ts,
         })
@@ -265,6 +446,9 @@ def _compute_unidentified_profiles(
         max_search = max(
             _safe_int(e.get("search_queries_total", "")) for e in events
         )
+        total_search = sum(
+            _safe_int(e.get("search_queries_total", "")) for e in events
+        )
 
         events.sort(key=lambda r: r.get("ts", ""))
         first_ts = events[0].get("ts", "")[:10]
@@ -282,6 +466,7 @@ def _compute_unidentified_profiles(
             "max_agents": max_agents,
             "max_skills": max_skills,
             "max_search_queries": max_search,
+            "total_search_queries": total_search,
             "first_seen": first_ts,
             "latest_seen": latest_ts,
         })
@@ -464,10 +649,16 @@ def _build_markdown_tables(
     search: dict,
     features: list[dict],
     rows: list[dict[str, str]],
+    exec_summary_md: str | None = None,
 ) -> str:
     """Build all markdown tables as a single string."""
     total = metrics["total_events"]
     lines = []
+
+    # Executive Summary (at the top if available)
+    if exec_summary_md:
+        lines.append(exec_summary_md)
+        lines.append("")
 
     # Key Metrics
     lines.append("## Key Metrics")
@@ -500,12 +691,12 @@ def _build_markdown_tables(
     lines.append(
         "| Registry ID | Cloud | Compute | Storage | Auth "
         "| Federation | Arch | Servers | Agents | Skills "
-        "| Search | Events | First Seen |"
+        "| Search (Max) | Search (Total) | Events | First Seen |"
     )
     lines.append(
         "|-------------|-------|---------|---------|------"
         "|------------|------|---------|--------|--------"
-        "|--------|--------|------------|"
+        "|--------------|----------------|--------|------------|"
     )
     for inst in instances:
         fed = "Yes" if inst["federation"] else "No"
@@ -521,6 +712,7 @@ def _build_markdown_tables(
             f"| {inst['max_agents']} "
             f"| {inst['max_skills']} "
             f"| {inst['max_search_queries']} "
+            f"| {inst['total_search_queries']} "
             f"| {inst['events']} "
             f"| {inst['first_seen']} |"
         )
@@ -532,12 +724,12 @@ def _build_markdown_tables(
     lines.append(
         "| Cloud | Compute | Arch | Storage | Auth "
         "| Mode | Servers | Agents | Skills "
-        "| Search | Events | Period |"
+        "| Search (Max) | Search (Total) | Events | Period |"
     )
     lines.append(
         "|-------|---------|------|---------|------"
         "|------|---------|--------|--------"
-        "|--------|--------|--------|"
+        "|--------------|----------------|--------|--------|"
     )
     for prof in unidentified:
         period = prof["first_seen"]
@@ -554,6 +746,7 @@ def _build_markdown_tables(
             f"| {prof['max_agents']} "
             f"| {prof['max_skills']} "
             f"| {prof['max_search_queries']} "
+            f"| {prof['total_search_queries']} "
             f"| {prof['events']} "
             f"| {period} |"
         )
@@ -720,6 +913,14 @@ def main() -> None:
         default=None,
         help="Report date (YYYY-MM-DD). Defaults to today.",
     )
+    parser.add_argument(
+        "--previous-metrics",
+        default=None,
+        help=(
+            "Path to previous metrics JSON for comparison. "
+            "If not provided, auto-detects the most recent one in output-dir."
+        ),
+    )
     args = parser.parse_args()
 
     if not os.path.exists(args.csv):
@@ -740,16 +941,41 @@ def main() -> None:
     versions = _compute_version_table(rows)
     search = _compute_search_stats(rows)
     features = _compute_feature_adoption(rows)
+    cloud_installs = _compute_per_cloud_unique_installs(rows)
+
+    # Load previous metrics for comparison
+    prev_metrics_path = args.previous_metrics
+    if not prev_metrics_path:
+        prev_metrics_path = _find_previous_metrics(args.output_dir, date_str)
+
+    previous_metrics = None
+    previous_cloud_installs = None
+    if prev_metrics_path:
+        previous_metrics = _load_previous_metrics(prev_metrics_path)
+        if previous_metrics:
+            previous_cloud_installs = previous_metrics.get(
+                "per_cloud_unique_installs", None
+            )
+
+    # Build executive summary
+    exec_summary_md = _build_exec_summary_md(
+        metrics,
+        previous_metrics,
+        cloud_installs,
+        previous_cloud_installs,
+    )
 
     md_content = _build_markdown_tables(
         metrics, distributions, instances, unidentified,
         versions, search, features, rows,
+        exec_summary_md=exec_summary_md,
     )
 
     # Build JSON with all computed data
     metrics_json = {
         "report_date": date_str,
         "key_metrics": metrics,
+        "per_cloud_unique_installs": cloud_installs,
         "distributions": {
             k: dict(v.most_common()) for k, v in distributions.items()
         },

--- a/.claude/skills/usage-report/generate_timeseries_chart.py
+++ b/.claude/skills/usage-report/generate_timeseries_chart.py
@@ -1,0 +1,280 @@
+"""Generate a timeseries chart of unique registry installs per cloud provider.
+
+Reads ALL CSV files in a given directory, deduplicates events, and produces
+a PNG line chart showing cumulative unique registry_id values per cloud
+provider over time.
+"""
+import argparse
+import csv
+import logging
+import os
+from collections import defaultdict
+from datetime import datetime
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import seaborn as sns
+
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = "AI Registry -- Unique Registry Installs per Cloud Provider"
+FIGURE_WIDTH: int = 14
+FIGURE_HEIGHT: int = 7
+LINE_PALETTE: str = "Set2"
+
+
+def _find_csv_files(
+    directory: str,
+) -> list[str]:
+    """Find all CSV files in the given directory."""
+    csv_files = []
+    for filename in os.listdir(directory):
+        if filename.endswith(".csv"):
+            csv_files.append(os.path.join(directory, filename))
+    csv_files.sort()
+    logger.info(f"Found {len(csv_files)} CSV files in {directory}")
+    return csv_files
+
+
+def _read_all_csvs(
+    csv_files: list[str],
+) -> list[dict[str, str]]:
+    """Read and combine all CSV files into a single list of rows."""
+    all_rows = []
+    for csv_path in csv_files:
+        with open(csv_path, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        logger.info(f"Read {len(rows)} rows from {csv_path}")
+        all_rows.extend(rows)
+    logger.info(f"Total rows across all CSVs: {len(all_rows)}")
+    return all_rows
+
+
+def _deduplicate_events(
+    rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Deduplicate rows by (registry_id, ts) to avoid double-counting."""
+    seen = set()
+    unique_rows = []
+    for row in rows:
+        rid = row.get("registry_id", "").strip()
+        ts = row.get("ts", "").strip()
+        key = (rid, ts)
+        if key not in seen:
+            seen.add(key)
+            unique_rows.append(row)
+    logger.info(
+        f"Deduplicated: {len(rows)} -> {len(unique_rows)} unique events"
+    )
+    return unique_rows
+
+
+def _extract_date(
+    ts: str,
+) -> str | None:
+    """Extract YYYY-MM-DD date from an ISO timestamp string."""
+    if not ts or len(ts) < 10:
+        return None
+    return ts[:10]
+
+
+def _compute_cumulative_installs(
+    rows: list[dict[str, str]],
+) -> dict[str, list[tuple[str, int]]]:
+    """Compute cumulative unique registry installs per cloud provider per date.
+
+    Returns a dict keyed by cloud provider, each value is a sorted list
+    of (date_str, cumulative_unique_count) tuples.
+    """
+    # Group events by cloud provider
+    cloud_events = defaultdict(list)
+    for row in rows:
+        rid = row.get("registry_id", "").strip()
+        if not rid:
+            continue
+        cloud = row.get("cloud") or "unknown"
+        ts = row.get("ts", "")
+        date = _extract_date(ts)
+        if not date:
+            continue
+        cloud_events[cloud].append((date, rid))
+
+    # For each cloud, compute cumulative unique registry_ids per date
+    result = {}
+    for cloud, events in cloud_events.items():
+        events.sort(key=lambda x: x[0])
+
+        # Collect all dates and track cumulative set
+        seen_ids = set()
+        daily_cumulative = {}
+        for date, rid in events:
+            seen_ids.add(rid)
+            daily_cumulative[date] = len(seen_ids)
+
+        # Convert to sorted list of tuples
+        sorted_dates = sorted(daily_cumulative.keys())
+        result[cloud] = [
+            (d, daily_cumulative[d]) for d in sorted_dates
+        ]
+
+    return result
+
+
+def _compute_daily_unique_installs(
+    rows: list[dict[str, str]],
+) -> dict[str, list[tuple[str, int]]]:
+    """Compute daily unique registry installs per cloud provider.
+
+    Returns a dict keyed by cloud provider, each value is a sorted list
+    of (date_str, unique_count_that_day) tuples.
+    """
+    # Group by (cloud, date) -> set of registry_ids
+    cloud_date_ids = defaultdict(lambda: defaultdict(set))
+    for row in rows:
+        rid = row.get("registry_id", "").strip()
+        if not rid:
+            continue
+        cloud = row.get("cloud") or "unknown"
+        ts = row.get("ts", "")
+        date = _extract_date(ts)
+        if not date:
+            continue
+        cloud_date_ids[cloud][date].add(rid)
+
+    result = {}
+    for cloud, date_ids in cloud_date_ids.items():
+        sorted_dates = sorted(date_ids.keys())
+        result[cloud] = [
+            (d, len(date_ids[d])) for d in sorted_dates
+        ]
+
+    return result
+
+
+def _generate_chart(
+    cumulative_data: dict[str, list[tuple[str, int]]],
+    daily_data: dict[str, list[tuple[str, int]]],
+    output_path: str,
+) -> None:
+    """Generate and save the timeseries chart with two subplots."""
+    sns.set_theme(style="whitegrid")
+
+    fig, (ax_cumulative, ax_daily) = plt.subplots(
+        2, 1,
+        figsize=(FIGURE_WIDTH, FIGURE_HEIGHT),
+        sharex=True,
+    )
+    fig.suptitle(
+        CHART_TITLE,
+        fontsize=14,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    colors = sns.color_palette(LINE_PALETTE, len(cumulative_data))
+
+    # Plot cumulative installs
+    for idx, (cloud, series) in enumerate(sorted(cumulative_data.items())):
+        dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
+        counts = [c for _, c in series]
+        ax_cumulative.plot(
+            dates,
+            counts,
+            marker="o",
+            markersize=5,
+            linewidth=2,
+            label=cloud,
+            color=colors[idx],
+        )
+
+    ax_cumulative.set_ylabel("Cumulative Unique Installs")
+    ax_cumulative.set_title("Cumulative Unique Registry Installs", fontsize=11)
+    ax_cumulative.legend(title="Cloud Provider", loc="upper left")
+    ax_cumulative.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+
+    # Plot daily active installs
+    for idx, (cloud, series) in enumerate(sorted(daily_data.items())):
+        dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
+        counts = [c for _, c in series]
+        ax_daily.plot(
+            dates,
+            counts,
+            marker="s",
+            markersize=4,
+            linewidth=2,
+            label=cloud,
+            color=colors[idx],
+        )
+
+    ax_daily.set_ylabel("Daily Unique Installs")
+    ax_daily.set_title("Daily Active Registry Installs", fontsize=11)
+    ax_daily.legend(title="Cloud Provider", loc="upper left")
+    ax_daily.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+
+    # Format x-axis dates
+    ax_daily.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax_daily.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+    plt.setp(ax_daily.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Timeseries chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments and generate the timeseries chart."""
+    parser = argparse.ArgumentParser(
+        description="Generate timeseries chart of unique registry installs per cloud provider",
+    )
+    parser.add_argument(
+        "--csv-dir",
+        required=True,
+        help="Directory containing CSV files to read",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.csv_dir):
+        logger.error(f"Directory not found: {args.csv_dir}")
+        raise SystemExit(1)
+
+    csv_files = _find_csv_files(args.csv_dir)
+    if not csv_files:
+        logger.error(f"No CSV files found in {args.csv_dir}")
+        raise SystemExit(1)
+
+    all_rows = _read_all_csvs(csv_files)
+    if not all_rows:
+        logger.error("No data found in CSV files")
+        raise SystemExit(1)
+
+    unique_rows = _deduplicate_events(all_rows)
+
+    cumulative_data = _compute_cumulative_installs(unique_rows)
+    daily_data = _compute_daily_unique_installs(unique_rows)
+
+    if not cumulative_data:
+        logger.error("No identified registry instances found in data")
+        raise SystemExit(1)
+
+    _generate_chart(cumulative_data, daily_data, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `generate_timeseries_chart.py` that reads ALL CSV files in the usage reports directory, deduplicates events by `(registry_id, ts)`, and produces a PNG with two subplots: cumulative unique registry installs and daily active installs per cloud provider
- Update `analyze_telemetry.py` to auto-detect the most recent previous `metrics-*.json` file and generate an executive summary with comparison deltas at the top of the report. Also adds `per_cloud_unique_installs` to the JSON output and splits the Search column into Search (Max) and Search (Total) for both identified and unidentified instance tables
- Update `SKILL.md` workflow with new Step 5b for timeseries chart generation, document `--previous-metrics` flag, and restructure report template with executive summary at top

## Test plan

- [ ] Run `/usage-report` and verify the executive summary appears at the top with comparison deltas against the previous report
- [ ] Verify the timeseries chart PNG is generated showing per-cloud-provider unique installs
- [ ] Verify the identified instances table shows both Search (Max) and Search (Total) columns
- [ ] Run with no previous metrics file and verify graceful fallback (shows "No previous report available")
- [ ] Run with `--previous-metrics` explicit flag to verify manual override works