### PR TITLE
fix: allow network-trusted auth method to generate JWT tokens

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1948,11 +1948,11 @@ async def generate_user_token(request: GenerateTokenRequest):
             f"groups={user_groups}, scopes={requested_scopes}"
         )
 
-        # For OAuth users, generate a self-signed JWT with their identity and groups
+        # For OAuth and network-trusted users, generate a self-signed JWT with their identity and groups
         # This token is issued by our auth server and can be verified using SECRET_KEY
-        if auth_method == "oauth2":
+        if auth_method in ("oauth2", "network-trusted"):
             logger.info(
-                f"Generating self-signed JWT for OAuth user '{hash_username(username)}' "
+                f"Generating self-signed JWT for {auth_method} user '{hash_username(username)}' "
                 f"with groups: {user_groups}"
             )
 
@@ -1969,7 +1969,7 @@ async def generate_user_token(request: GenerateTokenRequest):
                 "groups": user_groups,
                 "scope": " ".join(requested_scopes) if requested_scopes else "",
                 "token_use": "access",
-                "auth_method": "oauth2",
+                "auth_method": auth_method,
                 "provider": provider,
                 "iat": current_time,
                 "exp": current_time + expires_in,


### PR DESCRIPTION
## Summary
- Widen the `auth_method` check in `/api/tokens/generate` from only `"oauth2"` to also accept `"network-trusted"` so network-trusted users can generate self-signed JWTs
- Use the actual `auth_method` value in JWT claims instead of hardcoding `"oauth2"`
- Update comment and log message to reflect both auth methods

Closes #611

## Test plan
- [ ] Verify OAuth2 token generation still works unchanged
- [ ] Verify network-trusted token generation now succeeds
- [ ] Verify JWT claims contain correct `auth_method` value for each auth type