### PR TITLE
feat: Add configurable UI tab visibility independent of REGISTRY_MODE (#743)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,16 @@ REGISTRY_CONTACT_URL=
 # Default: full (uncomment to change)
 # REGISTRY_MODE=full
 
+# Tab visibility overrides (AND-ed with REGISTRY_MODE feature flags)
+# These control which tabs are shown in the UI without affecting backend APIs.
+# REGISTRY_MODE is the master control — SHOW_*_TAB can only further restrict, never expand.
+# Formula: tab_visible = REGISTRY_MODE_enables_feature AND SHOW_*_TAB
+# All default to true (backward compatible). Set to false to hide a tab.
+# SHOW_SERVERS_TAB=true
+# SHOW_VIRTUAL_SERVERS_TAB=true
+# SHOW_SKILLS_TAB=true
+# SHOW_AGENTS_TAB=true
+
 # =============================================================================
 # AUTH SERVER CONFIGURATION
 # =============================================================================

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -193,6 +193,12 @@ registry:
     # Registry mode: full, skills-only, mcp-servers-only, agents-only
     registryMode: full
 
+    # Tab visibility overrides (AND-ed with registryMode)
+    showServersTab: true
+    showVirtualServersTab: true
+    showSkillsTab: true
+    showAgentsTab: true
+
     # Federation OAuth2 authentication (alternative to static token)
     federationTokenEndpoint: ""
     federationClientId: ""

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -69,6 +69,14 @@ spec:
               value: {{ .Values.app.deploymentMode | default "with-gateway" | quote }}
             - name: REGISTRY_MODE
               value: {{ .Values.app.registryMode | default "full" | quote }}
+            - name: SHOW_SERVERS_TAB
+              value: {{ .Values.app.showServersTab | default true | quote }}
+            - name: SHOW_VIRTUAL_SERVERS_TAB
+              value: {{ .Values.app.showVirtualServersTab | default true | quote }}
+            - name: SHOW_SKILLS_TAB
+              value: {{ .Values.app.showSkillsTab | default true | quote }}
+            - name: SHOW_AGENTS_TAB
+              value: {{ .Values.app.showAgentsTab | default true | quote }}
             {{- if .Values.awsRegistry.federationEnabled }}
             - name: AWS_REGISTRY_FEDERATION_ENABLED
               value: "true"

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -61,6 +61,12 @@ app:
   # Registry mode: full, skills-only, mcp-servers-only, agents-only
   registryMode: full
 
+  # Tab visibility overrides (AND-ed with registryMode)
+  showServersTab: true
+  showVirtualServersTab: true
+  showSkillsTab: true
+  showAgentsTab: true
+
 # AWS Agent Registry Federation
 awsRegistry:
   federationEnabled: false  # Enable AWS Agent Registry federation (overrides MongoDB config on startup)

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -13,6 +13,11 @@ services:
       # Deployment Mode Configuration
       - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-with-gateway}
       - REGISTRY_MODE=${REGISTRY_MODE:-full}
+      # Tab visibility overrides (AND-ed with REGISTRY_MODE)
+      # - SHOW_SERVERS_TAB=${SHOW_SERVERS_TAB:-true}
+      # - SHOW_VIRTUAL_SERVERS_TAB=${SHOW_VIRTUAL_SERVERS_TAB:-true}
+      # - SHOW_SKILLS_TAB=${SHOW_SKILLS_TAB:-true}
+      # - SHOW_AGENTS_TAB=${SHOW_AGENTS_TAB:-true}
       - GATEWAY_ADDITIONAL_SERVER_NAMES=${GATEWAY_ADDITIONAL_SERVER_NAMES:-}
       # Registry Card Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -18,6 +18,11 @@ services:
       # Deployment Mode Configuration
       - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-with-gateway}
       - REGISTRY_MODE=${REGISTRY_MODE:-full}
+      # Tab visibility overrides (AND-ed with REGISTRY_MODE)
+      # - SHOW_SERVERS_TAB=${SHOW_SERVERS_TAB:-true}
+      # - SHOW_VIRTUAL_SERVERS_TAB=${SHOW_VIRTUAL_SERVERS_TAB:-true}
+      # - SHOW_SKILLS_TAB=${SHOW_SKILLS_TAB:-true}
+      # - SHOW_AGENTS_TAB=${SHOW_AGENTS_TAB:-true}
       - GATEWAY_ADDITIONAL_SERVER_NAMES=${GATEWAY_ADDITIONAL_SERVER_NAMES:-}
       # Registry Card Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,11 @@ services:
       # Deployment Mode Configuration
       - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-with-gateway}
       - REGISTRY_MODE=${REGISTRY_MODE:-full}
