### PR TITLE
fix: Handle wildcard `*` in accessible_servers for non-admin server visibility (#763)

### DIFF
--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -298,6 +298,11 @@ class ServerService:
             logger.debug("User has no accessible servers, returning empty dict")
             return {}
 
+        # Wildcard access — return all servers (non-admin with server: '*')
+        if "*" in accessible_servers:
+            logger.debug("Wildcard access detected in accessible_servers, returning all servers")
+            return await self.get_all_servers(include_inactive=include_inactive)
+
         # Query repository directly instead of using cache
         all_servers = await self._repo.list_all()
 
@@ -358,6 +363,10 @@ class ServerService:
             # Admin access - return all servers
             logger.debug("Admin access - returning all servers")
             return await self.get_all_servers()
+        elif "*" in accessible_servers:
+            # Wildcard access — return all servers (non-admin with server: '*')
+            logger.debug("Wildcard access detected in accessible_servers, returning all servers")
+            return await self.get_all_servers()
         else:
             # Filtered access - return only accessible servers
             logger.debug(
@@ -413,6 +422,10 @@ class ServerService:
         server_info = await self.get_server_info(path)
         if not server_info:
             return False
+
+        # Wildcard access — grant access to any existing server (non-admin with server: '*')
+        if "*" in accessible_servers:
+            return True
 
         # Extract technical name from path (remove leading and trailing slashes)
         technical_name = path.strip("/")

--- a/tests/unit/services/test_server_service.py
+++ b/tests/unit/services/test_server_service.py
@@ -813,6 +813,109 @@ class TestGetAllServersWithPermissions:
 
 
 # =============================================================================
+# TEST: Wildcard Server Scope Access
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.servers
+class TestWildcardServerAccess:
+    """Test that server: '*' in scopes grants full server visibility for non-admin users."""
+
+    @pytest.mark.asyncio
+    async def test_get_filtered_servers_wildcard_returns_all(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        sample_server_dict_2: dict[str, Any],
+        mock_server_repository,
+    ):
+        """Test get_filtered_servers with ['*'] returns all servers."""
+        mock_server_repository.list_all.return_value = {
+            sample_server_dict["path"]: sample_server_dict,
+            sample_server_dict_2["path"]: sample_server_dict_2,
+        }
+
+        result = await server_service.get_filtered_servers(["*"])
+
+        assert len(result) == 2
+        assert sample_server_dict["path"] in result
+        assert sample_server_dict_2["path"] in result
+
+    @pytest.mark.asyncio
+    async def test_get_filtered_servers_wildcard_respects_include_inactive(
+        self,
+        server_service: ServerService,
+        mock_server_repository,
+    ):
+        """Test get_filtered_servers with ['*'] and include_inactive=True returns inactive servers."""
+        active = {"path": "/active", "server_name": "active", "is_active": True}
+        inactive = {"path": "/inactive", "server_name": "inactive", "is_active": False}
+        mock_server_repository.list_all.return_value = {
+            "/active": active,
+            "/inactive": inactive,
+        }
+
+        result = await server_service.get_filtered_servers(["*"], include_inactive=True)
+        assert len(result) == 2
+
+        result_active_only = await server_service.get_filtered_servers(["*"], include_inactive=False)
+        assert len(result_active_only) == 1
+        assert "/active" in result_active_only
+
+    @pytest.mark.asyncio
+    async def test_get_all_servers_with_permissions_wildcard_returns_all(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        sample_server_dict_2: dict[str, Any],
+        mock_server_repository,
+    ):
+        """Test get_all_servers_with_permissions with ['*'] returns all servers."""
+        mock_server_repository.list_all.return_value = {
+            sample_server_dict["path"]: sample_server_dict,
+            sample_server_dict_2["path"]: sample_server_dict_2,
+        }
+
+        result = await server_service.get_all_servers_with_permissions(
+            accessible_servers=["*"],
+        )
+
+        assert len(result) == 2
+        assert sample_server_dict["path"] in result
+        assert sample_server_dict_2["path"] in result
+
+    @pytest.mark.asyncio
+    async def test_user_can_access_server_path_wildcard_existing(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+    ):
+        """Test user_can_access_server_path with ['*'] returns True for existing server."""
+        mock_server_repository.get.return_value = sample_server_dict
+
+        result = await server_service.user_can_access_server_path(
+            sample_server_dict["path"], ["*"]
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_user_can_access_server_path_wildcard_nonexistent(
+        self,
+        server_service: ServerService,
+        mock_server_repository,
+    ):
+        """Test user_can_access_server_path with ['*'] returns False for nonexistent server."""
+        mock_server_repository.get.return_value = None
+
+        result = await server_service.user_can_access_server_path("/nonexistent", ["*"])
+
+        assert result is False
+
+
+# =============================================================================
 # TEST: Service State Management
 # =============================================================================
 


### PR DESCRIPTION
Fixes #763

Non-admin roles configured with `server: '*'` see zero servers because three functions in `server_service.py` compare `"*"` as a literal string against server names. Since `"*" == "my-server"` always evaluates to `False`, wildcard-scoped users get empty results. Admin users are unaffected because `is_admin=True` bypasses the filtered path entirely.

### Changes

**registry/services/server_service.py**
- Add `"*" in accessible_servers` wildcard guard clause to `get_filtered_servers` — returns all servers via `get_all_servers(include_inactive=include_inactive)`
- Add `"*" in accessible_servers` wildcard guard clause to `get_all_servers_with_permissions` — returns all servers via `get_all_servers()`
- Add `"*" in accessible_servers` wildcard guard clause to `user_can_access_server_path` — returns `True` after server existence check (nonexistent servers still return `False`)

**tests/unit/services/test_server_service.py**
- 5 unit tests covering wildcard returns all servers, wildcard respects `include_inactive`, wildcard grants access to existing server, wildcard denies access to nonexistent server
