### PR TITLE
feat: add GET /api/servers/{path} endpoint for single server retrieval

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2428,6 +2428,133 @@
         ]
       }
     },
+    "/api/servers/{path}": {
+      "get": {
+        "tags": [
+          "Server Management"
+        ],
+        "summary": "Get Server",
+        "description": "Get detailed information about a single MCP server.\n\nReturns the server card including tools, versions, and health status.\nMirrors the GET /api/agents/{path} endpoint pattern.\n\n**Authentication:** JWT Bearer token (via nginx X-User header)\n\n**Path parameter:**\n- `path`: Server path (e.g., /my-server)\n\n**Response:**\n- `200 OK`: Server details\n- `403 Forbidden`: User lacks access\n- `404 Not Found`: Server not found",
+        "operationId": "get_server_api_servers__path__get",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "server_name": {
+                      "type": "string",
+                      "description": "Server display name"
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Server description"
+                    },
+                    "path": {
+                      "type": "string",
+                      "description": "Server path"
+                    },
+                    "proxy_pass_url": {
+                      "type": "string",
+                      "description": "Backend URL (only in registry-only mode for non-admin users)",
+                      "nullable": true
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Server tags"
+                    },
+                    "num_tools": {
+                      "type": "integer",
+                      "description": "Number of tools"
+                    },
+                    "tool_list": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Tool definitions"
+                    },
+                    "is_enabled": {
+                      "type": "boolean",
+                      "description": "Whether server is enabled"
+                    },
+                    "health_status": {
+                      "type": "string",
+                      "description": "Health status",
+                      "nullable": true
+                    },
+                    "transport": {
+                      "type": "string",
+                      "description": "Transport type",
+                      "nullable": true
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "Server version",
+                      "nullable": true
+                    },
+                    "versions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Version list",
+                      "nullable": true
+                    },
+                    "license": {
+                      "type": "string",
+                      "description": "License"
+                    },
+                    "registered_by": {
+                      "type": "string",
+                      "description": "Who registered the server",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "User lacks access to this server"
+          },
+          "404": {
+            "description": "Server not found at the given path"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/agents/{path}/ans/link": {
       "post": {
         "tags": [

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -131,6 +131,27 @@ class ServerDetail(BaseModel):
     external_tags: list[str] = Field(default_factory=list, description="Tags from external source")
 
 
+class ServerDetailResponse(BaseModel):
+    """Response model for single server retrieval via GET /api/servers/{path}."""
+
+    server_name: str = Field(default="", description="Server display name")
+    description: str = Field(default="", description="Server description")
+    path: str = Field(..., description="Server path (e.g., /my-server)")
+    proxy_pass_url: str | None = Field(None, description="Backend URL")
+    tags: list[str] = Field(default_factory=list, description="Server tags")
+    num_tools: int = Field(default=0, description="Number of tools")
+    tool_list: list[dict[str, Any]] = Field(default_factory=list, description="Tool definitions")
+    is_enabled: bool = Field(default=False, description="Whether server is enabled")
+    health_status: str | None = Field(None, description="Health status")
+    transport: str | None = Field(None, description="Transport type")
+    version: str | None = Field(None, description="Server version")
+    versions: list[dict[str, Any]] | None = Field(None, description="Version list")
+    license: str = Field(default="N/A", description="License")
+    registered_by: str | None = Field(None, description="Who registered")
+
+    model_config = ConfigDict(extra="allow")
+
+
 class ServerListResponse(BaseModel):
     """Server list response model."""
 
@@ -2436,6 +2457,30 @@ class RegistryClient:
 
         result = RatingResponse(**response.json())
         logger.info(f"Server '{path}' rated successfully. New average: {result.average_rating:.2f}")
+        return result
+
+    def get_server(
+        self,
+        path: str,
+    ) -> ServerDetailResponse:
+        """
+        Get detailed information about a specific server.
+
+        Args:
+            path: Server path (e.g., /my-server)
+
+        Returns:
+            Server detail response
+
+        Raises:
+            requests.HTTPError: If server not found (404) or unauthorized (403)
+        """
+        logger.info(f"Getting server details: {path}")
+
+        response = self._make_request(method="GET", endpoint=f"/api/servers{path}")
+
+        result = ServerDetailResponse(**response.json())
+        logger.info(f"Retrieved server details: {path}")
         return result
 
     def get_server_rating(self, path: str) -> RatingInfoResponse:

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -1072,6 +1072,44 @@ def cmd_describe_group(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_server_get(args: argparse.Namespace) -> int:
+    """
+    Get detailed information about a specific server.
+
+    Args:
+        args: Command arguments
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        client = _create_client(args)
+        server = client.get_server(args.path)
+
+        logger.info(f"Retrieved server: {server.server_name}")
+        output = {
+            "server_name": server.server_name,
+            "path": server.path,
+            "description": server.description,
+            "proxy_pass_url": server.proxy_pass_url,
+            "tags": server.tags,
+            "num_tools": server.num_tools,
+            "tool_list": server.tool_list,
+            "is_enabled": server.is_enabled,
+            "health_status": server.health_status,
+            "transport": server.transport,
+            "version": server.version,
+            "versions": server.versions,
+            "license": server.license,
+        }
+        print(json.dumps(output, indent=2, default=str))
+        return 0
+
+    except Exception as e:
+        logger.error(f"Get server failed: {e}")
+        return 1
+
+
 def cmd_server_rate(args: argparse.Namespace) -> int:
     """
     Rate a server (1-5 stars).
@@ -4412,6 +4450,12 @@ Examples:
         "--json", action="store_true", help="Output raw JSON response"
     )
 
+    # Server get command
+    server_get_parser = subparsers.add_parser("server-get", help="Get details of a specific server")
+    server_get_parser.add_argument(
+        "--path", required=True, help="Server path (e.g., /my-server)"
+    )
+
     # Server rate command
     server_rate_parser = subparsers.add_parser("server-rate", help="Rate a server (1-5 stars)")
     server_rate_parser.add_argument(
@@ -5199,6 +5243,7 @@ Examples:
         "import-group": cmd_import_group,
         "list-groups": cmd_list_groups,
         "describe-group": cmd_describe_group,
+        "server-get": cmd_server_get,
         "server-rate": cmd_server_rate,
         "server-rating": cmd_server_rating,
         "security-scan": cmd_security_scan,

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,7 +27,7 @@ This document provides a comprehensive overview of all 49 API endpoints availabl
 | Anthropic Registry API v0 (Servers) | 3 | JWT Bearer Token | Standard MCP server discovery via Anthropic API spec |
 | Internal Server Management (UI) | 10 | Session Cookie | Dashboard and service management |
 | Internal Server Management (Admin) | 12 | HTTP Basic Auth | Administrative operations and group management |
-| JWT Server Management | 10 | JWT Bearer Token | Programmatic server registration, auth credentials, and management |
+| JWT Server Management | 11 | JWT Bearer Token | Programmatic server registration, auth credentials, and management |
 | Authentication & Login | 7 | OAuth2 + Session | User authentication and provider management |
 | Health Monitoring | 3 | Session Cookie / None | Real-time health updates and statistics |
 | Discovery | 1 | None (Public) | Public MCP server discovery |
@@ -976,6 +976,34 @@ curl -X POST https://registry.example.com/api/servers/groups/add \
   -H "Authorization: Bearer $JWT_TOKEN" \
   -F "server_name=myservice" \
   -F "group_names=admin,developers"
+```
+
+---
+
+#### 11. Get Single Server
+
+**Endpoint:** `GET /api/servers/{path:path}`
+
+**Purpose:** Get detailed information about a single MCP server by path. Mirrors the `GET /api/agents/{path}` endpoint pattern.
+
+**Path Parameter:**
+- `path` - Server path (e.g., `/my-server`)
+
+**Response:** `200 OK` with server details including tools, versions, health status
+
+**Notes:**
+- `proxy_pass_url` is stripped for non-admin users in with-gateway deployment mode
+- In registry-only deployment mode, `proxy_pass_url` is included for all users (needed to connect directly)
+- Credentials are never included in the response
+
+**Error Codes:**
+- `403 Forbidden` - User lacks access to this server
+- `404 Not Found` - Server not found at the given path
+
+**Example:**
+```bash
+curl -X GET https://registry.example.com/api/servers/my-server \
+  -H "Authorization: Bearer $JWT_TOKEN"
 ```
 
 ---

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -15,7 +15,7 @@ from ..auth.csrf import generate_csrf_token, verify_csrf_token, verify_csrf_toke
 from ..auth.dependencies import enhanced_auth, nginx_proxied_auth
 from ..auth.internal import validate_internal_auth
 from ..constants import VALID_AUTH_SCHEMES
-from ..core.config import settings
+from ..core.config import DeploymentMode, settings
 from ..core.schemas import AuthCredentialUpdateRequest
 from ..services.security_scanner import security_scanner_service
 from ..services.server_service import server_service
@@ -4112,3 +4112,76 @@ async def get_server_versions(
 
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+# IMPORTANT: This catch-all route must remain AFTER all /servers/{path}/... suffixed routes
+@router.get("/servers/{path:path}")
+async def get_server(
+    request: Request,
+    path: str,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+):
+    """
+    Get detailed information about a single MCP server.
+
+    Returns the server card including tools, versions, and health status.
+    Mirrors the GET /api/agents/{path} endpoint pattern.
+
+    **Authentication:** JWT Bearer token (via nginx X-User header)
+
+    **Path parameter:**
+    - `path`: Server path (e.g., /my-server)
+
+    **Response:**
+    - `200 OK`: Server details
+    - `403 Forbidden`: User lacks access
+    - `404 Not Found`: Server not found
+
+    **Example:**
+    ```bash
+    curl -X GET https://registry.example.com/api/servers/my-server \\
+      -H "Authorization: Bearer $JWT_TOKEN"
+    ```
+    """
+    set_audit_action(
+        request,
+        "read",
+        "server",
+        resource_id=path,
+        description=f"Read server {path}",
+    )
+
+    # Normalize path — add leading slash if missing
+    if not path.startswith("/"):
+        path = "/" + path
+
+    # Look up server
+    server_info = await server_service.get_server_info(path)
+    if not server_info:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}'",
+        )
+
+    # Access control — admin users bypass checks
+    if not user_context.get("is_admin"):
+        accessible_servers = user_context.get("accessible_servers", [])
+        has_access = await server_service.user_can_access_server_path(
+            path, accessible_servers
+        )
+        if not has_access:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this server",
+            )
+
+    # Strip proxy_pass_url for non-admin users in with-gateway mode.
+    # In registry-only mode, users need the URL to connect directly.
+    if not user_context.get("is_admin"):
+        if settings.deployment_mode != DeploymentMode.REGISTRY_ONLY:
+            server_info.pop("proxy_pass_url", None)
+
+    return JSONResponse(
+        status_code=200,
+        content=json.loads(json.dumps(server_info, default=str)),
+    )

--- a/tests/unit/api/test_server_get_endpoint.py
+++ b/tests/unit/api/test_server_get_endpoint.py
@@ -1,0 +1,472 @@
+"""
+Unit tests for GET /api/servers/{path} endpoint.
+
+Tests the single server retrieval endpoint including:
+- Successful retrieval for admin and regular users
+- 404 when server not found
+- 403 when user lacks access
+- Path normalization (with/without leading slash)
+- Credentials are never in the response
+- proxy_pass_url stripping behavior based on deployment mode
+- Audit logging
+"""
+
+import logging
+from typing import Any
+from unittest.mock import (
+    AsyncMock,
+    MagicMock,
+    patch,
+)
+
+import pytest
+from fastapi.testclient import TestClient
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def admin_user_context() -> dict[str, Any]:
+    """Create admin user context."""
+    return {
+        "username": "admin",
+        "is_admin": True,
+        "groups": ["mcp-registry-admin"],
+        "scopes": ["mcp-servers-unrestricted/read"],
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "accessible_agents": ["all"],
+        "ui_permissions": {
+            "list_service": ["all"],
+            "toggle_service": ["all"],
+            "register_service": ["all"],
+            "view_tools": ["all"],
+            "refresh_service": ["all"],
+            "modify_service": ["all"],
+        },
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def regular_user_context() -> dict[str, Any]:
+    """Create regular (non-admin) user context."""
+    return {
+        "username": "testuser",
+        "is_admin": False,
+        "groups": ["test-group"],
+        "scopes": ["test-server/read"],
+        "accessible_servers": ["test-server"],
+        "accessible_services": ["test-server"],
+        "accessible_agents": ["test-agent"],
+        "ui_permissions": {
+            "list_service": ["test-server"],
+            "view_tools": ["test-server"],
+        },
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def sample_server_info() -> dict[str, Any]:
+    """Create sample server info dict as returned by server_service.get_server_info()."""
+    return {
+        "server_name": "Test Server",
+        "description": "A test MCP server",
+        "path": "/test-server",
+        "proxy_pass_url": "http://internal-backend:8080",
+        "tags": ["test", "demo"],
+        "num_tools": 2,
+        "tool_list": [
+            {
+                "name": "get_weather",
+                "description": "Get weather data",
+                "inputSchema": {"type": "object"},
+            },
+            {
+                "name": "search_docs",
+                "description": "Search documents",
+                "inputSchema": {"type": "object"},
+            },
+        ],
+        "is_enabled": True,
+        "health_status": "healthy",
+        "transport": "sse",
+        "supported_transports": ["sse", "streamable-http"],
+        "version": "v1.0.0",
+        "versions": [{"version": "v1.0.0", "status": "active", "is_default": True}],
+        "license": "Apache-2.0",
+        "registered_at": "2026-04-01T00:00:00Z",
+        "registered_by": "admin",
+    }
+
+
+@pytest.fixture
+def mock_server_service():
+    """Mock server_service dependency."""
+    mock_service = MagicMock()
+    mock_service.get_server_info = AsyncMock(return_value=None)
+    mock_service.get_all_servers = AsyncMock(return_value={})
+    mock_service.get_all_servers_with_permissions = AsyncMock(return_value={})
+    mock_service.is_service_enabled = AsyncMock(return_value=True)
+    mock_service.toggle_service = AsyncMock(return_value=True)
+    mock_service.register_server = AsyncMock(
+        return_value={
+            "success": True,
+            "message": "Server registered successfully",
+            "is_new_version": False,
+        }
+    )
+    mock_service.update_server = AsyncMock(return_value=True)
+    mock_service.remove_server = AsyncMock(return_value=True)
+    mock_service.get_enabled_services = AsyncMock(return_value=[])
+    mock_service.user_can_access_server_path = AsyncMock(return_value=True)
+    return mock_service
+
+
+@pytest.fixture
+def _mock_auth_admin(admin_user_context, mock_settings):
+    """Mock authentication dependencies with admin user."""
+    from registry.auth.dependencies import (
+        enhanced_auth,
+        nginx_proxied_auth,
+    )
+    from registry.main import app
+
+    def mock_enhanced_auth_override():
+        return admin_user_context
+
+    def mock_nginx_proxied_auth_override():
+        return admin_user_context
+
+    app.dependency_overrides[enhanced_auth] = mock_enhanced_auth_override
+    app.dependency_overrides[nginx_proxied_auth] = mock_nginx_proxied_auth_override
+
+    yield admin_user_context
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def _mock_auth_regular(regular_user_context, mock_settings):
+    """Mock authentication dependencies with regular user."""
+    from registry.auth.dependencies import (
+        enhanced_auth,
+        nginx_proxied_auth,
+    )
+    from registry.main import app
+
+    def mock_enhanced_auth_override():
+        return regular_user_context
+
+    def mock_nginx_proxied_auth_override():
+        return regular_user_context
+
+    app.dependency_overrides[enhanced_auth] = mock_enhanced_auth_override
+    app.dependency_overrides[nginx_proxied_auth] = mock_nginx_proxied_auth_override
+
+    yield regular_user_context
+
+    app.dependency_overrides.clear()
+
+
+def _create_test_client(
+    mock_server_service: MagicMock,
+    user_context: dict[str, Any],
+) -> TestClient:
+    """Create a FastAPI test client with mocked services.
+
+    Args:
+        mock_server_service: Mocked server service
+        user_context: User context for auth
+
+    Returns:
+        TestClient instance
+    """
+
+    def mock_enhanced_auth_func(session=None):
+        return user_context
+
+    with (
+        patch("registry.api.server_routes.server_service", mock_server_service),
+        patch("registry.search.service.faiss_service", MagicMock()),
+        patch("registry.health.service.health_service", MagicMock()),
+        patch("registry.core.nginx_service.nginx_service", MagicMock()),
+        patch("registry.api.server_routes.security_scanner_service", MagicMock()),
+        patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
+        patch("registry.api.server_routes.enhanced_auth", mock_enhanced_auth_func),
+    ):
+        from registry.auth.csrf import verify_csrf_token_flexible
+        from registry.main import app
+
+        app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+
+        client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+        yield client
+
+        app.dependency_overrides.pop(verify_csrf_token_flexible, None)
+
+
+@pytest.fixture
+def test_client_admin(
+    mock_settings,
+    mock_server_service,
+    _mock_auth_admin,
+    admin_user_context,
+):
+    """Create test client with admin auth."""
+    yield from _create_test_client(mock_server_service, admin_user_context)
+
+
+@pytest.fixture
+def test_client_regular(
+    mock_settings,
+    mock_server_service,
+    _mock_auth_regular,
+    regular_user_context,
+):
+    """Create test client with regular user auth."""
+    yield from _create_test_client(mock_server_service, regular_user_context)
+
+
+# =============================================================================
+# TESTS: GET /api/servers/{path}
+# =============================================================================
+
+
+class TestGetServer:
+    """Tests for GET /api/servers/{path} endpoint."""
+
+    def test_get_server_success_admin(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test successful server retrieval as admin."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["server_name"] == "Test Server"
+        assert data["path"] == "/test-server"
+        assert data["description"] == "A test MCP server"
+        assert data["num_tools"] == 2
+        assert len(data["tool_list"]) == 2
+        assert data["is_enabled"] is True
+
+    def test_get_server_success_regular_user(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test successful server retrieval as regular user."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        mock_server_service.user_can_access_server_path.return_value = True
+
+        response = test_client_regular.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["server_name"] == "Test Server"
+
+    def test_get_server_not_found(
+        self,
+        test_client_admin,
+        mock_server_service,
+    ):
+        """Test 404 when server does not exist."""
+        mock_server_service.get_server_info.return_value = None
+
+        response = test_client_admin.get("/api/servers/nonexistent-server")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+    def test_get_server_forbidden(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test 403 when user lacks access to the server."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        mock_server_service.user_can_access_server_path.return_value = False
+
+        response = test_client_regular.get("/api/servers/test-server")
+
+        assert response.status_code == 403
+        assert "access" in response.json()["detail"].lower()
+
+    def test_get_server_admin_bypasses_access_check(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test that admin users bypass the access control check."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        # user_can_access_server_path should NOT be called for admin
+        mock_server_service.user_can_access_server_path.assert_not_called()
+
+    def test_get_server_path_normalization_no_slash(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test that paths without leading slash are normalized."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/my-server")
+
+        assert response.status_code == 200
+        # Verify get_server_info was called with normalized path (leading slash)
+        mock_server_service.get_server_info.assert_called_once_with("/my-server")
+
+    def test_get_server_credentials_stripped(
+        self,
+        test_client_admin,
+        mock_server_service,
+    ):
+        """Test that credentials are never included in the response."""
+        server_info = {
+            "server_name": "Test Server",
+            "path": "/test-server",
+            "description": "Test",
+            "is_enabled": True,
+        }
+        mock_server_service.get_server_info.return_value = server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "auth_credential_encrypted" not in data
+        assert "auth_credential" not in data
+
+    def test_get_server_includes_tools(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test that the response includes tool_list."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "tool_list" in data
+        assert len(data["tool_list"]) == 2
+        assert data["tool_list"][0]["name"] == "get_weather"
+
+    def test_get_server_includes_versions(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test that the response includes versions for multi-version servers."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "versions" in data
+        assert len(data["versions"]) == 1
+        assert data["versions"][0]["version"] == "v1.0.0"
+
+    def test_get_server_proxy_pass_url_stripped_for_non_admin_with_gateway(
+        self,
+        test_client_regular,
+        mock_server_service,
+        mock_settings,
+        sample_server_info,
+    ):
+        """Test proxy_pass_url is stripped for non-admin users in with-gateway mode."""
+        from registry.core.config import DeploymentMode
+
+        mock_settings.deployment_mode = DeploymentMode.WITH_GATEWAY
+        # Use a copy so dict.pop in the endpoint doesn't affect other tests
+        mock_server_service.get_server_info.return_value = dict(sample_server_info)
+        mock_server_service.user_can_access_server_path.return_value = True
+
+        response = test_client_regular.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "proxy_pass_url" not in data
+
+    def test_get_server_proxy_pass_url_kept_for_non_admin_registry_only(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test proxy_pass_url is kept for non-admin users in registry-only mode."""
+        from registry.core.config import DeploymentMode
+
+        # Use a copy so dict.pop in the endpoint doesn't affect other tests
+        mock_server_service.get_server_info.return_value = dict(sample_server_info)
+        mock_server_service.user_can_access_server_path.return_value = True
+
+        # Patch deployment_mode at the module level where the endpoint reads it
+        with patch(
+            "registry.api.server_routes.settings.deployment_mode",
+            DeploymentMode.REGISTRY_ONLY,
+        ):
+            response = test_client_regular.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "proxy_pass_url" in data
+        assert data["proxy_pass_url"] == "http://internal-backend:8080"
+
+    def test_get_server_proxy_pass_url_kept_for_admin(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test proxy_pass_url is always kept for admin users."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        response = test_client_admin.get("/api/servers/test-server")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "proxy_pass_url" in data
+        assert data["proxy_pass_url"] == "http://internal-backend:8080"
+
+    def test_get_server_audit_logged(
+        self,
+        test_client_admin,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Test that the read action is audit logged."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+
+        with patch("registry.api.server_routes.set_audit_action") as mock_audit:
+            response = test_client_admin.get("/api/servers/test-server")
+
+            assert response.status_code == 200
+            mock_audit.assert_called_once()
+            call_args = mock_audit.call_args
+            assert call_args[0][1] == "read"
+            assert call_args[0][2] == "server"


### PR DESCRIPTION
## Summary

Closes #801

- Adds `GET /api/servers/{path}` endpoint with JWT Bearer auth, mirroring the existing `GET /api/agents/{path}` pattern
- Strips `proxy_pass_url` for non-admin users in with-gateway mode; keeps it in registry-only mode so users can connect directly
- Updates API client (`ServerDetailResponse` model + `get_server()` method), CLI (`server-get` command), openapi.json, and api-reference docs
- 13 unit tests covering success, 404, 403, admin bypass, path normalization, credential stripping, proxy_pass_url deployment mode behavior, and audit logging

## Test plan

- [x] All 13 new unit tests pass
- [x] Full test suite: 2157 passed, 67 skipped (1 pre-existing failure in unrelated skill_scanner test)
- [x] Manual verification: tested `curl` and CLI `server-get` against live local registry with `/cloudflare-docs` and `/aws-kb`
- [x] py_compile passes on all modified files