### PR TITLE
feat: Support authenticated GitHub access for SKILL.md fetching (private repos)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -347,6 +347,10 @@ GITHUB_ENABLED=false
 # Auth headers are sent ONLY to github.com, raw.githubusercontent.com, and hosts listed here
 # GITHUB_EXTRA_HOSTS=github.mycompany.com,raw.github.mycompany.com
 
+# GitHub API base URL (default: https://api.github.com)
+# For GitHub Enterprise Server, use: https://github.mycompany.com/api/v3
+# GITHUB_API_BASE_URL=https://api.github.com
+
 # =============================================================================
 # GOOGLE OAUTH2 CONFIGURATION
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -325,6 +325,29 @@ GITHUB_CLIENT_SECRET=your_github_client_secret_here
 GITHUB_ENABLED=false
 
 # =============================================================================
+# GITHUB PRIVATE REPOSITORY ACCESS (SKILL.md fetching)
+# =============================================================================
+# Enable authenticated access to SKILL.md files in private GitHub repositories.
+# Two options: Personal Access Token (simple) or GitHub App (enterprise).
+# If both are configured, GitHub App takes priority.
+
+# Option 1: Personal Access Token
+# Generate at https://github.com/settings/tokens with 'repo' scope
+# Fine-grained PATs: scope to 'contents: read' on specific repos
+# GITHUB_PAT=ghp_your_token_here
+
+# Option 2: GitHub App (recommended for organizations)
+# Create at https://github.com/settings/apps
+# Required permissions: Contents (read-only)
+# GITHUB_APP_ID=123456
+# GITHUB_APP_INSTALLATION_ID=78901234
+# GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+
+# Extra GitHub hosts for enterprise instances (comma-separated)
+# Auth headers are sent ONLY to github.com, raw.githubusercontent.com, and hosts listed here
+# GITHUB_EXTRA_HOSTS=github.mycompany.com,raw.github.mycompany.com
+
+# =============================================================================
 # GOOGLE OAUTH2 CONFIGURATION
 # =============================================================================
 

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -51,6 +51,7 @@ from ..services.skill_service import (
 )
 from ..services.tool_validation_service import get_tool_validation_service
 from ..utils.path_utils import normalize_skill_path
