### PR TITLE
fix: replace hardcoded 3-per-type search cap with global ranking and soft caps (#803)

### DIFF
--- a/docs/design/hybrid-search-architecture.md
+++ b/docs/design/hybrid-search-architecture.md
@@ -46,12 +46,20 @@ The registry implements hybrid search that combines semantic (vector) search wit
                                      |
                                      v
                           +---------------------+
+                          |  Result Distribution|
+                          |  Global ranking     |
+                          |  with competitive   |
+                          |  soft caps (60%)    |
+                          |  up to max_results  |
+                          +----------+----------+
+                                     |
+                                     v
+                          +---------------------+
                           |  Result Grouping    |
-                          |  - servers (top 3)  |
-                          |  - agents (top 3)   |
+                          |  - servers          |
+                          |  - agents           |
                           |  - virtual_servers  |
-                          |    (top 3)          |
-                          |  - skills (top 3)   |
+                          |  - skills           |
                           +----------+----------+
                                      |
                                      v
@@ -59,7 +67,7 @@ The registry implements hybrid search that combines semantic (vector) search wit
                           |  Tool Extraction    |
                           |  Extract matching   |
                           |  tools from servers |
-                          |  -> tools[] (top 3) |
+                          |  -> tools[]         |
                           +---------------------+
 ```
 
@@ -117,15 +125,15 @@ Text boost values (cumulative per keyword match):
 
 ### 4. Score-Before-Filter Pattern
 
-All candidate results are scored before applying the top-3-per-entity-type filter. This ensures the highest-scoring documents are selected:
+All candidate results are scored before applying the distribution filter. This ensures the highest-scoring documents are selected:
 
 1. Vector search returns candidates (up to `k` results)
 2. Keyword search returns additional matches (merged by highest boost per document)
 3. Every candidate receives a hybrid score (vector + text boost)
 4. All candidates are sorted by hybrid score descending
-5. Top 3 per entity type (servers, agents, tools) are selected from the sorted list
+5. The `_distribute_results()` function selects up to `max_results` items using global ranking with competitive soft caps (see [Result Distribution](#result-distribution) below)
 
-This prevents lower-scoring documents from consuming a top-3 slot before higher-scoring documents are evaluated.
+This prevents lower-scoring documents from consuming a slot before higher-scoring documents are evaluated.
 
 ### 5. Diagnostic Logging
 
@@ -136,9 +144,121 @@ Score for 'Context7' (type=mcp_server): vector=0.3412, normalized_vector=0.6706,
   text_boost=8.0, boost_contrib=0.8000, final=1.0000
 ```
 
-### 6. Result Structure
+### 6. Result Distribution
 
-Search returns grouped results (top 3 per entity type):
+The `max_results` parameter (range 1-50, default 10) controls how many total results are returned. Results are distributed across entity types using **global ranking with competitive soft caps**.
+
+#### Algorithm
+
+The `_distribute_results()` function in `search_repository.py` implements a two-pass approach:
+
+**Pass 1 -- Pick with soft caps:**
+1. Sort all scored candidates by `relevance_score` descending (all entity types on the same 0-1 scale)
+2. Walk the sorted list, picking items up to `max_results`
+3. If a type reaches its soft cap (`ceil(max_results * 0.6)`), check whether other entity types still have results remaining below in the ranking
+4. If other types are waiting: skip this item (enforce cap for diversity)
+5. If no other types remain: lift the cap (no point leaving slots empty)
+
+**Pass 2 -- Backfill:**
+6. If pass 1 didn't fill all `max_results` slots (because some items were skipped), backfill from the skipped items in score order
+
+#### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `SOFT_CAP_RATIO` | `0.6` | No single entity type can claim more than 60% of slots when other types are competing |
+| Tool extraction limit | `max(3, ceil(max_results * 0.6))` | Scales tool extraction with `max_results`, minimum 3 for backward compatibility |
+| Pipeline candidate limit | `max(max_results * 3, 50)` | Fetch enough candidates for global ranking |
+
+#### Examples
+
+**Example 1: Only servers exist (max_results=10)**
+
+A registry with 20 MCP servers and no agents, tools, or skills.
+
+```
+Candidates (sorted by relevance_score):
+  S(0.95), S(0.93), S(0.91), S(0.89), S(0.87), S(0.85),
+  S(0.83), S(0.81), S(0.79), S(0.77), S(0.75), ...
+
+soft_cap = ceil(10 * 0.6) = 6
+
+Pass 1:
+  Pick S(0.95) ... S(0.85) -> 6 servers (cap reached)
+  S(0.83): cap hit, check remaining types -> only mcp_server left
+           -> no competition, cap lifted
+  Pick S(0.83) ... S(0.77) -> 4 more servers
+
+Result: 10 servers (no artificial limit when only one type exists)
+```
+
+**Example 2: Mixed types (max_results=10)**
+
+A registry with servers, agents, and tools.
+
+```
+Candidates (sorted by relevance_score):
+  S(0.95), S(0.93), S(0.91), A(0.88), S(0.87), T(0.85),
+  S(0.83), A(0.80), S(0.78), T(0.75), A(0.72), S(0.70)
+
+soft_cap = ceil(10 * 0.6) = 6
+
+Pass 1:
+  Pick S(0.95), S(0.93), S(0.91)          -> 3 servers
+  Pick A(0.88)                              -> 1 agent
+  Pick S(0.87), T(0.85), S(0.83), A(0.80) -> 2 more servers, 1 tool, 1 agent
+  Pick S(0.78)                              -> 6th server (cap reached)
+  T(0.75): pick                             -> 2nd tool
+  A(0.72): pick                             -> 10th total (done)
+
+Result: 6 servers, 3 agents, 1 tool = 10 total
+  (diverse results, highest relevance wins, cap prevents server dominance)
+```
+
+**Example 3: Small max_results (max_results=5)**
+
+```
+soft_cap = ceil(5 * 0.6) = 3
+
+With mixed types, the dominant type gets at most 3 slots,
+leaving 2 for other types. Similar diversity to the previous
+default behavior of 3 per type.
+```
+
+**Example 4: Large max_results with one dominant type (max_results=50)**
+
+A registry with 40 servers, 3 agents, and 2 tools.
+
+```
+soft_cap = ceil(50 * 0.6) = 30
+
+Pass 1:
+  Servers fill 30 slots (cap reached while agents/tools still available)
+  3 agents and 2 tools fill 5 slots
+  Cap lifted for servers (no more agents/tools)
+  12 more servers fill remaining slots
+
+Result: 42 servers, 3 agents, 2 tools = 47 total
+  (all available entities returned, servers got the rest)
+```
+
+#### Backward Compatibility
+
+With the default `max_results=10`, the soft cap is 6. In a typical registry with multiple entity types, results look similar to the previous 3-per-type behavior: the dominant type gets 5-6 results, others share the rest. The key difference is that `max_results=50` now actually returns up to 50 results instead of being capped at 15 (3 per type * 5 types).
+
+#### Applies to All Search Paths
+
+The same `_distribute_results()` function is used by all three search code paths:
+
+| Search Path | When Used | Integration |
+|-------------|-----------|-------------|
+| Hybrid (DocumentDB) | Production with vector index | Scored tuples fed directly to `_distribute_results()` |
+| Client-side (MongoDB CE) | Local dev without vector search | Dict results converted to tuples, then distributed |
+| Lexical-only | When embedding model unavailable | Scores computed from `text_boost / MAX_LEXICAL_BOOST`, then distributed |
+
+### 7. Result Structure
+
+Search returns grouped results (up to `max_results` total, distributed across entity types):
 
 ```json
 {
@@ -426,8 +546,8 @@ The `efSearch` setting is configured in `registry/core/config.py` as `vector_sea
 
 ## Performance Considerations
 
-1. **Result Limiting**: Top 3 per entity type to reduce payload size
-2. **Score-Before-Filter**: All candidates scored and sorted before applying top-3 filter
+1. **Result Distribution**: Global ranking with competitive soft caps limits results to `max_results` (default 10, max 50). The distribution algorithm is O(n) where n is the candidate set size (at most 150 documents).
+2. **Score-Before-Filter**: All candidates scored and sorted before applying the distribution filter
 3. **Index Reuse**: HNSW index parameters (m=16, efConstruction=128) optimized for recall
 4. **efSearch Tuning**: Set to 100 for near-exact recall in typical deployments
 5. **Embedding Caching**: Lazy-loaded model with singleton pattern

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -458,7 +458,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', selectedTag
     error: semanticError
   } = useSemanticSearch(committedQuery, {
     minLength: 2,
-    maxResults: 12,
+    maxResults: 10,
     enabled: semanticEnabled,
     tags: selectedTags.length > 0 ? selectedTags : undefined,
   });

