### PR TITLE
feat(skills): add auth credentials, multi-file support, and content drift detection

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2674,26 +2674,30 @@ async def oauth2_login(provider: str, request: Request, redirect_uri: str = None
         # Determine the OAuth2 callback URI based on the request origin
         # This is critical for dual-mode (CloudFront + custom domain) deployments
         # The callback_uri MUST match exactly between authorization and token exchange
-        host = request.headers.get("host", "localhost:8888")
-        # Check CloudFront header first, then X-Forwarded-Proto for HTTPS detection
-        cloudfront_proto = request.headers.get("x-cloudfront-forwarded-proto", "").lower()
-        forwarded_proto = request.headers.get("x-forwarded-proto", "").lower()
-        scheme = (
-            "https"
-            if cloudfront_proto == "https"
-            or forwarded_proto == "https"
-            or request.url.scheme == "https"
-            else "http"
-        )
-        logger.info(
-            f"OAuth2 login - host: {host}, x-cloudfront-forwarded-proto: {cloudfront_proto}, x-forwarded-proto: {forwarded_proto}, scheme: {scheme}"
-        )
-
-        # Special case for localhost to include port
-        if "localhost" in host and ":" not in host:
-            auth_server_url = f"{scheme}://localhost:8888{ROOT_PATH}"
+        auth_server_external_url = os.environ.get("AUTH_SERVER_EXTERNAL_URL", "").rstrip("/")
+        if auth_server_external_url:
+            auth_server_url = f"{auth_server_external_url}{ROOT_PATH}"
+            scheme = "https" if auth_server_external_url.startswith("https") else "http"
+            logger.info(f"OAuth2 login - using AUTH_SERVER_EXTERNAL_URL: {auth_server_url}")
         else:
-            auth_server_url = f"{scheme}://{host}{ROOT_PATH}"
+            host = request.headers.get("host", "localhost:8888")
+            cloudfront_proto = request.headers.get("x-cloudfront-forwarded-proto", "").lower()
+            forwarded_proto = request.headers.get("x-forwarded-proto", "").lower()
+            scheme = (
+                "https"
+                if cloudfront_proto == "https"
+                or forwarded_proto == "https"
+                or request.url.scheme == "https"
+                else "http"
+            )
+            logger.info(
+                f"OAuth2 login - host: {host}, x-cloudfront-forwarded-proto: {cloudfront_proto}, x-forwarded-proto: {forwarded_proto}, scheme: {scheme}"
+            )
+
+            if "localhost" in host and ":" not in host:
+                auth_server_url = f"{scheme}://localhost:8888{ROOT_PATH}"
+            else:
+                auth_server_url = f"{scheme}://{host}{ROOT_PATH}"
 
         callback_uri = f"{auth_server_url}/oauth2/callback/{provider}"
         logger.info(f"OAuth2 callback URI (from request host): {callback_uri}")

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -140,6 +140,12 @@ if [ "$USE_DHI" = true ]; then
     log "Ensure you have authenticated: docker login dhi.io"
 fi
 
+OVERRIDE_FILE="docker-compose.override.yml"
+if [ -f "$OVERRIDE_FILE" ]; then
+    COMPOSE_FILES="$COMPOSE_FILES -f $OVERRIDE_FILE"
+    log "Applying local overrides from $OVERRIDE_FILE"
+fi
+
 if [ "$USE_PREBUILT" = true ]; then
     log "Using pre-built container images for fast deployment"
     log "Will pull latest images from container registry during startup..."
@@ -570,7 +576,7 @@ else
 fi
 
 # Check auth service
-if curl -f http://localhost:8888/health &>/dev/null; then
+if curl -f http://localhost:18888/health &>/dev/null; then
     log "Auth service is healthy"
 else
     log "WARNING: Auth service may still be starting up..."

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -216,11 +216,11 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
       setSkillMdContent(response.data.content);
     } catch (error: any) {
       console.error('Failed to fetch SKILL.md content:', error);
-      if (onShowToast) {
-        onShowToast(
-          error.response?.data?.detail || 'Failed to load SKILL.md content',
-          'error'
-        );
+      const detail = error.response?.data?.detail;
+      if (error.response?.status === 409 && detail) {
+        setSkillMdContent(`> **Content Drift Detected**\n>\n> ${detail}\n>\n> Re-register this skill to update the integrity baseline and re-enable it.`);
+      } else if (onShowToast) {
+        onShowToast(detail || 'Failed to load SKILL.md content', 'error');
       }
     } finally {
       setLoadingDetails(false);
@@ -458,7 +458,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                 <span
                   key={tag}
                   className={`px-2 py-1 text-xs font-medium rounded ${
-                    tag === 'security-pending'
+                    tag === 'security-pending' || tag === 'content-drifted'
                       ? 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-700'
                       : 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300'
                   }`}
@@ -555,6 +555,16 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
                   {skill.is_enabled ? 'Enabled' : 'Disabled'}
                 </span>
+                {!skill.is_enabled && skill.tags?.includes('content-drifted') && (
+                  <span className="text-xs text-red-600 dark:text-red-400 font-medium" title="Skill content changed since registration. Re-register to update the baseline.">
+                    — content drifted
+                  </span>
+                )}
+                {!skill.is_enabled && skill.tags?.includes('security-pending') && !skill.tags?.includes('content-drifted') && (
+                  <span className="text-xs text-red-600 dark:text-red-400 font-medium">
+                    — security review pending
+                  </span>
+                )}
               </div>
 
               <div className="w-px h-4 bg-amber-200 dark:bg-amber-600" />

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -7,11 +7,12 @@ All recommendations implemented:
 - Path normalization via dependency
 - Domain-specific exception handling
 - Discovery endpoint for coding assistants
-- Resource listing endpoints
+- Resource content served via the /content endpoint
 """
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from typing import (
     Annotated,
     Any,
@@ -50,6 +51,8 @@ from ..schemas.skill_models import (
 )
 from ..services.github_auth import github_auth_provider as _github_auth
 from ..services.skill_service import (
+    _build_fetch_headers,
+    _discover_skill_resources,
     _is_safe_url,
     get_skill_service,
 )
@@ -74,6 +77,8 @@ class RatingRequest(BaseModel):
 
 
 router = APIRouter(prefix="/skills", tags=["skills"])
+
+_SKILL_CARD_EXCLUDE = {"auth_credential_encrypted"}
 
 
 # Dependency for normalized path
@@ -358,6 +363,54 @@ async def search_skills(
     }
 
 
+@router.get("/{skill_path:path}/integrity", summary="Get content integrity status")
+async def get_integrity_status(
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    skill_path: str = Path(..., description="Skill path or name"),
+) -> dict:
+    """Return the stored content integrity record for a skill.
+
+    This is a read-only view of the baseline hashes and drift state
+    that were computed at registration and updated on every content fetch.
+    No external requests are made.
+    """
+    normalized_path = normalize_skill_path(skill_path)
+    service = get_skill_service()
+    skill = await service.get_skill(normalized_path)
+
+    if not skill:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Skill not found: {normalized_path}",
+        )
+
+    if not _user_can_access_skill(skill, user_context):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    integrity = skill.content_integrity
+    if not integrity:
+        return {
+            "path": normalized_path,
+            "has_baseline": False,
+            "message": "No integrity baseline. Re-register the skill to compute one.",
+        }
+
+    return {
+        "path": normalized_path,
+        "has_baseline": True,
+        "composite_hash": integrity.composite_hash,
+        "computed_at": integrity.computed_at.isoformat() if integrity.computed_at else None,
+        "drift_detected": integrity.drift_detected,
+        "last_drift_check": integrity.last_drift_check.isoformat() if integrity.last_drift_check else None,
+        "drifted_files": integrity.drifted_files,
+        "file_count": len(integrity.file_hashes),
+        "files": [
+            {"path": fh.path, "sha256": fh.sha256, "size_bytes": fh.size_bytes}
+            for fh in integrity.file_hashes
+        ],
+    }
+
+
 @router.get("/{skill_path:path}/health", summary="Check skill health")
 async def check_skill_health(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
@@ -379,15 +432,24 @@ async def check_skill_health(
     }
 
 
+MAX_RESOURCE_SIZE = 512 * 1024  # 512 KB
+
+
 @router.get("/{skill_path:path}/content", summary="Get SKILL.md content")
 async def get_skill_content(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     skill_path: str = Path(..., description="Skill path or name"),
+    resource: str | None = Query(
+        None,
+        description="Optional relative path to a companion resource file. "
+        "When omitted, returns SKILL.md content.",
+    ),
 ) -> dict:
-    """Fetch SKILL.md content from the raw URL.
+    """Fetch skill content.
 
-    This endpoint proxies the SKILL.md content to avoid CORS issues
-    when the frontend tries to fetch from GitHub directly.
+    Without ``resource``: returns SKILL.md markdown and the resource manifest.
+    With ``resource``: returns the content of the specified companion file
+    (validated against the stored manifest to prevent path traversal).
     """
     normalized_path = normalize_skill_path(skill_path)
     service = get_skill_service()
@@ -399,9 +461,21 @@ async def get_skill_content(
             detail=f"Skill not found: {normalized_path}",
         )
 
-    # Check visibility
     if not _user_can_access_skill(skill, user_context):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    if (
+        skill.content_integrity
+        and skill.content_integrity.drift_detected
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Content drift detected for {normalized_path}. "
+                f"Drifted files: {', '.join(skill.content_integrity.drifted_files)}. "
+                "The skill has been disabled. Re-register to update the baseline."
+            ),
+        )
 
     # For federated skills with inline content, serve directly from DB
     if skill.skill_md_content:
@@ -411,7 +485,6 @@ async def get_skill_content(
             "path": normalized_path,
         }
 
-    # Fetch content from raw URL
     raw_url = skill.skill_md_raw_url or skill.skill_md_url
     if not raw_url:
         raise HTTPException(
@@ -419,49 +492,56 @@ async def get_skill_content(
             detail="No SKILL.md URL configured for this skill",
         )
 
-    # SSRF protection: validate URL before making request
-    if not _is_safe_url(str(raw_url)):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="URL failed SSRF validation - private/internal addresses are not allowed",
-        )
-
-    try:
-        import httpx
-
-        async with httpx.AsyncClient() as client:
-            headers = await _github_auth.get_auth_headers(str(raw_url))
-            response = await client.get(
-                str(raw_url), headers=headers, follow_redirects=True, timeout=30.0
+    if resource is not None:
+        manifest = skill.resource_manifest
+        if not manifest:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No resource manifest available for this skill",
+            )
+        all_resources = manifest.references + manifest.scripts + manifest.agents + manifest.assets
+        matched = [r for r in all_resources if r.path == resource]
+        if not matched:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Resource '{resource}' not found in manifest",
             )
 
