### PR TITLE
fix: convert AgentCard to dict in federation peer sync

### DIFF
--- a/registry/services/peer_federation_service.py
+++ b/registry/services/peer_federation_service.py
@@ -1051,8 +1051,8 @@ class PeerFederationService:
                     logger.warning(f"Agent not found for orphan marking: {item_path}")
                     return False
 
-                # get_agent_info returns a dict
-                agent_dict = existing_agent
+                # get_agent_info returns an AgentCard Pydantic model, convert to dict
+                agent_dict = existing_agent.model_dump()
 
                 # Update sync_metadata
                 sync_metadata = agent_dict.get("sync_metadata") or {}
@@ -1195,8 +1195,8 @@ class PeerFederationService:
                     logger.warning(f"Agent not found for local override: {item_path}")
                     return False
 
-                # get_agent_info returns a dict
-                agent_dict = existing_agent
+                # get_agent_info returns an AgentCard Pydantic model, convert to dict
+                agent_dict = existing_agent.model_dump()
 
                 # Update sync_metadata
                 sync_metadata = agent_dict.get("sync_metadata") or {}
@@ -1440,8 +1440,8 @@ class PeerFederationService:
 
                     if existing_agent:
                         # Check if locally overridden - if so, skip update
-                        # get_agent_info returns a dict
-                        if self.is_locally_overridden(existing_agent):
+                        # get_agent_info returns an AgentCard, convert to dict for is_locally_overridden
+                        if self.is_locally_overridden(existing_agent.model_dump()):
                             logger.debug(
                                 f"Skipping update for locally overridden agent: {prefixed_path}"
                             )


### PR DESCRIPTION
## Summary
- `agent_service.get_agent_info()` returns an `AgentCard` Pydantic model, not a dict
- Three call sites in `peer_federation_service.py` were calling `.get()` on the model, causing `AttributeError: 'AgentCard' object has no attribute 'get'`
- Fix: call `.model_dump()` to convert to dict before using dict methods

Affected functions:
- `mark_item_as_orphaned` -- orphan marking during federation sync
- `set_local_override` -- local override flag management
- `_store_synced_items` via `is_locally_overridden` -- skip check during sync

## Test plan
- [ ] Run federation sync with a peer that has agents -- no more `AttributeError` in logs
- [ ] Verify orphaned agents are correctly marked during sync
- [ ] Verify locally overridden agents are skipped during sync updates