--- a/registry/repositories/documentdb/search_repository.py
+++ b/registry/repositories/documentdb/search_repository.py
@@ -1,6 +1,7 @@
 """DocumentDB-based repository for hybrid search (text + vector)."""
 
 import logging
+import math
 import re
 from typing import Any
 
@@ -106,6 +107,105 @@ def _tokens_match_text(
 # Maximum possible text_boost sum for lexical scoring normalization
 # path(5.0) + name(3.0) + description(2.0) + tag(1.5) + metadata(1.0) + tool(1.0) = 13.5
 MAX_LEXICAL_BOOST: float = 13.5
+
+# Maximum fraction of max_results any single entity type can claim
+# when other entity types have results competing for slots.
+# 0.6 means no type gets more than 60% of total unless no competition.
+SOFT_CAP_RATIO: float = 0.6
+
+
+def _tool_extraction_limit(
+    max_results: int,
+) -> int:
+    """Calculate the maximum number of tools to extract from server matching_tools.
+
+    Uses the soft cap ratio but never goes below 3 for backward compatibility.
+
+    Args:
+        max_results: The max_results parameter from the search request.
+
+    Returns:
+        Maximum number of tools to extract.
+    """
+    return max(3, math.ceil(max_results * SOFT_CAP_RATIO))
+
+
+def _distribute_results(
+    scored_results: list[tuple[dict, float]],
+    max_results: int,
+) -> list[tuple[dict, float]]:
+    """Select top results with competitive soft caps per entity type.
+
+    Picks the top max_results items by relevance_score. A soft cap prevents
+    any single entity type from taking more than 60% of slots -- but the cap
+    is only enforced when other entity types have results waiting below in
+    the ranking. If no other types remain, the cap is lifted.
+
+    Uses a two-pass approach:
+    1. First pass: pick items respecting soft caps
+    2. Backfill pass: if we haven't reached max_results, fill remaining
+       slots from skipped items (highest score first)
+
+    Args:
+        scored_results: List of (doc, relevance_score) tuples, sorted by
+            relevance_score descending.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        Filtered list of (doc, relevance_score) tuples, length <= max_results.
+    """
+    if not scored_results or max_results <= 0:
+        return []
+
+    soft_cap = max(1, math.ceil(max_results * SOFT_CAP_RATIO))
+    type_counts: dict[str, int] = {}
+    selected: list[tuple[dict, float]] = []
+    skipped: list[tuple[dict, float]] = []
+
+    # Pre-compute which entity types exist at each position onward.
+    # remaining_types[i] = set of entity types present in scored_results[i:]
+    total = len(scored_results)
+    remaining_types: list[set[str]] = [set() for _ in range(total + 1)]
+    for i in range(total - 1, -1, -1):
+        entity_type = scored_results[i][0].get("entity_type", "")
+        remaining_types[i] = remaining_types[i + 1] | {entity_type}
+
+    # Pass 1: pick items respecting soft caps
+    for i, (doc, score) in enumerate(scored_results):
+        if len(selected) >= max_results:
+            break
+
+        entity_type = doc.get("entity_type", "")
+        current_count = type_counts.get(entity_type, 0)
+
+        if current_count >= soft_cap:
+            # Check if other types still have results after this position
+            types_after = remaining_types[i + 1] - {entity_type}
+            if types_after:
+                skipped.append((doc, score))
+                continue  # Other types waiting -- enforce cap
+            # No competition -- allow this type to fill remaining slots
+
+        selected.append((doc, score))
+        type_counts[entity_type] = current_count + 1
+
+    # Pass 2: backfill from skipped items if we haven't reached max_results
+    # Skipped items are already in descending score order
+    for doc, score in skipped:
+        if len(selected) >= max_results:
+            break
+        selected.append((doc, score))
+
+    logger.debug(
+        "Search distribution: max_results=%d, soft_cap=%d, "
+        "selected=%d, per_type=%s",
+        max_results,
+        soft_cap,
+        len(selected),
+        dict(type_counts),
+    )
+
+    return selected
 
 
 def _flatten_metadata_to_text(metadata: dict[str, Any]) -> str:
@@ -853,7 +953,7 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
         for doc in results:
             doc["text_boost"] = MAX_LEXICAL_BOOST
             doc["matching_tools"] = []
-        return self._format_lexical_results(results)
+        return self._format_lexical_results(results, max_results)
 
     async def get_all_tags(self) -> list[str]:
         """Return a sorted list of all unique tags across all indexed entities."""
@@ -1037,27 +1137,11 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             # Sort by relevance score (descending)
             scored_docs.sort(key=lambda x: x["relevance_score"], reverse=True)
 
-            # Separate by entity type and take top 3 of each
-            servers = []
-            agents = []
-            tools = []
-            skills = []
-            virtual_servers = []
-
-            for item in scored_docs:
-                doc = item["doc"]
-                entity_type = doc.get("entity_type")
-
-                if entity_type == "mcp_server" and len(servers) < 3:
-                    servers.append(item)
-                elif entity_type == "a2a_agent" and len(agents) < 3:
-                    agents.append(item)
-                elif entity_type == "mcp_tool" and len(tools) < 3:
-                    tools.append(item)
-                elif entity_type == "skill" and len(skills) < 3:
-                    skills.append(item)
-                elif entity_type == "virtual_server" and len(virtual_servers) < 3:
-                    virtual_servers.append(item)
+            # Convert to (doc, score) tuples and distribute with soft caps
+            scored_tuples = [
+                (item["doc"], item["relevance_score"]) for item in scored_docs
+            ]
+            selected = _distribute_results(scored_tuples, max_results)
 
             # Format results to match the API contract
             grouped_results = {
@@ -1069,145 +1153,138 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             }
 
             tool_count = 0
-            for item in servers:
-                doc = item["doc"]
-                relevance_score = item["relevance_score"]
-                matching_tools = doc.get("_matching_tools", [])
-                server_metadata = doc.get("metadata", {})
+            tool_limit = _tool_extraction_limit(max_results)
 
-                result_entry = {
-                    "entity_type": "mcp_server",
-                    "path": doc.get("path"),
-                    "server_name": doc.get("name"),
-                    "description": doc.get("description"),
-                    "tags": doc.get("tags", []),
-                    "num_tools": server_metadata.get("num_tools", 0),
-                    "is_enabled": doc.get("is_enabled", False),
-                    "relevance_score": relevance_score,
-                    "match_context": doc.get("description"),
-                    "matching_tools": matching_tools,
-                    "proxy_pass_url": server_metadata.get("proxy_pass_url"),
-                    "mcp_endpoint": server_metadata.get("mcp_endpoint"),
-                    "sse_endpoint": server_metadata.get("sse_endpoint"),
-                    "supported_transports": server_metadata.get("supported_transports", []),
-                }
-                grouped_results["servers"].append(result_entry)
+            for doc, relevance_score in selected:
+                entity_type = doc.get("entity_type")
 
-                # Also add matching tools to the top-level tools array
-                # Build a lookup map from tool name to inputSchema from original tools
-                original_tools = doc.get("tools", [])
-                tool_schema_map = {
-                    t.get("name", ""): t.get("inputSchema", {}) for t in original_tools
-                }
+                if entity_type == "mcp_server":
+                    matching_tools = doc.get("_matching_tools", [])
+                    server_metadata = doc.get("metadata", {})
 
-                server_path = doc.get("path", "")
-                server_name = doc.get("name", "")
-                for tool in matching_tools:
-                    if tool_count >= 3:
-                        break
-                    tool_name = tool.get("tool_name", "")
-                    grouped_results["tools"].append(
-                        {
-                            "entity_type": "tool",
-                            "server_path": server_path,
-                            "server_name": server_name,
-                            "tool_name": tool_name,
-                            "description": tool.get("description", ""),
-                            "inputSchema": tool_schema_map.get(tool_name, {}),
-                            "relevance_score": tool.get("relevance_score", relevance_score),
-                            "match_context": tool.get("match_context", ""),
-                        }
-                    )
-                    tool_count += 1
+                    result_entry = {
+                        "entity_type": "mcp_server",
+                        "path": doc.get("path"),
+                        "server_name": doc.get("name"),
+                        "description": doc.get("description"),
+                        "tags": doc.get("tags", []),
+                        "num_tools": server_metadata.get("num_tools", 0),
+                        "is_enabled": doc.get("is_enabled", False),
+                        "relevance_score": relevance_score,
+                        "match_context": doc.get("description"),
+                        "matching_tools": matching_tools,
+                        "proxy_pass_url": server_metadata.get("proxy_pass_url"),
+                        "mcp_endpoint": server_metadata.get("mcp_endpoint"),
+                        "sse_endpoint": server_metadata.get("sse_endpoint"),
+                        "supported_transports": server_metadata.get("supported_transports", []),
+                    }
+                    grouped_results["servers"].append(result_entry)
 
-            for item in agents:
-                doc = item["doc"]
-                relevance_score = item["relevance_score"]
-                metadata = doc.get("metadata", {})
+                    # Also add matching tools to the top-level tools array
+                    original_tools = doc.get("tools", [])
+                    tool_schema_map = {
+                        t.get("name", ""): t.get("inputSchema", {}) for t in original_tools
+                    }
 
-                result_entry = {
-                    "entity_type": "a2a_agent",
-                    "path": doc.get("path"),
-                    "agent_name": doc.get("name"),
-                    "description": doc.get("description"),
-                    "tags": doc.get("tags", []),
-                    "skills": metadata.get("skills", []),
-                    "visibility": metadata.get("visibility", "public"),
-                    "trust_level": metadata.get("trust_level"),
-                    "is_enabled": doc.get("is_enabled", False),
-                    "relevance_score": relevance_score,
-                    "match_context": doc.get("description"),
-                    "agent_card": metadata.get("agent_card", {}),
-                }
-                grouped_results["agents"].append(result_entry)
+                    server_path = doc.get("path", "")
+                    server_name = doc.get("name", "")
+                    for tool in matching_tools:
+                        if tool_count >= tool_limit:
+                            break
+                        tool_name = tool.get("tool_name", "")
+                        grouped_results["tools"].append(
+                            {
+                                "entity_type": "tool",
+                                "server_path": server_path,
+                                "server_name": server_name,
+                                "tool_name": tool_name,
+                                "description": tool.get("description", ""),
+                                "inputSchema": tool_schema_map.get(tool_name, {}),
+                                "relevance_score": tool.get("relevance_score", relevance_score),
+                                "match_context": tool.get("match_context", ""),
+                            }
+                        )
+                        tool_count += 1
 
-            for item in tools:
-                doc = item["doc"]
-                relevance_score = item["relevance_score"]
+                elif entity_type == "a2a_agent":
+                    metadata = doc.get("metadata", {})
+                    result_entry = {
+                        "entity_type": "a2a_agent",
+                        "path": doc.get("path"),
+                        "agent_name": doc.get("name"),
+                        "description": doc.get("description"),
+                        "tags": doc.get("tags", []),
+                        "skills": metadata.get("skills", []),
+                        "visibility": metadata.get("visibility", "public"),
+                        "trust_level": metadata.get("trust_level"),
+                        "is_enabled": doc.get("is_enabled", False),
+                        "relevance_score": relevance_score,
+                        "match_context": doc.get("description"),
+                        "agent_card": metadata.get("agent_card", {}),
+                    }
+                    grouped_results["agents"].append(result_entry)
 
-                result_entry = {
-                    "entity_type": "mcp_tool",
-                    "path": doc.get("path"),
-                    "tool_name": doc.get("name"),
-                    "description": doc.get("description"),
-                    "inputSchema": doc.get("inputSchema", {}),
-                    "relevance_score": relevance_score,
-                    "match_context": doc.get("description"),
-                }
-                grouped_results["tools"].append(result_entry)
+                elif entity_type == "mcp_tool":
+                    result_entry = {
+                        "entity_type": "mcp_tool",
+                        "path": doc.get("path"),
+                        "tool_name": doc.get("name"),
+                        "description": doc.get("description"),
+                        "inputSchema": doc.get("inputSchema", {}),
+                        "relevance_score": relevance_score,
+                        "match_context": doc.get("description"),
+                    }
+                    grouped_results["tools"].append(result_entry)
 
-            for item in skills:
-                doc = item["doc"]
-                relevance_score = item["relevance_score"]
-                metadata = doc.get("metadata", {})
+                elif entity_type == "skill":
+                    metadata = doc.get("metadata", {})
+                    result_entry = {
+                        "entity_type": "skill",
+                        "path": doc.get("path"),
+                        "skill_name": doc.get("name"),
+                        "description": doc.get("description"),
+                        "tags": doc.get("tags", []),
+                        "skill_md_url": metadata.get("skill_md_url"),
+                        "version": metadata.get("version"),
+                        "author": metadata.get("author"),
+                        "visibility": doc.get("visibility", "public"),
+                        "owner": doc.get("owner"),
+                        "is_enabled": doc.get("is_enabled", False),
+                        "relevance_score": relevance_score,
+                        "match_context": doc.get("description"),
+                    }
+                    grouped_results["skills"].append(result_entry)
 
-                result_entry = {
-                    "entity_type": "skill",
-                    "path": doc.get("path"),
-                    "skill_name": doc.get("name"),
-                    "description": doc.get("description"),
-                    "tags": doc.get("tags", []),
-                    "skill_md_url": metadata.get("skill_md_url"),
-                    "version": metadata.get("version"),
-                    "author": metadata.get("author"),
-                    "visibility": doc.get("visibility", "public"),
-                    "owner": doc.get("owner"),
-                    "is_enabled": doc.get("is_enabled", False),
-                    "relevance_score": relevance_score,
-                    "match_context": doc.get("description"),
-                }
-                grouped_results["skills"].append(result_entry)
-
-            for item in virtual_servers:
-                doc = item["doc"]
-                relevance_score = item["relevance_score"]
-                metadata = doc.get("metadata", {})
-                matching_tools = doc.get("_matching_tools", [])
-
-                result_entry = {
-                    "entity_type": "virtual_server",
-                    "path": doc.get("path"),
-                    "server_name": doc.get("name"),
-                    "description": doc.get("description"),
-                    "tags": doc.get("tags", []),
-                    "num_tools": metadata.get("num_tools", 0),
-                    "backend_count": metadata.get("backend_count", 0),
-                    "backend_paths": metadata.get("backend_paths", []),
-                    "is_enabled": doc.get("is_enabled", False),
-                    "relevance_score": relevance_score,
-                    "match_context": doc.get("description"),
-                    "matching_tools": matching_tools,
-                }
-                grouped_results["virtual_servers"].append(result_entry)
+                elif entity_type == "virtual_server":
+                    metadata = doc.get("metadata", {})
+                    matching_tools = doc.get("_matching_tools", [])
+                    result_entry = {
+                        "entity_type": "virtual_server",
+                        "path": doc.get("path"),
+                        "server_name": doc.get("name"),
+                        "description": doc.get("description"),
+                        "tags": doc.get("tags", []),
+                        "num_tools": metadata.get("num_tools", 0),
+                        "backend_count": metadata.get("backend_count", 0),
+                        "backend_paths": metadata.get("backend_paths", []),
+                        "is_enabled": doc.get("is_enabled", False),
+                        "relevance_score": relevance_score,
+                        "match_context": doc.get("description"),
+                        "matching_tools": matching_tools,
+                    }
+                    grouped_results["virtual_servers"].append(result_entry)
 
             logger.info(
-                f"Client-side search returned "
-                f"{len(grouped_results['servers'])} servers, "
-                f"{len(grouped_results['tools'])} tools, "
-                f"{len(grouped_results['agents'])} agents, "
-                f"{len(grouped_results['skills'])} skills, "
-                f"{len(grouped_results['virtual_servers'])} virtual_servers "
-                f"from {len(all_docs)} total documents (top 3 per type)"
+                "Client-side search returned "
+                "%d servers, %d tools, %d agents, %d skills, "
+                "%d virtual_servers from %d total documents (max_results=%d)",
+                len(grouped_results["servers"]),
+                len(grouped_results["tools"]),
+                len(grouped_results["agents"]),
+                len(grouped_results["skills"]),
+                len(grouped_results["virtual_servers"]),
+                len(all_docs),
+                max_results,
             )
 
             return grouped_results
@@ -1262,13 +1339,13 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             {"$match": keyword_match_filter},
             text_boost_stage,
             {"$sort": {"text_boost": -1}},
-            {"$limit": max_results},
+            {"$limit": max(max_results * 3, 50)},
         ]
 
         cursor = collection.aggregate(pipeline)
