### PR TITLE
feat: add DISABLE_AI_REGISTRY_TOOLS_SERVER env var (#764)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -826,3 +826,7 @@ WORKDAY_TOKEN_URL=https://your-tenant.workday.com/ccx/oauth2/your_instance/token
 
 # Debug mode: log telemetry payloads instead of sending (default: false)
 # TELEMETRY_DEBUG=true
+
+# Disable built-in airegistry-tools server auto-registration
+# Set to true for production/GitOps deployments that manage their own server registrations
+# DISABLE_AI_REGISTRY_TOOLS_SERVER=false

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -218,6 +218,9 @@ registry:
     mcpTelemetryOptIn: false  # Set to true to enable daily heartbeat with aggregate counts
     telemetryDebug: false  # Set to true to log payloads instead of sending
 
+    # Demo server configuration
+    disableAiRegistryToolsServer: false  # Set to true to disable auto-registration of the built-in airegistry-tools server
+
   # ANS (Agent Name Service) Integration
   ans:
     enabled: false  # Enable ANS integration for trust verification

--- a/charts/registry/templates/configmap-otel.yaml
+++ b/charts/registry/templates/configmap-otel.yaml
@@ -28,4 +28,7 @@ data:
   {{- if .Values.app.telemetryDebug }}
   MCP_TELEMETRY_DEBUG: {{ .Values.app.telemetryDebug | quote }}
   {{- end }}
+  {{- if .Values.app.disableAiRegistryToolsServer }}
+  DISABLE_AI_REGISTRY_TOOLS_SERVER: {{ .Values.app.disableAiRegistryToolsServer | quote }}
+  {{- end }}
 

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -51,6 +51,9 @@ app:
   mcpTelemetryOptIn: false  # Set to true to enable daily heartbeat with aggregate counts
   telemetryDebug: false  # Set to true to log payloads instead of sending
 
+  # Demo server configuration
+  disableAiRegistryToolsServer: false  # Set to true to disable auto-registration of the built-in airegistry-tools server
+
   # Deployment mode: with-gateway (nginx integration) or registry-only (catalog only)
   deploymentMode: with-gateway
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,6 +211,7 @@ services:
       - MCP_TELEMETRY_DISABLED=${MCP_TELEMETRY_DISABLED:-}
       - MCP_TELEMETRY_OPT_IN=${MCP_TELEMETRY_OPT_IN:-}
       - TELEMETRY_DEBUG=${TELEMETRY_DEBUG:-false}
+      - DISABLE_AI_REGISTRY_TOOLS_SERVER=${DISABLE_AI_REGISTRY_TOOLS_SERVER:-false}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)
       - "443:8443"  # Map host 443 to container 8443 (non-root nginx)

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -27,7 +27,7 @@ RATE_LIMIT_WINDOW_SECONDS = 60
 
 
 # ---------------------------------------------------------------------------
-# Configuration group definitions — 15 groups, ordered 1-15
+# Configuration group definitions — 16 groups, ordered 1-16
 # Groups may contain optional "subgroups" for nested display (e.g. Identity Providers)
 # Each field tuple: (settings_attr_name, display_label, is_sensitive)
 # ---------------------------------------------------------------------------
@@ -243,6 +243,13 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("telemetry_opt_in", "Telemetry Opt-In (Daily Heartbeat)", False),
             ("telemetry_debug", "Debug Mode", False),
             ("telemetry_endpoint", "Collector Endpoint", False),
+        ],
+    },
+    "demo_server": {
+        "title": "Demo Server Configuration",
+        "order": 16,
+        "fields": [
+            ("disable_ai_registry_tools_server", "Disable AI Registry Tools Server", False),
         ],
     },
 }

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -331,6 +331,12 @@ class Settings(BaseSettings):
         description="Log telemetry payloads instead of sending (for debugging)",
     )
 
+    # Demo server configuration
+    disable_ai_registry_tools_server: bool = Field(
+        default=False,
+        description="Disable auto-registration of the built-in airegistry-tools server on startup. Set DISABLE_AI_REGISTRY_TOOLS_SERVER=true to opt out.",
+    )
+
     @property
     def nginx_updates_enabled(self) -> bool:
         """Check if nginx updates should be performed."""

--- a/registry/main.py
+++ b/registry/main.py
@@ -440,10 +440,14 @@ async def lifespan(app: FastAPI):
             logger.info("ANS sync scheduler started")
 
         # Initialize built-in demo servers (airegistry-tools)
-        # This ensures the registry management tools are always available
-        from registry.services.demo_servers_init import initialize_demo_servers
+        # Skipped when DISABLE_AI_REGISTRY_TOOLS_SERVER=true (e.g. GitOps/production deployments)
+        if not settings.disable_ai_registry_tools_server:
+            logger.info("Initializing demo servers...")
+            from registry.services.demo_servers_init import initialize_demo_servers
 
