### PR TITLE
fix: add UV_NATIVE_TLS for enterprise Macs with custom CA certificates (#784)

### DIFF
--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -312,6 +312,12 @@ Log: `{ 4, "Environment File Setup", DONE, ".env created and configured" }`
 
 **Announce:** "Installing Python dependencies via `uv sync`..."
 
+First, enable native TLS so that `uv` uses the macOS system certificate store. This is required on enterprise Macs with corporate proxies or custom CA certificates, and is harmless on personal Macs.
+
+```bash
+export UV_NATIVE_TLS=true
+```
+
 ```bash
 cd "${INSTALL_DIR}"
 uv sync
@@ -915,6 +921,12 @@ KEYCLOAK_CONTAINER=$(docker ps --format "{{.Names}}" | grep keycloak | grep -v d
 2. Re-run Phase 9 SSL fix
 3. Verify Keycloak is responding: `curl -s http://localhost:8080/realms/master`
 4. Retry Phase 10
+
+### TLS certificate errors with uv
+On enterprise Macs with corporate proxies or custom CA certificates, `uv` may fail with TLS errors. The setup already sets `export UV_NATIVE_TLS=true` in Phase 5, but if the error occurs in a later shell session, re-export it:
+```bash
+export UV_NATIVE_TLS=true
+```
 
 ### Cloudflare registration fails
 1. Verify services are healthy: `docker compose ps`

--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -95,6 +95,10 @@ ls -la
 
 ### Setup Python Virtual Environment
 ```bash
+# Enable native TLS for enterprise Macs with corporate proxies/custom CA certificates
+# (harmless on personal Macs -- uses macOS system certificate store)
+export UV_NATIVE_TLS=true
+
 # Create and activate Python virtual environment
 uv sync
 source .venv/bin/activate

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,6 +67,7 @@ cd mcp-gateway-registry
 cp .env.example .env
 
 # Setup Python virtual environment
+# (Enterprise Macs: export UV_NATIVE_TLS=true if you hit TLS certificate errors)
 uv sync
 source .venv/bin/activate
 ```


### PR DESCRIPTION
## Summary
- Fix TLS certificate errors when running `uv` on enterprise Macs with corporate proxies or custom CA certificates
- Set `UV_NATIVE_TLS=true` before all `uv` commands so it uses the macOS system keychain instead of its bundled certificate store
- This is always-on and harmless on personal Macs (same standard CAs in the system keychain)

## Changes
- `.claude/skills/macos-setup/SKILL.md` - add `export UV_NATIVE_TLS=true` in Phase 5 before `uv sync`, add TLS troubleshooting entry
- `docs/macos-setup-guide.md` - add export before `uv sync` in manual setup
- `docs/quickstart.md` - add hint comment about `UV_NATIVE_TLS=true`

## Test plan
- [ ] Run `/macos-setup` on an enterprise Mac with corporate proxy -- `uv sync` should succeed
- [ ] Run `/macos-setup` on a personal Mac -- no change in behavior

Closes #784