### PR TITLE
chore: bump Helm chart image tags to 1.0.19

### DIFF
--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -2,7 +2,7 @@
 global:
   image:
     repository: public.ecr.aws/p3v1o3c6/auth-server
-    tag: 1.0.18
+    tag: 1.0.19
     pullPolicy: IfNotPresent
 
 # Application configuration

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -3,7 +3,7 @@ global:
   # Image tag for all services (auth-server, registry, mcpgw)
   # This value is passed down to all subcharts via Helm's global scope
   image:
-    tag: 1.0.18
+    tag: 1.0.19
 
   # When installing chart from repository, add --set global.chartVersion=$(git rev-parse HEAD) to add the git hash to a configmap for debugging
   chartVersion:

--- a/charts/mcpgw/values.yaml
+++ b/charts/mcpgw/values.yaml
@@ -2,7 +2,7 @@
 global:
   image:
     repository: public.ecr.aws/p3v1o3c6/mcpgw
-    tag: 1.0.18
+    tag: 1.0.19
     pullPolicy: IfNotPresent
 
 # Application configuration

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -2,7 +2,7 @@
 global:
   image:
     repository: public.ecr.aws/p3v1o3c6/registry
-    tag: 1.0.18
+    tag: 1.0.19
     pullPolicy: IfNotPresent
 
 # Application configuration


### PR DESCRIPTION
## Summary
- Bump image tags from 1.0.18 to 1.0.19 in all four Helm values.yaml files
- The automated "Update Helm Charts on Release" workflow failed due to a duplicate Authorization header error, so this is a manual bump

## Files Changed
- charts/mcp-gateway-registry-stack/values.yaml
- charts/registry/values.yaml
- charts/mcpgw/values.yaml
- charts/auth-server/values.yaml