-        await initialize_demo_servers()
+            await initialize_demo_servers()
+        else:
+            logger.info("Demo server auto-registration disabled (DISABLE_AI_REGISTRY_TOOLS_SERVER=true)")
 
         # Always generate nginx configuration at startup to ensure placeholders are replaced
         # In registry-only mode, generate base config without MCP server location blocks

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -206,6 +206,9 @@ module "mcp_gateway" {
   mcp_telemetry_opt_in   = var.mcp_telemetry_opt_in
   telemetry_debug        = var.telemetry_debug
 
+  # Demo server configuration
+  disable_ai_registry_tools_server = var.disable_ai_registry_tools_server
+
   # Wait for S3 bucket policy to propagate (30s delay)
   # This prevents "Access Denied" errors when ALB tests write permissions
   depends_on = [time_sleep.wait_for_bucket_policy]

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -848,6 +848,11 @@ module "ecs_service_registry" {
           name  = "TELEMETRY_DEBUG"
           value = var.telemetry_debug
         },
+        # Demo server configuration
+        {
+          name  = "DISABLE_AI_REGISTRY_TOOLS_SERVER"
+          value = var.disable_ai_registry_tools_server
+        },
         # Metrics pipeline (only wired when observability is enabled)
         {
           name  = "METRICS_SERVICE_URL"

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -867,3 +867,9 @@ variable "telemetry_debug" {
   type        = string
   default     = "false"
 }
+
+variable "disable_ai_registry_tools_server" {
+  description = "Disable auto-registration of the built-in airegistry-tools server on startup. Set to 'true' for GitOps/production deployments."
+  type        = string
+  default     = "false"
+}

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -600,3 +600,13 @@ grafana_admin_password = "CHANGE-ME-SET-STRONG-PASSWORD"
 # Debug mode: log telemetry payload to stdout instead of sending
 # Useful for verifying what data would be sent
 # telemetry_debug = "false"
+
+# ============================================================================
+# DEMO SERVER CONFIGURATION (Issue #764)
+# ============================================================================
+# Disable built-in airegistry-tools server auto-registration.
+# Set to "true" for production/GitOps deployments that control all server
+# registrations through a pipeline. Default: "false" (demo server registers on startup).
+# Note: this flag prevents new registrations only; it does not remove the server
+# if it was already registered in a previous run.
+# disable_ai_registry_tools_server = "false"

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -849,6 +849,12 @@ variable "telemetry_debug" {
   default     = "false"
 }
 
+variable "disable_ai_registry_tools_server" {
+  description = "Disable auto-registration of the built-in airegistry-tools server on startup. Set to 'true' for GitOps/production deployments."
+  type        = string
+  default     = "false"
+}
+
 # =============================================================================
 # WAF CONFIGURATION (Issue #603 Security Hardening)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `DISABLE_AI_REGISTRY_TOOLS_SERVER` boolean env var to opt out of built-in `airegistry-tools` server auto-registration at startup
- Wired across all deployment paths: Docker Compose, Terraform ECS (root + module variables, task definition env), and Helm charts (registry + umbrella values, ConfigMap template)
- Displays the new parameter in the **Settings -> System Config** admin page under a new "Demo Server Configuration" group
- Follows the existing `MCP_TELEMETRY_DISABLED` pattern for consistency
- Default is `false` (existing behavior preserved); set to `true` for production/GitOps deployments that manage server registrations externally

## Files Changed

| Layer | Files |
|-------|-------|
| Core | `registry/core/config.py`, `registry/main.py` |
| Admin UI Config | `registry/api/config_routes.py` |
| Docker | `docker-compose.yml`, `.env.example` |
| Terraform ECS | `variables.tf`, `terraform.tfvars.example`, `main.tf`, `modules/mcp-gateway/variables.tf`, `modules/mcp-gateway/ecs-services.tf` |
| Helm | `charts/registry/values.yaml`, `charts/registry/templates/configmap-otel.yaml`, `charts/mcp-gateway-registry-stack/values.yaml` |

## Test Plan

- [x] Unit tests pass (3 pre-existing failures unrelated to this change)
- [x] Full Docker Compose stack tested with Keycloak auth
- [x] Flag OFF: `airegistry-tools` server appears in UI
- [x] Flag ON: `airegistry-tools` server absent from UI, log confirms `Demo server auto-registration disabled`
- [x] Flag OFF again: `airegistry-tools` server re-registers on restart
- [x] New config param visible in Settings -> System Config page

Closes #764