### PR TITLE
fix: Entra group management bugs and IdP group filtering (#780)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -279,6 +279,17 @@ ENTRA_GROUP_ADMIN_ID=your-admin-group-object-id-here
 # Users Group Example
 ENTRA_GROUP_USERS_ID=your-users-group-object-id-here
 
+# IdP Group Filtering (optional, applies to all identity providers)
+# Comma-separated list of prefixes. Only groups whose name starts with
+# any of these prefixes are shown in IAM > Groups page.
+# For Entra ID, uses Microsoft Graph $filter for server-side filtering.
+# For Keycloak, Okta, Auth0, filtering is applied client-side.
+# Leave empty to show all groups (default).
+# Examples:
+#   IDP_GROUP_FILTER_PREFIX=mcp-
+#   IDP_GROUP_FILTER_PREFIX=mcp-,registry-,ai-
+IDP_GROUP_FILTER_PREFIX=
+
 # =============================================================================
 # OKTA CONFIGURATION (if AUTH_PROVIDER=okta)
 # =============================================================================

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1808,8 +1808,7 @@ class RegistryClient:
         data = {"group_name": group_name}
         if description:
             data["description"] = description
-        if create_in_idp:
-            data["create_in_idp"] = True
+        data["create_in_idp"] = str(create_in_idp).lower()
 
         response = self._make_request(
             method="POST", endpoint="/api/servers/groups/create", data=data

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -228,6 +228,11 @@ registry:
     contactEmail: ""  # Optional contact email
     contactUrl: ""  # Optional contact URL/website
 
+  # IdP group filtering (applies to all identity providers)
+  # When set, only groups whose name starts with any of these prefixes are shown in IAM > Groups
+  # Example: "mcp-,registry-,ai-"
+  idpGroupFilterPrefix: ""
+
   ingress:
     enabled: true
     ingressClassName: alb

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
                   name: {{ .Values.entra.clientSecretExistingSecret }}
                   key: {{ .Values.entra.clientSecretExistingSecretKey }}
             {{- end }}
+            {{- if .Values.idpGroupFilterPrefix }}
+            - name: IDP_GROUP_FILTER_PREFIX
+              value: {{ .Values.idpGroupFilterPrefix | quote }}
+            {{- end }}
             {{- if .Values.okta.clientSecretExistingSecret }}
             - name: OKTA_CLIENT_SECRET
               valueFrom:

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -83,10 +83,6 @@ spec:
                   name: {{ .Values.entra.clientSecretExistingSecret }}
                   key: {{ .Values.entra.clientSecretExistingSecretKey }}
             {{- end }}
-            {{- if .Values.idpGroupFilterPrefix }}
-            - name: IDP_GROUP_FILTER_PREFIX
-              value: {{ .Values.idpGroupFilterPrefix | quote }}
-            {{- end }}
             {{- if .Values.okta.clientSecretExistingSecret }}
             - name: OKTA_CLIENT_SECRET
               valueFrom:

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -131,6 +131,9 @@ data:
   {{- end }}
 {{- end }}
   ROOT_PATH: {{ $rootPath | b64enc | quote }}
+  {{- if .Values.idpGroupFilterPrefix }}
+  IDP_GROUP_FILTER_PREFIX: {{ .Values.idpGroupFilterPrefix | b64enc | quote }}
+  {{- end }}
   SKILL_SECURITY_SCAN_ENABLED: {{ .Values.app.skillSecurityScanEnabled | toString | b64enc | quote }}
   SKILL_SECURITY_ANALYZERS: {{ .Values.app.skillSecurityAnalyzers | b64enc | quote }}
   # ANS (Agent Name Service) Integration

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -80,6 +80,11 @@ entra:
   clientSecretExistingSecretKey: "ENTRA_CLIENT_SECRET"  # Key within the existing secret
   tenantId: ""
 
+# IdP group filtering (applies to all identity providers)
+# When set, only groups matching any of these prefixes are shown in IAM > Groups
+# Example: "mcp-,registry-,ai-"
+idpGroupFilterPrefix: ""
+
 # Okta integration (used when authProvider.type = "okta" in standalone deployment)
 okta:
   domain: ""  # e.g., dev-123456.okta.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,8 @@ services:
       - ENTRA_CLIENT_ID=${ENTRA_CLIENT_ID}
       - ENTRA_CLIENT_SECRET=${ENTRA_CLIENT_SECRET}
       - ENTRA_ENABLED=${ENTRA_ENABLED:-false}
+      # IdP group filtering (applies to all identity providers)
+      - IDP_GROUP_FILTER_PREFIX=${IDP_GROUP_FILTER_PREFIX:-}
       # Okta configuration
       - OKTA_DOMAIN=${OKTA_DOMAIN:-}
       - OKTA_CLIENT_ID=${OKTA_CLIENT_ID:-}
@@ -321,6 +323,8 @@ services:
       - ENTRA_CLIENT_ID=${ENTRA_CLIENT_ID}
       - ENTRA_CLIENT_SECRET=${ENTRA_CLIENT_SECRET}
       - ENTRA_ENABLED=${ENTRA_ENABLED:-false}
+      # IdP group filtering (applies to all identity providers)
+      - IDP_GROUP_FILTER_PREFIX=${IDP_GROUP_FILTER_PREFIX:-}
       # Okta configuration
       - OKTA_DOMAIN=${OKTA_DOMAIN:-}
       - OKTA_CLIENT_ID=${OKTA_CLIENT_ID:-}

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -76,7 +76,9 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
     "identity_providers": {
         "title": "Identity Providers",
         "order": 4,
-        "fields": [],
+        "fields": [
+            ("idp_group_filter_prefix", "Group Filter Prefixes (comma-separated)", False),
+        ],
         "subgroups": [
             {
                 "id": "keycloak",

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -408,35 +408,56 @@ async def management_create_group(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
-    Create a new group in the identity provider and MongoDB (admin only).
+    Create a new group in the identity provider and/or MongoDB (admin only).
 
-    This creates the group in both:
-    1. The configured identity provider (Keycloak or Entra ID)
-    2. MongoDB scopes collection for authorization
+    When create_in_idp is True (default), creates in both the configured
+    identity provider and MongoDB scopes collection.
+    When create_in_idp is False, creates only in MongoDB scopes collection.
     """
     _require_admin(user_context)
 
     iam = get_iam_manager()
 
+    # Extract create_in_idp from scope_config (frontend sends it there)
+    create_in_idp = True  # default: create in IdP
+    if payload.scope_config and "create_in_idp" in payload.scope_config:
+        create_in_idp = bool(payload.scope_config["create_in_idp"])
+    logger.debug(
+        "create_in_idp=%s for group '%s' (from scope_config)",
+        create_in_idp,
+        payload.name,
+    )
+
     try:
-        # Step 1: Create group in identity provider
-        result = await iam.create_group(
-            group_name=payload.name, description=payload.description or ""
-        )
+        result = {}
+        group_mapping_id = payload.name  # default for local-only groups
 
-        # Step 2: Determine group mapping identifier
-        # For Keycloak: use group name
-        # For Entra ID: use the Object ID (GUID) returned from Graph API
-        provider = AUTH_PROVIDER.lower()
-        if provider == "entra":
-            # Entra ID tokens contain group Object IDs, not names
-            group_mapping_id = result.get("id", payload.name)
+        # Step 1: Create group in identity provider (only if requested)
+        if create_in_idp:
+            result = await iam.create_group(
+                group_name=payload.name,
+                description=payload.description or "",
+            )
+
+            # For Entra ID: use Object ID for group mapping
+            # For Keycloak/Okta: use group name
+            provider = AUTH_PROVIDER.lower()
+            if provider == "entra":
+                group_mapping_id = result.get("id", payload.name)
         else:
-            # Keycloak tokens contain group names
-            group_mapping_id = payload.name
+            # Local-only group: build a result dict without calling IdP
+            result = {
+                "id": payload.name,
+                "name": payload.name,
+                "path": f"/{payload.name}",
+                "attributes": {"description": [payload.description or ""]},
+            }
+            logger.info(
+                "Group '%s' created locally only (create_in_idp=False)",
+                payload.name,
+            )
 
-        # Step 3: Create in MongoDB scopes collection
-        # Extract server_access, ui_permissions, and agent_access from scope_config if provided
+        # Step 2: Create in MongoDB scopes collection (always)
         server_access = []
         ui_permissions = {}
         agent_access = []
@@ -460,7 +481,11 @@ async def management_create_group(
         )
 
         if not import_success:
-            logger.warning("Group created in IdP but failed to create in MongoDB: %s", payload.name)
+            logger.warning(
+                "Group %s in IdP but failed to create in MongoDB: %s",
+                "created" if create_in_idp else "skipped",
+                payload.name,
+            )
 
         return GroupSummary(
             id=result.get("id", ""),
@@ -488,19 +513,30 @@ async def management_delete_group(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
-    Delete a group from the identity provider and MongoDB (admin only).
+    Delete a group from the identity provider and/or MongoDB (admin only).
 
-    This deletes the group from both:
-    1. The configured identity provider (Keycloak or Entra ID)
-    2. MongoDB scopes collection
+    Attempts to delete from IdP first. If the group does not exist in the IdP
+    (e.g., it was created with create_in_idp=False), the IdP error is logged
+    and the MongoDB deletion proceeds.
     """
     _require_admin(user_context)
 
     iam = get_iam_manager()
 
     try:
-        # Step 1: Delete from identity provider
-        await iam.delete_group(group_name=group_name)
+        # Step 1: Attempt to delete from identity provider
+        try:
+            await iam.delete_group(group_name=group_name)
+        except Exception as idp_exc:
+            idp_detail = str(idp_exc).lower()
+            if "not found" in idp_detail or "404" in idp_detail:
+                logger.info(
+                    "Group '%s' not found in IdP (may be local-only), "
+                    "proceeding with MongoDB deletion",
+                    group_name,
+                )
+            else:
+                raise
 
         # Step 2: Delete from MongoDB scopes collection
         delete_success = await scope_service.delete_group(

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -253,6 +253,12 @@ class Settings(BaseSettings):
         description="Microsoft Entra ID admin group ID",
     )
 
+    # IdP Group Filtering (applies to all identity providers)
+    idp_group_filter_prefix: str = Field(
+        default="",
+        description="Comma-separated prefixes to filter IdP groups in IAM > Groups page",
+    )
+
     # ANS Integration
     ans_integration_enabled: bool = Field(
         default=False,

--- a/registry/utils/entra_manager.py
+++ b/registry/utils/entra_manager.py
@@ -58,6 +58,27 @@ def _auth_headers(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
+def _build_prefix_odata_filter(
+    prefixes: list[str],
+) -> str:
+    """
+    Build an OData $filter expression for multiple displayName prefixes.
+
+    For a single prefix: startswith(displayName,'mcp-')
+    For multiple: startswith(displayName,'mcp-') or startswith(displayName,'ai-')
+
+    Args:
+        prefixes: List of prefix strings (already validated)
+
+    Returns:
+        OData $filter expression string
+    """
+    conditions = [
+        f"startswith(displayName,'{prefix}')" for prefix in prefixes
+    ]
+    return " or ".join(conditions)
+
+
 async def _get_entra_admin_token() -> str:
     """
     Get admin access token from Entra ID for Graph API calls.
@@ -516,23 +537,48 @@ async def delete_entra_user(username_or_id: str) -> bool:
 
 async def list_entra_groups() -> list[dict[str, Any]]:
     """
-    List all groups in Entra ID tenant.
+    List groups in Entra ID tenant.
+
+    When IDP_GROUP_FILTER_PREFIX is set, uses Microsoft Graph API OData $filter
+    for server-side filtering (more efficient than client-side for large tenants).
+    When not set, all groups are returned (backward compatible).
 
     Returns:
         List of group dictionaries
     """
+    from .iam_manager import IDP_GROUP_FILTER_PREFIXES
+
     admin_token = await _get_entra_admin_token()
+
+    params: dict[str, str] = {
+        "$select": "id,displayName,description,securityEnabled",
+    }
+
+    if IDP_GROUP_FILTER_PREFIXES:
+        params["$filter"] = _build_prefix_odata_filter(IDP_GROUP_FILTER_PREFIXES)
+        logger.info(
+            "Filtering Entra ID groups by prefixes (server-side): %s",
+            IDP_GROUP_FILTER_PREFIXES,
+        )
 
     async with httpx.AsyncClient(timeout=10.0) as client:
         response = await client.get(
             f"{GRAPH_BASE_URL}/groups",
             headers=_auth_headers(admin_token),
-            params={"$select": "id,displayName,description,securityEnabled"},
+            params=params,
         )
         response.raise_for_status()
 
         data = response.json()
         groups = data.get("value", [])
+
+        logger.info(
+            "Retrieved %d groups from Entra ID%s",
+            len(groups),
+            f" (prefix filter: {IDP_GROUP_FILTER_PREFIXES})"
+            if IDP_GROUP_FILTER_PREFIXES
+            else "",
+        )
 
         return [
             {

--- a/registry/utils/iam_manager.py
+++ b/registry/utils/iam_manager.py
@@ -2,11 +2,12 @@
 IAM Manager factory for multi-provider support.
 
 This module provides a unified interface for IAM operations across
-different identity providers (Keycloak, Entra ID).
+different identity providers (Keycloak, Entra ID, Okta, Auth0).
 """
 
 import logging
 import os
+import re
 from typing import (
     Any,
     Protocol,
@@ -22,6 +23,49 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 AUTH_PROVIDER: str = os.environ.get("AUTH_PROVIDER", "keycloak")
+
+# IdP group filtering -- applies to all identity providers
+IDP_GROUP_FILTER_PREFIX: str = os.environ.get("IDP_GROUP_FILTER_PREFIX", "")
+
+# Parse comma-separated prefixes and validate each one to prevent injection
+IDP_GROUP_FILTER_PREFIXES: list[str] = []
+if IDP_GROUP_FILTER_PREFIX:
+    IDP_GROUP_FILTER_PREFIXES = [
+        p.strip() for p in IDP_GROUP_FILTER_PREFIX.split(",") if p.strip()
+    ]
+    for _prefix in IDP_GROUP_FILTER_PREFIXES:
+        if not re.match(r"^[a-zA-Z0-9\-_ ]+$", _prefix):
+            raise ValueError(
+                f"IDP_GROUP_FILTER_PREFIX contains invalid characters in "
+                f"prefix '{_prefix}'. "
+                f"Only alphanumeric, hyphens, underscores, and spaces are allowed."
+            )
+    logger.info("IdP group filter prefixes: %s", IDP_GROUP_FILTER_PREFIXES)
+
+
+def _filter_groups_by_prefix(
+    groups: list[dict[str, Any]],
+    prefixes: list[str],
+) -> list[dict[str, Any]]:
+    """
+    Filter groups by display name prefix (client-side fallback).
+
+    Used when the IdP API does not support server-side prefix filtering.
+
+    Args:
+        groups: List of group dictionaries with a 'name' key
+        prefixes: List of allowed prefixes
+
+    Returns:
+        Filtered list of groups whose name starts with any prefix
+    """
+    if not prefixes:
+        return groups
+
+    return [
+        g for g in groups
+        if any(g.get("name", "").startswith(prefix) for prefix in prefixes)
+    ]
 
 
 @runtime_checkable
@@ -215,10 +259,11 @@ class KeycloakIAMManager:
         return await delete_keycloak_user(username=username)
 
     async def list_groups(self) -> list[dict[str, Any]]:
-        """List all groups from Keycloak."""
+        """List groups from Keycloak, filtered by IDP_GROUP_FILTER_PREFIX if set."""
         from .keycloak_manager import list_keycloak_groups
 
-        return await list_keycloak_groups()
+        groups = await list_keycloak_groups()
+        return _filter_groups_by_prefix(groups, IDP_GROUP_FILTER_PREFIXES)
 
     async def create_group(self, group_name: str, description: str = "") -> dict[str, Any]:
         """Create a group in Keycloak."""
@@ -401,10 +446,11 @@ class OktaIAMManager:
         return await delete_okta_user(username_or_id=username)
 
     async def list_groups(self) -> list[dict[str, Any]]:
-        """List all groups from Okta."""
+        """List groups from Okta, filtered by IDP_GROUP_FILTER_PREFIX if set."""
         from .okta_manager import list_okta_groups
 
-        return await list_okta_groups()
+        groups = await list_okta_groups()
+        return _filter_groups_by_prefix(groups, IDP_GROUP_FILTER_PREFIXES)
 
     async def create_group(self, group_name: str, description: str = "") -> dict[str, Any]:
         """Create a group in Okta."""
@@ -496,10 +542,11 @@ class Auth0IAMManager:
         return await delete_auth0_user(username_or_id=username)
 
     async def list_groups(self) -> list[dict[str, Any]]:
-        """List all roles (groups) from Auth0."""
+        """List roles (groups) from Auth0, filtered by IDP_GROUP_FILTER_PREFIX if set."""
         from .auth0_manager import list_auth0_groups
 
-        return await list_auth0_groups()
+        groups = await list_auth0_groups()
+        return _filter_groups_by_prefix(groups, IDP_GROUP_FILTER_PREFIXES)
 
     async def create_group(self, group_name: str, description: str = "") -> dict[str, Any]:
         """Create a role (group) in Auth0."""

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -125,10 +125,11 @@ module "mcp_gateway" {
   security_add_pending_tag      = var.security_add_pending_tag
 
   # Microsoft Entra ID configuration
-  entra_enabled       = var.entra_enabled
-  entra_tenant_id     = var.entra_tenant_id
-  entra_client_id     = var.entra_client_id
-  entra_client_secret = var.entra_client_secret
+  entra_enabled              = var.entra_enabled
+  entra_tenant_id            = var.entra_tenant_id
+  entra_client_id            = var.entra_client_id
+  entra_client_secret        = var.entra_client_secret
+  idp_group_filter_prefix    = var.idp_group_filter_prefix
 
   # Okta configuration
   okta_enabled           = var.okta_enabled

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -141,6 +141,10 @@ module "ecs_service_auth" {
           name  = "ENTRA_CLIENT_ID"
           value = var.entra_client_id
         },
+        {
+          name  = "IDP_GROUP_FILTER_PREFIX"
+          value = var.idp_group_filter_prefix
+        },
         # Okta configuration
         {
           name  = "OKTA_ENABLED"
@@ -589,6 +593,10 @@ module "ecs_service_registry" {
         {
           name  = "ENTRA_CLIENT_ID"
           value = var.entra_client_id
+        },
+        {
+          name  = "IDP_GROUP_FILTER_PREFIX"
+          value = var.idp_group_filter_prefix
         },
         # Okta configuration
         {

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -510,6 +510,12 @@ variable "entra_client_secret" {
   sensitive   = true
 }
 
+variable "idp_group_filter_prefix" {
+  description = "Comma-separated list of prefixes to filter IdP groups in IAM > Groups page (e.g., 'mcp-,registry-'). Applies to all identity providers."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # OKTA CONFIGURATION
 # =============================================================================

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -415,6 +415,13 @@ registry_api_token = "m3zT65wREARMVDToKosg_DgNkKqS_434hNxy3sslGPY"
 #   - Azure Germany: https://login.microsoftonline.de
 # entra_login_base_url = "https://login.microsoftonline.com"
 
+# IdP Group Filter Prefix (optional, comma-separated, applies to all identity providers)
+# Only groups whose name starts with any of these prefixes are shown in IAM > Groups
+# Example with single prefix:
+# idp_group_filter_prefix = "mcp-"
+# Example with multiple prefixes:
+# idp_group_filter_prefix = "mcp-,registry-,ai-"
+
 # ============================================================================
 # OKTA CONFIGURATION (Alternative to Keycloak)
 # ============================================================================

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -441,6 +441,12 @@ variable "entra_client_secret" {
   sensitive   = true
 }
 
+variable "idp_group_filter_prefix" {
+  description = "Comma-separated list of prefixes to filter IdP groups in IAM > Groups page (e.g., 'mcp-,registry-'). Applies to all identity providers."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # OKTA CONFIGURATION
 # =============================================================================

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -594,6 +594,173 @@ class TestManagementCreateGroup:
 
 
 # =============================================================================
+# TEST POST /management/iam/groups - Create Group with create_in_idp flag
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestManagementCreateGroupCreateInIdp:
+    """Tests for create_in_idp flag handling in group creation."""
+
+    def test_create_group_with_create_in_idp_false(self, test_client_admin):
+        """When create_in_idp is False, group should only be created in MongoDB."""
+        # Arrange
+        client, mock_iam = test_client_admin
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_import_group,
+            patch("registry.api.management_routes.AUTH_PROVIDER", "entra"),
+        ):
+            # Act
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "local-only-group",
+                    "description": "Local only group",
+                    "scope_config": {"create_in_idp": False},
+                },
+            )
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == "local-only-group"
+
+            # IdP create_group should NOT have been called
+            mock_iam.create_group.assert_not_called()
+
+            # MongoDB scope should still be created with group name as mapping
+            mock_import_group.assert_called_once_with(
+                scope_name="local-only-group",
+                description="Local only group",
+                group_mappings=["local-only-group"],
+                server_access=[],
+                ui_permissions={},
+                agent_access=[],
+            )
+
+    def test_create_group_with_create_in_idp_true(self, test_client_admin):
+        """When create_in_idp is True, group should be created in both IdP and MongoDB."""
+        # Arrange
+        client, mock_iam = test_client_admin
+        entra_group_id = "12345678-1234-1234-1234-123456789abc"
+        mock_iam.create_group.return_value = {
+            "id": entra_group_id,
+            "name": "idp-group",
+            "path": "/idp-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_import_group,
+            patch("registry.api.management_routes.AUTH_PROVIDER", "entra"),
+        ):
+            # Act
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "idp-group",
+                    "description": "IdP group",
+                    "scope_config": {"create_in_idp": True},
+                },
+            )
+
+            # Assert
+            assert response.status_code == 200
+            data = response.json()
+            assert data["id"] == entra_group_id
+
+            # IdP create_group SHOULD have been called
+            mock_iam.create_group.assert_called_once_with(
+                group_name="idp-group",
+                description="IdP group",
+            )
+
+            # MongoDB scope created with Entra Object ID as mapping
+            mock_import_group.assert_called_once_with(
+                scope_name="idp-group",
+                description="IdP group",
+                group_mappings=[entra_group_id],
+                server_access=[],
+                ui_permissions={},
+                agent_access=[],
+            )
+
+    def test_create_group_default_creates_in_idp(self, test_client_admin):
+        """When create_in_idp not in scope_config, default to creating in IdP."""
+        # Arrange
+        client, mock_iam = test_client_admin
+        mock_iam.create_group.return_value = {
+            "id": "default-group-id",
+            "name": "default-group",
+            "path": "/default-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
+        ):
+            # Act
+            response = client.post(
+                "/api/management/iam/groups",
+                json={"name": "default-group"},
+            )
+
+            # Assert
+            assert response.status_code == 200
+            mock_iam.create_group.assert_called_once()
+
+
+# =============================================================================
+# TEST DELETE /management/iam/groups/{group_name} - Delete Group (with local-only)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestManagementDeleteGroupLocalOnly:
+    """Tests for deleting groups that only exist in MongoDB (local-only)."""
+
+    def test_delete_local_only_group_succeeds(self, test_client_admin):
+        """Delete succeeds when group only exists in MongoDB (IdP returns not found)."""
+        # Arrange
+        client, mock_iam = test_client_admin
+        mock_iam.delete_group.side_effect = Exception("Group 'local-group' not found")
+
+        with patch(
+            "registry.api.management_routes.scope_service.delete_group",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_delete_scope:
+            # Act
+            response = client.delete("/api/management/iam/groups/local-group")
+
+            # Assert - should succeed because IdP "not found" is handled gracefully
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == "local-group"
+
+            # MongoDB deletion should still proceed
+            mock_delete_scope.assert_called_once_with(
+                group_name="local-group", remove_from_mappings=True
+            )
+
+
+# =============================================================================
 # TEST DELETE /management/iam/groups/{group_name} - Delete Group
 # =============================================================================
 
@@ -640,18 +807,29 @@ class TestManagementDeleteGroup:
         assert response.status_code == 403
         assert "Administrator permissions" in response.json()["detail"]
 
-    def test_delete_group_not_found(self, test_client_admin):
-        """Test error handling when group is not found."""
+    def test_delete_group_not_found_in_idp_still_deletes_from_mongodb(self, test_client_admin):
+        """Test that IdP 'not found' is handled gracefully (local-only group delete)."""
         # Arrange
         client, mock_iam = test_client_admin
         mock_iam.delete_group.side_effect = Exception("Group 'nonexistent' not found")
 
-        # Act
-        response = client.delete("/api/management/iam/groups/nonexistent")
+        with patch(
+            "registry.api.management_routes.scope_service.delete_group",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_delete_scope:
+            # Act
+            response = client.delete("/api/management/iam/groups/nonexistent")
 
-        # Assert
-        assert response.status_code == 404
-        assert "not found" in response.json()["detail"]
+            # Assert - should succeed because IdP "not found" is handled gracefully
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == "nonexistent"
+
+            # MongoDB deletion should still proceed
+            mock_delete_scope.assert_called_once_with(
+                group_name="nonexistent", remove_from_mappings=True
+            )
 
     def test_delete_group_iam_error(self, test_client_admin):
         """Test error handling when IAM manager fails."""

--- a/tests/unit/test_entra_manager.py
+++ b/tests/unit/test_entra_manager.py
@@ -20,6 +20,7 @@ import pytest
 
 from registry.utils.entra_manager import (
     EntraAdminError,
+    _build_prefix_odata_filter,
     _generate_temp_password,
     _is_guid,
     create_entra_group,
@@ -935,3 +936,239 @@ class TestListEntraGroups:
 
         # Assert
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_groups_with_single_prefix(
+        self,
+        entra_env_vars,
+        mock_token_response: dict[str, Any],
+    ):
+        """Test that $filter is added when single prefix is configured."""
+        # Arrange
+        mock_token_resp = MagicMock()
+        mock_token_resp.status_code = 200
+        mock_token_resp.raise_for_status.return_value = None
+        mock_token_resp.json.return_value = mock_token_response
+
+        mock_groups_resp = MagicMock()
+        mock_groups_resp.status_code = 200
+        mock_groups_resp.raise_for_status.return_value = None
+        mock_groups_resp.json.return_value = {"value": []}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_token_resp
+        mock_client.get.return_value = mock_groups_resp
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        # Act
+        with (
+            patch("registry.utils.entra_manager.httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "registry.utils.iam_manager.IDP_GROUP_FILTER_PREFIXES",
+                ["mcp-"],
+            ),
+        ):
+            await list_entra_groups()
+
+        # Assert - verify $filter was passed in params
+        call_args = mock_client.get.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "$filter" in params
+        assert params["$filter"] == "startswith(displayName,'mcp-')"
+
+    @pytest.mark.asyncio
+    async def test_list_groups_with_multiple_prefixes(
+        self,
+        entra_env_vars,
+        mock_token_response: dict[str, Any],
+    ):
+        """Test that $filter uses or-joined startswith for multiple prefixes."""
+        # Arrange
+        mock_token_resp = MagicMock()
+        mock_token_resp.status_code = 200
+        mock_token_resp.raise_for_status.return_value = None
+        mock_token_resp.json.return_value = mock_token_response
+
+        mock_groups_resp = MagicMock()
+        mock_groups_resp.status_code = 200
+        mock_groups_resp.raise_for_status.return_value = None
+        mock_groups_resp.json.return_value = {"value": []}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_token_resp
+        mock_client.get.return_value = mock_groups_resp
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        # Act
+        with (
+            patch("registry.utils.entra_manager.httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "registry.utils.iam_manager.IDP_GROUP_FILTER_PREFIXES",
+                ["mcp-", "registry-", "ai-"],
+            ),
+        ):
+            await list_entra_groups()
+
+        # Assert - verify $filter has or-joined conditions
+        call_args = mock_client.get.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "$filter" in params
+        expected_filter = (
+            "startswith(displayName,'mcp-') or "
+            "startswith(displayName,'registry-') or "
+            "startswith(displayName,'ai-')"
+        )
+        assert params["$filter"] == expected_filter
+
+    @pytest.mark.asyncio
+    async def test_list_groups_without_prefix_no_filter(
+        self,
+        entra_env_vars,
+        mock_token_response: dict[str, Any],
+    ):
+        """Test that no $filter is added when no prefix is configured."""
+        # Arrange
+        mock_token_resp = MagicMock()
+        mock_token_resp.status_code = 200
+        mock_token_resp.raise_for_status.return_value = None
+        mock_token_resp.json.return_value = mock_token_response
+
+        mock_groups_resp = MagicMock()
+        mock_groups_resp.status_code = 200
+        mock_groups_resp.raise_for_status.return_value = None
+        mock_groups_resp.json.return_value = {"value": []}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_token_resp
+        mock_client.get.return_value = mock_groups_resp
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+
+        # Act
+        with (
+            patch("registry.utils.entra_manager.httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "registry.utils.iam_manager.IDP_GROUP_FILTER_PREFIXES",
+                [],
+            ),
+        ):
+            await list_entra_groups()
+
+        # Assert - no $filter param when prefix list is empty
+        call_args = mock_client.get.call_args
+        params = call_args.kwargs.get("params", {})
+        assert "$filter" not in params
+
+
+# =============================================================================
+# TEST: _build_prefix_odata_filter()
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestBuildPrefixOdataFilter:
+    """Tests for _build_prefix_odata_filter helper function."""
+
+    def test_single_prefix(self):
+        """Test OData filter for a single prefix."""
+        # Act
+        result = _build_prefix_odata_filter(["mcp-"])
+
+        # Assert
+        assert result == "startswith(displayName,'mcp-')"
+
+    def test_multiple_prefixes(self):
+        """Test OData filter with or-joined conditions for multiple prefixes."""
+        # Act
+        result = _build_prefix_odata_filter(["mcp-", "registry-", "ai-"])
+
+        # Assert
+        expected = (
+            "startswith(displayName,'mcp-') or "
+            "startswith(displayName,'registry-') or "
+            "startswith(displayName,'ai-')"
+        )
+        assert result == expected
+
+    def test_two_prefixes(self):
+        """Test OData filter with exactly two prefixes."""
+        # Act
+        result = _build_prefix_odata_filter(["dev-", "staging-"])
+
+        # Assert
+        expected = "startswith(displayName,'dev-') or startswith(displayName,'staging-')"
+        assert result == expected
+
+
+# =============================================================================
+# TEST: IDP_GROUP_FILTER_PREFIX validation
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPrefixValidation:
+    """Tests for IDP_GROUP_FILTER_PREFIX parsing and validation."""
+
+    def test_valid_single_prefix_parsing(self):
+        """Test that a single prefix is parsed correctly."""
+        # Arrange
+        raw = "mcp-"
+        prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+
+        # Assert
+        assert prefixes == ["mcp-"]
+
+    def test_valid_multiple_prefixes_parsing(self):
+        """Test that comma-separated prefixes are parsed correctly."""
+        # Arrange
+        raw = "mcp-,registry-,ai-"
+        prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+
+        # Assert
+        assert prefixes == ["mcp-", "registry-", "ai-"]
+
+    def test_whitespace_trimming(self):
+        """Test that whitespace around prefixes is trimmed."""
+        # Arrange
+        raw = " mcp- , registry- , ai- "
+        prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+
+        # Assert
+        assert prefixes == ["mcp-", "registry-", "ai-"]
+
+    def test_empty_entries_skipped(self):
+        """Test that empty entries from trailing commas are skipped."""
+        # Arrange
+        raw = "mcp-,,registry-,"
+        prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+
+        # Assert
+        assert prefixes == ["mcp-", "registry-"]
+
+    def test_empty_string_gives_empty_list(self):
+        """Test that empty string gives empty list."""
+        # Arrange
+        raw = ""
+        prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+
+        # Assert
+        assert prefixes == []
+
+    def test_valid_prefix_characters(self):
+        """Test that valid prefixes pass regex validation."""
+        import re
+
+        valid_prefixes = ["mcp-", "registry_groups", "AI Teams", "test123"]
+        for prefix in valid_prefixes:
+            assert re.match(r"^[a-zA-Z0-9\-_ ]+$", prefix), (
+                f"Prefix '{prefix}' should be valid"
+            )
+
+    def test_invalid_prefix_with_single_quote(self):
+        """Test that single quotes are rejected (OData injection prevention)."""
+        import re
+
+        invalid_prefix = "mcp-') or (1 eq 1) or startswith(displayName,'"
+        assert not re.match(r"^[a-zA-Z0-9\-_ ]+$", invalid_prefix)


### PR DESCRIPTION
## Summary
- **Bug 1**: `management_create_group` now respects `create_in_idp` toggle from `scope_config`, allowing local-only group creation without calling the IdP
- **Bug 1b**: `management_delete_group` gracefully handles local-only groups not present in the IdP, proceeding with MongoDB deletion instead of returning 404
- **Bug 2**: `registry_client` now always sends `create_in_idp` value (previously only sent when `True`)
- **Bug 3**: Add `IDP_GROUP_FILTER_PREFIX` env var for prefix-based group filtering across all identity providers. Entra uses server-side OData `$filter`; Keycloak, Okta, and Auth0 use client-side filtering. When unset, all groups are shown.
- Infrastructure: wired `IDP_GROUP_FILTER_PREFIX` through docker-compose, Helm charts (registry), and Terraform ECS task definitions (auth-server + registry)

## Changed files
- `registry/api/management_routes.py` - create_in_idp conditional, graceful delete for local-only groups
- `registry/utils/iam_manager.py` - IDP_GROUP_FILTER_PREFIX parsing, validation, `_filter_groups_by_prefix()` helper, client-side filtering in Keycloak/Okta/Auth0 managers
- `registry/utils/entra_manager.py` - `_build_prefix_odata_filter()` for server-side Entra filtering
- `api/registry_client.py` - always send create_in_idp value
- `docker-compose.yml` - add IDP_GROUP_FILTER_PREFIX env var to registry and auth-server
- `charts/registry/` - add idpGroupFilterPrefix to values and deployment template
- `charts/mcp-gateway-registry-stack/values.yaml` - add idpGroupFilterPrefix, fix duplicate tenantId
- `terraform/aws-ecs/` - add idp_group_filter_prefix variable and wire to ECS tasks
- `.env.example` - document IDP_GROUP_FILTER_PREFIX

## Test plan
- [x] Unit tests for create_in_idp=False (no IdP call, MongoDB-only creation)
- [x] Unit tests for create_in_idp=True (IdP + MongoDB creation)
- [x] Unit test for deleting local-only group (IdP 404 handled gracefully)
- [x] Unit tests for OData filter building (single/multiple prefixes)
- [x] Unit tests for prefix validation (valid chars, rejection of special chars)
- [x] Unit tests for list_groups with prefix filtering (single, multiple, none)
- [x] Full test suite: 2144 passed, 67 skipped, 1 pre-existing failure (unrelated)
- [x] Manual test: set IDP_GROUP_FILTER_PREFIX in .env, verified filtering in UI

Closes #780