### PR TITLE
feat: make heartbeat telemetry opt-out with configurable interval

### DIFF
--- a/.claude/skills/agentcore-register/SKILL.md
+++ b/.claude/skills/agentcore-register/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: agentcore-register
+description: Given an MCP server URL, probe the server via curl to discover its metadata and tools, then generate a markdown file with copy-pasteable content for each field in the Amazon Bedrock AgentCore "Create record" form.
+argument-hint: "<mcp-server-url>"
+---
+
+# AgentCore Register
+
+Given a remote MCP server URL, probe it to discover server info and tools, then generate a markdown file containing copy-pasteable values for every field in the Amazon Bedrock AgentCore **Create record** form.
+
+The MCP server URL is provided as `$ARGUMENTS`.
+
+If `$ARGUMENTS` is empty, ask the user for the MCP server URL using AskUserQuestion.
+
+## Steps
+
+### 1. Initialize the MCP session
+
+Send the MCP `initialize` request and capture the response headers (for the session ID) and body (for server info).
+
+```bash
+curl -s --max-time 15 -D /tmp/_agentcore_mcp_headers.txt \
+  -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2024-11-05",
+      "capabilities": {},
+      "clientInfo": {"name": "agentcore-register", "version": "1.0.0"}
+    }
+  }' > /tmp/_agentcore_mcp_init.json 2>&1
+```
+
+Parse the response to extract:
+- `serverInfo.name` - the server name
+- `serverInfo.version` - the server version
+- `protocolVersion` - the MCP protocol version
+- `capabilities` - what the server supports
+
+Extract the `mcp-session-id` header value from `/tmp/_agentcore_mcp_headers.txt`.
+
+#### Error handling
+
+- If the curl request fails or times out, tell the user the server is unreachable and stop.
+- If the response is a 502/503/504, tell the user the server backend is down and stop.
+- If the response is HTML (not JSON), tell the user the URL may not be an MCP endpoint and stop.
+
+### 2. List the tools
+
+Using the session ID from step 1, send a `tools/list` request:
+
+```bash
+SESSION_ID=$(grep -i 'mcp-session-id' /tmp/_agentcore_mcp_headers.txt | awk '{print $2}' | tr -d '\r')
+
+curl -s --max-time 15 \
+  -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "mcp-session-id: $SESSION_ID" \
+  -d '{"jsonrpc": "2.0", "id": 3, "method": "tools/list", "params": {}}' \
+  > /tmp/_agentcore_mcp_tools.json 2>&1
+```
+
+The response may be plain JSON or SSE-formatted (`data: {...}`). Handle both:
+- If the response starts with `{`, parse it directly as JSON.
+- If the response contains `data:` lines, extract the JSON from the `data:` line.
+
+Parse the tools array from `result.tools`. For each tool, capture:
+- `name`
+- `description`
+- `inputSchema` (the full JSON schema object)
+
+### 3. Generate the markdown file
+
+Create a markdown file at `.scratchpad/agentcore-register-<server-name>.md` with all the values the user needs to copy-paste into the AgentCore form.
+
+Use this exact template, replacing placeholders with the discovered values:
+
+```markdown
+# AgentCore Registry Record: <server_name>
+
+*Generated: <current date>*
+*Source: <MCP_URL>*
+
+---
+
+## Record Details
+
+**Name:**
+```
+<server_name as a valid record ID, e.g. record_novacolor_finishes>
+```
+
+**Description:**
+```
+<server description derived from tools and server name, 1-2 sentences>
+```
+
+**Record version:**
+```
+<server version, e.g. 0.1>
+```
+
+**Record type:** MCP
+
+---
+
+## MCP Server Definition
+
+Copy-paste the JSON below into the "Your MCP server definition" editor:
+
+```json
+{
+  "name": "<namespace/slug, must match ^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$>",
+  "description": "<max 100 chars, concise description>",
+  "version": "<version>",
+  "remotes": [
+    {
+      "type": "<transport type, e.g. streamable-http>",
+      "url": "<MCP_URL>"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Definition
+
+Copy-paste the JSON below into the "Your Tool definition" editor:
+
+```json
+{
+  "tools": [
+    <for each tool, include the full tool object with name, description, and inputSchema>
+  ]
+}
+```
+
+---
+
+## Discovery Summary
+
+| Field | Value |
+|-------|-------|
+| Server name | `<serverInfo.name>` |
+| Version | `<version>` |
+| Protocol | `<protocolVersion>` |
+| Transport | `<transport type>` |
+| URL | `<MCP_URL>` |
+| Tools | <comma-separated tool names> |
+| Capabilities | <comma-separated capabilities> |
+```
+
+#### Rules for populating the template
+
+- **Record name**: Convert the server name to a valid AgentCore record ID. Use lowercase, replace spaces and hyphens with underscores, prefix with `record_`. Only use letters, digits, underscores. Example: `record_novacolor_finishes`.
+- **Description**: Write a concise 1-2 sentence description based on the server name and tool names/descriptions.
+- **Transport**: Determine from how the server responded:
+  - If the initialize response included `mcp-session-id` header and responded to POST with JSON, use `streamable-http`.
+  - If the server used SSE (event-stream responses for initialize), use `sse`.
+  - Default to `streamable-http` for remote HTTP servers.
+- **MCP server definition JSON**: Must include `name`, `description`, `version`, and `remotes` fields. The `remotes` array contains the transport type and URL so that the AgentCore sync can extract `proxy_pass_url` correctly via `remotes[0].url`.
+  - **name** MUST match the pattern `^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$` (namespace/name format). Derive the namespace from the server's domain (e.g., `com.agenthost` for `agenthost.club`, `io.github.user` for GitHub). Example: `com.agenthost/novacolor-italian-finishes`.
+  - **description** MUST be 100 characters or fewer. Keep it concise.
+  - **remotes** MUST be an array with at least one object containing `type` (transport type) and `url` (the MCP endpoint URL). Do NOT use top-level `url` and `transport` fields -- use the `remotes` array format instead.
+- **Tool definition JSON**: Include the complete tool objects exactly as returned by the server, wrapped in a `{"tools": [...]}` envelope.
+- **Tool inputSchema**: Include the full inputSchema for each tool exactly as returned by the server. Do NOT simplify or omit properties.
+
+### 4. Cleanup
+
+Remove temporary files:
+
+```bash
+rm -f /tmp/_agentcore_mcp_headers.txt /tmp/_agentcore_mcp_init.json /tmp/_agentcore_mcp_tools.json
+```
+
+### 5. Report to the user
+
+After generating the file, display:
+
+1. The path to the generated markdown file.
+2. A brief summary: server name, number of tools, transport type.
+3. Tell the user they can open the file and copy-paste each section into the AgentCore "Create record" form.
+
+## Example
+
+```
+User: /agentcore-register https://novacoloritalianfinishes.agenthost.club/mcp
+
+Output:
+Generated `.scratchpad/agentcore-register-novacolor.md`
+
+Summary:
+- Server: some-agent (v0.1)
+- Transport: streamable-http
+- Tools: 3 (search_site_products, search, fetch)
+
+Open the file and copy-paste each section into the AgentCore "Create record" form.
+```

--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -98,6 +98,22 @@ This produces a PNG with two subplots:
 - **Cumulative Unique Registry Installs** -- running total of unique registry_ids per cloud provider
 - **Daily Active Registry Installs** -- unique registry_ids seen each day per cloud provider
 
+### Step 5c: Generate Instance Lifetime Chart
+
+Generate a density plot showing the distribution of instance lifetimes (age in days). This reads the metrics JSON produced by the analysis step, so it must run after Step 6. However, the SKILL.md lists it here for logical grouping with other charts:
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_lifetime_chart.py \
+  --metrics OUTPUT_DIR/metrics-YYYY-MM-DD.json \
+  --output OUTPUT_DIR/instance-lifetime-YYYY-MM-DD.png
+```
+
+This produces a PNG with two panels:
+- **Age Distribution** -- histogram with KDE density overlay showing instance ages in days, with stats annotation (mean, max, multi-day vs single-day counts)
+- **Age Buckets** -- horizontal bar chart grouping instances into age ranges (0 days, 1-2 days, 3-5 days, etc.) with counts and percentages
+
+**Note**: Run this after Step 6 (telemetry analysis) since it reads the metrics JSON.
+
 ### Step 6: Run Telemetry Analysis
 
 Run the analysis script to compute all distributions, instance timelines, and metrics. This produces two files:
@@ -128,6 +144,7 @@ Or with an explicit previous metrics file:
 Read the generated `tables-YYYY-MM-DD.md` and include its tables directly in the report. Add narrative sections (Executive Summary, Architecture Patterns, Recommendations) around the data tables. The tables file contains:
 
 - Key Metrics table
+- Registry Instance Lifetime table (age in days, sorted descending)
 - Identified and Unidentified instance tables
 - Cloud, Compute, Architecture, Storage, Auth distribution tables
 - Version Adoption table
@@ -148,7 +165,7 @@ Read the generated `tables-YYYY-MM-DD.md` and include its tables directly in the
 
 ## Executive Summary
 
-2-line TL;DR paragraph: total unique installs since tracking began, dominant cloud/compute/IdP, average daily install rate, and notable growth trends. Follow immediately with the timeseries chart.
+Lead with the number of new registry installs since the last report (if available), then total unique installs since tracking began, dominant cloud/compute/IdP, average daily install rate, and notable growth trends. Follow immediately with the timeseries chart.
 
 ![Registry Installs Timeseries](registry-installs-timeseries-YYYY-MM-DD.png)
 
@@ -166,6 +183,11 @@ Read the generated `tables-YYYY-MM-DD.md` and include its tables directly in the
 | Total Events | N |
 | Unique Registry Instances | N |
 | ... | ... |
+
+## Registry Instance Lifetime
+Commentary on average/max lifetime, how many are multi-day vs single-day.
+Density chart showing age distribution (histogram + KDE) and age buckets.
+Table sorted by age (days) descending showing each instance with cloud, compute, auth, first seen, last seen, age in days, and event count.
 
 ## Deployment Landscape
 

--- a/.claude/skills/usage-report/analyze_telemetry.py
+++ b/.claude/skills/usage-report/analyze_telemetry.py
@@ -183,6 +183,42 @@ def _compute_per_cloud_unique_installs(
     return {cloud: len(ids) for cloud, ids in sorted(cloud_ids.items())}
 
 
+def _compute_instance_lifetime(
+    instances: list[dict],
+) -> list[dict]:
+    """Compute the lifetime (age in days) for each identified instance.
+
+    Lifetime is the number of days between the first event and the
+    last event for that instance. A single-day instance has age 0.
+
+    Returns a list sorted by age descending.
+    """
+    result = []
+    for inst in instances:
+        first = inst.get("first_seen", "")
+        latest = inst.get("latest_seen", "")
+        if not first or not latest:
+            continue
+
+        first_date = datetime.strptime(first, "%Y-%m-%d")
+        latest_date = datetime.strptime(latest, "%Y-%m-%d")
+        age_days = (latest_date - first_date).days
+
+        result.append({
+            "registry_id": inst["registry_id"],
+            "cloud": inst["cloud"],
+            "compute": inst["compute"],
+            "auth": inst["auth"],
+            "first_seen": first,
+            "latest_seen": latest,
+            "age_days": age_days,
+            "events": inst["events"],
+        })
+
+    result.sort(key=lambda x: x["age_days"], reverse=True)
+    return result
+
+
 def _build_exec_summary_md(
     current_metrics: dict,
     previous_metrics: dict | None,
@@ -195,11 +231,40 @@ def _build_exec_summary_md(
     lines.append("")
 
     curr = current_metrics
-    lines.append(
-        f"This report covers **{curr['total_events']} events** "
-        f"from **{curr['identified_instances']} unique identified registry instances** "
-        f"over the period {curr['earliest_ts'][:10]} to {curr['latest_ts'][:10]}."
-    )
+
+    # Lead with new installs if we have a previous report
+    if previous_metrics:
+        prev = previous_metrics.get("key_metrics", {})
+        prev_identified = prev.get("identified_instances", 0)
+        new_installs = curr["identified_instances"] - prev_identified
+        prev_date = previous_metrics.get("report_date", "unknown")
+        if new_installs > 0:
+            lines.append(
+                f"**{new_installs} new registry installs** since the last "
+                f"report ({prev_date}), bringing the total to "
+                f"**{curr['identified_instances']} unique identified "
+                f"registry instances** across "
+                f"**{curr['total_events']} events** "
+                f"over the period {curr['earliest_ts'][:10]} to "
+                f"{curr['latest_ts'][:10]}."
+            )
+        else:
+            lines.append(
+                f"This report covers **{curr['total_events']} events** "
+                f"from **{curr['identified_instances']} unique identified "
+                f"registry instances** "
+                f"over the period {curr['earliest_ts'][:10]} to "
+                f"{curr['latest_ts'][:10]}. No new installs since the "
+                f"last report ({prev_date})."
+            )
+    else:
+        lines.append(
+            f"This report covers **{curr['total_events']} events** "
+            f"from **{curr['identified_instances']} unique identified "
+            f"registry instances** "
+            f"over the period {curr['earliest_ts'][:10]} to "
+            f"{curr['latest_ts'][:10]}."
+        )
     lines.append("")
 
     if previous_metrics is None:
@@ -262,7 +327,6 @@ def _build_exec_summary_md(
 
     # Distribution shift highlights
     prev_dists = previous_metrics.get("distributions", {})
-    curr_cloud = current_cloud_installs
     prev_cloud_dist = prev_dists.get("cloud", {})
 
     # Highlight new cloud providers
@@ -630,12 +694,20 @@ def _compute_feature_adoption(
             "rate": _format_pct(reg_only, total),
         },
         {
-            "feature": "Heartbeat opt-in",
-            "enabled": sum(
+            "feature": "Heartbeat (opt-out, on by default)",
+            "enabled": len({
+                r.get("registry_id", "").strip()
+                for r in rows
+                if r.get("event") == "heartbeat"
+                and r.get("registry_id", "").strip()
+            }),
+            "disabled": total - sum(
                 1 for r in rows if r.get("event") == "heartbeat"
             ),
-            "disabled": total,
-            "rate": "0%",
+            "rate": _format_pct(
+                sum(1 for r in rows if r.get("event") == "heartbeat"),
+                total,
+            ),
         },
     ]
 
@@ -650,6 +722,7 @@ def _build_markdown_tables(
     features: list[dict],
     rows: list[dict[str, str]],
     exec_summary_md: str | None = None,
+    instance_lifetime: list[dict] | None = None,
 ) -> str:
     """Build all markdown tables as a single string."""
     total = metrics["total_events"]
@@ -682,6 +755,44 @@ def _build_markdown_tables(
         f"| {metrics['earliest_ts'][:10]} to {metrics['latest_ts'][:10]} |"
     )
     lines.append("")
+
+    # Instance Lifetime / Age table
+    if instance_lifetime:
+        ages = [inst["age_days"] for inst in instance_lifetime]
+        avg_age = sum(ages) / len(ages) if ages else 0
+        max_age = max(ages) if ages else 0
+        active_count = sum(1 for a in ages if a > 0)
+
+        lines.append("## Registry Instance Lifetime")
+        lines.append("")
+        lines.append(
+            f"Across {len(instance_lifetime)} identified instances, "
+            f"the average lifetime is **{avg_age:.1f} days** "
+            f"(max {max_age} days). "
+            f"{active_count} instances have been seen across multiple days, "
+            f"while {len(ages) - active_count} were only seen on a single day."
+        )
+        lines.append("")
+        lines.append(
+            "| Registry ID | Cloud | Compute | Auth "
+            "| First Seen | Last Seen | Age (days) | Events |"
+        )
+        lines.append(
+            "|-------------|-------|---------|------"
+            "|------------|-----------|------------|--------|"
+        )
+        for inst in instance_lifetime:
+            lines.append(
+                f"| `{inst['registry_id']}` "
+                f"| {inst['cloud']} "
+                f"| {inst['compute']} "
+                f"| {inst['auth']} "
+                f"| {inst['first_seen']} "
+                f"| {inst['latest_seen']} "
+                f"| {inst['age_days']} "
+                f"| {inst['events']} |"
+            )
+        lines.append("")
 
     # Identified Instances
     lines.append("## Deployment Landscape")
@@ -937,6 +1048,7 @@ def main() -> None:
     metrics = _compute_key_metrics(rows)
     distributions = _compute_distributions(rows)
     instances = _compute_instance_table(rows)
+    instance_lifetime = _compute_instance_lifetime(instances)
     unidentified = _compute_unidentified_profiles(rows)
     versions = _compute_version_table(rows)
     search = _compute_search_stats(rows)
@@ -969,6 +1081,7 @@ def main() -> None:
         metrics, distributions, instances, unidentified,
         versions, search, features, rows,
         exec_summary_md=exec_summary_md,
+        instance_lifetime=instance_lifetime,
     )
 
     # Build JSON with all computed data
@@ -976,6 +1089,7 @@ def main() -> None:
         "report_date": date_str,
         "key_metrics": metrics,
         "per_cloud_unique_installs": cloud_installs,
+        "instance_lifetime": instance_lifetime,
         "distributions": {
             k: dict(v.most_common()) for k, v in distributions.items()
         },

--- a/.claude/skills/usage-report/generate_lifetime_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_chart.py
@@ -1,0 +1,200 @@
+"""Generate a density plot showing registry instance age distribution.
+
+Reads the metrics JSON (which contains instance_lifetime data) and
+produces a PNG with a histogram + KDE overlay of instance ages in days.
+"""
+import argparse
+import json
+import logging
+import os
+from collections import Counter
+
+import matplotlib
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = "AI Registry -- Instance Lifetime Distribution"
+FIGURE_WIDTH: int = 12
+FIGURE_HEIGHT: int = 6
+
+
+def _load_lifetime_data(
+    metrics_path: str,
+) -> list[int]:
+    """Load instance lifetime ages from metrics JSON."""
+    with open(metrics_path) as f:
+        data = json.load(f)
+
+    lifetime_list = data.get("instance_lifetime", [])
+    if not lifetime_list:
+        logger.error("No instance_lifetime data in metrics JSON")
+        return []
+
+    ages = [inst["age_days"] for inst in lifetime_list]
+    logger.info(f"Loaded {len(ages)} instance ages from {metrics_path}")
+    return ages
+
+
+def _generate_chart(
+    ages: list[int],
+    output_path: str,
+) -> None:
+    """Generate and save the lifetime density chart."""
+    sns.set_theme(style="whitegrid")
+
+    fig, (ax_hist, ax_bar) = plt.subplots(
+        1, 2,
+        figsize=(FIGURE_WIDTH, FIGURE_HEIGHT),
+        gridspec_kw={"width_ratios": [3, 2]},
+    )
+
+    fig.suptitle(
+        f"{CHART_TITLE}\n({len(ages)} instances)",
+        fontsize=14,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    # Compute stats
+    avg_age = sum(ages) / len(ages) if ages else 0
+    max_age = max(ages) if ages else 0
+    multi_day = sum(1 for a in ages if a > 0)
+    single_day = sum(1 for a in ages if a == 0)
+
+    # Left panel: histogram with KDE overlay
+    # Use integer bins from 0 to max_age + 1
+    bin_edges = list(range(0, max_age + 2))
+
+    ax_hist.hist(
+        ages,
+        bins=bin_edges,
+        color=sns.color_palette("Blues_d")[2],
+        edgecolor="white",
+        alpha=0.7,
+        align="left",
+        label="Count",
+    )
+
+    # Add KDE curve on secondary y-axis for density
+    ax_kde = ax_hist.twinx()
+    if len(set(ages)) > 1:
+        sns.kdeplot(
+            ages,
+            ax=ax_kde,
+            color=sns.color_palette("deep")[3],
+            linewidth=2,
+            bw_adjust=0.8,
+            label="Density",
+        )
+    ax_kde.set_ylabel("Density", fontsize=10, color="gray")
+    ax_kde.tick_params(axis="y", labelcolor="gray")
+
+    ax_hist.set_xlabel("Instance Age (days)", fontsize=11)
+    ax_hist.set_ylabel("Number of Instances", fontsize=11)
+    ax_hist.set_title("Age Distribution", fontsize=12, fontweight="bold")
+
+    # Set x-axis to integer ticks
+    ax_hist.set_xticks(range(0, max_age + 1))
+
+    # Add stats annotation
+    stats_text = (
+        f"Mean: {avg_age:.1f} days\n"
+        f"Max: {max_age} days\n"
+        f"Multi-day: {multi_day}\n"
+        f"Single-day: {single_day}"
+    )
+    ax_hist.text(
+        0.97, 0.95,
+        stats_text,
+        transform=ax_hist.transAxes,
+        fontsize=10,
+        verticalalignment="top",
+        horizontalalignment="right",
+        bbox={"boxstyle": "round,pad=0.5", "facecolor": "wheat", "alpha": 0.8},
+    )
+
+    # Right panel: horizontal bar showing age buckets
+    buckets = {
+        "0 days (single session)": single_day,
+        "1-2 days": sum(1 for a in ages if 1 <= a <= 2),
+        "3-5 days": sum(1 for a in ages if 3 <= a <= 5),
+        "6-10 days": sum(1 for a in ages if 6 <= a <= 10),
+        "11+ days": sum(1 for a in ages if a >= 11),
+    }
+
+    # Remove empty buckets
+    buckets = {k: v for k, v in buckets.items() if v > 0}
+
+    labels = list(buckets.keys())[::-1]
+    counts = list(buckets.values())[::-1]
+    total = len(ages)
+
+    colors = sns.color_palette("Blues_d", len(labels))
+    bars = ax_bar.barh(labels, counts, color=colors)
+
+    ax_bar.set_title("Age Buckets", fontsize=12, fontweight="bold")
+    ax_bar.set_xlabel("Number of Instances", fontsize=11)
+
+    for bar, count in zip(bars, counts):
+        pct = count / total * 100
+        label_text = f" {count} ({pct:.0f}%)"
+        ax_bar.text(
+            bar.get_width() + 0.2,
+            bar.get_y() + bar.get_height() / 2,
+            label_text,
+            va="center",
+            fontsize=10,
+        )
+
+    max_count = max(counts) if counts else 1
+    ax_bar.set_xlim(0, max_count * 1.4)
+
+    plt.tight_layout(rect=[0, 0, 1, 0.93])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Lifetime chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments and generate the lifetime density chart."""
+    parser = argparse.ArgumentParser(
+        description="Generate registry instance lifetime density chart",
+    )
+    parser.add_argument(
+        "--metrics",
+        required=True,
+        help="Path to metrics-YYYY-MM-DD.json",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.metrics):
+        logger.error(f"Metrics file not found: {args.metrics}")
+        raise SystemExit(1)
+
+    ages = _load_lifetime_data(args.metrics)
+
+    if not ages:
+        logger.error("No lifetime data available")
+        raise SystemExit(1)
+
+    _generate_chart(ages, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.env.example
+++ b/.env.example
@@ -830,9 +830,12 @@ WORKDAY_TOKEN_URL=https://your-tenant.workday.com/ccx/oauth2/your_instance/token
 # Disable telemetry entirely (default: not set, telemetry is ON)
 # MCP_TELEMETRY_DISABLED=1
 
-# Enable richer telemetry with daily heartbeat (default: not set, opt-in OFF)
-# Sends aggregate counts: servers, agents, skills, peers, uptime
-# MCP_TELEMETRY_OPT_IN=1
+# Disable daily heartbeat telemetry only (default: not set, heartbeat ON)
+# Startup ping is still sent. Set to 1 to opt out of heartbeat only.
+# MCP_TELEMETRY_OPT_OUT=1
+
+# Heartbeat telemetry interval in minutes (default: 1440 = 24 hours)
+MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440
 
 # Telemetry collector endpoint (default: central collector)
 # Override to use a self-hosted collector

--- a/README.md
+++ b/README.md
@@ -720,16 +720,24 @@ echo 'ASOR_ACCESS_TOKEN=your_token' >> .env
 
 ## Telemetry
 
-The registry collects **anonymous, non-sensitive** usage telemetry to help us understand adoption patterns and improve the product. This is an **opt-out** feature -- by default, a single startup ping is sent containing only deployment metadata.
+The registry collects **anonymous, non-sensitive** usage telemetry to help us understand adoption patterns and improve the product. Both tiers are **opt-out** and **on by default**.
 
-**What is sent (Tier 1 -- default ON):** Registry version, Python version, OS, CPU architecture, cloud provider, storage backend, auth provider, and deployment mode. No IP addresses, hostnames, file paths, user data, or any PII.
+**What is sent (Tier 1 -- startup ping):** Registry version, Python version, OS, CPU architecture, cloud provider, storage backend, auth provider, and deployment mode. No IP addresses, hostnames, file paths, user data, or any PII.
 
-**What is NOT sent by default (Tier 2 -- opt-in):** Aggregate counts (number of servers, agents, skills, peers), search backend, embeddings provider, and uptime. Enable with `MCP_TELEMETRY_OPT_IN=1`.
+**Also sent by default (Tier 2 -- daily heartbeat):** Aggregate counts (number of servers, agents, skills, peers), search backend, embeddings provider, and uptime. Same privacy guarantees as Tier 1. Disable heartbeat only: `MCP_TELEMETRY_OPT_OUT=1`.
+
+> **Behavior change (post v1.0.18):** The daily heartbeat was previously opt-in (`MCP_TELEMETRY_OPT_IN=1`). It is now opt-out and sent by default. Since the heartbeat contains only aggregate counts (no PII), this aligns it with the startup ping behavior.
 
 **To opt out completely:**
 
 ```bash
-export MCP_TELEMETRY_DISABLED=1
+export MCP_TELEMETRY_DISABLED=1   # Disables both startup ping and heartbeat
+```
+
+**To disable heartbeat only (startup ping still sent):**
+
+```bash
+export MCP_TELEMETRY_OPT_OUT=1
 ```
 
 All requests are HMAC-signed, rate-limited, and schema-validated. Telemetry is fail-silent and never impacts registry operation. Full details in the [Telemetry Documentation](docs/TELEMETRY.md).

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -213,9 +213,10 @@ registry:
     otelExporterOtlpMetricsTemporalityPreference: "cumulative"  # cumulative or delta
 
     # Telemetry configuration
-    # Anonymous usage telemetry (opt-out: set mcpTelemetryDisabled to true to disable)
+    # Anonymous usage telemetry (startup ping + daily heartbeat, both on by default)
     mcpTelemetryDisabled: false  # Set to true to disable all telemetry
-    mcpTelemetryOptIn: false  # Set to true to enable daily heartbeat with aggregate counts
+    mcpTelemetryOptOut: false  # Set to true to disable daily heartbeat only (startup ping still sent)
+    telemetryHeartbeatIntervalMinutes: "1440"  # Heartbeat interval in minutes (default: 1440 = 24 hours)
     telemetryDebug: false  # Set to true to log payloads instead of sending
 
     # Demo server configuration

--- a/charts/registry/templates/configmap-otel.yaml
+++ b/charts/registry/templates/configmap-otel.yaml
@@ -22,8 +22,11 @@ data:
   {{- if .Values.app.mcpTelemetryDisabled }}
   MCP_TELEMETRY_DISABLED: {{ .Values.app.mcpTelemetryDisabled | quote }}
   {{- end }}
-  {{- if .Values.app.mcpTelemetryOptIn }}
-  MCP_TELEMETRY_OPT_IN: {{ .Values.app.mcpTelemetryOptIn | quote }}
+  {{- if .Values.app.mcpTelemetryOptOut }}
+  MCP_TELEMETRY_OPT_OUT: {{ .Values.app.mcpTelemetryOptOut | quote }}
+  {{- end }}
+  {{- if .Values.app.telemetryHeartbeatIntervalMinutes }}
+  MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES: {{ .Values.app.telemetryHeartbeatIntervalMinutes | quote }}
   {{- end }}
   {{- if .Values.app.telemetryDebug }}
   MCP_TELEMETRY_DEBUG: {{ .Values.app.telemetryDebug | quote }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -46,9 +46,10 @@ app:
   otelExporterOtlpMetricsTemporalityPreference: "cumulative"  # cumulative or delta
 
   # Telemetry configuration
-  # Anonymous usage telemetry (opt-out: set mcpTelemetryDisabled to true to disable)
+  # Anonymous usage telemetry (startup ping + daily heartbeat, both on by default)
   mcpTelemetryDisabled: false  # Set to true to disable all telemetry
-  mcpTelemetryOptIn: false  # Set to true to enable daily heartbeat with aggregate counts
+  mcpTelemetryOptOut: false  # Set to true to disable daily heartbeat only (startup ping still sent)
+  telemetryHeartbeatIntervalMinutes: "1440"  # Heartbeat interval in minutes (default: 1440 = 24 hours)
   telemetryDebug: false  # Set to true to log payloads instead of sending
 
   # Demo server configuration

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -111,12 +111,14 @@ services:
       - REGISTRY_API_TOKEN=${REGISTRY_API_TOKEN:-}
       - MAX_TOKENS_PER_USER_PER_HOUR=${MAX_TOKENS_PER_USER_PER_HOUR:-100}
       # Telemetry Configuration
-      # Opt-out:  set MCP_TELEMETRY_DISABLED=1  to disable all telemetry
-      # Opt-in:   set MCP_TELEMETRY_OPT_IN=1    for daily heartbeat with aggregate counts
+      # Disable all:       set MCP_TELEMETRY_DISABLED=1  to disable all telemetry (startup ping + heartbeat)
+      # Heartbeat opt-out: set MCP_TELEMETRY_OPT_OUT=1   to disable daily heartbeat only
+      # Heartbeat interval: set MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440  (default: 1440 = 24h)
       # Endpoint: set TELEMETRY_ENDPOINT=<url>   to use a self-hosted collector
       # Debug:    set TELEMETRY_DEBUG=true        to log payloads without sending
       - MCP_TELEMETRY_DISABLED=${MCP_TELEMETRY_DISABLED:-}
-      - MCP_TELEMETRY_OPT_IN=${MCP_TELEMETRY_OPT_IN:-}
+      - MCP_TELEMETRY_OPT_OUT=${MCP_TELEMETRY_OPT_OUT:-}
+      - MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=${MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES:-1440}
       - TELEMETRY_DEBUG=${TELEMETRY_DEBUG:-false}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -114,12 +114,14 @@ services:
       - REGISTRY_API_TOKEN=${REGISTRY_API_TOKEN:-}
       - MAX_TOKENS_PER_USER_PER_HOUR=${MAX_TOKENS_PER_USER_PER_HOUR:-100}
       # Telemetry Configuration
-      # Opt-out:  set MCP_TELEMETRY_DISABLED=1  to disable all telemetry
-      # Opt-in:   set MCP_TELEMETRY_OPT_IN=1    for daily heartbeat with aggregate counts
+      # Disable all:       set MCP_TELEMETRY_DISABLED=1  to disable all telemetry (startup ping + heartbeat)
+      # Heartbeat opt-out: set MCP_TELEMETRY_OPT_OUT=1   to disable daily heartbeat only
+      # Heartbeat interval: set MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440  (default: 1440 = 24h)
       # Endpoint: set TELEMETRY_ENDPOINT=<url>   to use a self-hosted collector
       # Debug:    set TELEMETRY_DEBUG=true        to log payloads without sending
       - MCP_TELEMETRY_DISABLED=${MCP_TELEMETRY_DISABLED:-}
-      - MCP_TELEMETRY_OPT_IN=${MCP_TELEMETRY_OPT_IN:-}
+      - MCP_TELEMETRY_OPT_OUT=${MCP_TELEMETRY_OPT_OUT:-}
+      - MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=${MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES:-1440}
       - TELEMETRY_DEBUG=${TELEMETRY_DEBUG:-false}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,12 +204,14 @@ services:
       - OTEL_OTLP_EXPORT_INTERVAL_MS=${OTEL_OTLP_EXPORT_INTERVAL_MS:-30000}
       - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
       # Telemetry Configuration
-      # Opt-out:  set MCP_TELEMETRY_DISABLED=1  to disable all telemetry
-      # Opt-in:   set MCP_TELEMETRY_OPT_IN=1    for daily heartbeat with aggregate counts
+      # Disable all:       set MCP_TELEMETRY_DISABLED=1  to disable all telemetry (startup ping + heartbeat)
+      # Heartbeat opt-out: set MCP_TELEMETRY_OPT_OUT=1   to disable daily heartbeat only
+      # Heartbeat interval: set MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440  (default: 1440 = 24h)
       # Endpoint: set TELEMETRY_ENDPOINT=<url>   to use a self-hosted collector
       # Debug:    set TELEMETRY_DEBUG=true        to log payloads without sending
       - MCP_TELEMETRY_DISABLED=${MCP_TELEMETRY_DISABLED:-}
-      - MCP_TELEMETRY_OPT_IN=${MCP_TELEMETRY_OPT_IN:-}
+      - MCP_TELEMETRY_OPT_OUT=${MCP_TELEMETRY_OPT_OUT:-}
+      - MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=${MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES:-1440}
       - TELEMETRY_DEBUG=${TELEMETRY_DEBUG:-false}
       - DISABLE_AI_REGISTRY_TOOLS_SERVER=${DISABLE_AI_REGISTRY_TOOLS_SERVER:-false}
     ports:

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -29,9 +29,11 @@ Sent once at startup:
 | `search_queries_1h` | `3` | Search queries in the last hour |
 | `ts` | `2026-03-18T00:00:00Z` | ISO 8601 timestamp |
 
-### Tier 2: Daily Heartbeat (Opt-In, Default OFF)
+### Tier 2: Daily Heartbeat (Opt-Out, Default ON)
 
-Sent daily when explicitly enabled. Includes all Tier 1 fields plus:
+> **Behavior change (post v1.0.18):** The daily heartbeat was previously opt-in (`MCP_TELEMETRY_OPT_IN=1`). It is now opt-out and sent by default every 24 hours. Since the heartbeat contains only aggregate counts (no PII), this aligns it with the startup ping behavior.
+
+Sent at a configurable interval (default: every 24 hours). Includes all Tier 1 fields plus:
 
 | Field | Example | Description |
 |-------|---------|-------------|
@@ -109,10 +111,10 @@ When telemetry is enabled (the default), you will see this banner at startup:
 
 ```
 ==============================================================================
-[telemetry] Anonymous usage telemetry is ON
+[telemetry] Anonymous usage telemetry is ON (startup ping + daily heartbeat)
 [telemetry] No PII is collected (no IPs, hostnames, or user data)
 [telemetry] Endpoint: https://m3ijrhd020.execute-api.us-east-1.amazonaws.com/v1/collect
-[telemetry] To disable: set MCP_TELEMETRY_DISABLED=1
+[telemetry] To disable all: set MCP_TELEMETRY_DISABLED=1
 [telemetry] Details: https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/TELEMETRY.md
 ==============================================================================
 ```
@@ -121,8 +123,9 @@ When telemetry is enabled (the default), you will see this banner at startup:
 
 | Environment Variable | Purpose | Default |
 |---------------------|---------|---------|
-| `MCP_TELEMETRY_DISABLED` | Set to `1` to disable all telemetry | _(not set, telemetry ON)_ |
-| `MCP_TELEMETRY_OPT_IN` | Set to `1` to enable daily heartbeat with aggregate counts | _(not set, heartbeat OFF)_ |
+| `MCP_TELEMETRY_DISABLED` | Set to `1` to disable all telemetry (startup ping + heartbeat) | _(not set, telemetry ON)_ |
+| `MCP_TELEMETRY_OPT_OUT` | Set to `1` to disable daily heartbeat only (startup ping still sent) | _(not set, heartbeat ON)_ |
+| `MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES` | Heartbeat send frequency in minutes | `1440` (24 hours) |
 | `MCP_TELEMETRY_ENDPOINT` | HTTPS URL for a self-hosted telemetry collector | _(built-in endpoint)_ |
 | `MCP_TELEMETRY_DEBUG` | Set to `true` to log payloads instead of sending | `false` |
 
@@ -132,8 +135,9 @@ Add these to your `.env` file in the project root:
 
 ```bash
 # .env
-MCP_TELEMETRY_DISABLED=1          # Disable all telemetry
-MCP_TELEMETRY_OPT_IN=1            # Enable daily heartbeat (optional)
+MCP_TELEMETRY_DISABLED=1          # Disable all telemetry (startup ping + heartbeat)
+MCP_TELEMETRY_OPT_OUT=1           # Disable heartbeat only (startup ping still sent)
+MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440  # Heartbeat interval in minutes (default: 1440 = 24h)
 MCP_TELEMETRY_ENDPOINT=https://your-collector.example.com/v1/collect  # Self-hosted (optional)
 MCP_TELEMETRY_DEBUG=true           # Debug mode (optional)
 ```
@@ -146,9 +150,10 @@ Add these to your `terraform.tfvars`:
 
 ```hcl
 # terraform.tfvars
-mcp_telemetry_disabled = "1"       # Disable all telemetry
-mcp_telemetry_opt_in   = "1"       # Enable daily heartbeat (optional)
-telemetry_debug        = "true"    # Debug mode (optional)
+mcp_telemetry_disabled                   = "1"     # Disable all telemetry
+mcp_telemetry_opt_out                    = "1"     # Disable heartbeat only (startup ping still sent)
+mcp_telemetry_heartbeat_interval_minutes = "1440"  # Heartbeat interval in minutes (default: 1440 = 24h)
+telemetry_debug                          = "true"  # Debug mode (optional)
 ```
 
 The corresponding Terraform variables are defined in `terraform/aws-ecs/variables.tf`.
@@ -161,7 +166,8 @@ Set these in your `values.yaml` or pass with `--set`:
 # values.yaml (standalone chart)
 app:
   mcpTelemetryDisabled: true       # Disable all telemetry
-  mcpTelemetryOptIn: true          # Enable daily heartbeat (optional)
+  mcpTelemetryOptOut: true         # Disable heartbeat only (startup ping still sent)
+  telemetryHeartbeatIntervalMinutes: "1440"  # Heartbeat interval in minutes (default: 1440 = 24h)
   telemetryDebug: true             # Debug mode (optional)
 
 # -- OR for the stack chart --
@@ -169,7 +175,8 @@ app:
 registry:
   app:
     mcpTelemetryDisabled: true
-    mcpTelemetryOptIn: true
+    mcpTelemetryOptOut: true
+    telemetryHeartbeatIntervalMinutes: "1440"
     telemetryDebug: true
 ```
 
@@ -178,7 +185,7 @@ Or with `helm install`/`helm upgrade`:
 ```bash
 helm upgrade my-release charts/registry \
   --set app.mcpTelemetryDisabled=true \
-  --set app.mcpTelemetryOptIn=true
+  --set app.mcpTelemetryOptOut=true
 ```
 
 These values are injected as environment variables via the `registry-otel-config` ConfigMap.
@@ -193,14 +200,16 @@ When telemetry is disabled, you'll see this message at startup:
 [telemetry] Telemetry is disabled.
 ```
 
-## How to Opt-In to Richer Data
+## How to Opt-Out of Heartbeat Only
 
-Set `MCP_TELEMETRY_OPT_IN=1` using the method for your deployment (see above).
+Both startup ping and daily heartbeat are enabled by default. To disable the heartbeat while keeping the startup ping:
 
-When opted in, you'll see:
+Set `MCP_TELEMETRY_OPT_OUT=1` using the method for your deployment (see above).
+
+When heartbeat is opted out, you'll see:
 
 ```
-[telemetry] Enhanced telemetry is ON (opted in)
+[telemetry] Heartbeat scheduler not started (opted out or telemetry disabled)
 ```
 
 ## Debug Mode
@@ -223,7 +232,7 @@ This logs the full JSON payload to stderr instead of sending it to the collector
 In multi-replica deployments (ECS, Kubernetes), telemetry uses MongoDB-based distributed locks to prevent duplicate sends. Only one replica will send telemetry within the configured interval:
 
 - **Startup ping**: At most once per 60 seconds
-- **Heartbeat**: At most once per 24 hours
+- **Heartbeat**: At most once per configured interval (default: 1440 minutes = 24 hours)
 
 ## Self-Hosted Telemetry Collector
 

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -240,7 +240,8 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
         "order": 15,
         "fields": [
             ("telemetry_enabled", "Telemetry Enabled", False),
-            ("telemetry_opt_in", "Telemetry Opt-In (Daily Heartbeat)", False),
+            ("telemetry_opt_out", "Heartbeat Opt-Out", False),
+            ("telemetry_heartbeat_interval_minutes", "Heartbeat Interval (minutes)", False),
             ("telemetry_debug", "Debug Mode", False),
             ("telemetry_endpoint", "Collector Endpoint", False),
         ],

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -318,9 +318,13 @@ class Settings(BaseSettings):
         default=True,
         description="Enable anonymous telemetry (startup ping). Opt-out: MCP_TELEMETRY_DISABLED=1",
     )
-    telemetry_opt_in: bool = Field(
+    telemetry_opt_out: bool = Field(
         default=False,
-        description="Enable richer telemetry (daily heartbeat with counts). Opt-in: MCP_TELEMETRY_OPT_IN=1",
+        description="Disable daily heartbeat telemetry only. Opt-out: MCP_TELEMETRY_OPT_OUT=1",
+    )
+    telemetry_heartbeat_interval_minutes: int = Field(
+        default=1440,
+        description="Heartbeat telemetry interval in minutes (default: 1440 = 24 hours). MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=1440",
     )
     telemetry_endpoint: str = Field(
         default="https://m3ijrhd020.execute-api.us-east-1.amazonaws.com/v1/collect",

--- a/registry/core/telemetry.py
+++ b/registry/core/telemetry.py
@@ -29,14 +29,11 @@ logger = logging.getLogger(__name__)
 
 # Telemetry constants
 STARTUP_LOCK_INTERVAL_SECONDS = 60  # Don't send startup ping more than once per minute
-HEARTBEAT_INTERVAL_HOURS = 24  # Send heartbeat once per day
-
 # HMAC signing key for telemetry requests.
 # This is NOT a secret — it's embedded in open-source code. Its purpose is to
 # raise the bar against casual abuse (random curl requests) by requiring
 # callers to compute a valid HMAC signature over the request body.
 TELEMETRY_SIGNING_KEY = "mcp-registry-telemetry-v1-a7f3b9c2e1d4"
-HEARTBEAT_LOCK_INTERVAL_SECONDS = HEARTBEAT_INTERVAL_HOURS * 3600
 TELEMETRY_TIMEOUT_SECONDS = 5  # HTTP request timeout
 
 
@@ -158,18 +155,32 @@ def _is_telemetry_enabled() -> bool:
     return settings.telemetry_enabled
 
 
-def _is_opt_in_enabled() -> bool:
-    """Check if opt-in telemetry (heartbeat) is enabled."""
-    # Must have base telemetry enabled
+def _is_heartbeat_enabled() -> bool:
+    """Check if heartbeat telemetry is enabled (on by default, opt-out)."""
     if not _is_telemetry_enabled():
         return False
 
-    # Check environment variable override
-    opt_in_env = os.getenv("MCP_TELEMETRY_OPT_IN", "").lower()
-    if opt_in_env in ("1", "true", "yes"):
-        return True
+    # Check environment variable override for heartbeat opt-out
+    opt_out_env = os.getenv("MCP_TELEMETRY_OPT_OUT", "").lower()
+    if opt_out_env in ("1", "true", "yes"):
+        return False
 
-    return settings.telemetry_opt_in
+    return not settings.telemetry_opt_out
+
+
+def _get_heartbeat_interval_minutes() -> int:
+    """Get heartbeat interval from settings (default 1440 minutes = 24 hours)."""
+    # Environment variable override takes precedence
+    env_val = os.getenv("MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES", "")
+    if env_val.isdigit() and int(env_val) > 0:
+        return int(env_val)
+
+    return settings.telemetry_heartbeat_interval_minutes
+
+
+def _get_heartbeat_lock_interval_seconds() -> int:
+    """Get heartbeat lock interval derived from heartbeat interval."""
+    return _get_heartbeat_interval_minutes() * 60
 
 
 async def _get_or_create_instance_id() -> str:
@@ -554,10 +565,10 @@ async def send_startup_ping() -> None:
 
     # Log conspicuous disclosure
     logger.info("=" * 78)
-    logger.info("[telemetry] Anonymous usage telemetry is ON")
+    logger.info("[telemetry] Anonymous usage telemetry is ON (startup ping + daily heartbeat)")
     logger.info("[telemetry] No PII is collected (no IPs, hostnames, or user data)")
     logger.info(f"[telemetry] Endpoint: {settings.telemetry_endpoint}")
-    logger.info("[telemetry] To disable: set MCP_TELEMETRY_DISABLED=1")
+    logger.info("[telemetry] To disable all: set MCP_TELEMETRY_DISABLED=1")
     logger.info(
         "[telemetry] Details: https://github.com/agentic-community/"
         "mcp-gateway-registry/blob/main/docs/TELEMETRY.md"
@@ -582,14 +593,14 @@ async def send_startup_ping() -> None:
 
 async def start_heartbeat_scheduler() -> None:
     """
-    Start the daily heartbeat scheduler (Tier 2 - Opt-In).
+    Start the heartbeat scheduler (Tier 2 - Opt-Out, default ON).
 
-    No-op if opt-in not enabled. Called during lifespan startup.
+    No-op if heartbeat is disabled. Called during lifespan startup.
     """
     global _telemetry_scheduler
 
-    if not _is_opt_in_enabled():
-        logger.info("[telemetry] Heartbeat scheduler not enabled (opt-in required)")
+    if not _is_heartbeat_enabled():
+        logger.info("[telemetry] Heartbeat scheduler not started (opted out or telemetry disabled)")
         return
 
     if _telemetry_scheduler is not None:
@@ -598,7 +609,8 @@ async def start_heartbeat_scheduler() -> None:
 
     _telemetry_scheduler = TelemetryScheduler()
     await _telemetry_scheduler.start()
-    logger.info("[telemetry] Enhanced telemetry is ON (opted in)")
+    interval = _get_heartbeat_interval_minutes()
+    logger.info(f"[telemetry] Daily heartbeat telemetry is ON ({interval}-minute interval)")
 
 
 async def stop_heartbeat_scheduler() -> None:
@@ -612,7 +624,7 @@ async def stop_heartbeat_scheduler() -> None:
 
 async def send_forced_heartbeat() -> dict:
     """
-    Force-send a heartbeat event immediately, bypassing the 24-hour lock.
+    Force-send a heartbeat event immediately, bypassing the interval lock.
 
     Called from admin API endpoint. Respects telemetry enabled/disabled setting
     but skips the distributed lock so the event is always sent.
@@ -703,8 +715,9 @@ class TelemetryScheduler:
         logger.info("[telemetry] Heartbeat scheduler stopped")
 
     async def _scheduler_loop(self) -> None:
-        """Main scheduler loop that sends heartbeat every 24 hours."""
-        logger.info("[telemetry] Heartbeat loop started (24-hour interval)")
+        """Main scheduler loop that sends heartbeat at configured interval."""
+        interval_minutes = _get_heartbeat_interval_minutes()
+        logger.info(f"[telemetry] Heartbeat loop started ({interval_minutes}-minute interval)")
 
         while self._running:
             try:
@@ -712,13 +725,13 @@ class TelemetryScheduler:
             except Exception as e:
                 logger.error(f"[telemetry] Error in heartbeat scheduler: {e}", exc_info=True)
 
-            # Wait 24 hours before next heartbeat
-            await asyncio.sleep(HEARTBEAT_INTERVAL_HOURS * 3600)
+            # Wait for configured interval before next heartbeat
+            await asyncio.sleep(interval_minutes * 60)
 
     async def _send_heartbeat(self) -> None:
         """Send heartbeat event if lock acquired."""
-        # Acquire lock (24-hour interval)
-        lock_acquired = await _acquire_telemetry_lock("heartbeat", HEARTBEAT_LOCK_INTERVAL_SECONDS)
+        # Acquire lock (interval matches heartbeat frequency)
+        lock_acquired = await _acquire_telemetry_lock("heartbeat", _get_heartbeat_lock_interval_seconds())
 
         if not lock_acquired:
             logger.info("[telemetry] Heartbeat already sent recently by another replica")

--- a/release-notes/v1.0.18.md
+++ b/release-notes/v1.0.18.md
@@ -33,8 +33,7 @@ There are no breaking changes in this release.
 | `ANS_SYNC_INTERVAL_HOURS` | `6` | Background re-verification interval |
 | `ANS_VERIFICATION_CACHE_TTL_SECONDS` | `3600` | Cache TTL for verification results |
 | `MCP_TELEMETRY_DISABLED` | `false` | Set to true to disable all telemetry |
-| `MCP_TELEMETRY_OPT_OUT` | `false` | Set to true to disable daily heartbeat only (startup ping still sent) |
-| `MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES` | `1440` | Heartbeat telemetry interval in minutes (default: 1440 = 24 hours) |
+| `MCP_TELEMETRY_OPT_IN` | `false` | Set to true to enable daily heartbeat with aggregate counts |
 | `MCP_TELEMETRY_DEBUG` | `false` | Set to true to log payloads instead of sending |
 | `REGISTRY_NAME` | (auto-generated) | Human-readable registry name for federation |
 | `REGISTRY_ORGANIZATION_NAME` | `ACME Inc.` | Organization operating this registry |

--- a/release-notes/v1.0.18.md
+++ b/release-notes/v1.0.18.md
@@ -33,7 +33,8 @@ There are no breaking changes in this release.
 | `ANS_SYNC_INTERVAL_HOURS` | `6` | Background re-verification interval |
 | `ANS_VERIFICATION_CACHE_TTL_SECONDS` | `3600` | Cache TTL for verification results |
 | `MCP_TELEMETRY_DISABLED` | `false` | Set to true to disable all telemetry |
-| `MCP_TELEMETRY_OPT_IN` | `false` | Set to true to enable daily heartbeat with aggregate counts |
+| `MCP_TELEMETRY_OPT_OUT` | `false` | Set to true to disable daily heartbeat only (startup ping still sent) |
+| `MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES` | `1440` | Heartbeat telemetry interval in minutes (default: 1440 = 24 hours) |
 | `MCP_TELEMETRY_DEBUG` | `false` | Set to true to log payloads instead of sending |
 | `REGISTRY_NAME` | (auto-generated) | Human-readable registry name for federation |
 | `REGISTRY_ORGANIZATION_NAME` | `ACME Inc.` | Organization operating this registry |

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -205,9 +205,10 @@ module "mcp_gateway" {
   otel_exporter_otlp_metrics_temporality_preference = var.otel_exporter_otlp_metrics_temporality_preference
 
   # Telemetry configuration
-  mcp_telemetry_disabled = var.mcp_telemetry_disabled
-  mcp_telemetry_opt_in   = var.mcp_telemetry_opt_in
-  telemetry_debug        = var.telemetry_debug
+  mcp_telemetry_disabled                   = var.mcp_telemetry_disabled
+  mcp_telemetry_opt_out                    = var.mcp_telemetry_opt_out
+  mcp_telemetry_heartbeat_interval_minutes = var.mcp_telemetry_heartbeat_interval_minutes
+  telemetry_debug                          = var.telemetry_debug
 
   # Demo server configuration
   disable_ai_registry_tools_server = var.disable_ai_registry_tools_server

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -851,8 +851,12 @@ module "ecs_service_registry" {
           value = var.mcp_telemetry_disabled
         },
         {
-          name  = "MCP_TELEMETRY_OPT_IN"
-          value = var.mcp_telemetry_opt_in
+          name  = "MCP_TELEMETRY_OPT_OUT"
+          value = var.mcp_telemetry_opt_out
+        },
+        {
+          name  = "MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES"
+          value = var.mcp_telemetry_heartbeat_interval_minutes
         },
         {
           name  = "TELEMETRY_DEBUG"

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -866,10 +866,16 @@ variable "mcp_telemetry_disabled" {
   default     = ""
 }
 
-variable "mcp_telemetry_opt_in" {
-  description = "Enable opt-in daily heartbeat telemetry. Set to '1' to enable."
+variable "mcp_telemetry_opt_out" {
+  description = "Disable daily heartbeat telemetry only. Set to '1' to opt out (startup ping still sent)."
   type        = string
   default     = ""
+}
+
+variable "mcp_telemetry_heartbeat_interval_minutes" {
+  description = "Heartbeat telemetry interval in minutes. Default: 1440 (24 hours)."
+  type        = string
+  default     = "1440"
 }
 
 variable "telemetry_debug" {

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -592,10 +592,12 @@ grafana_admin_password = "CHANGE-ME-SET-STRONG-PASSWORD"
 # Set to "1" to opt out
 # mcp_telemetry_disabled = ""
 
-# Enable daily heartbeat telemetry (opt-in, default OFF)
-# Sends aggregate counts (servers, agents, skills, peers, uptime) once per day
-# Set to "1" to opt in
-# mcp_telemetry_opt_in = ""
+# Disable daily heartbeat telemetry only (startup ping still sent, default: heartbeat ON)
+# Set to "1" to opt out of heartbeat
+# mcp_telemetry_opt_out = ""
+
+# Heartbeat telemetry interval in minutes (default: 1440 = 24 hours)
+# mcp_telemetry_heartbeat_interval_minutes = "1440"
 
 # Debug mode: log telemetry payload to stdout instead of sending
 # Useful for verifying what data would be sent

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -847,10 +847,16 @@ variable "mcp_telemetry_disabled" {
   default     = ""
 }
 
-variable "mcp_telemetry_opt_in" {
-  description = "Enable opt-in daily heartbeat telemetry. Set to '1' to enable."
+variable "mcp_telemetry_opt_out" {
+  description = "Disable daily heartbeat telemetry only. Set to '1' to opt out (startup ping still sent)."
   type        = string
   default     = ""
+}
+
+variable "mcp_telemetry_heartbeat_interval_minutes" {
+  description = "Heartbeat telemetry interval in minutes. Default: 1440 (24 hours)."
+  type        = string
+  default     = "1440"
 }
 
 variable "telemetry_debug" {

--- a/tests/integration/test_telemetry_e2e.py
+++ b/tests/integration/test_telemetry_e2e.py
@@ -1,10 +1,10 @@
 """
-End-to-end integration tests for telemetry opt-in/opt-out and detailed information mode.
+End-to-end integration tests for telemetry opt-out behavior.
 
 Tests cover:
 - Opt-out: MCP_TELEMETRY_DISABLED=1 suppresses all telemetry
-- Default state: startup ping sent, heartbeat NOT started (opt-in off)
-- Opt-in (detailed mode): startup ping + heartbeat scheduler both active
+- Default state: startup ping + heartbeat both sent (heartbeat is opt-out, ON by default)
+- Heartbeat opt-out: MCP_TELEMETRY_OPT_OUT=1 disables heartbeat only
 - Debug mode: payloads logged, no network call made
 
 Live AWS tests (require deployed collector + AWS credentials) are marked
@@ -32,7 +32,8 @@ pytestmark = pytest.mark.asyncio
 def _mock_settings(
     storage_backend: str = "file",
     telemetry_enabled: bool = True,
-    telemetry_opt_in: bool = False,
+    telemetry_opt_out: bool = False,
+    telemetry_heartbeat_interval_minutes: int = 1440,
     telemetry_debug: bool = False,
     telemetry_endpoint: str = "https://telemetry.mcpgateway.io/v1/collect",
     embeddings_provider: str = "sentence-transformers",
@@ -45,7 +46,8 @@ def _mock_settings(
     mock = MagicMock()
     mock.storage_backend = storage_backend
     mock.telemetry_enabled = telemetry_enabled
-    mock.telemetry_opt_in = telemetry_opt_in
+    mock.telemetry_opt_out = telemetry_opt_out
+    mock.telemetry_heartbeat_interval_minutes = telemetry_heartbeat_interval_minutes
     mock.telemetry_debug = telemetry_debug
     mock.telemetry_endpoint = telemetry_endpoint
     mock.embeddings_provider = embeddings_provider
@@ -75,7 +77,7 @@ class TestOptOut:
     async def test_startup_ping_not_sent_when_disabled(self, monkeypatch):
         """No HTTP request made when telemetry is disabled."""
         monkeypatch.setenv("MCP_TELEMETRY_DISABLED", "1")
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         from registry.core.telemetry import _is_telemetry_enabled, send_startup_ping
 
@@ -89,11 +91,10 @@ class TestOptOut:
     async def test_heartbeat_not_started_when_disabled(self, monkeypatch):
         """Heartbeat scheduler does not start when telemetry is disabled."""
         monkeypatch.setenv("MCP_TELEMETRY_DISABLED", "1")
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
 
-        from registry.core.telemetry import _is_opt_in_enabled, start_heartbeat_scheduler
+        from registry.core.telemetry import _is_heartbeat_enabled, start_heartbeat_scheduler
 
-        assert _is_opt_in_enabled() is False
+        assert _is_heartbeat_enabled() is False
 
         with patch("registry.core.telemetry.settings", _mock_settings(telemetry_enabled=False)):
             with patch("registry.core.telemetry._send_telemetry") as mock_send:
@@ -129,12 +130,12 @@ class TestOptOut:
 
 
 class TestDefaultState:
-    """Without MCP_TELEMETRY_OPT_IN, only the startup ping fires."""
+    """By default, both startup ping and heartbeat are enabled (opt-out model)."""
 
     async def test_startup_ping_sent_by_default(self, monkeypatch):
         """Startup ping is sent when telemetry is enabled (default)."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         captured = []
 
@@ -160,25 +161,26 @@ class TestDefaultState:
         assert len(captured) == 1
         assert captured[0]["event"] == "startup"
 
-    async def test_opt_in_disabled_by_default(self, monkeypatch):
-        """opt-in is off unless MCP_TELEMETRY_OPT_IN=1 is set."""
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
-        with patch(
-            "registry.core.telemetry.settings",
-            _mock_settings(telemetry_opt_in=False),
-        ):
-            from registry.core.telemetry import _is_opt_in_enabled
-
-            assert _is_opt_in_enabled() is False
-
-    async def test_heartbeat_not_sent_without_opt_in(self, monkeypatch):
-        """Heartbeat scheduler exits immediately when opt-in is off."""
+    async def test_heartbeat_enabled_by_default(self, monkeypatch):
+        """Heartbeat is enabled by default (opt-out model)."""
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
+        with patch(
+            "registry.core.telemetry.settings",
+            _mock_settings(telemetry_opt_out=False),
+        ):
+            from registry.core.telemetry import _is_heartbeat_enabled
+
+            assert _is_heartbeat_enabled() is True
+
+    async def test_heartbeat_disabled_via_opt_out(self, monkeypatch):
+        """Heartbeat scheduler exits immediately when MCP_TELEMETRY_OPT_OUT=1."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "1")
 
         with patch(
             "registry.core.telemetry.settings",
-            _mock_settings(telemetry_opt_in=False),
+            _mock_settings(telemetry_opt_out=True),
         ):
             with patch("registry.core.telemetry._send_telemetry") as mock_send:
                 from registry.core.telemetry import start_heartbeat_scheduler
@@ -222,30 +224,42 @@ class TestDefaultState:
 
 
 # ---------------------------------------------------------------------------
-# Class 3: Opt-in / detailed information mode
+# Class 3: Heartbeat (opt-out, on by default)
 # ---------------------------------------------------------------------------
 
 
-class TestOptIn:
-    """MCP_TELEMETRY_OPT_IN=1 enables the daily heartbeat with aggregate counts."""
+class TestHeartbeat:
+    """Heartbeat is enabled by default (opt-out model) with aggregate counts."""
 
-    async def test_opt_in_enables_heartbeat(self, monkeypatch):
-        """opt-in flag enables the heartbeat path."""
+    async def test_heartbeat_enabled_when_not_opted_out(self, monkeypatch):
+        """Heartbeat is enabled when MCP_TELEMETRY_OPT_OUT is not set."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         with patch(
             "registry.core.telemetry.settings",
-            _mock_settings(telemetry_opt_in=True),
+            _mock_settings(telemetry_opt_out=False),
         ):
-            from registry.core.telemetry import _is_opt_in_enabled
+            from registry.core.telemetry import _is_heartbeat_enabled
 
-            assert _is_opt_in_enabled() is True
+            assert _is_heartbeat_enabled() is True
+
+    async def test_heartbeat_disabled_when_opted_out(self, monkeypatch):
+        """Heartbeat is disabled when MCP_TELEMETRY_OPT_OUT=1."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "1")
+
+        with patch(
+            "registry.core.telemetry.settings",
+            _mock_settings(telemetry_opt_out=True),
+        ):
+            from registry.core.telemetry import _is_heartbeat_enabled
+
+            assert _is_heartbeat_enabled() is False
 
     async def test_heartbeat_payload_fields(self, monkeypatch):
-        """Heartbeat (detailed mode) payload contains all required schema fields."""
+        """Heartbeat payload contains all required schema fields."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
 
         repo = _mock_repo_factory()
 
@@ -347,10 +361,10 @@ class TestOptIn:
 
         assert payload["search_backend"] == "documentdb"
 
-    async def test_both_startup_and_heartbeat_sent_when_opted_in(self, monkeypatch):
-        """When opted in, startup ping fires AND heartbeat scheduler starts."""
+    async def test_both_startup_and_heartbeat_sent_by_default(self, monkeypatch):
+        """By default, startup ping fires AND heartbeat scheduler starts."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         events_sent = []
 
@@ -368,7 +382,7 @@ class TestOptIn:
         }
 
         with (
-            patch("registry.core.telemetry.settings", _mock_settings(telemetry_opt_in=True)),
+            patch("registry.core.telemetry.settings", _mock_settings(telemetry_opt_out=False)),
             patch("registry.core.telemetry._send_telemetry", side_effect=fake_send),
             patch(
                 "registry.core.telemetry._acquire_telemetry_lock",
@@ -415,9 +429,9 @@ class TestOptIn:
         assert "heartbeat" in events_sent
 
     async def test_heartbeat_not_sent_twice_within_lock_window(self, monkeypatch):
-        """Lock mechanism prevents sending heartbeat twice within the 24-hour window."""
+        """Lock mechanism prevents sending heartbeat twice within the lock window."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         events_sent = []
 
@@ -431,7 +445,7 @@ class TestOptIn:
             return next(lock_results)
 
         with (
-            patch("registry.core.telemetry.settings", _mock_settings(telemetry_opt_in=True)),
+            patch("registry.core.telemetry.settings", _mock_settings(telemetry_opt_out=False)),
             patch("registry.core.telemetry._send_telemetry", side_effect=fake_send),
             patch("registry.core.telemetry._acquire_telemetry_lock", side_effect=mock_lock),
             patch(

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -8,18 +8,18 @@ import httpx
 import pytest
 
 from registry.core.telemetry import (
-    HEARTBEAT_INTERVAL_HOURS,
-    HEARTBEAT_LOCK_INTERVAL_SECONDS,
     STARTUP_LOCK_INTERVAL_SECONDS,
     TELEMETRY_TIMEOUT_SECONDS,
     TelemetryScheduler,
     _acquire_telemetry_lock,
     _build_heartbeat_payload,
     _build_startup_payload,
+    _get_heartbeat_interval_minutes,
+    _get_heartbeat_lock_interval_seconds,
     _get_or_create_instance_id,
     _get_registry_id,
     _initialize_telemetry_collection,
-    _is_opt_in_enabled,
+    _is_heartbeat_enabled,
     _is_telemetry_enabled,
     _send_telemetry,
     send_startup_ping,
@@ -52,27 +52,44 @@ class TestTelemetryEnabled:
         monkeypatch.setenv("MCP_TELEMETRY_DISABLED", "yes")
         assert _is_telemetry_enabled() is False
 
-    def test_opt_in_disabled_by_default(self, monkeypatch):
-        """Test opt-in is disabled by default."""
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
-        with patch("registry.core.telemetry.settings") as mock_settings:
-            mock_settings.telemetry_enabled = True
-            mock_settings.telemetry_opt_in = False
-            assert _is_opt_in_enabled() is False
-
-    def test_opt_in_enabled_via_env_var(self, monkeypatch):
-        """Test opt-in can be enabled via env var."""
+    def test_heartbeat_enabled_by_default(self, monkeypatch):
+        """Test heartbeat is enabled by default (opt-out model)."""
         monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
         with patch("registry.core.telemetry.settings") as mock_settings:
             mock_settings.telemetry_enabled = True
-            assert _is_opt_in_enabled() is True
+            mock_settings.telemetry_opt_out = False
+            assert _is_heartbeat_enabled() is True
 
-    def test_opt_in_requires_base_telemetry(self, monkeypatch):
-        """Test opt-in requires base telemetry to be enabled."""
+    def test_heartbeat_disabled_via_opt_out_env_var(self, monkeypatch):
+        """Test heartbeat can be disabled via MCP_TELEMETRY_OPT_OUT=1."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "1")
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_enabled = True
+            assert _is_heartbeat_enabled() is False
+
+    def test_heartbeat_disabled_via_opt_out_true(self, monkeypatch):
+        """Test heartbeat can be disabled via MCP_TELEMETRY_OPT_OUT=true."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "true")
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_enabled = True
+            assert _is_heartbeat_enabled() is False
+
+    def test_heartbeat_disabled_via_opt_out_yes(self, monkeypatch):
+        """Test heartbeat can be disabled via MCP_TELEMETRY_OPT_OUT=yes."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "yes")
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_enabled = True
+            assert _is_heartbeat_enabled() is False
+
+    def test_heartbeat_disabled_when_telemetry_disabled(self, monkeypatch):
+        """Test heartbeat is disabled when all telemetry is disabled."""
         monkeypatch.setenv("MCP_TELEMETRY_DISABLED", "1")
-        monkeypatch.setenv("MCP_TELEMETRY_OPT_IN", "1")
-        assert _is_opt_in_enabled() is False
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
+        assert _is_heartbeat_enabled() is False
 
 
 class TestGetRegistryIdFallback:
@@ -635,17 +652,39 @@ class TestPublicAPI:
             assert "Telemetry is disabled" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_start_heartbeat_scheduler_requires_opt_in(self, monkeypatch):
-        """Test heartbeat scheduler requires opt-in."""
-        monkeypatch.delenv("MCP_TELEMETRY_OPT_IN", raising=False)
+    async def test_heartbeat_scheduler_starts_by_default(self, monkeypatch):
+        """Test heartbeat scheduler starts by default (opt-out model)."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.delenv("MCP_TELEMETRY_OPT_OUT", raising=False)
 
         with patch("registry.core.telemetry.settings") as mock_settings:
             mock_settings.telemetry_enabled = True
-            mock_settings.telemetry_opt_in = False
+            mock_settings.telemetry_opt_out = False
+            mock_settings.telemetry_heartbeat_interval_minutes = 1440
 
             await start_heartbeat_scheduler()
 
-            # Scheduler should not be started
+            from registry.core.telemetry import _telemetry_scheduler
+
+            # Scheduler should be started
+            assert _telemetry_scheduler is not None
+
+            # Clean up
+            from registry.core.telemetry import stop_heartbeat_scheduler
+
+            await stop_heartbeat_scheduler()
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_scheduler_not_started_when_opted_out(self, monkeypatch):
+        """Test heartbeat scheduler does not start when opted out."""
+        monkeypatch.delenv("MCP_TELEMETRY_DISABLED", raising=False)
+        monkeypatch.setenv("MCP_TELEMETRY_OPT_OUT", "1")
+
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_enabled = True
+
+            await start_heartbeat_scheduler()
+
             from registry.core.telemetry import _telemetry_scheduler
 
             assert _telemetry_scheduler is None
@@ -700,11 +739,28 @@ class TestRepositoryFailures:
 
 
 class TestConstants:
-    """Tests for telemetry constants."""
+    """Tests for telemetry constants and configurable intervals."""
 
     def test_telemetry_constants(self):
         """Test telemetry constants have expected values."""
         assert STARTUP_LOCK_INTERVAL_SECONDS == 60
-        assert HEARTBEAT_INTERVAL_HOURS == 24
-        assert HEARTBEAT_LOCK_INTERVAL_SECONDS == 24 * 3600
         assert TELEMETRY_TIMEOUT_SECONDS == 5
+
+    def test_heartbeat_interval_from_settings(self):
+        """Test heartbeat interval reads from settings."""
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_heartbeat_interval_minutes = 1440
+            assert _get_heartbeat_interval_minutes() == 1440
+
+    def test_heartbeat_lock_interval_matches(self):
+        """Test heartbeat lock interval = interval minutes * 60."""
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_heartbeat_interval_minutes = 1440
+            assert _get_heartbeat_lock_interval_seconds() == 1440 * 60
+
+    def test_custom_heartbeat_interval(self):
+        """Test custom heartbeat interval is respected."""
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.telemetry_heartbeat_interval_minutes = 5
+            assert _get_heartbeat_interval_minutes() == 5
+            assert _get_heartbeat_lock_interval_seconds() == 300


### PR DESCRIPTION
## Summary

Resolves #810. Changes the daily heartbeat telemetry from opt-in (`MCP_TELEMETRY_OPT_IN=1`) to opt-out (`MCP_TELEMETRY_OPT_OUT=1`), sent by default every 24 hours. Also adds a configurable heartbeat interval via `MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES`.

- **Core**: Replace `telemetry_opt_in` with `telemetry_opt_out` (default `false` = heartbeat ON) and add `telemetry_heartbeat_interval_minutes` (default `1440` = 24h) in config and telemetry modules
- **Infrastructure**: Propagate new env vars to Docker Compose (3 files), Helm values/configmap, Terraform variables/ECS services, and `.env.example`
- **Docs**: Update `TELEMETRY.md` and `README.md` with behavior change note explaining the opt-in to opt-out transition
- **Tests**: Rewrite unit and integration telemetry tests for opt-out model (56 telemetry tests pass)
- **Usage report skill**: Update feature adoption tracking for heartbeat

### Breaking Change

`MCP_TELEMETRY_OPT_IN` is removed. Users who had `MCP_TELEMETRY_OPT_IN=1` set no longer need it -- heartbeat is now on by default. Users who want to disable heartbeat should set `MCP_TELEMETRY_OPT_OUT=1`.

## Test plan

- [x] `uv run python -m py_compile` on all changed Python files
- [x] `uv run pytest tests/ -n 8` -- 2290 passed (2 unrelated failures in skill scanner)
- [x] All 56 telemetry-specific tests pass
- [x] `grep -r "MCP_TELEMETRY_OPT_IN"` returns only historical behavior-change notes in docs
- [x] `grep -r "telemetry_opt_in" *.py` returns zero matches
- [x] Verified heartbeat sends every 5 minutes on local Docker with `MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES=5`
- [x] Confirmed heartbeat events arriving at telemetry collector (2 heartbeats received)