+      # Tab visibility overrides (AND-ed with REGISTRY_MODE)
+      # - SHOW_SERVERS_TAB=${SHOW_SERVERS_TAB:-true}
+      # - SHOW_VIRTUAL_SERVERS_TAB=${SHOW_VIRTUAL_SERVERS_TAB:-true}
+      # - SHOW_SKILLS_TAB=${SHOW_SKILLS_TAB:-true}
+      # - SHOW_AGENTS_TAB=${SHOW_AGENTS_TAB:-true}
       - GATEWAY_ADDITIONAL_SERVER_NAMES=${GATEWAY_ADDITIONAL_SERVER_NAMES:-}
       # Registry Card Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}

--- a/frontend/src/hooks/useRegistryConfig.ts
+++ b/frontend/src/hooks/useRegistryConfig.ts
@@ -9,6 +9,7 @@ interface RegistryConfig {
     mcp_servers: boolean;
     agents: boolean;
     skills: boolean;
+    virtual_servers: boolean;
     federation: boolean;
     gateway_proxy: boolean;
   };
@@ -22,6 +23,7 @@ const DEFAULT_CONFIG: RegistryConfig = {
     mcp_servers: true,
     agents: true,
     skills: true,
+    virtual_servers: true,
     federation: true,
     gateway_proxy: true,
   },

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2224,7 +2224,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         )}
 
       {/* Virtual MCP Servers Section */}
