### PR TITLE
feat: auto-extract repository URL from SKILL.md URL and add View Skill/View Repo links (#846)

### DIFF
--- a/frontend/src/components/SemanticSearchResults.tsx
+++ b/frontend/src/components/SemanticSearchResults.tsx
@@ -343,7 +343,18 @@ const SkillContentModal: React.FC<SkillContentModalProps> = ({
               className="flex items-center gap-1 text-sm text-amber-700 dark:text-amber-300 hover:underline"
             >
               <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-              View on GitHub
+              View Skill
+            </a>
+          )}
+          {skill.repository_url && (
+            <a
+              href={skill.repository_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-sm text-amber-700 dark:text-amber-300 hover:underline"
+            >
+              <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+              View Repo
             </a>
           )}
           {content && (

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -657,7 +657,18 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                   className="flex items-center gap-1 text-sm text-amber-700 dark:text-amber-300 hover:underline"
                 >
                   <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-                  View on GitHub
+                  View Skill
+                </a>
+              )}
+              {skill.repository_url && (
+                <a
+                  href={skill.repository_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-sm text-amber-700 dark:text-amber-300 hover:underline"
+                >
+                  <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+                  View Repo
                 </a>
               )}
               {skillMdContent && (

--- a/frontend/src/hooks/useSemanticSearch.ts
+++ b/frontend/src/hooks/useSemanticSearch.ts
@@ -71,6 +71,7 @@ export interface SemanticSkillHit {
   tags: string[];
   skill_md_url?: string;
   skill_md_raw_url?: string;
+  repository_url?: string;
   version?: string;
   author?: string;
   visibility?: string;

--- a/frontend/src/hooks/useSkills.ts
+++ b/frontend/src/hooks/useSkills.ts
@@ -37,6 +37,7 @@ export const useSkills = (): UseSkillsReturn => {
         description: skillInfo.description || '',
         skill_md_url: skillInfo.skill_md_url || '',
         skill_md_raw_url: skillInfo.skill_md_raw_url || '',
+        repository_url: skillInfo.repository_url,
         version: skillInfo.version,
         author: skillInfo.author,
         visibility: skillInfo.visibility || 'public',

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1384,7 +1384,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         name: skill.name,
         description: skill.description || '',
         skill_md_url: skill.skill_md_url || '',
-        repository_url: '',
+        repository_url: skill.repository_url || '',
         version: skill.version || '',
         visibility: skill.visibility || 'public',
         tags: (skill.tags || []).join(', '),

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1432,6 +1432,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
           description: data.description || prev.description,
           version: data.version || prev.version,
           tags: data.tags?.length > 0 ? data.tags.join(', ') : prev.tags,
+          repository_url: data.repository_url || prev.repository_url,
         }));
         showToast('Parsed SKILL.md successfully!', 'success');
       } else {

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -53,6 +53,7 @@ export interface Skill {
   allowed_tools?: AllowedTool[];
   requirements?: SkillRequirement[];
   metadata?: SkillMetadata | null;
+  repository_url?: string;
   num_stars?: number;
   status?: 'active' | 'draft' | 'deprecated' | 'beta';
   health_status?: 'healthy' | 'unhealthy' | 'unknown';

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -181,6 +181,7 @@ async def list_skills(
                 description=s.description,
                 skill_md_url=str(s.skill_md_url),
                 skill_md_raw_url=str(s.skill_md_raw_url) if s.skill_md_raw_url else None,
+                repository_url=s.repository_url,
                 tags=s.tags,
                 author=s.metadata.author if s.metadata else None,
                 version=s.metadata.version if s.metadata else None,

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -250,6 +250,7 @@ async def parse_skill_md(
             "content_version": result.get("content_version"),
             "skill_md_url": result.get("skill_md_url"),
             "skill_md_raw_url": result.get("skill_md_raw_url"),
+            "repository_url": result.get("repository_url"),
         }
     except SkillUrlValidationError as e:
         raise HTTPException(

--- a/registry/schemas/skill_models.py
+++ b/registry/schemas/skill_models.py
@@ -247,6 +247,9 @@ class SkillInfo(BaseModel):
     description: str
     skill_md_url: str
     skill_md_raw_url: str | None = Field(None, description="Raw URL for fetching SKILL.md content")
+    repository_url: HttpUrl | None = Field(
+        None, description="URL to the git repository containing the skill"
+    )
     tags: list[str] = Field(default_factory=list)
     author: str | None = None
     version: str | None = None

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -38,7 +38,10 @@ from ..schemas.skill_models import (
     VisibilityEnum,
 )
 from ..utils.path_utils import normalize_skill_path
-from ..utils.url_utils import translate_skill_url
+from ..utils.url_utils import (
+    extract_repository_url,
+    translate_skill_url,
+)
 from .github_auth import github_auth_provider as _github_auth
 
 # Configure logging
@@ -242,6 +245,9 @@ async def _parse_skill_md_content(
     # Translate URL to get both user-provided and raw URL
     user_url, raw_url = translate_skill_url(url)
 
+    # Extract the repository URL from the user-provided URL
+    repository_url = extract_repository_url(url)
+
     # Normalize to string for further validation
     raw_url_str = str(raw_url)
 
@@ -284,6 +290,7 @@ async def _parse_skill_md_content(
                 "content_version": hashlib.sha256(response.content).hexdigest()[:16],
                 "skill_md_url": user_url,
                 "skill_md_raw_url": raw_url,
+                "repository_url": repository_url,
             }
 
             # Try to parse YAML frontmatter from multiple formats:

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -669,6 +669,7 @@ class SkillService:
                 description=s.description,
                 skill_md_url=str(s.skill_md_url),
                 skill_md_raw_url=str(s.skill_md_raw_url) if s.skill_md_raw_url else None,
+                repository_url=s.repository_url,
                 tags=s.tags,
                 author=s.metadata.author if s.metadata else None,
                 version=s.metadata.version if s.metadata else None,

--- a/registry/utils/url_utils.py
+++ b/registry/utils/url_utils.py
@@ -67,6 +67,36 @@ def _is_raw_github_url(
     return False
 
 
+def _map_to_base_hostname(
+    hostname: str,
+) -> str:
+    """Map a raw or regular GitHub hostname to the base GitHub hostname.
+
+    Args:
+        hostname: Lowercase hostname to map
+
+    Returns:
+        Base GitHub hostname for constructing repository URLs
+
+    Examples:
+        >>> _map_to_base_hostname("raw.githubusercontent.com")
+        'github.com'
+        >>> _map_to_base_hostname("raw.github.mycompany.com")
+        'github.mycompany.com'
+        >>> _map_to_base_hostname("github.com")
+        'github.com'
+    """
+    if hostname == "raw.githubusercontent.com":
+        return "github.com"
+
+    # Enterprise raw URLs: strip "raw." prefix
+    if hostname.startswith("raw.") and "github" in hostname:
+        return hostname[4:]
+
+    # Already a base hostname (github.com, github.mycompany.com, etc.)
+    return hostname
+
+
 def _translate_github_url_to_raw(
     url: str,
 ) -> str:
@@ -161,3 +191,64 @@ def translate_skill_url(
     # GitHub URL: translate to raw
     raw_url = _translate_github_url_to_raw(url)
     return (url, raw_url)
+
+
+def extract_repository_url(
+    url: str,
+) -> str | None:
+    """Extract the GitHub repository URL from a SKILL.md URL.
+
+    Given a URL pointing to a file in a GitHub repository (either a blob URL
+    or a raw content URL), this function extracts the base repository URL
+    in the form https://{hostname}/{owner}/{repo}.
+
+    Handles:
+    - github.com blob URLs
+    - raw.githubusercontent.com URLs
+    - Enterprise GitHub URLs (github.mycompany.com, raw.github.mycompany.com)
+
+    Args:
+        url: URL to extract repository from
+
+    Returns:
+        Repository URL string, or None if not a GitHub URL or malformed
+
+    Examples:
+        >>> extract_repository_url("https://github.com/anthropics/skills/blob/main/SKILL.md")
+        'https://github.com/anthropics/skills'
+        >>> extract_repository_url("https://raw.githubusercontent.com/anthropics/skills/refs/heads/main/SKILL.md")
+        'https://github.com/anthropics/skills'
+        >>> extract_repository_url("https://example.com/file.md")
+        None
+    """
+    if not url or not url.strip():
+        return None
+
+    url = url.strip()
+
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+
+    hostname = parsed.hostname or ""
+    if not hostname:
+        return None
+
+    # Only handle GitHub hostnames
+    if not _is_github_hostname(hostname):
+        return None
+
+    # Extract path segments (skip leading empty segment from leading slash)
+    path_segments = [s for s in parsed.path.split("/") if s]
+    if len(path_segments) < 2:
+        return None
+
+    owner = path_segments[0]
+    repo = path_segments[1]
+
+    # Map the hostname back to the base GitHub hostname
+    hostname_lower = hostname.lower()
+    base_hostname = _map_to_base_hostname(hostname_lower)
+
+    return f"https://{base_hostname}/{owner}/{repo}"

--- a/tests/unit/utils/test_url_utils.py
+++ b/tests/unit/utils/test_url_utils.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for registry.utils.url_utils.extract_repository_url.
+
+Validates extraction of GitHub repository URLs from SKILL.md URLs,
+including public GitHub, raw.githubusercontent.com, and enterprise instances.
+"""
+
+from registry.utils.url_utils import extract_repository_url
+
+
+class TestExtractRepositoryUrl:
+    """Tests for extract_repository_url utility function."""
+
+    def test_github_blob_url(self):
+        """Should extract repo URL from a standard GitHub blob URL."""
+        # Arrange
+        url = "https://github.com/anthropics/skills/blob/main/skills/art/SKILL.md"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result == "https://github.com/anthropics/skills"
+
+    def test_raw_githubusercontent_url(self):
+        """Should extract repo URL from a raw.githubusercontent.com URL."""
+        # Arrange
+        url = (
+            "https://raw.githubusercontent.com/anthropics/skills"
+            "/refs/heads/main/skills/art/SKILL.md"
+        )
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result == "https://github.com/anthropics/skills"
+
+    def test_enterprise_github_blob_url(self):
+        """Should extract repo URL from an enterprise GitHub blob URL."""
+        # Arrange
+        url = "https://github.mycompany.com/org/repo/blob/main/SKILL.md"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result == "https://github.mycompany.com/org/repo"
+
+    def test_enterprise_raw_url(self):
+        """Should extract repo URL from an enterprise raw GitHub URL."""
+        # Arrange
+        url = "https://raw.github.mycompany.com/org/repo/refs/heads/main/SKILL.md"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result == "https://github.mycompany.com/org/repo"
+
+    def test_non_github_url_returns_none(self):
+        """Should return None for non-GitHub URLs."""
+        # Arrange
+        url = "https://gitlab.com/org/repo/raw/main/SKILL.md"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        """Should return None for an empty string."""
+        # Arrange
+        url = ""
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result is None
+
+    def test_url_with_no_path_returns_none(self):
+        """Should return None when the URL has no path segments."""
+        # Arrange
+        url = "https://github.com"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result is None
+
+    def test_url_with_only_owner_returns_none(self):
+        """Should return None when the URL has only an owner, no repo."""
+        # Arrange
+        url = "https://github.com/anthropics"
+
+        # Act
+        result = extract_repository_url(url)
+
+        # Assert
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `extract_repository_url()` to `registry/utils/url_utils.py` that derives the GitHub repo URL from any SKILL.md URL format (blob, raw, enterprise)
- Wire it through the `/api/skills/parse-skill-md` endpoint so the Repository URL field auto-fills on Parse
- Replace "View on GitHub" with separate "View Skill" and "View Repo" links in the skill detail modal (`SkillCard.tsx` and `SemanticSearchResults.tsx`)
- Add `repository_url` to the frontend `Skill` and `SemanticSkillHit` TypeScript interfaces
- 8 unit tests covering all URL patterns and edge cases

Closes #846

## Test plan
- [ ] Register a skill with a `github.com/.../blob/main/.../SKILL.md` URL -- verify Repository URL auto-fills on Parse
- [ ] Register a skill with a `raw.githubusercontent.com/...` URL -- verify Repository URL auto-fills
- [ ] Verify the Repository URL field is still editable after auto-fill
- [ ] Click (i) on a skill that has a repository_url -- verify "View Skill" and "View Repo" links appear
- [ ] Click (i) on a skill without repository_url -- verify only "View Skill" appears
- [ ] Run `uv run pytest tests/unit/utils/test_url_utils.py -v` -- all 8 tests pass