-        results = await cursor.to_list(length=max_results)
+        results = await cursor.to_list(length=max(max_results * 3, 50))
 
-        grouped_results = self._format_lexical_results(results)
+        grouped_results = self._format_lexical_results(results, max_results)
 
         logger.info(
             "Lexical-only search for '%s' returned %d servers, %d tools, %d agents",
@@ -1283,17 +1360,31 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
     def _format_lexical_results(
         self,
         results: list[dict],
+        max_results: int = 10,
     ) -> dict[str, list[dict[str, Any]]]:
         """Format lexical search results into grouped response.
 
         Uses fixed-denominator normalization for relevance scoring.
+        Applies global ranking with competitive soft caps via _distribute_results().
 
         Args:
             results: Raw MongoDB documents with text_boost field
+            max_results: Maximum number of results to return
 
         Returns:
             Grouped search results dict with servers, tools, agents lists
         """
+        # Score results and sort by relevance before distributing
+        scored_tuples: list[tuple[dict, float]] = []
+        for doc in results:
+            text_boost = doc.get("text_boost", 0.0)
+            relevance_score = min(1.0, text_boost / MAX_LEXICAL_BOOST)
+            scored_tuples.append((doc, relevance_score))
+
+        scored_tuples.sort(key=lambda x: x[1], reverse=True)
+        selected = _distribute_results(scored_tuples, max_results)
+
+        # Group selected results by entity type
         grouped_results = {
             "servers": [],
             "tools": [],
@@ -1301,18 +1392,13 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             "skills": [],
             "virtual_servers": [],
         }
-        server_count = 0
-        agent_count = 0
         tool_count = 0
-        skill_count = 0
-        virtual_server_count = 0
+        tool_limit = _tool_extraction_limit(max_results)
 
-        for doc in results:
+        for doc, relevance_score in selected:
             entity_type = doc.get("entity_type")
-            text_boost = doc.get("text_boost", 0.0)
-            relevance_score = min(1.0, text_boost / MAX_LEXICAL_BOOST)
 
-            if entity_type == "mcp_server" and server_count < 3:
+            if entity_type == "mcp_server":
                 matching_tools = doc.get("matching_tools", [])
                 server_metadata = doc.get("metadata", {})
                 result_entry = {
@@ -1332,7 +1418,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "supported_transports": server_metadata.get("supported_transports", []),
                 }
                 grouped_results["servers"].append(result_entry)
-                server_count += 1
 
                 # Add matching tools to top-level tools array
                 original_tools = doc.get("tools", [])
@@ -1342,7 +1427,7 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                 server_path = doc.get("path", "")
                 server_name = doc.get("name", "")
                 for tool in matching_tools:
-                    if tool_count >= 3:
+                    if tool_count >= tool_limit:
                         break
                     tool_name = tool.get("tool_name", "")
                     grouped_results["tools"].append(
@@ -1359,7 +1444,7 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     )
                     tool_count += 1
 
-            elif entity_type == "a2a_agent" and agent_count < 3:
+            elif entity_type == "a2a_agent":
                 metadata = doc.get("metadata", {})
                 result_entry = {
                     "entity_type": "a2a_agent",
@@ -1376,9 +1461,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "agent_card": metadata.get("agent_card", {}),
                 }
                 grouped_results["agents"].append(result_entry)
-                agent_count += 1
 
-            elif entity_type == "mcp_tool" and tool_count < 3:
+            elif entity_type == "mcp_tool":
                 result_entry = {
                     "entity_type": "mcp_tool",
                     "path": doc.get("path"),
@@ -1389,9 +1473,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "match_context": doc.get("description"),
                 }
                 grouped_results["tools"].append(result_entry)
-                tool_count += 1
 
-            elif entity_type == "skill" and skill_count < 3:
+            elif entity_type == "skill":
                 metadata = doc.get("metadata", {})
                 result_entry = {
                     "entity_type": "skill",
@@ -1409,9 +1492,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "match_context": doc.get("description"),
                 }
                 grouped_results["skills"].append(result_entry)
-                skill_count += 1
 
-            elif entity_type == "virtual_server" and virtual_server_count < 3:
+            elif entity_type == "virtual_server":
                 metadata = doc.get("metadata", {})
                 matching_tools = doc.get("matching_tools", [])
                 result_entry = {
@@ -1429,7 +1511,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "matching_tools": matching_tools,
                 }
                 grouped_results["virtual_servers"].append(result_entry)
-                virtual_server_count += 1
 
         return grouped_results
 
@@ -1521,11 +1602,13 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             # Sort by text boost (descending), keeping vector search order as secondary
             pipeline.append({"$sort": {"text_boost": -1}})
 
-            # Limit to requested number of results
-            pipeline.append({"$limit": max_results})
+            # Fetch more candidates than max_results to allow for global ranking.
+            # The _distribute_results() function will pick the top max_results.
+            candidate_limit = max(max_results * 3, 50)
+            pipeline.append({"$limit": candidate_limit})
 
             cursor = collection.aggregate(pipeline)
-            results = await cursor.to_list(length=max_results)
+            results = await cursor.to_list(length=candidate_limit)
 
             # Log vector search results for diagnosis
             logger.info(
@@ -1669,10 +1752,13 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
 
                 scored_results.append((doc, relevance_score))
 
-            # Sort by hybrid score descending so top-3 picks the best
+            # Sort by hybrid score descending
             scored_results.sort(key=lambda x: x[1], reverse=True)
 
-            # Group results: top 3 per entity type
+            # Distribute results using global ranking with soft caps
+            selected_results = _distribute_results(scored_results, max_results)
+
+            # Group selected results by entity type for the response
             grouped_results = {
                 "servers": [],
                 "tools": [],
@@ -1680,26 +1766,11 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                 "skills": [],
                 "virtual_servers": [],
             }
-            server_count = 0
-            agent_count = 0
             tool_count = 0
-            skill_count = 0
-            virtual_server_count = 0
+            tool_limit = _tool_extraction_limit(max_results)
 
-            for doc, relevance_score in scored_results:
+            for doc, relevance_score in selected_results:
                 entity_type = doc.get("entity_type")
-
-                # Skip if we already have 3 of this type
-                if entity_type == "mcp_server" and server_count >= 3:
-                    continue
-                elif entity_type == "a2a_agent" and agent_count >= 3:
-                    continue
-                elif entity_type == "mcp_tool" and tool_count >= 3:
-                    continue
-                elif entity_type == "skill" and skill_count >= 3:
-                    continue
-                elif entity_type == "virtual_server" and virtual_server_count >= 3:
-                    continue
 
                 if entity_type == "mcp_server":
                     matching_tools = doc.get("matching_tools", [])
@@ -1722,10 +1793,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                         "supported_transports": server_metadata.get("supported_transports", []),
                     }
                     grouped_results["servers"].append(result_entry)
-                    server_count += 1
 
                     # Also add matching tools to the top-level tools array
-                    # Build a lookup map from tool name to inputSchema from original tools
                     original_tools = doc.get("tools", [])
                     tool_schema_map = {
                         t.get("name", ""): t.get("inputSchema", {}) for t in original_tools
@@ -1734,7 +1803,7 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     server_path = doc.get("path", "")
                     server_name = doc.get("name", "")
                     for tool in matching_tools:
-                        if tool_count >= 3:
+                        if tool_count >= tool_limit:
                             break
                         tool_name = tool.get("tool_name", "")
                         grouped_results["tools"].append(
@@ -1769,7 +1838,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                         "sync_metadata": metadata.get("sync_metadata"),
                     }
                     grouped_results["agents"].append(result_entry)
-                    agent_count += 1
 
                 elif entity_type == "mcp_tool":
                     result_entry = {
@@ -1782,7 +1850,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                         "match_context": doc.get("description"),
                     }
                     grouped_results["tools"].append(result_entry)
-                    tool_count += 1
 
                 elif entity_type == "skill":
                     metadata = doc.get("metadata", {})
@@ -1802,7 +1869,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                         "match_context": doc.get("description"),
                     }
                     grouped_results["skills"].append(result_entry)
-                    skill_count += 1
 
                 elif entity_type == "virtual_server":
                     metadata = doc.get("metadata", {})
@@ -1822,7 +1888,6 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                         "matching_tools": matching_tools,
                     }
                     grouped_results["virtual_servers"].append(result_entry)