-      {(viewFilter === 'virtual') &&
+      {registryConfig?.features.virtual_servers !== false &&
+        (viewFilter === 'virtual') &&
         (filteredVirtualServers.length > 0 || viewFilter === 'virtual') && (
           <div className="mb-8">
             <div className="flex items-center justify-between mb-4">
@@ -2514,16 +2515,18 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                 MCP Servers
               </button>
             )}
-            <button
-              onClick={() => handleChangeViewFilter('virtual')}
-              className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
-                viewFilter === 'virtual'
-                  ? 'border-teal-500 text-teal-600 dark:text-teal-400'
-                  : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
-              }`}
-            >
-              Virtual MCP Servers
-            </button>
+            {registryConfig?.features.virtual_servers !== false && (
+              <button
+                onClick={() => handleChangeViewFilter('virtual')}
+                className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
+                  viewFilter === 'virtual'
+                    ? 'border-teal-500 text-teal-600 dark:text-teal-400'
+                    : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                }`}
+              >
+                Virtual MCP Servers
+              </button>
+            )}
             {registryConfig?.features.agents !== false && (
               <button
                 onClick={() => handleChangeViewFilter('agents')}

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -565,10 +565,19 @@ async def get_config() -> dict[str, Any]:
         "nginx_updates_enabled": settings.nginx_updates_enabled,
         "asset_lifecycle_statuses": [s.value for s in LifecycleStatus],
         "features": {
-            "mcp_servers": settings.registry_mode
-            in (RegistryMode.FULL, RegistryMode.MCP_SERVERS_ONLY),
-            "agents": settings.registry_mode in (RegistryMode.FULL, RegistryMode.AGENTS_ONLY),
-            "skills": settings.registry_mode in (RegistryMode.FULL, RegistryMode.SKILLS_ONLY),
+            "mcp_servers": (
+                settings.registry_mode in (RegistryMode.FULL, RegistryMode.MCP_SERVERS_ONLY)
+                and settings.show_servers_tab
+            ),
+            "agents": (
+                settings.registry_mode in (RegistryMode.FULL, RegistryMode.AGENTS_ONLY)
+                and settings.show_agents_tab
+            ),
+            "skills": (
+                settings.registry_mode in (RegistryMode.FULL, RegistryMode.SKILLS_ONLY)
+                and settings.show_skills_tab
+            ),
+            "virtual_servers": settings.show_virtual_servers_tab,
             "federation": settings.registry_mode == RegistryMode.FULL,
             "gateway_proxy": settings.deployment_mode == DeploymentMode.WITH_GATEWAY,
         },

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -339,6 +339,12 @@ class Settings(BaseSettings):
         default=RegistryMode.FULL, description="Registry operating mode"
     )
 
+    # Tab visibility overrides (AND-ed with REGISTRY_MODE feature flags)
+    show_servers_tab: bool = True
+    show_virtual_servers_tab: bool = True
+    show_skills_tab: bool = True
+    show_agents_tab: bool = True
+
     # Telemetry settings (anonymous usage tracking)
     telemetry_enabled: bool = Field(
         default=True,
@@ -629,6 +635,35 @@ Auto-converting to:
 """
     logger.warning(banner)
     print(banner)
+
+
+def log_tab_visibility_warnings(s: Settings) -> None:
+    """Log warnings for SHOW_*_TAB parameters that are ineffective given REGISTRY_MODE."""
+    mode = s.registry_mode
+    checks = [
+        (
+            s.show_servers_tab,
+            "SHOW_SERVERS_TAB",
+            mode in (RegistryMode.FULL, RegistryMode.MCP_SERVERS_ONLY),
+        ),
+        (
+            s.show_agents_tab,
+            "SHOW_AGENTS_TAB",
+            mode in (RegistryMode.FULL, RegistryMode.AGENTS_ONLY),
+        ),
+        (
+            s.show_skills_tab,
+            "SHOW_SKILLS_TAB",
+            mode in (RegistryMode.FULL, RegistryMode.SKILLS_ONLY),
+        ),
+    ]
+    for show_tab, param_name, mode_enables in checks:
+        if show_tab and not mode_enables:
+            logger.warning(
+                "%s is true but REGISTRY_MODE=%s does not enable this feature; "
+                "the tab will remain hidden.",
+                param_name, mode.value,
+            )
 
 
 # Global settings instance

--- a/registry/main.py
+++ b/registry/main.py
@@ -61,6 +61,7 @@ from registry.core.config import (
     RegistryMode,
     _print_config_warning_banner,
     _validate_mode_combination,
+    log_tab_visibility_warnings,
     settings,
 )
 from registry.core.metrics import DEPLOYMENT_MODE_INFO
@@ -402,6 +403,9 @@ async def lifespan(app: FastAPI):
 
     # Log startup configuration
     _log_startup_configuration()
+
+    # Log warnings for ineffective SHOW_*_TAB overrides
+    log_tab_visibility_warnings(settings)
 
     # Initialize Prometheus metrics
     _initialize_deployment_metrics()

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -193,6 +193,12 @@ module "mcp_gateway" {
   deployment_mode = var.deployment_mode
   registry_mode   = var.registry_mode
 
+  # Tab visibility overrides
+  show_servers_tab         = var.show_servers_tab
+  show_virtual_servers_tab = var.show_virtual_servers_tab
+  show_skills_tab          = var.show_skills_tab
+  show_agents_tab          = var.show_agents_tab
+
   # Observability configuration
   enable_observability      = var.enable_observability
   metrics_service_image_uri = var.metrics_service_image_uri

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -832,6 +832,22 @@ module "ecs_service_registry" {
           value = var.registry_mode
         },
         {
+          name  = "SHOW_SERVERS_TAB"
+          value = tostring(var.show_servers_tab)
+        },
+        {
+          name  = "SHOW_VIRTUAL_SERVERS_TAB"
+          value = tostring(var.show_virtual_servers_tab)
+        },
+        {
+          name  = "SHOW_SKILLS_TAB"
+          value = tostring(var.show_skills_tab)
+        },
+        {
+          name  = "SHOW_AGENTS_TAB"
+          value = tostring(var.show_agents_tab)
+        },
+        {
           name  = "OAUTH_STORE_TOKENS_IN_SESSION"
           value = tostring(var.oauth_store_tokens_in_session)
         },

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -805,6 +805,30 @@ variable "registry_mode" {
   default     = "full"
 }
 
+variable "show_servers_tab" {
+  description = "Show the MCP Servers tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
+variable "show_virtual_servers_tab" {
+  description = "Show the Virtual MCP Servers tab in the UI."
+  type        = bool
+  default     = true
+}
+
+variable "show_skills_tab" {
+  description = "Show the Skills tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
+variable "show_agents_tab" {
+  description = "Show the Agents tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
 # =============================================================================
 # OBSERVABILITY CONFIGURATION (Metrics Pipeline)
 # =============================================================================

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -783,6 +783,30 @@ variable "registry_mode" {
   }
 }
 
+variable "show_servers_tab" {
+  description = "Show the MCP Servers tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
+variable "show_virtual_servers_tab" {
+  description = "Show the Virtual MCP Servers tab in the UI."
+  type        = bool
+  default     = true
+}
+
+variable "show_skills_tab" {
+  description = "Show the Skills tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
+variable "show_agents_tab" {
+  description = "Show the Agents tab in the UI. AND-ed with registry_mode."
+  type        = bool
+  default     = true
+}
+
 # =============================================================================
 # OBSERVABILITY CONFIGURATION (Metrics Pipeline)
 # =============================================================================

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -859,3 +859,120 @@ class TestSettingsAuthServerUrls:
         # Assert
         assert settings.auth_server_url == "http://auth-internal:8888"
         assert settings.auth_server_external_url == "https://auth.example.com"
+
+
+# =============================================================================
+# TEST CLASS: Settings Tab Visibility Feature Flags
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestSettingsTabVisibilityFeatureFlags:
+    """Test SHOW_*_TAB + REGISTRY_MODE precedence in get_config() response."""
+
+    @pytest.mark.asyncio
+    async def test_settings_tab_defaults_match_current_behavior(self):
+        """All defaults (true) produce same features as REGISTRY_MODE=full."""
+        from registry.api.config_routes import get_config
+
+        result = await get_config()
+        features = result["features"]
+
+        assert features["mcp_servers"] is True
+        assert features["agents"] is True
+        assert features["skills"] is True
+        assert features["virtual_servers"] is True
+
+    @pytest.mark.asyncio
+    async def test_settings_tab_show_false_hides_feature(self, monkeypatch, tmp_path):
+        """Setting SHOW_AGENTS_TAB=false hides the tab even with REGISTRY_MODE=full."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("SHOW_AGENTS_TAB", "false")
+
+        new_settings = Settings()
+        with patch("registry.api.config_routes.settings", new_settings):
+            from registry.api.config_routes import get_config
+            result = await get_config()
+            assert result["features"]["agents"] is False
+            assert result["features"]["mcp_servers"] is True
+
+    @pytest.mark.asyncio
+    async def test_settings_tab_mode_disables_feature_regardless(self, monkeypatch, tmp_path):
+        """REGISTRY_MODE=mcp-servers-only hides agents even if SHOW_AGENTS_TAB=true."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("REGISTRY_MODE", "mcp-servers-only")
+        monkeypatch.setenv("SHOW_AGENTS_TAB", "true")
+
+        new_settings = Settings()
+        with patch("registry.api.config_routes.settings", new_settings):
+            from registry.api.config_routes import get_config
+            result = await get_config()
+            assert result["features"]["agents"] is False
+            assert result["features"]["mcp_servers"] is True
+
+    @pytest.mark.asyncio
+    async def test_settings_tab_virtual_servers_key_present(self):
+        """virtual_servers key is present in features dict."""
+        from registry.api.config_routes import get_config
+
+        result = await get_config()
+        assert "virtual_servers" in result["features"]
+        assert result["features"]["virtual_servers"] is True
+
+    @pytest.mark.asyncio
+    async def test_settings_tab_virtual_servers_false(self, monkeypatch, tmp_path):
+        """SHOW_VIRTUAL_SERVERS_TAB=false hides virtual servers."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("SHOW_VIRTUAL_SERVERS_TAB", "false")
+
+        new_settings = Settings()
+        with patch("registry.api.config_routes.settings", new_settings):
+            from registry.api.config_routes import get_config
+            result = await get_config()
+            assert result["features"]["virtual_servers"] is False
+
+
+# =============================================================================
+# TEST CLASS: Settings Tab Visibility Startup Warnings
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestSettingsTabVisibilityStartupWarnings:
+    """Test log_tab_visibility_warnings() logs correctly."""
+
+    def test_settings_tab_warning_for_ineffective_override(self, monkeypatch, tmp_path, caplog):
+        """Warning logged when SHOW_AGENTS_TAB=true but mode disables agents."""
+        monkeypatch.delenv("SHOW_AGENTS_TAB", raising=False)
+        monkeypatch.setenv("REGISTRY_MODE", "mcp-servers-only")
+        monkeypatch.chdir(tmp_path)
+
+        import logging
+
+        from registry.core.config import log_tab_visibility_warnings
+
+        s = Settings()
+        with caplog.at_level(logging.WARNING):
+            log_tab_visibility_warnings(s)
+
+        assert any(
+            "SHOW_AGENTS_TAB" in msg and "mcp-servers-only" in msg
+            for msg in caplog.messages
+        )
+
+    def test_settings_tab_no_warning_when_consistent(self, monkeypatch, tmp_path, caplog):
+        """No warning when all SHOW_*_TAB are consistent with REGISTRY_MODE=full."""
+        monkeypatch.setenv("REGISTRY_MODE", "full")
+        monkeypatch.chdir(tmp_path)
+
+        import logging
+
+        from registry.core.config import log_tab_visibility_warnings
+
+        s = Settings()
+        with caplog.at_level(logging.WARNING):
+            log_tab_visibility_warnings(s)
+
+        assert not any("SHOW_" in msg for msg in caplog.messages)


### PR DESCRIPTION
Closes #743

## Description of changes:

### Summary

Adds four environment variables (`SHOW_SERVERS_TAB`, `SHOW_VIRTUAL_SERVERS_TAB`, `SHOW_SKILLS_TAB`, `SHOW_AGENTS_TAB`) that control UI tab visibility independently of `REGISTRY_MODE`. The formula: `tab_visible = REGISTRY_MODE_enables_feature AND SHOW_*_TAB`. All default to `true` for backward compatibility. Backend APIs remain fully functional regardless of tab visibility settings.

### Backend Changes

| File | Change |
|------|--------|
| `registry/core/config.py` | Added 4 boolean `show_*_tab` fields to `Settings` class (default `true`); added `log_tab_visibility_warnings()` function that logs WARNING for ineffective overrides at startup |
| `registry/main.py` | Call `log_tab_visibility_warnings(settings)` during application startup |
| `registry/api/config_routes.py` | Updated `get_config()` to AND each mode-derived feature flag with the corresponding `show_*_tab` setting; added `virtual_servers` key to features dict |
| `tests/unit/core/test_config.py` | **NEW** - 7 unit tests covering: defaults match current behavior, SHOW_TAB=false hides feature, REGISTRY_MODE precedence, virtual_servers key, startup warning logging |

### Frontend Changes

| File | Change |
|------|--------|
| `frontend/src/hooks/useRegistryConfig.ts` | Added `virtual_servers: boolean` to `RegistryConfig` interface and `DEFAULT_CONFIG` |
| `frontend/src/pages/Dashboard.tsx` | Added `registryConfig?.features.virtual_servers !== false` guard to Virtual MCP Servers tab button and content section |

### Configuration Changes

| File | Change |
|------|--------|
| `.env.example` | Added documented entries for all 4 `SHOW_*_TAB` variables with descriptions |
| `docker-compose.yml` | Added commented-out `SHOW_*_TAB` entries after `REGISTRY_MODE` |
| `docker-compose.prebuilt.yml` | Added commented-out `SHOW_*_TAB` entries after `REGISTRY_MODE` |
| `docker-compose.podman.yml` | Added commented-out `SHOW_*_TAB` entries after `REGISTRY_MODE` |
| `charts/registry/values.yaml` | Added `showServersTab`, `showVirtualServersTab`, `showSkillsTab`, `showAgentsTab` values (default `true`) |
| `charts/mcp-gateway-registry-stack/values.yaml` | Added same Helm values |
| `charts/registry/templates/deployment.yaml` | Added `SHOW_*_TAB` env vars to container spec |

### Terraform ECS Changes

| File | Change |
|------|--------|
| `terraform/aws-ecs/variables.tf` | Added 4 `show_*_tab` variables (type `bool`, default `true`) |
| `terraform/aws-ecs/modules/mcp-gateway/variables.tf` | Added same module-level variables |
| `terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf` | Added `SHOW_*_TAB` env vars to registry task definition |
| `terraform/aws-ecs/main.tf` | Passthrough from root to module |

### Precedence Matrix

| Scenario | Result |
|----------|--------|
| `REGISTRY_MODE=full` + `SHOW_AGENTS_TAB=true` | Agents tab shown |
| `REGISTRY_MODE=full` + `SHOW_AGENTS_TAB=false` | Agents tab hidden (backend APIs still work) |
| `REGISTRY_MODE=mcp-servers-only` + `SHOW_AGENTS_TAB=true` | Agents tab hidden (mode blocks it) |
| `REGISTRY_MODE=mcp-servers-only` + `SHOW_AGENTS_TAB=false` | Agents tab hidden |
