### PR TITLE
Quote default values in .env.example to prevent shell errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,16 +22,16 @@ REGISTRY_URL=http://localhost
 # Human-readable registry name (display name for your registry)
 # If not set, a random Docker-style name will be generated (e.g., "brave-falcon-registry")
 # Displayed in federated registry listings and UI headers
-REGISTRY_NAME=AI Gateway Registry
+REGISTRY_NAME="AI Gateway Registry"
 
 # Organization that operates this registry
 # If not set, defaults to "ACME Inc."
 # Used to identify the organization operating this registry instance
-REGISTRY_ORGANIZATION_NAME=ACME Inc.
+REGISTRY_ORGANIZATION_NAME="ACME Inc."
 
 # Registry description for federation
 # Describes the purpose and scope of this registry
-REGISTRY_DESCRIPTION=Central registry for all your AI assets
+REGISTRY_DESCRIPTION="Central registry for all your AI assets"
 
 # Contact email for registry administrators
 # Leave empty if not publicly shared


### PR DESCRIPTION
Default values are unquoted, resulting in shell errors with zsh