-                    virtual_server_count += 1
 
             # Sort each group by relevance_score (descending) to ensure highest matches
             # appear first. This is needed because the DB sorts by text_boost only,
@@ -1836,12 +1901,16 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
             )
 
             logger.info(
-                f"Hybrid search for '{query}' returned "
-                f"{len(grouped_results['servers'])} servers, "
-                f"{len(grouped_results['tools'])} tools, "
-                f"{len(grouped_results['agents'])} agents, "
-                f"{len(grouped_results['skills'])} skills, "
-                f"{len(grouped_results['virtual_servers'])} virtual_servers (top 3 per type)"
+                "Hybrid search for '%s' returned "
+                "%d servers, %d tools, %d agents, %d skills, "
+                "%d virtual_servers (max_results=%d)",
+                query,
+                len(grouped_results["servers"]),
+                len(grouped_results["tools"]),
+                len(grouped_results["agents"]),
+                len(grouped_results["skills"]),
+                len(grouped_results["virtual_servers"]),
+                max_results,
             )
 
             return grouped_results

--- a/tests/unit/repositories/test_search_result_distribution.py
+++ b/tests/unit/repositories/test_search_result_distribution.py
@@ -1,0 +1,399 @@
+"""Unit tests for search result distribution logic.
+
+Tests the _distribute_results() function and _tool_extraction_limit() helper
+that replace the old hardcoded cap of 3 per entity type with global ranking
+and competitive soft caps.
+
+Covers:
+- Empty results
+- Single-type dominance (no artificial cap when no competition)
+- Multi-type competition with soft cap enforcement
+- Soft cap lifted when no other types remain
+- Edge cases (max_results=1, max_results >= total)
+- Backward compatibility with default max_results=10
+- Tool extraction limit scaling
+"""
+
+import math
+
+import pytest
+
+from registry.repositories.documentdb.search_repository import (
+    SOFT_CAP_RATIO,
+    _distribute_results,
+    _tool_extraction_limit,
+)
+
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _make_doc(
+    entity_type: str,
+    name: str,
+    score: float,
+) -> tuple[dict, float]:
+    """Create a (doc, score) tuple for testing.
+
+    Args:
+        entity_type: Entity type string (e.g. "mcp_server")
+        name: Document name for identification
+        score: Relevance score
+
+    Returns:
+        Tuple of (doc_dict, score)
+    """
+    return (
+        {"entity_type": entity_type, "name": name},
+        score,
+    )
+
+
+def _make_servers(
+    count: int,
+    start_score: float = 0.95,
+    step: float = 0.02,
+) -> list[tuple[dict, float]]:
+    """Create a list of server result tuples with descending scores.
+
+    Args:
+        count: Number of servers to create
+        start_score: Score of the first server
+        step: Score decrement per server
+
+    Returns:
+        List of (doc, score) tuples sorted by score descending
+    """
+    return [
+        _make_doc("mcp_server", f"server-{i}", round(start_score - i * step, 4))
+        for i in range(count)
+    ]
+
+
+def _make_agents(
+    count: int,
+    start_score: float = 0.80,
+    step: float = 0.05,
+) -> list[tuple[dict, float]]:
+    """Create a list of agent result tuples with descending scores."""
+    return [
+        _make_doc("a2a_agent", f"agent-{i}", round(start_score - i * step, 4))
+        for i in range(count)
+    ]
+
+
+def _make_tools(
+    count: int,
+    start_score: float = 0.75,
+    step: float = 0.05,
+) -> list[tuple[dict, float]]:
+    """Create a list of tool result tuples with descending scores."""
+    return [
+        _make_doc("mcp_tool", f"tool-{i}", round(start_score - i * step, 4))
+        for i in range(count)
+    ]
+
+
+def _make_skills(
+    count: int,
+    start_score: float = 0.70,
+    step: float = 0.05,
+) -> list[tuple[dict, float]]:
+    """Create a list of skill result tuples with descending scores."""
+    return [
+        _make_doc("skill", f"skill-{i}", round(start_score - i * step, 4))
+        for i in range(count)
+    ]
+
+
+def _count_types(
+    results: list[tuple[dict, float]],
+) -> dict[str, int]:
+    """Count results per entity type.
+
+    Args:
+        results: List of (doc, score) tuples
+
+    Returns:
+        Dict mapping entity_type to count
+    """
+    counts: dict[str, int] = {}
+    for doc, _ in results:
+        entity_type = doc.get("entity_type", "")
+        counts[entity_type] = counts.get(entity_type, 0) + 1
+    return counts
+
+
+# =============================================================================
+# TESTS: _distribute_results()
+# =============================================================================
+
+
+class TestDistributeResults:
+    """Tests for the _distribute_results() function."""
+
+    def test_empty_results(self):
+        """Empty input returns empty output."""
+        result = _distribute_results([], 10)
+        assert result == []
+
+    def test_zero_max_results(self):
+        """max_results=0 returns empty output."""
+        scored = _make_servers(5)
+        result = _distribute_results(scored, 0)
+        assert result == []
+
+    def test_single_type_no_cap(self):
+        """Only servers in results -- all slots go to servers, no artificial limit."""
+        servers = _make_servers(20)
+        result = _distribute_results(servers, 10)
+
+        assert len(result) == 10
+        counts = _count_types(result)
+        assert counts["mcp_server"] == 10
+
+    def test_single_type_respects_max_results(self):
+        """20 servers with max_results=10 returns exactly 10."""
+        servers = _make_servers(20)
+        result = _distribute_results(servers, 10)
+        assert len(result) == 10
+
+    def test_single_type_fewer_than_max(self):
+        """5 servers with max_results=10 returns all 5."""
+        servers = _make_servers(5)
+        result = _distribute_results(servers, 10)
+
+        assert len(result) == 5
+        counts = _count_types(result)
+        assert counts["mcp_server"] == 5
+
+    def test_mixed_types_global_ranking(self):
+        """Higher-relevance items win regardless of type."""
+        # 3 servers at 0.95, 0.93, 0.91
+        # 3 agents at 0.80, 0.75, 0.70
+        scored = _make_servers(3) + _make_agents(3)
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 6)
+        assert len(result) == 6
+
+        # First 3 should be servers (highest scores)
+        for doc, _ in result[:3]:
+            assert doc["entity_type"] == "mcp_server"
+
+    def test_soft_cap_enforced(self):
+        """Dominant type capped at 60% when other types have results."""
+        # 10 servers (0.95 to 0.77) + 5 agents (0.80 to 0.60)
+        servers = _make_servers(10)
+        agents = _make_agents(5)
+        scored = servers + agents
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        max_results = 10
+        soft_cap = math.ceil(max_results * SOFT_CAP_RATIO)  # 6
+
+        result = _distribute_results(scored, max_results)
+        assert len(result) == max_results
+
+        counts = _count_types(result)
+        # Servers should be capped at soft_cap since agents are competing
+        assert counts["mcp_server"] <= soft_cap
+        # Agents should have gotten some slots
+        assert counts.get("a2a_agent", 0) > 0
+
+    def test_soft_cap_lifted_when_no_competition(self):
+        """Cap removed when only one type remains in the tail."""
+        # 15 servers (high scores) + 1 agent (lower score)
+        servers = _make_servers(15, start_score=0.95, step=0.02)
+        agents = [_make_doc("a2a_agent", "agent-0", 0.50)]
+        scored = servers + agents
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        max_results = 10
+        soft_cap = math.ceil(max_results * SOFT_CAP_RATIO)  # 6
+
+        result = _distribute_results(scored, max_results)
+        assert len(result) == max_results
+
+        counts = _count_types(result)
+        # Agent should be included (it's in the top candidates)
+        # But servers should get more than soft_cap since after the agent
+        # there are no more agents remaining, so the cap is lifted
+        assert counts["mcp_server"] >= soft_cap
+
+    def test_max_results_1(self):
+        """Edge case: max_results=1 returns exactly 1 result."""
+        scored = _make_servers(5) + _make_agents(3)
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 1)
+        assert len(result) == 1
+        # Should be the highest scored item
+        assert result[0][1] == max(s for _, s in scored)
+
+    def test_max_results_equals_total(self):
+        """max_results >= total results returns all results."""
+        servers = _make_servers(3)
+        agents = _make_agents(2)
+        scored = servers + agents
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 100)
+        assert len(result) == 5  # All results returned
+
+    def test_backward_compatible_default(self):
+        """max_results=10 with mixed types produces diverse results."""
+        servers = _make_servers(8, start_score=0.95)
+        agents = _make_agents(5, start_score=0.80)
+        tools = _make_tools(4, start_score=0.75)
+        scored = servers + agents + tools
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 10)
+        assert len(result) == 10
+
+        counts = _count_types(result)
+        # Should have diversity -- at least 2 types present
+        assert len(counts) >= 2
+        # No type should have more than 6 (soft cap for max_results=10)
+        for count in counts.values():
+            assert count <= math.ceil(10 * SOFT_CAP_RATIO)
+
+    def test_entity_types_filter_single(self):
+        """When only one entity_type in input, all slots go to it."""
+        agents = _make_agents(20, start_score=0.90, step=0.01)
+        result = _distribute_results(agents, 15)
+
+        assert len(result) == 15
+        counts = _count_types(result)
+        assert counts["a2a_agent"] == 15
+
+    def test_results_contain_highest_scores(self):
+        """Selected results include the highest-scoring items available."""
+        scored = _make_servers(5) + _make_agents(5)
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 8)
+        result_scores = sorted([s for _, s in result], reverse=True)
+        # The top score from the input should be in the results
+        assert result_scores[0] == scored[0][1]
+        assert len(result) == 8
+
+    def test_three_types_competing(self):
+        """Three entity types compete fairly."""
+        servers = _make_servers(10, start_score=0.95)
+        agents = _make_agents(8, start_score=0.85)
+        tools = _make_tools(6, start_score=0.75)
+        scored = servers + agents + tools
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 15)
+        assert len(result) == 15
+
+        counts = _count_types(result)
+        soft_cap = math.ceil(15 * SOFT_CAP_RATIO)  # 9
+
+        # All three types should be represented
+        assert len(counts) == 3
+        # No type exceeds soft cap (since all three have results)
+        for count in counts.values():
+            assert count <= soft_cap
+
+    def test_five_types_all_present(self):
+        """All five entity types get fair representation."""
+        servers = _make_servers(5, start_score=0.95)
+        agents = _make_agents(5, start_score=0.85)
+        tools = _make_tools(5, start_score=0.75)
+        skills = _make_skills(5, start_score=0.65)
+        virtual = [
+            _make_doc("virtual_server", f"vs-{i}", round(0.60 - i * 0.05, 4))
+            for i in range(5)
+        ]
+        scored = servers + agents + tools + skills + virtual
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 20)
+        assert len(result) == 20
+
+        counts = _count_types(result)
+        # All 5 types should be present
+        assert len(counts) == 5
+
+    def test_small_max_results_5(self):
+        """max_results=5 with mixed types -- soft_cap=3."""
+        servers = _make_servers(8, start_score=0.95)
+        agents = _make_agents(5, start_score=0.80)
+        scored = servers + agents
+        scored.sort(key=lambda x: x[1], reverse=True)
+
+        result = _distribute_results(scored, 5)
+        assert len(result) == 5
+
+        counts = _count_types(result)
+        soft_cap = math.ceil(5 * SOFT_CAP_RATIO)  # 3
+        # Servers should be capped at 3 since agents are competing
+        assert counts["mcp_server"] <= soft_cap
+        # Agents should get remaining slots
+        assert counts.get("a2a_agent", 0) > 0
+
+
+# =============================================================================
+# TESTS: _tool_extraction_limit()
+# =============================================================================
+
+
+class TestToolExtractionLimit:
+    """Tests for the _tool_extraction_limit() helper."""
+
+    def test_default_max_results(self):
+        """max_results=10 gives ceil(10*0.6)=6, which is >=3."""
+        result = _tool_extraction_limit(10)
+        assert result == 6
+
+    def test_small_max_results(self):
+        """max_results=1 still returns at least 3 (backward compat)."""
+        result = _tool_extraction_limit(1)
+        assert result == 3
+
+    def test_max_results_3(self):
+        """max_results=3 gives ceil(3*0.6)=2, floor is 3."""
+        result = _tool_extraction_limit(3)
+        assert result == 3
+
+    def test_large_max_results(self):
+        """max_results=50 gives ceil(50*0.6)=30."""
+        result = _tool_extraction_limit(50)
+        assert result == 30
+
+    def test_never_below_3(self):
+        """Tool limit never goes below 3 regardless of max_results."""
+        for max_results in range(1, 10):
+            assert _tool_extraction_limit(max_results) >= 3
+
+    def test_scales_with_max_results(self):
+        """Larger max_results produces larger tool limit."""
+        limit_10 = _tool_extraction_limit(10)
+        limit_50 = _tool_extraction_limit(50)
+        assert limit_50 > limit_10
+
+
+# =============================================================================
+# TESTS: SOFT_CAP_RATIO constant
+# =============================================================================
+
+
+class TestSoftCapRatio:
+    """Tests for the SOFT_CAP_RATIO constant value."""
+
+    def test_ratio_value(self):
+        """SOFT_CAP_RATIO is 0.6 as designed."""
+        assert SOFT_CAP_RATIO == 0.6
+
+    def test_ratio_produces_expected_caps(self):
+        """Verify soft cap values for common max_results values."""
+        assert math.ceil(10 * SOFT_CAP_RATIO) == 6
+        assert math.ceil(5 * SOFT_CAP_RATIO) == 3
+        assert math.ceil(50 * SOFT_CAP_RATIO) == 30
+        assert math.ceil(1 * SOFT_CAP_RATIO) == 1


