### PR TITLE
fix: ruff import order and test mock for github auth

### DIFF
--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -46,13 +46,13 @@ from ..schemas.skill_models import (
     ToolValidationResult,
     VisibilityEnum,
 )
+from ..services.github_auth import github_auth_provider as _github_auth
 from ..services.skill_service import (
     _is_safe_url,
     get_skill_service,
 )
 from ..services.tool_validation_service import get_tool_validation_service
 from ..utils.path_utils import normalize_skill_path
-from ..services.github_auth import github_auth_provider as _github_auth
 
 # Configure logging
 logging.basicConfig(

--- a/tests/unit/test_skill_routes_github_auth.py
+++ b/tests/unit/test_skill_routes_github_auth.py
@@ -22,6 +22,7 @@ class TestGetSkillContentAuth:
         mock_skill = MagicMock()
         mock_skill.skill_md_raw_url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
         mock_skill.skill_md_url = "https://github.com/o/r/blob/main/SKILL.md"
+        mock_skill.skill_md_content = None  # Force httpx path, not inline content
 
         mock_service = AsyncMock()
         mock_service.get_skill.return_value = mock_skill


### PR DESCRIPTION
## Summary

Follow-up to PR #782 (GitHub private repo auth). Fixes two issues found during review and testing:

- **Import ordering**: Moved `github_auth` import to correct alphabetical position among `..services.*` imports in `skill_routes.py` (ruff I001)
- **Test mock fix**: Set `mock_skill.skill_md_content = None` in `test_auth_headers_passed_to_get` so the test exercises the httpx fetch path instead of short-circuiting through the inline content early return

## Test plan

- [x] `uv run pytest tests/unit/test_skill_routes_github_auth.py` passes
- [x] `uv run ruff check` passes on both changed files
- [x] Full test suite passes (2320 passed, 67 skipped)