### PR TITLE
feat: build multi-arch Docker images (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -68,6 +71,7 @@ jobs:
           context: .
           file: docker/Dockerfile.auth
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/build-auth-server.yml
+++ b/.github/workflows/build-auth-server.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b6bd7fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/build-mcpgw.yml
+++ b/.github/workflows/build-mcpgw.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/build-mcpgw.yml
+++ b/.github/workflows/build-mcpgw.yml
@@ -36,10 +36,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b6bd7fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/build-mcpgw.yml
+++ b/.github/workflows/build-mcpgw.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -67,6 +70,7 @@ jobs:
           context: .
           file: docker/Dockerfile.mcp-server
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -72,6 +75,7 @@ jobs:
           context: .
           file: docker/Dockerfile.registry
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -41,10 +41,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b6bd7fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/build-registry.yml
+++ b/.github/workflows/build-registry.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure Role to Acquire Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@9d61c2c16e33ed086cb5928c4652a0e62f1b048f # v3.2.0
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
@@ -77,6 +80,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -45,10 +45,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b6bd7fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0


### PR DESCRIPTION
Resolves #856 

Update all image build workflows to build both linux/amd64 and linux/arm64 architectures using QEMU for cross-platform emulation. This enables running the registry on ARM64 machines.

Changes:
- Add docker/setup-qemu-action for ARM64 emulation
- Add platforms: linux/amd64,linux/arm64 to build-push-action

Affected workflows:
- build-mcpgw.yml
- build-auth-server.yml
- build-registry.yml
- release-images.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