### PR DESCRIPTION
## Summary
- Replace hardcoded 3-per-entity-type search cap with `_distribute_results()` two-pass algorithm using `SOFT_CAP_RATIO = 0.6` (60% max per type when other types compete)
- Apply distribution consistently across all 3 search paths: hybrid (DocumentDB vector), client-side (MongoDB CE cosine similarity), and lexical-only
- Add `_tool_extraction_limit()` that scales with max_results instead of fixed cap
- Increase pipeline candidate limit to `max(max_results * 3, 50)` for better global ranking
- Set Dashboard maxResults to 10 to match OpenAPI default
- Document the result distribution algorithm in hybrid search architecture docs
- Add 24 unit tests covering distribution, tool extraction limits, and soft cap behavior

## Changes
- `registry/repositories/documentdb/search_repository.py` -- core algorithm and all 3 search paths refactored
- `frontend/src/pages/Dashboard.tsx` -- fix maxResults from 12 to 10
- `docs/design/hybrid-search-architecture.md` -- document algorithm with worked examples
- `tests/unit/repositories/test_search_result_distribution.py` -- 24 new tests

## Test plan
- [x] All 24 new unit tests pass
- [x] Full test suite passes (701 passed, 57 skipped)
- [x] Verified algorithm on local Docker (MongoDB CE) with "currenttime", "mongodb", "provider: AWS", "coding skills" queries
- [x] Verified algorithm on ECS (DocumentDB) with "currenttime" and "current_time" queries via CLI and browser
- [x] Confirmed soft cap enforcement, backfill behavior, and tool extraction across different max_results values (10, 12, 15)