+from ..services.github_auth import GitHubAuthProvider
 
 # Configure logging
 logging.basicConfig(
@@ -58,6 +59,9 @@ logging.basicConfig(
     format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# GitHub auth provider for private repository access
+_github_auth = GitHubAuthProvider()
 
 
 class RatingRequest(BaseModel):
@@ -314,7 +318,8 @@ async def get_skill_content(
         import httpx
 
         async with httpx.AsyncClient() as client:
-            response = await client.get(str(raw_url), follow_redirects=True, timeout=30.0)
+            headers = await _github_auth.get_auth_headers(str(raw_url))
+            response = await client.get(str(raw_url), headers=headers, follow_redirects=True, timeout=30.0)
 
             # SSRF protection: validate final URL after redirects
             final_url = str(response.url)

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -51,7 +51,7 @@ from ..services.skill_service import (
 )
 from ..services.tool_validation_service import get_tool_validation_service
 from ..utils.path_utils import normalize_skill_path
-from ..services.github_auth import GitHubAuthProvider
+from ..services.github_auth import github_auth_provider as _github_auth
 
 # Configure logging
 logging.basicConfig(
@@ -59,9 +59,6 @@ logging.basicConfig(
     format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 logger = logging.getLogger(__name__)
-
-# GitHub auth provider for private repository access
-_github_auth = GitHubAuthProvider()
 
 
 class RatingRequest(BaseModel):

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -120,6 +120,28 @@ class Settings(BaseSettings):
     skill_scanner_virustotal_api_key: str = ""  # Optional VirusTotal API key
     skill_scanner_ai_defense_api_key: str = ""  # Optional Cisco AI Defense API key
 
+    # GitHub Private Repository Access (SKILL.md fetching)
+    github_pat: str = Field(
+        default="",
+        description="GitHub Personal Access Token for private repo SKILL.md access",
+    )
+    github_app_id: str = Field(
+        default="",
+        description="GitHub App ID for installation-based auth",
+    )
+    github_app_installation_id: str = Field(
+        default="",
+        description="GitHub App Installation ID",
+    )
+    github_app_private_key: str = Field(
+        default="",
+        description="GitHub App private key (PEM format, newlines as \\n)",
+    )
+    github_extra_hosts: str = Field(
+        default="",
+        description="Comma-separated extra GitHub hosts for auth (e.g. github.mycompany.com,raw.github.mycompany.com)",
+    )
+
     # Federation settings
     registry_id: str | None = None  # Unique identifier for this registry instance in federation
     federation_static_token_auth_enabled: bool = False  # Enable federation static token auth

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -141,6 +141,10 @@ class Settings(BaseSettings):
         default="",
         description="Comma-separated extra GitHub hosts for auth (e.g. github.mycompany.com,raw.github.mycompany.com)",
     )
+    github_api_base_url: str = Field(
+        default="https://api.github.com",
+        description="GitHub API base URL for App token exchange (for GHES: https://github.mycompany.com/api/v3)",
+    )
 
     # Federation settings
     registry_id: str | None = None  # Unique identifier for this registry instance in federation

--- a/registry/services/github_auth.py
+++ b/registry/services/github_auth.py
@@ -114,7 +114,9 @@ class GitHubAuthProvider:
             "exp": now + 600,
             "iss": settings.github_app_id,
         }
-        return jwt.encode(payload, settings.github_app_private_key, algorithm="RS256")
+        # Handle PEM key from env vars where newlines may be literal \n strings
+        private_key = settings.github_app_private_key.replace("\\n", "\n")
+        return jwt.encode(payload, private_key, algorithm="RS256")
 
     async def _get_github_app_token(self) -> str | None:
         """Get or refresh cached GitHub App installation token.
@@ -151,9 +153,24 @@ class GitHubAuthProvider:
                 return None
 
             data = response.json()
-            self._cached_token = data.get("token")
-            # Cache for 1 hour (GitHub's token lifetime)
-            self._token_expires_at = time.time() + 3600
+            token = data.get("token")
+            if not token:
+                logger.error("GitHub App token response missing 'token' field")
+                return None
+
+            self._cached_token = token
+
+            # Parse expiry from response, fall back to 1 hour
+            expires_at = data.get("expires_at")
+            if expires_at:
+                from datetime import UTC, datetime
+                try:
+                    expiry_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                    self._token_expires_at = expiry_dt.timestamp()
+                except ValueError:
+                    self._token_expires_at = time.time() + 3600
+            else:
+                self._token_expires_at = time.time() + 3600
 
             logger.debug("GitHub App installation token refreshed successfully")
             return self._cached_token

--- a/registry/services/github_auth.py
+++ b/registry/services/github_auth.py
@@ -10,7 +10,7 @@ Auth headers are only sent to explicitly allowed hosts.
 import asyncio
 import logging
 import time
-from datetime import UTC, datetime
+from datetime import datetime
 from urllib.parse import urlparse
 
 import httpx
@@ -46,6 +46,7 @@ class GitHubAuthProvider:
         self._allowed_hosts = self._build_allowed_hosts()
         self._cached_token: str | None = None
         self._token_expires_at: float = 0.0
+        self._failure_retry_after: float = 0.0
         self._token_lock = asyncio.Lock()
         self._log_active_tier()
 
@@ -61,7 +62,10 @@ class GitHubAuthProvider:
         """Check if URL hostname is in the allowed GitHub hosts set."""
         parsed = urlparse(url)
         hostname = (parsed.hostname or "").lower()
-        return hostname in self._allowed_hosts
+        allowed = hostname in self._allowed_hosts
+        if not allowed:
+            logger.debug("GitHub auth: host '%s' not in allowed hosts, skipping auth", hostname)
+        return allowed
 
     def _log_active_tier(self) -> None:
         """Log which auth tier is active at initialization."""
@@ -123,9 +127,15 @@ class GitHubAuthProvider:
 
     async def _get_github_app_token(self) -> str | None:
         """Get or refresh cached GitHub App installation token."""
+        now = time.time()
+
         # Fast path: valid cache (no lock needed)
-        if self._cached_token and time.time() < self._token_expires_at - 300:
+        if self._cached_token and now < self._token_expires_at - 300:
             return self._cached_token
+
+        # Negative cache: avoid hammering GitHub API on sustained misconfiguration
+        if not self._cached_token and now < self._failure_retry_after:
+            return None
 
         async with self._token_lock:
             # Double-check after acquiring lock
@@ -135,9 +145,8 @@ class GitHubAuthProvider:
             try:
                 app_jwt = self._create_jwt()
                 installation_id = settings.github_app_installation_id
-                # NOTE: GitHub App token exchange always uses api.github.com.
-                # GitHub Enterprise Server requires a separate github_api_base_url config (future enhancement).
-                url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
+                base_url = settings.github_api_base_url.rstrip("/")
+                url = f"{base_url}/app/installations/{installation_id}/access_tokens"
 
                 async with httpx.AsyncClient() as client:
                     response = await client.post(
@@ -155,12 +164,14 @@ class GitHubAuthProvider:
                         response.status_code,
                         response.text[:200],
                     )
+                    self._failure_retry_after = time.time() + 60
                     return None
 
                 data = response.json()
                 token = data.get("token")
                 if not token:
                     logger.error("GitHub App token response missing 'token' field")
+                    self._failure_retry_after = time.time() + 60
                     return None
 
                 self._cached_token = token
@@ -181,6 +192,7 @@ class GitHubAuthProvider:
 
             except (httpx.RequestError, KeyError, ValueError) as e:
                 logger.error("GitHub App token exchange error: %s", e)
+                self._failure_retry_after = time.time() + 60
                 return None
 
 

--- a/registry/services/github_auth.py
+++ b/registry/services/github_auth.py
@@ -7,8 +7,10 @@ Provides auth headers for httpx requests to GitHub, supporting:
 Auth headers are only sent to explicitly allowed hosts.
 """
 
+import asyncio
 import logging
 import time
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 
 import httpx
@@ -44,6 +46,7 @@ class GitHubAuthProvider:
         self._allowed_hosts = self._build_allowed_hosts()
         self._cached_token: str | None = None
         self._token_expires_at: float = 0.0
+        self._token_lock = asyncio.Lock()
         self._log_active_tier()
 
     def _build_allowed_hosts(self) -> frozenset[str]:
@@ -119,62 +122,67 @@ class GitHubAuthProvider:
         return jwt.encode(payload, private_key, algorithm="RS256")
 
     async def _get_github_app_token(self) -> str | None:
-        """Get or refresh cached GitHub App installation token.
-
-        1. Check in-memory cache (token + expiry timestamp)
-        2. If expired or missing: sign JWT, POST to GitHub API, cache result
-        3. Return token or None on failure
-        """
-        # Check cache (5-minute early expiry buffer)
+        """Get or refresh cached GitHub App installation token."""
+        # Fast path: valid cache (no lock needed)
         if self._cached_token and time.time() < self._token_expires_at - 300:
             return self._cached_token
 
-        try:
-            app_jwt = self._create_jwt()
-            installation_id = settings.github_app_installation_id
-            url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
+        async with self._token_lock:
+            # Double-check after acquiring lock
+            if self._cached_token and time.time() < self._token_expires_at - 300:
+                return self._cached_token
 
-            async with httpx.AsyncClient() as client:
-                response = await client.post(
-                    url,
-                    headers={
-                        "Authorization": f"Bearer {app_jwt}",
-                        "Accept": "application/vnd.github+json",
-                    },
-                    timeout=10,
-                )
+            try:
+                app_jwt = self._create_jwt()
+                installation_id = settings.github_app_installation_id
+                # NOTE: GitHub App token exchange always uses api.github.com.
+                # GitHub Enterprise Server requires a separate github_api_base_url config (future enhancement).
+                url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
 
-            if response.status_code != 201:
-                logger.error(
-                    "GitHub App token exchange failed: HTTP %d - %s",
-                    response.status_code,
-                    response.text[:200],
-                )
-                return None
+                async with httpx.AsyncClient() as client:
+                    response = await client.post(
+                        url,
+                        headers={
+                            "Authorization": f"Bearer {app_jwt}",
+                            "Accept": "application/vnd.github+json",
+                        },
+                        timeout=10,
+                    )
 
-            data = response.json()
-            token = data.get("token")
-            if not token:
-                logger.error("GitHub App token response missing 'token' field")
-                return None
+                if response.status_code != 201:
+                    logger.error(
+                        "GitHub App token exchange failed: HTTP %d - %s",
+                        response.status_code,
+                        response.text[:200],
+                    )
+                    return None
 
-            self._cached_token = token
+                data = response.json()
+                token = data.get("token")
+                if not token:
+                    logger.error("GitHub App token response missing 'token' field")
+                    return None
 
-            # Parse expiry from response, fall back to 1 hour
-            expires_at = data.get("expires_at")
-            if expires_at:
-                from datetime import UTC, datetime
-                try:
-                    expiry_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-                    self._token_expires_at = expiry_dt.timestamp()
-                except ValueError:
+                self._cached_token = token
+
+                # Parse expiry from response, fall back to 1 hour
+                expires_at = data.get("expires_at")
+                if expires_at:
+                    try:
+                        expiry_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                        self._token_expires_at = expiry_dt.timestamp()
+                    except ValueError:
+                        self._token_expires_at = time.time() + 3600
+                else:
                     self._token_expires_at = time.time() + 3600
-            else:
-                self._token_expires_at = time.time() + 3600
 
-            logger.debug("GitHub App installation token refreshed successfully")
-            return self._cached_token
+                logger.debug("GitHub App installation token refreshed successfully")
+                return self._cached_token
 
-        except (httpx.RequestError, KeyError, ValueError) as e:
-            logger.error("GitHub App token exchange error: %s", e)
-            return None
+            except (httpx.RequestError, KeyError, ValueError) as e:
+                logger.error("GitHub App token exchange error: %s", e)
+                return None
+
+
+# Module-level singleton -- shared across all consumers
+github_auth_provider = GitHubAuthProvider()

--- a/registry/services/github_auth.py
+++ b/registry/services/github_auth.py
@@ -1,0 +1,163 @@
+"""GitHub authentication provider for private repository access.
+
+Provides auth headers for httpx requests to GitHub, supporting:
+- Personal Access Token (PAT) -- static, user-scoped
+- GitHub App installation token -- ephemeral, org-scoped
+
+Auth headers are only sent to explicitly allowed hosts.
+"""
+
+import logging
+import time
+from urllib.parse import urlparse
+
+import httpx
+import jwt
+
+from ..core.config import settings
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Default GitHub hosts that receive auth headers
+_DEFAULT_GITHUB_HOSTS: frozenset[str] = frozenset({
+    "github.com",
+    "raw.githubusercontent.com",
+})
+
+
+class GitHubAuthProvider:
+    """Provides auth headers for GitHub API requests.
+
+    Supports two credential tiers with automatic fallback:
+    1. GitHub App (installation token, ephemeral, org-scoped)
+    2. Personal Access Token (static, user-scoped)
+
+    Auth headers are only sent to explicitly allowed hosts.
+    """
+
+    def __init__(self) -> None:
+        self._allowed_hosts = self._build_allowed_hosts()
+        self._cached_token: str | None = None
+        self._token_expires_at: float = 0.0
+        self._log_active_tier()
+
+    def _build_allowed_hosts(self) -> frozenset[str]:
+        """Build allowed hosts from defaults + github_extra_hosts config."""
+        extra_raw = settings.github_extra_hosts
+        extra = frozenset(
+            h.strip().lower() for h in extra_raw.split(",") if h.strip()
+        )
+        return _DEFAULT_GITHUB_HOSTS | extra
+
+    def _is_allowed_host(self, url: str) -> bool:
+        """Check if URL hostname is in the allowed GitHub hosts set."""
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").lower()
+        return hostname in self._allowed_hosts
+
+    def _log_active_tier(self) -> None:
+        """Log which auth tier is active at initialization."""
+        if self._has_app_credentials():
+            logger.info("GitHub auth: GitHub App credentials configured")
+        elif settings.github_pat:
+            logger.info("GitHub auth: Personal Access Token configured")
+        else:
+            logger.info("GitHub auth: No credentials configured (unauthenticated access)")
+
+    def _has_app_credentials(self) -> bool:
+        """Check if all GitHub App credentials are present."""
+        return bool(
+            settings.github_app_id
+            and settings.github_app_installation_id
+            and settings.github_app_private_key
+        )
+
+    async def get_auth_headers(self, url: str) -> dict[str, str]:
+        """Return auth headers if url matches an allowed GitHub host.
+
+        Returns empty dict if:
+        - URL host is not in the allowed hosts set
+        - No credentials are configured
+        - Token exchange fails (logged, falls back gracefully)
+        """
+        if not self._is_allowed_host(url):
+            return {}
+
+        # Tier 2: GitHub App
+        if self._has_app_credentials():
+            token = await self._get_github_app_token()
+            if token:
+                return {"Authorization": f"Bearer {token}"}
+            logger.warning("GitHub App token exchange failed, falling back to PAT")
+
+        # Tier 1: PAT
+        if settings.github_pat:
+            return {"Authorization": f"Bearer {settings.github_pat}"}
+
+        # Tier 0: Unauthenticated
+        return {}
+
+    def _create_jwt(self) -> str:
+        """Create signed JWT for GitHub App authentication.
+
+        Uses RS256 algorithm per GitHub's requirements.
+        Claims: iat (now - 60s for clock skew), exp (now + 600s), iss (app_id).
+        """
+        now = int(time.time())
+        payload = {
+            "iat": now - 60,
+            "exp": now + 600,
+            "iss": settings.github_app_id,
+        }
+        return jwt.encode(payload, settings.github_app_private_key, algorithm="RS256")
+
+    async def _get_github_app_token(self) -> str | None:
+        """Get or refresh cached GitHub App installation token.
+
+        1. Check in-memory cache (token + expiry timestamp)
+        2. If expired or missing: sign JWT, POST to GitHub API, cache result
+        3. Return token or None on failure
+        """
+        # Check cache (5-minute early expiry buffer)
+        if self._cached_token and time.time() < self._token_expires_at - 300:
+            return self._cached_token
+
+        try:
+            app_jwt = self._create_jwt()
+            installation_id = settings.github_app_installation_id
+            url = f"https://api.github.com/app/installations/{installation_id}/access_tokens"
+
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {app_jwt}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                    timeout=10,
+                )
+
+            if response.status_code != 201:
+                logger.error(
+                    "GitHub App token exchange failed: HTTP %d - %s",
+                    response.status_code,
+                    response.text[:200],
+                )
+                return None
+
+            data = response.json()
+            self._cached_token = data.get("token")
+            # Cache for 1 hour (GitHub's token lifetime)
+            self._token_expires_at = time.time() + 3600
+
+            logger.debug("GitHub App installation token refreshed successfully")
+            return self._cached_token
+
+        except (httpx.RequestError, KeyError, ValueError) as e:
+            logger.error("GitHub App token exchange error: %s", e)
+            return None

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -39,7 +39,7 @@ from ..schemas.skill_models import (
 )
 from ..utils.path_utils import normalize_skill_path
 from ..utils.url_utils import translate_skill_url
-from .github_auth import GitHubAuthProvider
+from .github_auth import github_auth_provider as _github_auth
 
 # Configure logging
 logging.basicConfig(
@@ -47,9 +47,6 @@ logging.basicConfig(
     format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 logger = logging.getLogger(__name__)
-
-# GitHub auth provider for private repository access
-_github_auth = GitHubAuthProvider()
 
 # Constants
 URL_VALIDATION_TIMEOUT: int = 10

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -48,6 +48,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+
 # Constants
 URL_VALIDATION_TIMEOUT: int = 10
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -39,6 +39,7 @@ from ..schemas.skill_models import (
 )
 from ..utils.path_utils import normalize_skill_path
 from ..utils.url_utils import translate_skill_url
+from .github_auth import GitHubAuthProvider
 
 # Configure logging
 logging.basicConfig(
@@ -47,6 +48,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+# GitHub auth provider for private repository access
+_github_auth = GitHubAuthProvider()
 
 # Constants
 URL_VALIDATION_TIMEOUT: int = 10
@@ -183,8 +186,9 @@ async def _validate_skill_md_url(
 
     try:
         async with httpx.AsyncClient() as client:
+            headers = await _github_auth.get_auth_headers(str(url))
             response = await client.get(
-                str(url), follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                str(url), headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
 
             # SSRF protection: validate final URL after redirects
@@ -256,9 +260,10 @@ async def _parse_skill_md_content(
 
     try:
         async with httpx.AsyncClient() as client:
-            # Fetch from raw URL
+            # Fetch from raw URL with GitHub auth if applicable
+            headers = await _github_auth.get_auth_headers(raw_url_str)
             response = await client.get(
-                raw_url_str, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                raw_url_str, headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
 
             # SSRF protection: validate final URL after redirects
@@ -425,8 +430,9 @@ async def _check_skill_health(
 
     try:
         async with httpx.AsyncClient() as client:
+            headers = await _github_auth.get_auth_headers(str(url))
             response = await client.head(
-                str(url), follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                str(url), headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
 
             # SSRF protection: validate final URL after redirects

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -199,3 +199,158 @@ class TestJWTCreation:
 
         header = jwt.get_unverified_header(token)
         assert header["alg"] == "RS256"
+
+
+class TestTokenExchange:
+    """Tests for GitHub App token exchange and caching."""
+
+    @patch("registry.services.github_auth.settings")
+    async def test_successful_token_exchange(self, mock_settings):
+        """Successful token exchange returns bearer header."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = "ghp_fallback"
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"token": "ghs_installation_token_abc"}
+
+        with patch("registry.services.github_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            headers = await provider.get_auth_headers("https://github.com/owner/repo")
+            assert headers == {"Authorization": "Bearer ghs_installation_token_abc"}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_cached_token_reused(self, mock_settings):
+        """Second call within TTL reuses cached token."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"token": "ghs_cached_token"}
+
+        with patch("registry.services.github_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            # First call -- fetches token
+            headers1 = await provider.get_auth_headers("https://github.com/owner/repo")
+            # Second call -- should reuse cache, no new POST
+            headers2 = await provider.get_auth_headers("https://github.com/owner/repo")
+
+            assert headers1 == {"Authorization": "Bearer ghs_cached_token"}
+            assert headers2 == {"Authorization": "Bearer ghs_cached_token"}
+            # POST should only be called once
+            assert mock_client.post.call_count == 1
+
+    @patch("registry.services.github_auth.settings")
+    async def test_exchange_failure_falls_back_to_pat(self, mock_settings):
+        """Failed token exchange falls back to PAT."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = "ghp_fallback_token"
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Bad credentials"
+
+        with patch("registry.services.github_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            headers = await provider.get_auth_headers("https://github.com/owner/repo")
+            assert headers == {"Authorization": "Bearer ghp_fallback_token"}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_exchange_failure_no_pat_returns_empty(self, mock_settings):
+        """Failed token exchange with no PAT returns empty headers."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+
+        with patch("registry.services.github_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = httpx.ConnectError("Connection refused")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            headers = await provider.get_auth_headers("https://github.com/owner/repo")
+            assert headers == {}

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -1,0 +1,71 @@
+"""Unit tests for GitHubAuthProvider."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestDomainMatching:
+    """Tests for _is_allowed_host and host allowlist logic."""
+
+    def test_github_com_is_allowed(self):
+        """Public github.com is allowed by default."""
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host("https://github.com/owner/repo") is True
+
+    def test_raw_githubusercontent_is_allowed(self):
+        """raw.githubusercontent.com is allowed by default."""
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host(
+            "https://raw.githubusercontent.com/owner/repo/main/SKILL.md"
+        ) is True
+
+    def test_non_github_host_is_not_allowed(self):
+        """Non-GitHub hosts are rejected."""
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host("https://gitlab.com/owner/repo") is False
+
+    def test_case_insensitive_matching(self):
+        """Host matching is case-insensitive."""
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host("https://GitHub.COM/owner/repo") is True
+
+    @patch("registry.services.github_auth.settings")
+    def test_extra_hosts_from_config(self, mock_settings):
+        """Extra hosts from config are included in allowlist."""
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = "github.mycompany.com,raw.github.mycompany.com"
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host("https://github.mycompany.com/org/repo") is True
+        assert provider._is_allowed_host(
+            "https://raw.github.mycompany.com/org/repo/main/f"
+        ) is True
+
+    @patch("registry.services.github_auth.settings")
+    def test_empty_extra_hosts(self, mock_settings):
+        """Empty extra hosts config doesn't break anything."""
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        assert provider._is_allowed_host("https://github.com/owner/repo") is True
+        assert provider._is_allowed_host("https://example.com/foo") is False

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-import pytest
-
 
 class TestDomainMatching:
     """Tests for _is_allowed_host and host allowlist logic."""
@@ -69,3 +67,69 @@ class TestDomainMatching:
         provider = GitHubAuthProvider()
         assert provider._is_allowed_host("https://github.com/owner/repo") is True
         assert provider._is_allowed_host("https://example.com/foo") is False
+
+
+class TestPATAuth:
+    """Tests for Personal Access Token authentication."""
+
+    @patch("registry.services.github_auth.settings")
+    async def test_pat_returns_bearer_header(self, mock_settings):
+        """PAT produces Authorization: Bearer header."""
+        mock_settings.github_pat = "ghp_test_token_123"
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        headers = await provider.get_auth_headers("https://github.com/owner/repo")
+        assert headers == {"Authorization": "Bearer ghp_test_token_123"}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_no_credentials_returns_empty(self, mock_settings):
+        """No credentials configured returns empty headers."""
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        headers = await provider.get_auth_headers("https://github.com/owner/repo")
+        assert headers == {}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_non_github_host_returns_empty_even_with_pat(self, mock_settings):
+        """PAT is not sent to non-GitHub hosts."""
+        mock_settings.github_pat = "ghp_test_token_123"
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        headers = await provider.get_auth_headers("https://gitlab.com/owner/repo")
+        assert headers == {}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_pat_works_with_raw_githubusercontent(self, mock_settings):
+        """PAT is sent to raw.githubusercontent.com."""
+        mock_settings.github_pat = "ghp_test_token_123"
+        mock_settings.github_app_id = ""
+        mock_settings.github_app_installation_id = ""
+        mock_settings.github_app_private_key = ""
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        headers = await provider.get_auth_headers(
+            "https://raw.githubusercontent.com/owner/repo/main/SKILL.md"
+        )
+        assert headers == {"Authorization": "Bearer ghp_test_token_123"}

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -1,6 +1,9 @@
 """Unit tests for GitHubAuthProvider."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import jwt
 
 
 class TestDomainMatching:
@@ -133,3 +136,66 @@ class TestPATAuth:
             "https://raw.githubusercontent.com/owner/repo/main/SKILL.md"
         )
         assert headers == {"Authorization": "Bearer ghp_test_token_123"}
+
+
+class TestJWTCreation:
+    """Tests for GitHub App JWT creation."""
+
+    @patch("registry.services.github_auth.settings")
+    def test_jwt_has_correct_claims(self, mock_settings):
+        """JWT contains iat, exp, iss claims."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        token = provider._create_jwt()
+
+        # Decode without verification to check claims
+        claims = jwt.decode(token, options={"verify_signature": False})
+        assert claims["iss"] == "12345"
+        assert "iat" in claims
+        assert "exp" in claims
+        # exp should be ~10 minutes after iat
+        assert claims["exp"] - claims["iat"] <= 660  # 10 min + 60s skew
+
+    @patch("registry.services.github_auth.settings")
+    def test_jwt_uses_rs256(self, mock_settings):
+        """JWT is signed with RS256 algorithm."""
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        pem = private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        mock_settings.github_pat = ""
+        mock_settings.github_app_id = "12345"
+        mock_settings.github_app_installation_id = "67890"
+        mock_settings.github_app_private_key = pem
+        mock_settings.github_extra_hosts = ""
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+        token = provider._create_jwt()
+
+        header = jwt.get_unverified_header(token)
+        assert header["alg"] == "RS256"

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -4,6 +4,30 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture()
+def rsa_private_key_pem() -> str:
+    """Generate a fresh RSA private key in PEM format for testing."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _mock_app_settings(mock_settings, pem: str, pat: str = "") -> None:
+    """Configure mock_settings for GitHub App auth tests."""
+    mock_settings.github_pat = pat
+    mock_settings.github_app_id = "12345"
+    mock_settings.github_app_installation_id = "67890"
+    mock_settings.github_app_private_key = pem
+    mock_settings.github_extra_hosts = ""
+    mock_settings.github_api_base_url = "https://api.github.com"
 
 
 class TestDomainMatching:
@@ -142,55 +166,25 @@ class TestJWTCreation:
     """Tests for GitHub App JWT creation."""
 
     @patch("registry.services.github_auth.settings")
-    def test_jwt_has_correct_claims(self, mock_settings):
+    def test_jwt_has_correct_claims(self, mock_settings, rsa_private_key_pem):
         """JWT contains iat, exp, iss claims."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = ""
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem)
 
         from registry.services.github_auth import GitHubAuthProvider
 
         provider = GitHubAuthProvider()
         token = provider._create_jwt()
 
-        # Decode without verification to check claims
         claims = jwt.decode(token, options={"verify_signature": False})
         assert claims["iss"] == "12345"
         assert "iat" in claims
         assert "exp" in claims
-        # exp should be ~10 minutes after iat
-        assert claims["exp"] - claims["iat"] <= 660  # 10 min + 60s skew
+        assert claims["exp"] - claims["iat"] <= 660
 
     @patch("registry.services.github_auth.settings")
-    def test_jwt_uses_rs256(self, mock_settings):
+    def test_jwt_uses_rs256(self, mock_settings, rsa_private_key_pem):
         """JWT is signed with RS256 algorithm."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = ""
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem)
 
         from registry.services.github_auth import GitHubAuthProvider
 
@@ -205,23 +199,9 @@ class TestTokenExchange:
     """Tests for GitHub App token exchange and caching."""
 
     @patch("registry.services.github_auth.settings")
-    async def test_successful_token_exchange(self, mock_settings):
+    async def test_successful_token_exchange(self, mock_settings, rsa_private_key_pem):
         """Successful token exchange returns bearer header."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = "ghp_fallback"
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem, pat="ghp_fallback")
 
         from registry.services.github_auth import GitHubAuthProvider
 
@@ -242,23 +222,9 @@ class TestTokenExchange:
             assert headers == {"Authorization": "Bearer ghs_installation_token_abc"}
 
     @patch("registry.services.github_auth.settings")
-    async def test_cached_token_reused(self, mock_settings):
+    async def test_cached_token_reused(self, mock_settings, rsa_private_key_pem):
         """Second call within TTL reuses cached token."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = ""
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem)
 
         from registry.services.github_auth import GitHubAuthProvider
 
@@ -275,34 +241,17 @@ class TestTokenExchange:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            # First call -- fetches token
             headers1 = await provider.get_auth_headers("https://github.com/owner/repo")
-            # Second call -- should reuse cache, no new POST
             headers2 = await provider.get_auth_headers("https://github.com/owner/repo")
 
             assert headers1 == {"Authorization": "Bearer ghs_cached_token"}
             assert headers2 == {"Authorization": "Bearer ghs_cached_token"}
-            # POST should only be called once
             assert mock_client.post.call_count == 1
 
     @patch("registry.services.github_auth.settings")
-    async def test_exchange_failure_falls_back_to_pat(self, mock_settings):
+    async def test_exchange_failure_falls_back_to_pat(self, mock_settings, rsa_private_key_pem):
         """Failed token exchange falls back to PAT."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = "ghp_fallback_token"
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem, pat="ghp_fallback_token")
 
         from registry.services.github_auth import GitHubAuthProvider
 
@@ -323,23 +272,9 @@ class TestTokenExchange:
             assert headers == {"Authorization": "Bearer ghp_fallback_token"}
 
     @patch("registry.services.github_auth.settings")
-    async def test_exchange_failure_no_pat_returns_empty(self, mock_settings):
+    async def test_exchange_failure_no_pat_returns_empty(self, mock_settings, rsa_private_key_pem):
         """Failed token exchange with no PAT returns empty headers."""
-        from cryptography.hazmat.primitives import serialization
-        from cryptography.hazmat.primitives.asymmetric import rsa
-
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-        pem = private_key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.PKCS8,
-            serialization.NoEncryption(),
-        ).decode()
-
-        mock_settings.github_pat = ""
-        mock_settings.github_app_id = "12345"
-        mock_settings.github_app_installation_id = "67890"
-        mock_settings.github_app_private_key = pem
-        mock_settings.github_extra_hosts = ""
+        _mock_app_settings(mock_settings, rsa_private_key_pem)
 
         from registry.services.github_auth import GitHubAuthProvider
 
@@ -354,3 +289,41 @@ class TestTokenExchange:
 
             headers = await provider.get_auth_headers("https://github.com/owner/repo")
             assert headers == {}
+
+    @patch("registry.services.github_auth.settings")
+    async def test_custom_api_base_url_used_in_exchange(
+        self, mock_settings, rsa_private_key_pem
+    ):
+        """Custom github_api_base_url is used for token exchange requests."""
+        _mock_app_settings(mock_settings, rsa_private_key_pem)
+        mock_settings.github_api_base_url = "https://github.mycompany.com/api/v3"
+
+        from registry.services.github_auth import GitHubAuthProvider
+
+        provider = GitHubAuthProvider()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"token": "ghs_enterprise_token"}
+
+        with patch("registry.services.github_auth.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            # Need to allow the enterprise host for auth headers
+            mock_settings.github_extra_hosts = "github.mycompany.com"
+            provider._allowed_hosts = provider._build_allowed_hosts()
+
+            headers = await provider.get_auth_headers(
+                "https://github.mycompany.com/org/repo"
+            )
+            assert headers == {"Authorization": "Bearer ghs_enterprise_token"}
+
+            # Verify the POST was made to the custom API URL
+            post_call = mock_client.post.call_args
+            assert post_call.args[0] == (
+                "https://github.mycompany.com/api/v3/app/installations/67890/access_tokens"
+            )

--- a/tests/unit/test_skill_routes_github_auth.py
+++ b/tests/unit/test_skill_routes_github_auth.py
@@ -1,0 +1,51 @@
+"""Tests that GitHub auth headers are injected into skill routes httpx calls."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestGetSkillContentAuth:
+    """Tests for auth header injection in get_skill_content."""
+
+    @patch("registry.api.skill_routes._github_auth")
+    @patch("registry.api.skill_routes._is_safe_url", return_value=True)
+    @patch("registry.api.skill_routes._user_can_access_skill", return_value=True)
+    @patch("registry.api.skill_routes.get_skill_service")
+    async def test_auth_headers_passed_to_get(
+        self, mock_get_service, mock_access, mock_safe_url, mock_auth
+    ):
+        """Auth headers from GitHubAuthProvider are passed to httpx.get."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_test"}
+        )
+
+        # Mock skill service to return a skill with raw URL
+        mock_skill = MagicMock()
+        mock_skill.skill_md_raw_url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+        mock_skill.skill_md_url = "https://github.com/o/r/blob/main/SKILL.md"
+
+        mock_service = AsyncMock()
+        mock_service.get_skill.return_value = mock_skill
+        mock_get_service.return_value = mock_service
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "# My Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.api.skill_routes import get_skill_content
+
+            result = await get_skill_content(
+                user_context={"sub": "test-user"},
+                skill_path="test/skill",
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
+            assert result["content"] == "# My Skill"

--- a/tests/unit/test_skill_service_github_auth.py
+++ b/tests/unit/test_skill_service_github_auth.py
@@ -64,6 +64,46 @@ class TestValidateSkillMdUrlAuth:
             assert call_kwargs.kwargs.get("headers") == {}
 
 
+class TestParseSkillMdContentAuth:
+    """Tests for auth header injection in _parse_skill_md_content."""
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    @patch("registry.services.skill_service.translate_skill_url")
+    async def test_auth_headers_passed_to_get(self, mock_translate, mock_safe_url, mock_auth):
+        """Auth headers are passed to httpx.get when fetching SKILL.md content."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_test"}
+        )
+        mock_translate.return_value = (
+            "https://github.com/o/r/blob/main/SKILL.md",
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"---\nname: test\n---\n# Test Skill"
+        mock_response.text = "---\nname: test\n---\n# Test Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md"
+
+        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.services.skill_service import _parse_skill_md_content
+
+            result = await _parse_skill_md_content(
+                "https://github.com/o/r/blob/main/SKILL.md"
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
+            assert result["name"] == "test"
+
+
 class TestCheckSkillHealthAuth:
     """Tests for auth header injection in _check_skill_health."""
 

--- a/tests/unit/test_skill_service_github_auth.py
+++ b/tests/unit/test_skill_service_github_auth.py
@@ -1,0 +1,97 @@
+"""Tests that GitHub auth headers are injected into skill service httpx calls."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestValidateSkillMdUrlAuth:
+    """Tests for auth header injection in _validate_skill_md_url."""
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    async def test_auth_headers_passed_to_get(self, mock_safe_url, mock_auth):
+        """Auth headers from GitHubAuthProvider are passed to httpx.get."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_test"}
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"# Test Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+
+        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.services.skill_service import _validate_skill_md_url
+
+            result = await _validate_skill_md_url(
+                "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
+            assert result["valid"] is True
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    async def test_empty_headers_when_no_credentials(self, mock_safe_url, mock_auth):
+        """Empty headers passed when no credentials configured."""
+        mock_auth.get_auth_headers = AsyncMock(return_value={})
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"# Test Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+
+        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.services.skill_service import _validate_skill_md_url
+
+            await _validate_skill_md_url(
+                "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {}
+
+
+class TestCheckSkillHealthAuth:
+    """Tests for auth header injection in _check_skill_health."""
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    async def test_auth_headers_passed_to_head(self, mock_safe_url, mock_auth):
+        """Auth headers are passed to httpx.head in health check."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_test"}
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+
+        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.head.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.services.skill_service import _check_skill_health
+
+            result = await _check_skill_health(
+                "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+            )
+
+            call_kwargs = mock_client.head.call_args
+            assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
+            assert result["healthy"] is True


### PR DESCRIPTION
## Summary

Adds two-tier GitHub authentication for SKILL.md fetching from private repositories, resolving the blocker for enterprise/org adopters whose internal skills live in private repos.

- **Tier 1 (PAT):** Read `GITHUB_PAT` env var, inject `Authorization: Bearer <token>` into GitHub requests. Zero new dependencies, immediate unblock for private repo use.
- **Tier 2 (GitHub App):** Read `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` env vars. Signs JWT, exchanges for 1-hour installation token via GitHub API, caches in-memory with TTL. Recommended for organizations (ephemeral tokens, org-scoped permissions, survives employee offboarding).

**Auth priority:** GitHub App > PAT > unauthenticated (graceful fallback).

**Security:** Auth headers are only sent to explicitly allowed hosts (`github.com` and `raw.githubusercontent.com` by default). Enterprise GitHub instances can be added via `GITHUB_EXTRA_HOSTS` config. Token cache is protected with `asyncio.Lock` for concurrent request safety.

## Changes

- `registry/core/config.py` -- 5 new settings fields (`github_pat`, `github_app_id`, `github_app_installation_id`, `github_app_private_key`, `github_extra_hosts`)
- `registry/services/github_auth.py` -- New `GitHubAuthProvider` class (~190 lines) with domain-gated auth, JWT signing, token exchange, in-memory caching
- `registry/services/skill_service.py` -- Inject auth headers into 3 httpx calls (`_validate_skill_md_url`, `_parse_skill_md_content`, `_check_skill_health`)
- `registry/api/skill_routes.py` -- Inject auth headers into `get_skill_content`
- `.env.example` -- Configuration documentation for both auth tiers
- 21 unit tests across 3 test files

## Test plan

- [x] 21 new unit tests pass (domain matching, PAT auth, JWT creation, token exchange, caching, fallback, header injection at all 4 call sites)
- [x] Full unit test suite passes with 0 regressions (1828 passed, 11 skipped)
- [x] All modified files compile cleanly
- [ ] Manual test with `GITHUB_PAT` against a private repo
- [ ] Manual test with GitHub App credentials against a private repo

Closes #660