### PR TITLE
Patch container base images for openssl/zlib/musl CVEs

### DIFF
--- a/agents/a2a/src/flight-booking-agent/Dockerfile
+++ b/agents/a2a/src/flight-booking-agent/Dockerfile
@@ -4,9 +4,12 @@ FROM --platform=${TARGETPLATFORM} public.ecr.aws/docker/library/python:3.14-slim
 WORKDIR /app
 
 # Install system dependencies and uv
-RUN apt-get update && apt-get install -y \
+# build-essential is required to compile asyncpg from source (no py3.14 wheel yet)
+# apt-get upgrade ensures latest security patches (e.g. openssl ~deb13u2)
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     sqlite3 \
     curl \
+    build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && pip install uv
 

--- a/agents/a2a/src/travel-assistant-agent/Dockerfile
+++ b/agents/a2a/src/travel-assistant-agent/Dockerfile
@@ -4,9 +4,12 @@ FROM --platform=${TARGETPLATFORM} public.ecr.aws/docker/library/python:3.14-slim
 WORKDIR /app
 
 # Install system dependencies and uv
-RUN apt-get update && apt-get install -y \
+# build-essential is required to compile asyncpg from source (no py3.14 wheel yet)
+# apt-get upgrade ensures latest security patches (e.g. openssl ~deb13u2)
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     sqlite3 \
     curl \
+    build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && pip install uv
 

--- a/terraform/aws-ecs/grafana/Dockerfile
+++ b/terraform/aws-ecs/grafana/Dockerfile
@@ -1,12 +1,13 @@
 # Grafana OSS for MCP Gateway Observability Pipeline
 # Pinned to stable version to avoid breaking changes
-FROM grafana/grafana:12.3.1
+FROM grafana/grafana:12.4.3
 
 # Switch to root to set up directories
 USER root
 
 # Install wget for health checks
-RUN apk add --no-cache wget
+# apk upgrade ensures latest Alpine security patches (openssl, zlib, musl)
+RUN apk update && apk upgrade --no-cache && apk add --no-cache wget
 
 # Copy provisioning configurations
 COPY provisioning/datasources /etc/grafana/provisioning/datasources


### PR DESCRIPTION
## Summary

Remediates three Mirador container vulnerability findings by refreshing base image layers and adding missing build dependencies.

| Image | Fix | Advisory version now installed |
|---|---|---|
| mcp-gateway-travel-assistant-agent | `apt-get upgrade -y` + `build-essential` | openssl `3.5.5-1~deb13u2` |
| mcp-gateway-flight-booking-agent | `apt-get upgrade -y` + `build-essential` | openssl `3.5.5-1~deb13u2` |
| mcp-gateway-grafana | base bump `12.3.1` -> `12.4.3` + `apk upgrade` | openssl `3.5.6-r0`, zlib `1.3.2-r0`, musl `1.2.5-r23` |

### Why `build-essential`?

Debian 13 / python 3.14-slim currently has no prebuilt manylinux wheel for `asyncpg 0.30.0` (pulled in transitively via `strands-agents[a2a]` -> `a2a-sdk[sql]` -> `sqlalchemy[postgresql-asyncpg]`), so `uv sync` compiles it from source and needs `gcc`. This regression appeared with the recent 3.14 upgrade; the previous 3.12 base had wheel coverage. `build-essential` is the minimal tool set to compile.

### Why bump grafana?

The `grafana/grafana:12.3.1` tag is immutable and ships stale Alpine packages. `apk upgrade` alone helps, but bumping to `12.4.3` rebases on a newer Alpine and is the cleanest long-term fix.

## Test plan

- [x] Build all three images locally and push to ECR
- [x] Verify installed package versions match Mirador advisory versions:
  - `dpkg -l openssl` on both A2A images -> `3.5.5-1~deb13u2`
  - `apk info -v` on grafana -> `libssl3-3.5.6-r0`, `zlib-1.3.2-r0`, `musl-1.2.5-r23`
- [x] Force new ECS deployment for all affected services (travel-assistant-agent, flight-booking-agent, grafana)
- [x] Confirm all services rolled over to `deployments: 1, running: 1`
- [ ] Next Inspector scan clears the findings (automated, will confirm post-merge)