-            # SSRF protection: validate final URL after redirects
-            final_url = str(response.url)
-            if final_url != str(raw_url) and not _is_safe_url(final_url):
-                logger.warning(
-                    f"SSRF protection: Blocked redirect from {raw_url} to unsafe URL {final_url}"
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Redirect to unsafe URL blocked: {final_url}",
-                )
+        from ..utils.url_utils import derive_resource_url
 
-            if response.status_code >= 400:
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"Failed to fetch SKILL.md: HTTP {response.status_code}",
-                )
-
-            return {
-                "content": response.text,
-                "url": str(raw_url),
-            }
-    except httpx.RequestError as e:
-        logger.error(f"Failed to fetch SKILL.md from {raw_url}: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Failed to fetch SKILL.md: {e}",
+        resource_url = derive_resource_url(str(raw_url), resource)
+        response = await _fetch_authenticated_content(
+            resource_url, skill, max_size=MAX_RESOURCE_SIZE,
         )
+
+        drift_task = asyncio.create_task(
+            _check_drift_inline(service, normalized_path, skill, resource, response.content)
+        )
+        drift_task.add_done_callback(_log_task_exception)
+
+        return {
+            "content": response.text,
+            "path": resource,
+            "type": matched[0].type,
+            "url": resource_url,
+        }
+
+    response = await _fetch_authenticated_content(str(raw_url), skill)
+
+    drift_task = asyncio.create_task(
+        _check_drift_inline(service, normalized_path, skill, "SKILL.md", response.content)
+    )
+    drift_task.add_done_callback(_log_task_exception)
+
+    result: dict[str, Any] = {
+        "content": response.text,
+        "url": str(raw_url),
+    }
+    if skill.resource_manifest:
+        result["resource_manifest"] = skill.resource_manifest.model_dump()
+    if skill.content_integrity:
+        result["drift_detected"] = skill.content_integrity.drift_detected
+    return result
 
 
 @router.get(
@@ -609,7 +689,67 @@ async def rescan_skill(
         )
 
 
-@router.get("/{skill_path:path}", response_model=SkillCard, summary="Get a skill by path")
+
+@router.post(
+    "/{skill_path:path}/refresh-resources",
+    response_model=dict,
+    summary="Refresh skill resource manifest",
+)
+async def refresh_skill_resources(
+    http_request: Request,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    skill_path: str = Path(..., description="Skill path or name"),
+) -> dict:
+    """Re-discover companion resource files and update the stored manifest.
+
+    Useful when new files have been added to the skill's repository directory
+    without re-registering the skill.
+    """
+    normalized_path = normalize_skill_path(skill_path)
+    service = get_skill_service()
+    skill = await service.get_skill(normalized_path)
+
+    if not skill:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Skill not found: {normalized_path}"
+        )
+
+    if not _user_can_modify_skill(skill, user_context):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    set_audit_action(
+        http_request,
+        "refresh_resources",
+        "skill",
+        resource_id=normalized_path,
+        description=f"Refresh resource manifest for {normalized_path}",
+    )
+
+    raw_url = str(skill.skill_md_raw_url or skill.skill_md_url)
+    auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
+
+    manifest = await _discover_skill_resources(
+        raw_url,
+        auth_scheme=auth_scheme,
+        auth_credential=credential,
+        auth_header_name=auth_header_name,
+    )
+
+    updates = {"resource_manifest": manifest.model_dump() if manifest else None}
+    await service.update_skill(normalized_path, updates)
+
+    total = 0
+    if manifest:
+        total = len(manifest.references) + len(manifest.scripts) + len(manifest.agents) + len(manifest.assets)
+
+    return {
+        "path": normalized_path,
+        "resources_discovered": total,
+        "resource_manifest": manifest.model_dump() if manifest else None,
+    }
+
+
+@router.get("/{skill_path:path}", response_model=SkillCard, response_model_exclude=_SKILL_CARD_EXCLUDE, summary="Get a skill by path")
 async def get_skill(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     skill_path: str = Path(..., description="Skill path or name"),
@@ -634,6 +774,7 @@ async def get_skill(
 @router.post(
     "",
     response_model=SkillCard,
+    response_model_exclude=_SKILL_CARD_EXCLUDE,
     status_code=status.HTTP_201_CREATED,
     summary="Register a new skill",
 )
@@ -678,8 +819,11 @@ async def register_skill(
         skill = await service.register_skill(request=request, owner=owner, validate_url=True)
         logger.info(f"Registered skill: {skill.name} by {owner}")
 
-        # Perform security scan on registration (non-blocking on failure)
-        await _perform_skill_security_scan_on_registration(skill, service)
+        # Security scanning if enabled (non-blocking — mirrors server registration pattern)
+        scan_task = asyncio.create_task(
+            _perform_skill_security_scan_on_registration(skill, service)
+        )
+        scan_task.add_done_callback(_log_task_exception)
 
         asyncio.create_task(
             send_registration_webhook(
@@ -707,7 +851,7 @@ async def register_skill(
         )
 
 
-@router.put("/{skill_path:path}", response_model=SkillCard, summary="Update a skill")
+@router.put("/{skill_path:path}", response_model=SkillCard, response_model_exclude=_SKILL_CARD_EXCLUDE, summary="Update a skill")
 async def update_skill(
     http_request: Request,
     request: SkillRegistrationRequest,
@@ -766,6 +910,19 @@ async def update_skill(
             version=raw_meta.get("version"),
             extra={k: v for k, v in raw_meta.items() if k not in ("author", "version")},
         ).model_dump(mode="json")
+
+    # Encrypt credential if provided on update
+    auth_credential = updates.pop("auth_credential", None)
+    auth_scheme = updates.get("auth_scheme", existing.auth_scheme)
+    if auth_credential and auth_scheme != "none":
+        from ..utils.credential_encryption import encrypt_credential
+
+        updates["auth_credential_encrypted"] = encrypt_credential(auth_credential)
+        updates["credential_updated_at"] = datetime.now(UTC).isoformat()
+    elif auth_scheme == "none":
+        updates["auth_credential_encrypted"] = None
+        updates["auth_header_name"] = None
+        updates["credential_updated_at"] = None
 
     updated = await service.update_skill(normalized_path, updates)
 
@@ -925,6 +1082,101 @@ async def rate_skill(
 # Helper functions
 
 
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Done-callback that surfaces unhandled exceptions from background tasks.
+
+    Without this, exceptions raised inside ``asyncio.create_task(...)``
+    fire-and-forget calls are only visible when the garbage collector
+    finalises the task, which is too late for production debugging.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Background task failed: %s", exc, exc_info=exc)
+
+
+def _decrypt_skill_auth(
+    skill: SkillCard,
+) -> tuple[str, str | None, str | None]:
+    """Extract and decrypt authentication details from a skill.
+
+    Returns (auth_scheme, plaintext_credential_or_none, auth_header_name).
+    """
+    auth_scheme = getattr(skill, "auth_scheme", "none")
+    encrypted_cred = getattr(skill, "auth_credential_encrypted", None)
+    credential = None
+    if auth_scheme != "none" and encrypted_cred:
+        from ..utils.credential_encryption import decrypt_credential
+
+        credential = decrypt_credential(encrypted_cred)
+    return auth_scheme, credential, getattr(skill, "auth_header_name", None)
+
+
+async def _fetch_authenticated_content(
+    url: str,
+    skill: SkillCard,
+    *,
+    max_size: int | None = None,
+    timeout: float = 30.0,
+) -> "httpx.Response":
+    """Fetch content from a URL using the skill's encrypted credentials.
+
+    Handles SSRF validation, credential decryption, header building,
+    and redirect safety checks. Raises HTTPException on failure.
+    """
+    import httpx as _httpx
+
+    if not _is_safe_url(url):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="URL failed SSRF validation - private/internal addresses are not allowed",
+        )
+
+    auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
+    fetch_url, fetch_headers = _build_fetch_headers(url, auth_scheme, credential, auth_header_name)
+
+    # Merge in GitHub App / token auth headers so public-repo fetches
+    # benefit from the higher rate-limit ceiling.  Per-skill credentials
+    # take precedence on key collisions because they are explicitly
+    # configured for this skill's source.
+    github_headers = await _github_auth.get_auth_headers(fetch_url)
+    merged_headers = {**github_headers, **fetch_headers}
+
+    try:
+        async with _httpx.AsyncClient() as client:
+            response = await client.get(
+                fetch_url, headers=merged_headers, follow_redirects=True, timeout=timeout,
+            )
+
+            final_url = str(response.url)
+            if final_url != fetch_url and not _is_safe_url(final_url):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Redirect to unsafe URL blocked: {final_url}",
+                )
+
+            if response.status_code >= 400:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"Failed to fetch content: HTTP {response.status_code}",
+                )
+
+            if max_size and len(response.content) > max_size:
+                raise HTTPException(
+                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    detail=f"Content exceeds {max_size // 1024} KB limit",
+                )
+
+            return response
+    except _httpx.RequestError as e:
+        logger.error("Failed to fetch from %s: %s", url, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to fetch content: {e}",
+        )
+
+
 def _user_can_access_skill(
     skill: SkillCard,
     user_context: dict,
@@ -963,8 +1215,14 @@ async def _perform_skill_security_scan_on_registration(
     skill: SkillCard,
     service,
 ) -> None:
-    """
-    Perform security scan on skill registration.
+    """Perform security scan on newly registered skill.
+
+    Mirrors the MCP server registration scan pattern:
+    - Builds auth headers from the skill's encrypted credential
+    - Passes headers to the scanner for authenticated downloads
+    - Adds security-pending tag if scan fails
+    - Disables skill if configured and scan fails
+    - All scan failures are non-fatal and logged but not raised.
 
     Args:
         skill: The registered skill card
@@ -981,9 +1239,18 @@ async def _perform_skill_security_scan_on_registration(
     logger.info(f"Performing security scan for skill: {skill.path}")
 
     try:
+        raw_url = str(skill.skill_md_raw_url or skill.skill_md_url)
+        auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
+        fetch_headers: dict[str, str] = {}
+        if credential:
+            raw_url, fetch_headers = _build_fetch_headers(
+                raw_url, auth_scheme, credential, auth_header_name,
+            )
+
         result = await skill_scanner_service.scan_skill(
             skill_path=skill.path,
-            skill_md_url=str(skill.skill_md_raw_url or skill.skill_md_url),
+            skill_md_url=raw_url,
+            headers=fetch_headers or None,
         )
 
         if not result.is_safe and config.block_unsafe_skills:
@@ -1008,3 +1275,84 @@ async def _perform_skill_security_scan_on_registration(
                     )
             except Exception as tag_err:
                 logger.error(f"Failed to add security-pending tag: {tag_err}")
+
+
+async def _check_drift_inline(
+    service: "SkillService",
+    skill_path: str,
+    skill: SkillCard,
+    file_path: str,
+    content_bytes: bytes,
+) -> None:
+    """Compare fetched content against the stored integrity baseline.
+
+    Runs as a fire-and-forget background task so it never blocks the
+    content response.  Updates the DB only when a change is detected
+    (or when a previously-drifted file returns to its baseline).
+    """
+    import hashlib
+    from datetime import UTC, datetime
+
+    integrity = skill.content_integrity
+    if not integrity or not integrity.file_hashes:
+        return
+
+    baseline = {fh.path: fh.sha256 for fh in integrity.file_hashes}
+    expected = baseline.get(file_path)
+    if expected is None:
+        return
+
+    actual = hashlib.sha256(content_bytes).hexdigest()
+    file_drifted = actual != expected
+
+    previously_drifted = file_path in (integrity.drifted_files or [])
+    now = datetime.now(UTC).isoformat()
+
+    try:
+        # Fast path: drift state for this file did not change.  Persist
+        # only the last-checked timestamp in a single update so we still
+        # have an audit trail of the verification.
+        if file_drifted == previously_drifted:
+            await service.update_skill(
+                skill_path,
+                {"content_integrity.last_drift_check": now},
+            )
+            return
+
+        current_drifted = list(integrity.drifted_files or [])
+        if file_drifted and file_path not in current_drifted:
+            current_drifted.append(file_path)
+        elif not file_drifted and file_path in current_drifted:
+            current_drifted.remove(file_path)
+
+        # Batch all field-level changes (integrity state + tags) into a
+        # single update_skill() call.  This halves DB round-trips and
+        # avoids interleaving where another task could observe a
+        # half-applied state.  Enable/disable is a separate persistence
+        # path (set_state vs update) and must remain its own call.
+        current_tags = list(skill.tags or [])
+        drift_tag = "content-drifted"
+        if current_drifted and drift_tag not in current_tags:
+            current_tags.append(drift_tag)
+        elif not current_drifted and drift_tag in current_tags:
+            current_tags.remove(drift_tag)
+
+        combined_updates: dict[str, Any] = {
+            "content_integrity.drift_detected": bool(current_drifted),
+            "content_integrity.last_drift_check": now,
+            "content_integrity.drifted_files": current_drifted,
+            "tags": current_tags,
+        }
+        await service.update_skill(skill_path, combined_updates)
+
+        if current_drifted:
+            await service.toggle_skill(skill_path, enabled=False)
+            logger.warning(
+                "Drift detected for %s in skill %s — skill disabled",
+                file_path, skill_path,
+            )
+        else:
+            await service.toggle_skill(skill_path, enabled=True)
+            logger.info("Drift cleared for skill %s — skill re-enabled", skill_path)
+    except Exception:
+        logger.debug("Failed to persist drift state for %s", skill_path, exc_info=True)

--- a/registry/schemas/skill_models.py
+++ b/registry/schemas/skill_models.py
@@ -10,7 +10,6 @@ All recommendations incorporated:
 - Progressive disclosure tier models
 - Owner field for access control
 - Content versioning fields
-- Registry Card fields (status, source timestamps, external_tags) for federation
 """
 
 import logging
@@ -88,10 +87,50 @@ class SkillResource(BaseModel):
     """Reference to a skill resource file."""
 
     path: str = Field(..., description="Relative path from skill root")
-    type: Literal["script", "reference", "asset"] = Field(...)
+    type: Literal["script", "reference", "asset", "agent"] = Field(...)
     size_bytes: int = Field(default=0)
     description: str | None = None
     language: str | None = Field(None, description="Programming language for scripts")
+
+
+class SkillResourceManifest(BaseModel):
+    """Manifest of available resources for a skill."""
+
+    scripts: list[SkillResource] = Field(default_factory=list)
+    references: list[SkillResource] = Field(default_factory=list)
+    assets: list[SkillResource] = Field(default_factory=list)
+    agents: list[SkillResource] = Field(default_factory=list)
+
+
+class FileHash(BaseModel):
+    """SHA-256 hash for a single file in the skill directory."""
+
+    path: str = Field(..., description="Relative path (e.g. 'SKILL.md' or 'references/arch.md')")
+    sha256: str = Field(..., description="Full SHA-256 hex digest of the file content")
+    size_bytes: int = Field(default=0, description="File size at hash time")
+
+
+class ContentIntegrity(BaseModel):
+    """Content integrity record computed at registration or refresh.
+
+    Stores per-file SHA-256 hashes and a composite hash derived from all
+    individual hashes, enabling drift detection without re-fetching content.
+    """
+
+    composite_hash: str = Field(
+        ..., description="SHA-256 of the sorted, concatenated per-file hashes"
+    )
+    file_hashes: list[FileHash] = Field(default_factory=list)
+    computed_at: datetime = Field(default_factory=_utc_now)
+    drift_detected: bool = Field(
+        default=False, description="True when a drift check found content differs from this baseline"
+    )
+    last_drift_check: datetime | None = Field(
+        None, description="When drift was last checked"
+    )
+    drifted_files: list[str] = Field(
+        default_factory=list, description="Paths of files that changed since baseline"
+    )
 
 
 class SkillCard(BaseModel):
@@ -168,6 +207,31 @@ class SkillCard(BaseModel):
     )
     owner: str | None = Field(None, description="Owner email/username for private visibility")
 
+    # Source authentication (for private Git repos)
+    # Literal keeps the wire-format strings compatible with existing clients
+    # while rejecting unsupported schemes at validation time.  Adding a new
+    # scheme requires updating both this list and SkillRegistrationRequest.
+    auth_scheme: Literal["none", "bearer", "api_key"] = Field(
+        default="none",
+        description="Auth scheme for fetching SKILL.md: none, bearer, api_key",
+    )
+    auth_credential_encrypted: str | None = Field(
+        None,
+        description="Encrypted credential for SKILL.md fetching",
+    )
+    auth_header_name: str | None = Field(
+        None,
+        description="Custom header name for credential (default: Authorization for bearer, PRIVATE-TOKEN for api_key)",
+    )
+    credential_updated_at: datetime | None = Field(
+        None, description="When the credential was last updated"
+    )
+
+    # Resource manifest (companion files: references, scripts, agents, assets)
+    resource_manifest: SkillResourceManifest | None = Field(
+        None, description="Manifest of companion resource files discovered in the skill directory"
+    )
+
     # State
     is_enabled: bool = Field(default=True, description="Whether the skill is enabled")
     registry_name: str = Field(default="local", description="Registry this skill belongs to")
@@ -187,6 +251,11 @@ class SkillCard(BaseModel):
     content_version: str | None = Field(None, description="Hash of SKILL.md for cache validation")
     content_updated_at: datetime | None = Field(
         None, description="When SKILL.md content was last updated"
+    )
+
+    # Content integrity (full hash of SKILL.md + all resources)
+    content_integrity: ContentIntegrity | None = Field(
+        None, description="Per-file hashes and composite hash for drift detection"
     )
 
     # Timestamps
@@ -308,6 +377,18 @@ class SkillRegistrationRequest(BaseModel):
         default="draft",
         description="Lifecycle status (default: draft). Allowed: active, deprecated, draft, beta",
     )
+    auth_scheme: Literal["none", "bearer", "api_key"] = Field(
+        default="none",
+        description="Auth scheme for fetching SKILL.md from private repos: none, bearer, api_key",
+    )
+    auth_credential: str | None = Field(
+        None,
+        description="Credential (token/key) for fetching SKILL.md; encrypted before storage, never persisted in plaintext",
+    )
+    auth_header_name: str | None = Field(
+        None,
+        description="Custom header name (default: Authorization for bearer, PRIVATE-TOKEN for api_key)",
+    )
 
     @field_validator("name")
     @classmethod
@@ -379,14 +460,6 @@ class SkillTier3_Resources(BaseModel):
     """Tier 3: Loaded on-demand."""
 
     available_resources: list[SkillResource] = Field(default_factory=list)
-
-
-class SkillResourceManifest(BaseModel):
-    """Manifest of available resources for a skill."""
-
-    scripts: list[SkillResource] = Field(default_factory=list)
-    references: list[SkillResource] = Field(default_factory=list)
-    assets: list[SkillResource] = Field(default_factory=list)
 
 
 class ToolValidationResult(BaseModel):

--- a/registry/services/skill_scanner.py
+++ b/registry/services/skill_scanner.py
@@ -68,6 +68,7 @@ class SkillScannerService:
         skill_content_path: str | None = None,
         analyzers: str | None = None,
         timeout: int | None = None,
+        headers: dict[str, str] | None = None,
     ) -> SkillSecurityScanResult:
         """
         Scan a skill for security vulnerabilities.
@@ -78,6 +79,7 @@ class SkillScannerService:
             skill_content_path: Local path to skill content (for local scanning)
             analyzers: Comma-separated list of analyzers
             timeout: Scan timeout in seconds
+            headers: Optional HTTP headers for authenticated SKILL.md downloads
 
         Returns:
             SkillSecurityScanResult containing scan results
@@ -99,6 +101,7 @@ class SkillScannerService:
                 skill_content_path=skill_content_path,
                 analyzers=analyzers,
                 timeout=timeout,
+                headers=headers,
             )
 
             is_safe, critical, high, medium, low = self._analyze_scan_results(raw_output)
@@ -150,6 +153,7 @@ class SkillScannerService:
         skill_content_path: str | None = None,
         analyzers: str = "static",
         timeout: int = 120,
+        headers: dict[str, str] | None = None,
     ) -> dict:
         """
         Run skill-scanner command and return raw output.
@@ -162,6 +166,7 @@ class SkillScannerService:
             skill_content_path: Local path to skill content
             analyzers: Comma-separated list of analyzers
             timeout: Scan timeout in seconds
+            headers: Optional HTTP headers for authenticated downloads
 
         Returns:
             Dict containing parsed scan results
@@ -176,7 +181,7 @@ class SkillScannerService:
         if skill_content_path:
             target = skill_content_path
         elif skill_md_url:
-            target = self._download_skill_content(skill_md_url)
+            target = self._download_skill_content(skill_md_url, headers=headers)
         else:
             raise ValueError("Either skill_content_path or skill_md_url must be provided")
 
@@ -226,12 +231,18 @@ class SkillScannerService:
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Skill scanner failed: {e.stderr}") from e
 
-    def _download_skill_content(self, skill_md_url: str) -> str:
+    def _download_skill_content(
+        self, skill_md_url: str, headers: dict[str, str] | None = None
+    ) -> str:
         """
         Download skill content for scanning.
 
+        Mirrors the MCP server scanner pattern: accepts optional headers
+        for authenticated endpoints (e.g., private Git repos).
+
         Args:
             skill_md_url: URL to SKILL.md file
+            headers: Optional HTTP headers for authentication
 
         Returns:
             Path to temporary directory containing downloaded skill content
@@ -244,7 +255,9 @@ class SkillScannerService:
         temp_dir = tempfile.mkdtemp(prefix="skill_scan_")
         skill_md_path = Path(temp_dir) / "SKILL.md"
 
-        response = httpx.get(skill_md_url, follow_redirects=True, timeout=30.0)
+        response = httpx.get(
+            skill_md_url, headers=headers or {}, follow_redirects=True, timeout=30.0
+        )
         response.raise_for_status()
         skill_md_path.write_text(response.text)
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -31,6 +31,8 @@ from ..repositories.interfaces import (
     SkillRepositoryBase,
 )
 from ..schemas.skill_models import (
+    ContentIntegrity,
+    FileHash,
     SkillCard,
     SkillInfo,
     SkillMetadata,
@@ -165,13 +167,173 @@ def _is_safe_url(
         return False
 
 
+def _build_fetch_headers(
+    url: str,
+    auth_scheme: str = "none",
+    auth_credential: str | None = None,
+    auth_header_name: str | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Build fetch URL and auth headers for a SKILL.md request.
+
+    Returns (fetch_url, headers) tuple.  The URL is returned unchanged;
+    platform-specific modules may override to translate web URLs to
+    authenticated API endpoints.
+    """
+    headers: dict[str, str] = {}
+    fetch_url = url
+
+    if auth_scheme == "none" or not auth_credential:
+        return fetch_url, headers
+
+    if auth_scheme == "bearer":
+        header_name = auth_header_name or "Authorization"
+        headers[header_name] = f"Bearer {auth_credential}"
+    elif auth_scheme == "api_key":
+        header_name = auth_header_name or "PRIVATE-TOKEN"
+        headers[header_name] = auth_credential
+
+    return fetch_url, headers
+
+
+_RESOURCE_TYPE_MAP: dict[str, str] = {
+    "references": "reference",
+    "scripts": "script",
+    "agents": "agent",
+    "assets": "asset",
+}
+
+_LANG_BY_EXT: dict[str, str] = {
+    ".py": "python",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".js": "javascript",
+    ".ts": "typescript",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".md": "markdown",
+    ".json": "json",
+}
+
+
+def _resolve_tree_api(
+    skill_md_url: str,
+) -> tuple[str, str, str, str] | None:
+    """Resolve a tree/directory listing API endpoint for a skill URL.
+
+    Returns (tree_api_url, encoded_project, ref, skill_dir) or None
+    when no hosting-platform provider handles the URL.  Override or
+    extend this function to add support for specific Git platforms.
+
+    .. note::
+       **This is intentionally a stub.**  The default implementation
+       always returns ``None``, which means :func:`_discover_skill_resources`
+       will not find any companion files until a deployment provides a
+       platform-specific implementation (e.g. GitHub Trees API, GitLab
+       Repository Tree, Bitbucket source listing).
+
+       Multi-file resource support is fully wired through the rest of the
+       stack (manifest storage, ``/content?resource=...`` serving, drift
+       detection); only the discovery step is gated on this hook.
+       Replace this function — or monkey-patch it from a deployment
+       module — with a provider that returns the tuple described above
+       to enable resource discovery for your hosting platform.
+    """
+    return None
+
+
+async def _discover_skill_resources(
+    skill_md_url: str,
+    auth_scheme: str = "none",
+    auth_credential: str | None = None,
+    auth_header_name: str | None = None,
+) -> "SkillResourceManifest | None":
+    """Discover companion resource files in the skill directory.
+
+    Calls the hosting platform's tree/directory listing API to find files
+    alongside SKILL.md and classifies them into the resource manifest.
+    Returns None when the platform is not recognised or on any failure.
+    """
+    from ..schemas.skill_models import SkillResource, SkillResourceManifest
+
+    tree_info = _resolve_tree_api(skill_md_url)
+    if not tree_info:
+        logger.debug("Cannot derive tree API URL from %s — skipping resource discovery", skill_md_url)
+        return None
+
+    tree_url, _encoded_project, _ref, skill_dir = tree_info
+    skill_dir_prefix = skill_dir + "/" if skill_dir else ""
+    _, headers = _build_fetch_headers(tree_url, auth_scheme, auth_credential, auth_header_name)
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(tree_url, headers=headers)
+            if resp.status_code >= 400:
+                logger.warning("Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url)
+                return None
+            items = resp.json()
+    except Exception as e:
+        logger.warning("Resource discovery error for %s: %s", tree_url, e)
+        return None
+
+    if not isinstance(items, list):
+        return None
+
+    manifest = SkillResourceManifest()
+    for item in items:
+        if item.get("type") != "blob":
+            continue
+        path = item.get("path", "")
+        name = item.get("name", "")
+        if name.upper() == "SKILL.MD" or name.upper() == "README.MD" or name.upper() == "LICENSE.TXT":
+            continue
+
+        parts = path.split("/")
+        if len(parts) < 2:
+            continue
+        subdir = parts[-2]  # immediate parent directory
+        resource_type = _RESOURCE_TYPE_MAP.get(subdir)
+        if not resource_type:
+            continue
+
+        ext = "." + name.rsplit(".", 1)[-1].lower() if "." in name else ""
+        relative_path = path[len(skill_dir_prefix):] if path.startswith(skill_dir_prefix) else path
+
+        resource = SkillResource(
+            path=relative_path,
+            type=resource_type,
+            size_bytes=item.get("size", 0),
+            language=_LANG_BY_EXT.get(ext),
+        )
+
+        bucket = getattr(manifest, f"{resource_type}s" if resource_type != "reference" else "references", None)
+        if bucket is not None:
+            bucket.append(resource)
+
+    total = len(manifest.references) + len(manifest.scripts) + len(manifest.agents) + len(manifest.assets)
+    if total == 0:
+        return None
+
+    logger.info(
+        "Discovered %d resources: %d references, %d scripts, %d agents, %d assets",
+        total, len(manifest.references), len(manifest.scripts),
+        len(manifest.agents), len(manifest.assets),
+    )
+    return manifest
+
+
 async def _validate_skill_md_url(
     url: str,
+    auth_scheme: str = "none",
+    auth_credential: str | None = None,
+    auth_header_name: str | None = None,
 ) -> dict[str, Any]:
     """Validate SKILL.md URL is accessible and get content hash.
 
     Args:
         url: URL to SKILL.md file
+        auth_scheme: Authentication scheme (none, bearer, api_key)
+        auth_credential: Plaintext credential for URL validation
+        auth_header_name: Custom header name for the credential
 
     Returns:
         Dict with validation result and content hash
@@ -179,22 +341,26 @@ async def _validate_skill_md_url(
     Raises:
         SkillUrlValidationError: If URL is not accessible or fails SSRF check
     """
-    # SSRF protection: validate URL before making request
     if not _is_safe_url(url):
         raise SkillUrlValidationError(
             url, "URL failed SSRF validation - private/internal addresses are not allowed"
         )
 
+    fetch_url, fetch_headers = _build_fetch_headers(
+        url, auth_scheme, auth_credential, auth_header_name
+    )
+
     try:
         async with httpx.AsyncClient() as client:
-            headers = await _github_auth.get_auth_headers(str(url))
+            github_headers = await _github_auth.get_auth_headers(str(url))
+            merged_headers = {**fetch_headers, **github_headers}
             response = await client.get(
-                str(url), headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                fetch_url, headers=merged_headers, follow_redirects=True,
+                timeout=URL_VALIDATION_TIMEOUT,
             )
 
-            # SSRF protection: validate final URL after redirects
             final_url = str(response.url)
-            if final_url != str(url) and not _is_safe_url(final_url):
+            if final_url != fetch_url and not _is_safe_url(final_url):
                 logger.warning(
                     f"SSRF protection: Blocked redirect from {url} to unsafe URL {final_url}"
                 )
@@ -203,7 +369,6 @@ async def _validate_skill_md_url(
             if response.status_code >= 400:
                 raise SkillUrlValidationError(url, f"HTTP {response.status_code}")
 
-            # Generate content hash for versioning
             content_hash = hashlib.sha256(response.content).hexdigest()[:16]
 
             return {
@@ -411,11 +576,17 @@ async def _parse_skill_md_content(
 
 async def _check_skill_health(
     url: str,
+    auth_scheme: str = "none",
+    auth_credential_encrypted: str | None = None,
+    auth_header_name: str | None = None,
 ) -> dict[str, Any]:
     """Check skill health by performing HEAD request to SKILL.md URL.
 
     Args:
         url: URL to SKILL.md file
+        auth_scheme: Auth scheme for private repos
+        auth_credential_encrypted: Encrypted credential
+        auth_header_name: Custom header name
 
     Returns:
         Dict with health status
@@ -433,11 +604,24 @@ async def _check_skill_health(
             "response_time_ms": 0,
         }
 
+    # Build auth headers for private repos
+    credential = None
+    if auth_scheme != "none" and auth_credential_encrypted:
+        from ..utils.credential_encryption import decrypt_credential
+
+        credential = decrypt_credential(auth_credential_encrypted)
+
+    fetch_url, fetch_headers = _build_fetch_headers(
+        url, auth_scheme, credential, auth_header_name
+    )
+
     try:
         async with httpx.AsyncClient() as client:
-            headers = await _github_auth.get_auth_headers(str(url))
+            github_headers = await _github_auth.get_auth_headers(str(url))
+            merged_headers = {**fetch_headers, **github_headers}
             response = await client.head(
-                str(url), headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                fetch_url, headers=merged_headers,
+                follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
             )
 
             # SSRF protection: validate final URL after redirects
@@ -475,6 +659,70 @@ async def _check_skill_health(
         }
 
 
+async def _compute_content_integrity(
+    skill_md_url: str,
+    resource_manifest: "SkillResourceManifest | None",
+    auth_scheme: str = "none",
+    auth_credential: str | None = None,
+    auth_header_name: str | None = None,
+) -> ContentIntegrity | None:
+    """Compute SHA-256 hashes for SKILL.md and all companion resources.
+
+    Returns a ContentIntegrity record with per-file hashes and a composite
+    hash, or None if the SKILL.md cannot be fetched.
+    """
+    file_hashes: list[FileHash] = []
+
+    async def _hash_url(url: str, rel_path: str) -> FileHash | None:
+        fetch_url, fetch_headers = _build_fetch_headers(
+            url, auth_scheme, auth_credential, auth_header_name,
+        )
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    fetch_url, headers=fetch_headers,
+                    follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
+                )
+                if resp.status_code >= 400:
+                    logger.warning("Integrity fetch failed for %s: HTTP %s", rel_path, resp.status_code)
+                    return None
+                digest = hashlib.sha256(resp.content).hexdigest()
+                return FileHash(path=rel_path, sha256=digest, size_bytes=len(resp.content))
+        except httpx.RequestError as e:
+            logger.warning("Integrity fetch error for %s: %s", rel_path, e)
+            return None
+
+    skill_md_hash = await _hash_url(skill_md_url, "SKILL.md")
+    if not skill_md_hash:
+        return None
+    file_hashes.append(skill_md_hash)
+
+    if resource_manifest:
+        from ..utils.url_utils import derive_resource_url
+
+        all_resources = (
+            resource_manifest.references
+            + resource_manifest.scripts
+            + resource_manifest.agents
+            + resource_manifest.assets
+        )
+        for res in all_resources:
+            res_url = derive_resource_url(skill_md_url, res.path)
+            fh = await _hash_url(res_url, res.path)
+            if fh:
+                file_hashes.append(fh)
+
+    sorted_entries = sorted(file_hashes, key=lambda h: h.path)
+    composite_input = "".join(f"{h.path}:{h.sha256}" for h in sorted_entries)
+    composite_hash = hashlib.sha256(composite_input.encode()).hexdigest()
+
+    return ContentIntegrity(
+        composite_hash=composite_hash,
+        file_hashes=file_hashes,
+        computed_at=datetime.now(UTC),
+    )
+
+
 def _build_skill_card(
     request: SkillRegistrationRequest,
     path: str,
@@ -482,6 +730,8 @@ def _build_skill_card(
     content_version: str | None,
     content_updated_at: datetime | None,
     skill_md_raw_url: str | None = None,
+    resource_manifest: "SkillResourceManifest | None" = None,
+    content_integrity: ContentIntegrity | None = None,
 ) -> SkillCard:
     """Build SkillCard from registration request.
 
@@ -492,6 +742,7 @@ def _build_skill_card(
         content_version: Content hash
         content_updated_at: Content update timestamp
         skill_md_raw_url: Raw URL for fetching SKILL.md content
+        resource_manifest: Discovered companion resource files
 
     Returns:
         SkillCard instance
@@ -512,6 +763,18 @@ def _build_skill_card(
             else {},
         )
 
+    # Encrypt credential if provided
+    auth_credential_encrypted = None
+    credential_updated_at = None
+    if (
+        getattr(request, "auth_credential", None)
+        and getattr(request, "auth_scheme", "none") != "none"
+    ):
+        from ..utils.credential_encryption import encrypt_credential
+
+        auth_credential_encrypted = encrypt_credential(request.auth_credential)
+        credential_updated_at = datetime.now(UTC)
+
     return SkillCard(
         path=path,
         name=request.name,
@@ -531,8 +794,14 @@ def _build_skill_card(
         owner=owner,
         is_enabled=True,
         status=request.status,
+        auth_scheme=getattr(request, "auth_scheme", "none"),
+        auth_credential_encrypted=auth_credential_encrypted,
+        auth_header_name=getattr(request, "auth_header_name", None),
+        credential_updated_at=credential_updated_at,
+        resource_manifest=resource_manifest,
         content_version=content_version,
         content_updated_at=content_updated_at,
+        content_integrity=content_integrity,
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
     )
@@ -592,9 +861,39 @@ class SkillService:
         content_updated_at = None
 
         if validate_url:
-            validation = await _validate_skill_md_url(raw_url)
+            validation = await _validate_skill_md_url(
+                raw_url,
+                auth_scheme=getattr(request, "auth_scheme", "none"),
+                auth_credential=getattr(request, "auth_credential", None),
+                auth_header_name=getattr(request, "auth_header_name", None),
+            )
             content_version = validation["content_version"]
             content_updated_at = validation["content_updated_at"]
+
+        # Discover companion resource files (non-fatal)
+        resource_manifest = None
+        try:
+            resource_manifest = await _discover_skill_resources(
+                raw_url,
+                auth_scheme=getattr(request, "auth_scheme", "none"),
+                auth_credential=getattr(request, "auth_credential", None),
+                auth_header_name=getattr(request, "auth_header_name", None),
+            )
+        except Exception as e:
+            logger.warning("Resource discovery failed for %s: %s", request.name, e)
+
+        # Compute content integrity (SKILL.md + all resources)
+        content_integrity = None
+        try:
+            content_integrity = await _compute_content_integrity(
+                raw_url,
+                resource_manifest,
+                auth_scheme=getattr(request, "auth_scheme", "none"),
+                auth_credential=getattr(request, "auth_credential", None),
+                auth_header_name=getattr(request, "auth_header_name", None),
+            )
+        except Exception as e:
+            logger.warning("Content integrity computation failed for %s: %s", request.name, e)
 
         # Build SkillCard
         skill = _build_skill_card(
@@ -604,6 +903,8 @@ class SkillService:
             content_version=content_version,
             content_updated_at=content_updated_at,
             skill_md_raw_url=raw_url,
+            resource_manifest=resource_manifest,
+            content_integrity=content_integrity,
         )
 
         # Save to repository
@@ -874,7 +1175,12 @@ class SkillService:
 
         # Use raw URL for health check (more reliable, returns actual content)
         url = skill.skill_md_raw_url or skill.skill_md_url
-        result = await _check_skill_health(str(url))
+        result = await _check_skill_health(
+            str(url),
+            auth_scheme=getattr(skill, "auth_scheme", "none"),
+            auth_credential_encrypted=getattr(skill, "auth_credential_encrypted", None),
+            auth_header_name=getattr(skill, "auth_header_name", None),
+        )
 
         # Persist health status to database
         health_status = "healthy" if result.get("healthy") else "unhealthy"

--- a/registry/utils/url_utils.py
+++ b/registry/utils/url_utils.py
@@ -252,3 +252,17 @@ def extract_repository_url(
     base_hostname = _map_to_base_hostname(hostname_lower)
 
     return f"https://{base_hostname}/{owner}/{repo}"
+
+
+def derive_resource_url(skill_md_url: str, resource_path: str) -> str:
+    """Derive a resource URL by replacing the filename in a SKILL.md URL.
+
+    Works by stripping the filename from the base URL and appending the
+    requested resource path.
+    """
+    if "/SKILL.md" in skill_md_url:
+        base = skill_md_url.rsplit("/SKILL.md", 1)[0]
+        return f"{base}/{resource_path}"
+
+    base = skill_md_url.rsplit("/", 1)[0]
+    return f"{base}/{resource_path}"

--- a/servers/mcpgw/models.py
+++ b/servers/mcpgw/models.py
@@ -37,8 +37,12 @@ class SkillInfo(BaseModel):
     path: str = Field(..., description="Skill path")
     name: str | None = Field(None, description="Name of the skill")
     description: str | None = Field(None, description="Skill description")
+    skill_md_url: str | None = Field(None, description="URL to the SKILL.md file")
+    skill_md_raw_url: str | None = Field(None, description="Raw URL for fetching SKILL.md content")
     tags: list[str] = Field(default_factory=list, description="Skill tags")
+    target_agents: list[str] = Field(default_factory=list, description="Target agent platforms")
     created_at: str | None = Field(None, description="Creation timestamp")
+
 
 
 class ToolSearchResult(BaseModel):

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -3,38 +3,132 @@
 This MCP server provides tools to interact with the MCP Gateway Registry API.
 It acts as a thin protocol adapter, translating MCP tool calls into registry HTTP requests.
 
-All tools require bearer token authentication via the Authorization header.
+Supports two auth modes:
+  - OAuth (OAuthProxy + Keycloak): set OIDC_ENABLED=true and provide Keycloak env vars.
+    Exposes /.well-known/oauth-protected-resource for MCP clients (Cursor, VS Code).
+  - Legacy bearer token: pass a Keycloak JWT via Authorization header directly.
 """
 
 import logging
 import os
+import time
 from typing import Any
 
 import httpx
 from fastmcp import Context, FastMCP
 from models import AgentInfo, RegistryStats, ServerInfo, SkillInfo, ToolSearchResult
 
-# Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
 )
 logger = logging.getLogger(__name__)
 
-# Get registry URL from environment (used inside Docker containers)
-# This is the internal registry URL that mcpgw uses to communicate with the registry
-# Example: http://registry:7860 (Docker), http://registry.namespace.svc.cluster.local:8000 (K8s)
 REGISTRY_URL = os.getenv("REGISTRY_BASE_URL", "http://localhost")
 
-# Input validation constants
 MAX_QUERY_LENGTH: int = 500
 MIN_TOP_N: int = 1
 MAX_TOP_N: int = 50
 
 logger.info(f"Registry URL: {REGISTRY_URL}")
 
-# Initialize FastMCP server
-mcp = FastMCP("mcpgw")
+# ---------------------------------------------------------------------------
+# OAuth configuration (optional – enable via OIDC_ENABLED=true)
+# ---------------------------------------------------------------------------
+OIDC_ENABLED = os.getenv("OIDC_ENABLED", "").lower() in ("true", "1", "yes")
+
+KEYCLOAK_INTERNAL_URL = os.getenv("KEYCLOAK_INTERNAL_URL", "http://keycloak:8080")
+KEYCLOAK_EXTERNAL_URL = os.getenv("KEYCLOAK_EXTERNAL_URL", "http://localhost:18080")
+KEYCLOAK_REALM = os.getenv("KEYCLOAK_REALM", "mcp-gateway")
+OIDC_CLIENT_ID = os.getenv("OIDC_CLIENT_ID", "mcp-gateway-web")
+OIDC_CLIENT_SECRET = os.getenv("OIDC_CLIENT_SECRET", "")
+M2M_CLIENT_ID = os.getenv("M2M_CLIENT_ID", "mcp-gateway-m2m")
+M2M_CLIENT_SECRET = os.getenv("M2M_CLIENT_SECRET", "")
+MCPGW_BASE_URL = os.getenv("MCPGW_BASE_URL", "http://localhost:18003")
+REGISTRY_API_TOKEN = os.getenv("REGISTRY_API_TOKEN", "")
+
+
+class _M2MTokenManager:
+    """Fetches and caches a Keycloak M2M token via client_credentials grant."""
+
+    def __init__(self, token_url: str, client_id: str, client_secret: str) -> None:
+        self._token_url = token_url
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._token: str | None = None
+        self._expires_at: float = 0
+
+    async def get_token(self) -> str:
+        if self._token and time.monotonic() < self._expires_at - 60:
+            return self._token
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                self._token_url,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": self._client_id,
+                    "client_secret": self._client_secret,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            self._token = data["access_token"]
+            self._expires_at = time.monotonic() + data.get("expires_in", 300)
+            logger.info("Obtained fresh M2M token (expires_in=%s)", data.get("expires_in"))
+            return self._token
+
+
+_auth_provider = None
+_m2m_manager: _M2MTokenManager | None = None
+_realm_path = f"/realms/{KEYCLOAK_REALM}/protocol/openid-connect"
+
+if M2M_CLIENT_ID and M2M_CLIENT_SECRET:
+    _m2m_manager = _M2MTokenManager(
+        token_url=f"{KEYCLOAK_INTERNAL_URL}{_realm_path}/token",
+        client_id=M2M_CLIENT_ID,
+        client_secret=M2M_CLIENT_SECRET,
+    )
+    logger.info("M2M token manager enabled (client=%s)", M2M_CLIENT_ID)
+
+if OIDC_ENABLED:
+    from fastmcp.server.auth.oauth_proxy import OAuthProxy
+    from fastmcp.server.auth.providers.jwt import JWTVerifier
+
+    _auth_provider = OAuthProxy(
+        upstream_authorization_endpoint=f"{KEYCLOAK_EXTERNAL_URL}{_realm_path}/auth",
+        upstream_token_endpoint=f"{KEYCLOAK_INTERNAL_URL}{_realm_path}/token",
+        upstream_revocation_endpoint=f"{KEYCLOAK_INTERNAL_URL}{_realm_path}/revoke",
+        upstream_client_id=OIDC_CLIENT_ID,
+        upstream_client_secret=OIDC_CLIENT_SECRET,
+        token_verifier=JWTVerifier(
+            jwks_uri=f"{KEYCLOAK_INTERNAL_URL}{_realm_path}/certs",
+            issuer=f"{KEYCLOAK_EXTERNAL_URL}/realms/{KEYCLOAK_REALM}",
+        ),
+        base_url=MCPGW_BASE_URL,
+        allowed_client_redirect_uris=[
+            "http://localhost:*",
+            "http://127.0.0.1:*",
+            "cursor://anysphere.cursor-mcp/*",
+            "vscode://anysphere.cursor-mcp/*",
+        ],
+        require_authorization_consent=False,
+    )
+    logger.info("OAuth enabled (OAuthProxy → Keycloak %s, realm=%s)", KEYCLOAK_EXTERNAL_URL, KEYCLOAK_REALM)
+else:
+    logger.info("OAuth disabled – using bearer-token passthrough with M2M for registry calls")
+
+mcp = FastMCP("mcpgw", auth=_auth_provider)
+
+if _auth_provider:
+    from starlette.responses import RedirectResponse
+
+    @mcp.custom_route("/.well-known/oauth-protected-resource", methods=["GET"])
+    async def _redirect_protected_resource(_):  # noqa: ANN001
+        """Redirect root well-known to the MCP-prefixed path (FastMCP path-prefix workaround)."""
+        return RedirectResponse(
+            url="/.well-known/oauth-protected-resource/mcp", status_code=302
+        )
 
 
 def _validate_top_n(top_n: int) -> int:
@@ -76,52 +170,44 @@ def _validate_query(query: str) -> str:
 
 
 def _extract_bearer_token(ctx: Context | None) -> str:
-    """Extract bearer token from FastMCP context via Starlette Request.
+    """Extract bearer token from FastMCP context (legacy / no-OAuth mode).
 
     Supports both standard Authorization header and MCP Gateway's X-Authorization header.
-
-    Args:
-        ctx: FastMCP context containing request information
-
-    Returns:
-        Bearer token string
-
-    Raises:
-        ValueError: If token cannot be extracted or is missing
     """
     if not ctx:
         raise ValueError("Authentication required: Context is None")
 
     try:
-        # Access the Starlette Request object from request_context
         if hasattr(ctx, "request_context") and ctx.request_context:
             request = ctx.request_context.request
             if request and hasattr(request, "headers"):
-                # Try standard Authorization header first (case-insensitive)
                 auth_header = request.headers.get("authorization")
-
-                # If not found, try MCP Gateway's X-Authorization header
                 if not auth_header:
                     auth_header = request.headers.get("x-authorization")
-
                 if auth_header and auth_header.lower().startswith("bearer "):
-                    token = auth_header.split(" ", 1)[1]
-                    logger.debug(f"Successfully extracted token (length: {len(token)})")
-                    return token
-
-                raise ValueError(
-                    "Authorization or X-Authorization header not found or not a Bearer token"
-                )
-            else:
-                raise ValueError("Request object or headers not found in request_context")
-        else:
-            raise ValueError("request_context not available in Context")
-
+                    return auth_header.split(" ", 1)[1]
+                raise ValueError("Bearer token not found in Authorization or X-Authorization header")
+            raise ValueError("Request object or headers not found in request_context")
+        raise ValueError("request_context not available in Context")
     except ValueError:
         raise
     except Exception as e:
         logger.error(f"Failed to extract token: {e}", exc_info=True)
         raise ValueError(f"Failed to extract bearer token: {e}") from e
+
+
+async def _get_registry_headers(ctx: Context | None) -> dict[str, str]:
+    """Return headers for internal registry API calls.
+
+    Priority: static API token > M2M service token > caller bearer token.
+    """
+    if REGISTRY_API_TOKEN:
+        return {"Authorization": f"Bearer {REGISTRY_API_TOKEN}"}
+    if _m2m_manager:
+        token = await _m2m_manager.get_token()
+        return {"X-Authorization": f"Bearer {token}"}
+    token = _extract_bearer_token(ctx)
+    return {"X-Authorization": f"Bearer {token}"}
 
 
 @mcp.tool()
@@ -135,16 +221,13 @@ async def list_services(ctx: Context | None = None) -> dict[str, Any]:
     logger.info("list_services called")
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        headers = await _get_registry_headers(ctx)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(f"{REGISTRY_URL}/api/servers", headers=headers)
             response.raise_for_status()
             data = response.json()
 
-        # Parse response
         if isinstance(data, dict) and "servers" in data:
             servers = data["servers"]
         elif isinstance(data, list):
@@ -152,7 +235,6 @@ async def list_services(ctx: Context | None = None) -> dict[str, Any]:
         else:
             servers = []
 
-        # Validate and convert to ServerInfo models
         services = []
         for s in servers:
             try:
@@ -205,9 +287,7 @@ async def list_agents(ctx: Context | None = None) -> dict[str, Any]:
     logger.info("list_agents called")
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        headers = await _get_registry_headers(ctx)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(f"{REGISTRY_URL}/api/agents", headers=headers)
@@ -260,9 +340,7 @@ async def list_skills(ctx: Context | None = None) -> dict[str, Any]:
     logger.info("list_skills called")
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        headers = await _get_registry_headers(ctx)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(f"{REGISTRY_URL}/api/skills", headers=headers)
@@ -304,6 +382,79 @@ async def list_skills(ctx: Context | None = None) -> dict[str, Any]:
         }
 
 
+
+@mcp.tool()
+async def get_skill_content(
+    skill_name: str,
+    resource_path: str | None = None,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """
+    Fetch skill content from the registry.
+
+    Without resource_path: returns the full SKILL.md markdown and resource manifest.
+    With resource_path: returns the content of a companion file (reference doc,
+    script, agent config, etc.) validated against the stored manifest.
+
+    Use this after list_skills or intelligent_tool_finder to retrieve the
+    complete workflow instructions for a skill, or to read companion resources
+    listed in the manifest.
+
+    Args:
+        skill_name: Name of the skill (e.g. "gerrit-workflow")
+        resource_path: Optional relative path to a companion resource
+                       (e.g. "references/architecture.md")
+
+    Returns:
+        Dictionary containing the skill name, content, source URL, and status
+    """
+    logger.info(
+        "get_skill_content called: skill_name=%s resource_path=%s",
+        skill_name,
+        resource_path,
+    )
+
+    if not skill_name or not skill_name.strip():
+        return {"error": "skill_name cannot be empty", "status": "failed"}
+
+    skill_name = skill_name.strip()
+
+    try:
+        headers = await _get_registry_headers(ctx)
+        url = f"{REGISTRY_URL}/api/skills/{skill_name}/content"
+        params: dict[str, str] = {}
+        if resource_path:
+            params["resource"] = resource_path
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, headers=headers, params=params)
+            response.raise_for_status()
+            data = response.json()
+
+        result: dict[str, Any] = {
+            "skill_name": skill_name,
+            "source_url": data.get("url", ""),
+            "content": data.get("content", ""),
+            "status": "success",
+        }
+        if resource_path:
+            result["resource_path"] = data.get("path", resource_path)
+            result["resource_type"] = data.get("type", "")
+        else:
+            manifest = data.get("resource_manifest")
+            if manifest:
+                result["resources"] = manifest
+        return result
+
+    except httpx.HTTPStatusError as e:
+        logger.error("HTTP error fetching skill content: %s", e.response.status_code)
+        return {"skill_name": skill_name, "error": f"HTTP {e.response.status_code}", "status": "failed"}
+    except Exception as e:
+        logger.error("Failed to get skill content: %s", e)
+        return {"skill_name": skill_name, "error": str(e), "status": "failed"}
+
+
+
 @mcp.tool()
 async def intelligent_tool_finder(
     query: str,
@@ -323,12 +474,9 @@ async def intelligent_tool_finder(
     logger.info(f"intelligent_tool_finder called: query={query}, top_n={top_n}")
 
     try:
-        # Validate inputs
         query = _validate_query(query)
         top_n = _validate_top_n(top_n)
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        headers = await _get_registry_headers(ctx)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
@@ -412,9 +560,7 @@ async def healthcheck(ctx: Context | None = None) -> dict[str, Any]:
     logger.info("healthcheck called")
 
     try:
-        token = _extract_bearer_token(ctx)
-        # Use X-Authorization header for internal registry API calls
-        headers = {"X-Authorization": f"Bearer {token}"}
+        headers = await _get_registry_headers(ctx)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(f"{REGISTRY_URL}/api/servers/health", headers=headers)

--- a/tests/unit/api/test_skill_inline_content.py
+++ b/tests/unit/api/test_skill_inline_content.py
@@ -74,6 +74,11 @@ def _make_mock_skill(
     mock.owner = owner
     mock.allowed_groups = []
     mock.tags = []
+    # Drift-detection guard in get_skill_content() reads .content_integrity;
+    # MagicMock's auto-attributes are truthy, which would trigger 409 Conflict.
+    # Tests that exercise drift behaviour should override this explicitly.
+    mock.content_integrity = None
+    mock.resource_manifest = None
     return mock
 
 

--- a/tests/unit/test_skill_routes_github_auth.py
+++ b/tests/unit/test_skill_routes_github_auth.py
@@ -21,6 +21,14 @@ class TestGetSkillContentAuth:
         mock_skill.skill_md_raw_url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
         mock_skill.skill_md_url = "https://github.com/o/r/blob/main/SKILL.md"
         mock_skill.skill_md_content = None  # Force httpx path, not inline content
+        # Drift-detection guard in get_skill_content() reads .content_integrity;
+        # MagicMock's default truthy attribute would otherwise trigger 409.
+        mock_skill.content_integrity = None
+        mock_skill.resource_manifest = None
+        mock_skill.tags = []
+        mock_skill.auth_scheme = "none"
+        mock_skill.auth_credential_encrypted = None
+        mock_skill.auth_header_name = None
 
         mock_service = AsyncMock()
         mock_service.get_skill.return_value = mock_skill


### PR DESCRIPTION
## Summary

Combines three related skill features into a single release:

1. **Per-skill auth credentials for private repo fetching**
   - Fernet-encrypted `auth_scheme` / `auth_credential` / `auth_header_name` fields on `SkillCard`
   - Credentials are never exposed in API responses
   - OAuth support via FastMCP `OAuthProxy` when `OIDC_ENABLED=true`

2. **Multi-file skill support with unified content endpoint**
   - `GET /content?resource=` serves companion files (references, scripts, agents)
   - Resources discovered at registration time via the hosting platform's tree API
   - Stored as `SkillResourceManifest` on the `SkillCard`
   - New `_resolve_tree_api()` extension point for platform-specific providers
   - New `derive_resource_url()` helper in `registry/utils/url_utils.py`

3. **Content integrity baseline and drift detection**
   - SHA-256 per-file hashes computed at registration (`ContentIntegrity` model)
   - Background drift check on every content fetch
   - Skills auto-disabled and tagged `content-drifted` when drift is found
   - `GET /{path}/integrity` read-only endpoint for inspection
   - `409` response on `/content` when drift is active
   - UI surfaces a drift banner and the `content-drifted` tag

### Files changed
- `auth_server/server.py` — honor `AUTH_SERVER_EXTERNAL_URL` for OAuth callbacks behind proxies
- `registry/api/skill_routes.py` — `/content`, `/integrity`, drift surfacing
- `registry/schemas/skill_models.py` — new auth + resource manifest + integrity schemas
- `registry/services/skill_scanner.py` — hash companion files at scan time
- `registry/services/skill_service.py` — per-skill auth header merge, resource discovery, drift detection
- `registry/utils/url_utils.py` — `derive_resource_url`
- `servers/mcpgw/server.py` — configurable bind host (default `127.0.0.1`, override via `HOST`)
- `frontend/src/components/SkillCard.tsx` — drift banner + `content-drifted` tag
- `build_and_run.sh` — supporting tweaks

## Test plan
- [ ] Register a public multi-file skill and verify `/content?resource=…` returns each companion file
- [ ] Register a private skill with `auth_scheme=bearer` and confirm the credential is stored encrypted and never echoed back in API responses
- [ ] Mutate a remote file and confirm the next `/content` fetch auto-disables the skill, flips the `content-drifted` tag, and returns `409`
- [ ] `GET /{path}/integrity` returns the recorded per-file SHA-256 map
- [ ] Existing single-file skills continue to work (backwards compatible)
- [ ] MCPGW container still binds correctly with `HOST=0.0.0.0`; local runs default to `127.0.0.1`

## Notes for reviewers
- The branch is cherry-picked cleanly onto current `origin/main`; all upstream merge conflicts were resolved by preserving upstream behavior (GitHub auth headers via `_github_auth.get_auth_headers`, `_fetch_authenticated_content`, `model_dump(mode="json")`) and layering the new auth/drift logic on top.
- Auth credentials are encrypted with the existing Fernet key; no new secrets are required at rest.
- No breaking changes to existing `SkillCard` consumers — all new fields are optional.