### PR TITLE
docs: document JWT server management API and auth-protected server registration

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,12 +9,13 @@ This document provides a comprehensive overview of all 49 API endpoints availabl
 3. [A2A Agent Management APIs](#a2a-agent-management-apis)
 4. [Anthropic MCP Registry API v0](#anthropic-mcp-registry-api-v0)
 5. [Internal Server Management APIs](#internal-server-management-apis)
-6. [Authentication & Login APIs](#authentication--login-apis)
-7. [Health Monitoring APIs](#health-monitoring-apis)
-8. [Discovery & Well-Known Endpoints](#discovery--well-known-endpoints)
-9. [Utility Endpoints](#utility-endpoints)
-10. [Response Codes & Error Handling](#response-codes--error-handling)
-11. [OpenAPI Specifications](#openapi-specifications)
+6. [JWT Server Management API](#jwt-server-management-api)
+7. [Authentication & Login APIs](#authentication--login-apis)
+8. [Health Monitoring APIs](#health-monitoring-apis)
+9. [Discovery & Well-Known Endpoints](#discovery--well-known-endpoints)
+10. [Utility Endpoints](#utility-endpoints)
+11. [Response Codes & Error Handling](#response-codes--error-handling)
+12. [OpenAPI Specifications](#openapi-specifications)
 
 ---
 
@@ -26,6 +27,7 @@ This document provides a comprehensive overview of all 49 API endpoints availabl
 | Anthropic Registry API v0 (Servers) | 3 | JWT Bearer Token | Standard MCP server discovery via Anthropic API spec |
 | Internal Server Management (UI) | 10 | Session Cookie | Dashboard and service management |
 | Internal Server Management (Admin) | 12 | HTTP Basic Auth | Administrative operations and group management |
+| JWT Server Management | 10 | JWT Bearer Token | Programmatic server registration, auth credentials, and management |
 | Authentication & Login | 7 | OAuth2 + Session | User authentication and provider management |
 | Health Monitoring | 3 | Session Cookie / None | Real-time health updates and statistics |
 | Discovery | 1 | None (Public) | Public MCP server discovery |
@@ -771,6 +773,210 @@ This section implements the official [Anthropic MCP Registry API specification](
 **Error Codes:**
 - `403 Forbidden` - Non-admin user
 - `500 Internal Server Error` - Configuration error
+
+---
+
+## JWT Server Management API
+
+Modern JWT-authenticated endpoints for programmatic server management. These are the external API equivalents of the internal UI endpoints.
+
+**File:** `registry/api/server_routes.py`
+**Route Prefix:** `/api`
+**Authentication:** JWT Bearer Token (nginx_proxied_auth)
+
+#### 1. Register Server
+
+**Endpoint:** `POST /api/servers/register`
+
+**Purpose:** Register an MCP server with optional backend authentication credentials
+
+**Request body (form data):**
+- `name` (required): Service name
+- `description` (required): Service description
+- `path` (required): Service path (e.g., `/myservice`)
+- `proxy_pass_url` (required): Backend URL (e.g., `http://localhost:8000`)
+- `tags` (optional): Comma-separated tags
+- `auth_scheme` (optional): Backend auth scheme -- `none` (default), `bearer`, or `api_key`
+- `auth_credential` (optional): Plaintext credential (encrypted before storage)
+- `auth_header_name` (optional): Custom header name (default: `Authorization` for bearer, `X-API-Key` for api_key)
+- `tool_list_json` (optional): JSON array of MCP tool definitions (for manual tool registration)
+- `supported_transports` (optional): JSON array of transports
+- `headers` (optional): JSON object of custom headers
+- `mcp_endpoint` (optional): Custom MCP endpoint URL
+- `sse_endpoint` (optional): Custom SSE endpoint URL
+- `version` (optional): Server version (e.g., `v1.0.0`)
+- `status` (optional): Lifecycle status (`active`, `deprecated`, `draft`, `beta`)
+- `provider_organization` (optional): Provider organization name
+- `provider_url` (optional): Provider URL
+
+**Response:** `201 Created`
+
+**Error Codes:**
+- `400 Bad Request` - Invalid input data
+- `401 Unauthorized` - Missing or invalid JWT token
+- `409 Conflict` - Server already exists with same version
+- `500 Internal Server Error` - Server error
+
+**Example:**
+```bash
+# Register a server behind Bearer token auth
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "name=My Protected Server" \
+  -F "description=An MCP server behind Bearer auth" \
+  -F "path=/my-protected-server" \
+  -F "proxy_pass_url=http://my-server:8000" \
+  -F "auth_scheme=bearer" \
+  -F "auth_credential=backend-server-token"
+```
+
+---
+
+#### 2. Update Server
+
+**Endpoint:** `PUT /api/servers/{server_path:path}`
+
+**Purpose:** Update an existing server's details
+
+**Path Parameter:**
+- `server_path` - Server path (e.g., `/my-server`)
+
+**Request body (form data):** Same fields as register
+
+**Response:** `200 OK` with updated server details
+
+**Error Codes:**
+- `404 Not Found` - Server not found
+
+---
+
+#### 3. Update Auth Credential
+
+**Endpoint:** `PATCH /api/servers/{server_path:path}/auth-credential`
+
+**Purpose:** Update or rotate the authentication credential for a registered server without re-registering
+
+**Path Parameter:**
+- `server_path` - Server path (e.g., `/my-server`)
+
+**Request body (JSON):**
+- `auth_scheme` (required): `none`, `bearer`, or `api_key`
+- `auth_credential` (optional): New credential. Required if auth_scheme is not `none`.
+- `auth_header_name` (optional): Custom header name. Default: `X-API-Key` for api_key.
+
+**Response:** `200 OK`
+
+**Error Codes:**
+- `400 Bad Request` - Invalid auth_scheme or missing credential
+- `404 Not Found` - Server not found
+
+**Example:**
+```bash
+# Rotate a Bearer token
+curl -X PATCH https://registry.example.com/api/servers/my-server/auth-credential \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"auth_scheme": "bearer", "auth_credential": "new-token"}'
+```
+
+---
+
+#### 4. Delete Server
+
+**Endpoint:** `DELETE /api/servers/{server_path:path}`
+
+**Purpose:** Remove a registered server
+
+**Path Parameter:**
+- `server_path` - Server path
+
+**Response:** `200 OK`
+
+**Error Codes:**
+- `404 Not Found` - Server not found
+
+**Example:**
+```bash
+curl -X DELETE https://registry.example.com/api/servers/my-server \
+  -H "Authorization: Bearer $JWT_TOKEN"
+```
+
+---
+
+#### 5. Toggle Server
+
+**Endpoint:** `POST /api/servers/toggle`
+
+**Purpose:** Enable or disable a server
+
+**Request body (form data):**
+- `path` (required): Service path
+- `new_state` (required): `true` (enabled) or `false` (disabled)
+
+**Response:** `200 OK` with updated status
+
+---
+
+#### 6. Get Health Status
+
+**Endpoint:** `GET /api/servers/health`
+
+**Purpose:** Get health status for all registered servers
+
+**Response:** `200 OK` with health data for all servers
+
+---
+
+#### 7. Get Server Rating
+
+**Endpoint:** `GET /api/servers/{server_path:path}/rating`
+
+**Purpose:** Get the rating for a server
+
+**Response:** `200 OK` with rating data
+
+---
+
+#### 8. Submit Server Rating
+
+**Endpoint:** `POST /api/servers/{server_path:path}/rating`
+
+**Purpose:** Submit a rating for a server
+
+**Request body (JSON):**
+- `rating` (required): Rating value (1-5)
+- `comment` (optional): Review comment
+
+**Response:** `201 Created`
+
+---
+
+#### 9. List Server Versions
+
+**Endpoint:** `GET /api/servers/{server_path:path}/versions`
+
+**Purpose:** List all versions for a server
+
+**Response:** `200 OK` with versions array
+
+---
+
+#### 10. Group Management
+
+**Add to groups:** `POST /api/servers/groups/add`
+**Remove from groups:** `POST /api/servers/groups/remove`
+
+**Request body (form data):**
+- `server_name` (required): Service name
+- `group_names` (required): Comma-separated group names
+
+**Example:**
+```bash
+curl -X POST https://registry.example.com/api/servers/groups/add \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "server_name=myservice" \
+  -F "group_names=admin,developers"
+```
 
 ---
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -28,4 +28,5 @@ Common questions and answers about the MCP Gateway Registry.
 
 ## Authentication and API Access
 
+- [How do I register and manage MCP servers that require authentication?](registering-auth-protected-servers.md)
 - [Can I use an Entra ID token to call the registry API instead of the UI-generated token?](use-entra-token-for-registry-api.md)

--- a/docs/faq/registering-auth-protected-servers.md
+++ b/docs/faq/registering-auth-protected-servers.md
@@ -1,0 +1,147 @@
+# How do I register and manage MCP servers that require authentication?
+
+The MCP Gateway Registry fully supports registering MCP servers that are behind access control (Bearer token or API key). When a server requires authentication, the registry stores the credential securely (encrypted at rest) and automatically injects it when performing health checks, tool discovery, and proxying requests.
+
+## Registering a Server with Authentication
+
+Use the `POST /api/servers/register` endpoint with JWT Bearer authentication. Include the `auth_scheme` and `auth_credential` fields to specify how the registry should authenticate with your backend MCP server.
+
+### Bearer Token Authentication
+
+```bash
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "name=My Protected Server" \
+  -F "description=An MCP server behind Bearer auth" \
+  -F "path=/my-protected-server" \
+  -F "proxy_pass_url=http://my-server:8000" \
+  -F "auth_scheme=bearer" \
+  -F "auth_credential=my-backend-server-token"
+```
+
+### API Key Authentication
+
+```bash
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "name=My API Key Server" \
+  -F "description=An MCP server behind API key auth" \
+  -F "path=/my-apikey-server" \
+  -F "proxy_pass_url=http://my-server:8000" \
+  -F "auth_scheme=api_key" \
+  -F "auth_credential=my-api-key-value" \
+  -F "auth_header_name=X-API-Key"
+```
+
+### Supported `auth_scheme` Values
+
+| Value | Behavior |
+|-------|----------|
+| `none` | No authentication (default) |
+| `bearer` | Sends `Authorization: Bearer <credential>` header |
+| `api_key` | Sends credential in a custom header (default: `X-API-Key`) |
+
+### Custom Header Name
+
+When using `api_key`, you can specify a custom header name via `auth_header_name`. For example, if your server expects `X-My-Custom-Key`, pass `auth_header_name=X-My-Custom-Key`.
+
+## How Tool Discovery Works with Auth
+
+Once registered with credentials, the registry automatically:
+
+1. **Health checks** -- Injects the decrypted credential when checking if the server is reachable
+2. **Tool discovery** -- Uses the credential to call the MCP `tools/list` method on the backend server
+3. **Request proxying** -- When clients connect through the gateway, the credential is injected into proxied requests
+
+This means tool discovery works the same way for protected servers as it does for public ones -- no additional configuration is needed beyond providing the credential at registration time.
+
+## Manually Providing Tools
+
+If your server is behind a firewall or tool auto-discovery is not possible, you can provide tools manually at registration time using the `tool_list_json` parameter:
+
+```bash
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "name=My Server" \
+  -F "description=Server with manually defined tools" \
+  -F "path=/my-server" \
+  -F "proxy_pass_url=http://my-server:8000" \
+  -F 'tool_list_json=[{"name": "get_weather", "description": "Get weather for a city", "inputSchema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}]'
+```
+
+The `tool_list_json` field accepts a JSON array of MCP tool definitions. These will be stored in the registry and returned to clients during tool discovery, even if the backend server is unreachable for live tool listing.
+
+## Updating or Rotating Credentials
+
+Use the `PATCH /api/servers/{path}/auth-credential` endpoint to update credentials without re-registering the server:
+
+```bash
+# Rotate a Bearer token
+curl -X PATCH https://registry.example.com/api/servers/my-protected-server/auth-credential \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "auth_scheme": "bearer",
+    "auth_credential": "new-backend-server-token"
+  }'
+```
+
+```bash
+# Switch from Bearer to API key
+curl -X PATCH https://registry.example.com/api/servers/my-protected-server/auth-credential \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "auth_scheme": "api_key",
+    "auth_credential": "new-api-key",
+    "auth_header_name": "X-API-Key"
+  }'
+```
+
+```bash
+# Remove authentication (make server public)
+curl -X PATCH https://registry.example.com/api/servers/my-protected-server/auth-credential \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "auth_scheme": "none"
+  }'
+```
+
+## Credential Security
+
+- Credentials are **encrypted at rest** using the `SECRET_KEY` configured in your deployment
+- Credentials are **never returned** in API responses or displayed in the UI
+- Credentials are **decrypted only in memory** when needed for health checks, tool discovery, or request proxying
+
+## Getting a JWT Token
+
+To authenticate with the registry API, you need a JWT token. Click the **Get JWT Token** button in the top-left corner of the registry UI, or use the token generation API:
+
+```bash
+curl -X POST https://registry.example.com/api/tokens/generate \
+  -H "Cookie: session=<your-session-cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "expires_in_hours": 8,
+    "description": "Server registration token"
+  }'
+```
+
+## Troubleshooting
+
+### Tools not discovered for a protected server
+
+1. Verify the credential is correct by testing it directly against your MCP server
+2. Check the server health status in the registry UI -- if unhealthy, the credential may be invalid or expired
+3. Use the credential update endpoint to provide a fresh credential
+4. As a fallback, provide tools manually via `tool_list_json` at registration time
+
+### "Failed to fetch tools" error
+
+This typically means:
+- The backend server is unreachable from the registry
+- The credential is invalid or expired
+- The server does not implement the standard MCP `tools/list` method
+
+Check the registry logs for detailed error messages about the connection failure.


### PR DESCRIPTION
## Summary
- Add FAQ article (`docs/faq/registering-auth-protected-servers.md`) explaining how to register MCP servers behind Bearer token or API key auth, rotate credentials, and manually provide tools via `tool_list_json`
- Add "JWT Server Management API" section to `docs/api-reference.md` covering all 10 programmatic endpoints: register, update, delete, auth-credential update, toggle, health, rating, versions, and group management
- Update FAQ index with link to new article

Closes #799

## Test plan
- [ ] Verify new FAQ article renders correctly on GitHub
- [ ] Verify api-reference.md table of contents links work
- [ ] Verify curl examples in FAQ are accurate against running registry