### PR TITLE
feat: add direct M2M client registration API (#851)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,28 @@ FEDERATION_STATIC_TOKEN=
 FEDERATION_ENCRYPTION_KEY=
 
 # =============================================================================
+# M2M DIRECT CLIENT REGISTRATION (Issue #851)
+# =============================================================================
+#
+# Enables the admin API at /api/iam/m2m-clients that lets operators register
+# M2M client_ids and their group mappings by writing directly to the
+# idp_m2m_clients MongoDB collection, WITHOUT requiring an IdP Admin API
+# token (e.g. OKTA_API_TOKEN). Useful when IdP Admin API access is gated.
+#
+# Records created via this API are tagged provider="manual" and cannot be
+# modified or deleted by this API if they were written by IdP sync.
+#
+# Endpoints gated by this flag:
+#   POST   /api/iam/m2m-clients         (admin)
+#   GET    /api/iam/m2m-clients         (any authenticated user)
+#   GET    /api/iam/m2m-clients/{id}    (any authenticated user)
+#   PATCH  /api/iam/m2m-clients/{id}    (admin)
+#   DELETE /api/iam/m2m-clients/{id}    (admin)
+#
+# Default: true (feature is on; set to false to disable the router entirely)
+M2M_DIRECT_REGISTRATION_ENABLED=true
+
+# =============================================================================
 # AUTHENTICATION PROVIDER CONFIGURATION
 # =============================================================================
 # Choose authentication provider: 'cognito', 'keycloak', 'entra', 'okta', or 'auth0'

--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1262,6 +1262,42 @@ class GroupSummary(BaseModel):
     attributes: dict[str, Any] | None = Field(None, description="Group attributes")
 
 
+class IdPM2MClient(BaseModel):
+    """M2M client record as stored in idp_m2m_clients.
+
+    Models the response shape from the /api/iam/m2m-clients direct
+    registration API (issue #851).
+    """
+
+    client_id: str = Field(..., description="IdP application client ID")
+    name: str = Field(..., description="Application name")
+    description: str | None = Field(None, description="Application description")
+    groups: list[str] = Field(
+        default_factory=list, description="Groups this client belongs to"
+    )
+    enabled: bool = Field(True, description="Whether the client is active")
+    provider: str = Field(
+        ..., description="Identity provider (okta, keycloak, entra, manual)"
+    )
+    idp_app_id: str | None = Field(None, description="IdP internal app ID")
+    created_by: str | None = Field(
+        None, description="Operator who registered this client (manual records)"
+    )
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+
+class M2MClientListResponse(BaseModel):
+    """Paginated response for GET /api/iam/m2m-clients."""
+
+    total: int = Field(..., description="Total number of matching records")
+    limit: int = Field(..., description="Limit applied to this page")
+    skip: int = Field(..., description="Offset applied to this page")
+    items: list[IdPM2MClient] = Field(
+        default_factory=list, description="Records on this page"
+    )
+
+
 class GroupSyncStatusResponse(BaseModel):
     """Response model for list groups endpoint with sync status."""
 
@@ -1462,6 +1498,7 @@ class RegistryClient:
         if (
             endpoint.startswith("/api/agents")
             or endpoint.startswith("/api/management")
+            or endpoint.startswith("/api/iam")
             or endpoint.startswith("/api/search")
             or endpoint.startswith("/api/federation")
             or endpoint.startswith("/api/peers")
@@ -4154,6 +4191,174 @@ class RegistryClient:
         result = response.json()
         logger.info(f"Startup ping result: {result.get('status')}")
         return result
+
+    # -------------------------------------------------------------------------
+    # Direct M2M client registration (issue #851, /api/iam/m2m-clients)
+    #
+    # These endpoints write directly to idp_m2m_clients without calling any
+    # IdP Admin API. Useful when OKTA_API_TOKEN / equivalent is unavailable.
+    # -------------------------------------------------------------------------
+
+    def create_m2m_client(
+        self,
+        client_id: str,
+        client_name: str,
+        groups: list[str] | None = None,
+        description: str | None = None,
+    ) -> IdPM2MClient:
+        """Register an M2M client directly (admin only).
+
+        Args:
+            client_id: IdP application client ID to register.
+            client_name: Human-readable name for the client.
+            groups: Group mappings for authorization.
+            description: Optional description.
+
+        Returns:
+            The persisted M2M client record.
+
+        Raises:
+            requests.HTTPError: 401/403 on auth, 409 if client_id already exists,
+                422 for invalid payload.
+        """
+        logger.info(f"Registering M2M client: {client_id}")
+
+        payload: dict[str, Any] = {
+            "client_id": client_id,
+            "client_name": client_name,
+            "groups": list(groups) if groups else [],
+        }
+        if description is not None:
+            payload["description"] = description
+
+        response = self._make_request(
+            method="POST",
+            endpoint="/api/iam/m2m-clients",
+            data=payload,
+        )
+        return IdPM2MClient(**response.json())
+
+    def list_m2m_clients(
+        self,
+        provider: str | None = None,
+        limit: int = 500,
+        skip: int = 0,
+    ) -> M2MClientListResponse:
+        """List M2M clients with pagination.
+
+        Args:
+            provider: Optional provider filter (e.g. "manual", "okta").
+            limit: Max records to return (1-1000).
+            skip: Offset for pagination.
+
+        Returns:
+            Paginated envelope with total, limit, skip, items.
+
+        Raises:
+            requests.HTTPError: 401 if unauthenticated.
+        """
+        logger.info(
+            f"Listing M2M clients (provider={provider}, limit={limit}, skip={skip})"
+        )
+
+        params: dict[str, Any] = {"limit": limit, "skip": skip}
+        if provider is not None:
+            params["provider"] = provider
+
+        response = self._make_request(
+            method="GET",
+            endpoint="/api/iam/m2m-clients",
+            params=params,
+        )
+        return M2MClientListResponse(**response.json())
+
+    def get_m2m_client(self, client_id: str) -> IdPM2MClient:
+        """Get a single M2M client by client_id.
+
+        Args:
+            client_id: IdP application client ID.
+
+        Returns:
+            The M2M client record.
+
+        Raises:
+            requests.HTTPError: 401 if unauthenticated, 404 if not found.
+        """
+        logger.info(f"Getting M2M client: {client_id}")
+
+        response = self._make_request(
+            method="GET",
+            endpoint=f"/api/iam/m2m-clients/{quote(client_id, safe='')}",
+        )
+        return IdPM2MClient(**response.json())
+
+    def patch_m2m_client(
+        self,
+        client_id: str,
+        client_name: str | None = None,
+        groups: list[str] | None = None,
+        description: str | None = None,
+        enabled: bool | None = None,
+    ) -> IdPM2MClient:
+        """Partially update an M2M client (admin only).
+
+        Only manual records (provider == "manual") can be updated. IdP-synced
+        records return 403.
+
+        Fields left as None are NOT sent to the server (unchanged). To clear
+        groups, pass an empty list explicitly.
+
+        Args:
+            client_id: IdP application client ID to update.
+            client_name: New name, or None to leave unchanged.
+            groups: New groups list (empty list clears), or None to leave unchanged.
+            description: New description, or None to leave unchanged.
+            enabled: New enabled flag, or None to leave unchanged.
+
+        Returns:
+            The updated M2M client record.
+
+        Raises:
+            requests.HTTPError: 401/403 on auth, 404 if not found, 403 if record
+                was IdP-synced.
+        """
+        logger.info(f"Updating M2M client: {client_id}")
+
+        payload: dict[str, Any] = {}
+        if client_name is not None:
+            payload["client_name"] = client_name
+        if groups is not None:
+            payload["groups"] = list(groups)
+        if description is not None:
+            payload["description"] = description
+        if enabled is not None:
+            payload["enabled"] = enabled
+
+        response = self._make_request(
+            method="PATCH",
+            endpoint=f"/api/iam/m2m-clients/{quote(client_id, safe='')}",
+            data=payload,
+        )
+        return IdPM2MClient(**response.json())
+
+    def delete_m2m_client(self, client_id: str) -> None:
+        """Delete a manual M2M client (admin only).
+
+        Only manual records (provider == "manual") can be deleted.
+
+        Args:
+            client_id: IdP application client ID to delete.
+
+        Raises:
+            requests.HTTPError: 401/403 on auth, 404 if not found, 403 if record
+                was IdP-synced.
+        """
+        logger.info(f"Deleting M2M client: {client_id}")
+
+        self._make_request(
+            method="DELETE",
+            endpoint=f"/api/iam/m2m-clients/{quote(client_id, safe='')}",
+        )
 
 
 def _format_tool_result(

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -3004,6 +3004,168 @@ def cmd_user_delete(args: argparse.Namespace) -> int:
         return 1
 
 
+def _print_m2m_client(client: Any) -> None:
+    """Print an IdPM2MClient record in a readable format."""
+    print(f"Client ID:    {client.client_id}")
+    print(f"Name:         {client.name}")
+    print(f"Provider:     {client.provider}")
+    print(f"Enabled:      {client.enabled}")
+    print(f"Groups:       {', '.join(client.groups) if client.groups else '(none)'}")
+    print(f"Description:  {client.description or '(none)'}")
+    print(f"Created by:   {client.created_by or '(not set)'}")
+    print(f"Created at:   {client.created_at}")
+    print(f"Updated at:   {client.updated_at}")
+
+
+def cmd_m2m_client_create(args: argparse.Namespace) -> int:
+    """Register an M2M client directly (admin only).
+
+    Args:
+        args: Command arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        groups = (
+            [g.strip() for g in args.groups.split(",") if g.strip()]
+            if args.groups
+            else []
+        )
+        client = _create_client(args)
+        result = client.create_m2m_client(
+            client_id=args.client_id,
+            client_name=args.client_name,
+            groups=groups,
+            description=args.description,
+        )
+        logger.info("M2M client registered successfully\n")
+        _print_m2m_client(result)
+        return 0
+    except Exception as e:
+        logger.error(f"Register M2M client failed: {e}")
+        return 1
+
+
+def cmd_m2m_client_list(args: argparse.Namespace) -> int:
+    """List M2M clients with pagination.
+
+    Args:
+        args: Command arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        client = _create_client(args)
+        result = client.list_m2m_clients(
+            provider=args.provider,
+            limit=args.limit,
+            skip=args.skip,
+        )
+
+        if args.json:
+            print(result.model_dump_json(indent=2))
+            return 0
+
+        print(
+            f"Total: {result.total}  (showing {len(result.items)} at skip={result.skip}, limit={result.limit})\n"
+        )
+        for item in result.items:
+            _print_m2m_client(item)
+            print("-" * 60)
+        return 0
+    except Exception as e:
+        logger.error(f"List M2M clients failed: {e}")
+        return 1
+
+
+def cmd_m2m_client_get(args: argparse.Namespace) -> int:
+    """Get a single M2M client by client_id.
+
+    Args:
+        args: Command arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        client = _create_client(args)
+        result = client.get_m2m_client(args.client_id)
+
+        if args.json:
+            print(result.model_dump_json(indent=2))
+            return 0
+
+        _print_m2m_client(result)
+        return 0
+    except Exception as e:
+        logger.error(f"Get M2M client failed: {e}")
+        return 1
+
+
+def cmd_m2m_client_update(args: argparse.Namespace) -> int:
+    """Partially update an M2M client (admin only).
+
+    Args:
+        args: Command arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        # groups is optional; empty-string input means "clear groups".
+        groups: list[str] | None = None
+        if args.groups is not None:
+            groups = [g.strip() for g in args.groups.split(",") if g.strip()]
+
+        enabled: bool | None = None
+        if args.enabled is not None:
+            enabled = args.enabled.lower() == "true"
+
+        client = _create_client(args)
+        result = client.patch_m2m_client(
+            client_id=args.client_id,
+            client_name=args.client_name,
+            groups=groups,
+            description=args.description,
+            enabled=enabled,
+        )
+        logger.info("M2M client updated successfully\n")
+        _print_m2m_client(result)
+        return 0
+    except Exception as e:
+        logger.error(f"Update M2M client failed: {e}")
+        return 1
+
+
+def cmd_m2m_client_delete(args: argparse.Namespace) -> int:
+    """Delete a manual M2M client (admin only).
+
+    Args:
+        args: Command arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        if not args.force:
+            confirmation = input(
+                f"Delete M2M client '{args.client_id}'? (yes/no): "
+            )
+            if confirmation.lower() != "yes":
+                logger.info("Operation cancelled")
+                return 0
+
+        client = _create_client(args)
+        client.delete_m2m_client(args.client_id)
+        logger.info(f"M2M client '{args.client_id}' deleted successfully")
+        return 0
+    except Exception as e:
+        logger.error(f"Delete M2M client failed: {e}")
+        return 1
+
+
 def cmd_group_create(args: argparse.Namespace) -> int:
     """
     Create a new IAM group.
@@ -4957,6 +5119,82 @@ Examples:
     user_delete_parser.add_argument("--username", required=True, help="Username to delete")
     user_delete_parser.add_argument("--force", action="store_true", help="Skip confirmation prompt")
 
+    # -------------------------------------------------------------------------
+    # M2M direct registration commands (issue #851)
+    # Write to idp_m2m_clients without IdP Admin API. Admin only for mutations.
+    # -------------------------------------------------------------------------
+
+    m2m_create_parser = subparsers.add_parser(
+        "m2m-client-create",
+        help="Register an M2M client directly (no IdP Admin API required)",
+    )
+    m2m_create_parser.add_argument(
+        "--client-id", required=True, help="IdP application client ID to register"
+    )
+    m2m_create_parser.add_argument(
+        "--client-name", required=True, help="Human-readable name for the client"
+    )
+    m2m_create_parser.add_argument(
+        "--groups",
+        default="",
+        help="Comma-separated group names (empty string = no groups)",
+    )
+    m2m_create_parser.add_argument("--description", help="Optional description")
+
+    m2m_list_parser = subparsers.add_parser(
+        "m2m-client-list", help="List registered M2M clients (paginated)"
+    )
+    m2m_list_parser.add_argument(
+        "--provider", help="Filter by provider (e.g. manual, okta, auth0)"
+    )
+    m2m_list_parser.add_argument(
+        "--limit", type=int, default=500, help="Max records per page (1-1000, default 500)"
+    )
+    m2m_list_parser.add_argument(
+        "--skip", type=int, default=0, help="Offset for pagination (default 0)"
+    )
+    m2m_list_parser.add_argument(
+        "--json", action="store_true", help="Output raw JSON instead of formatted text"
+    )
+
+    m2m_get_parser = subparsers.add_parser(
+        "m2m-client-get", help="Get a single M2M client by client_id"
+    )
+    m2m_get_parser.add_argument("--client-id", required=True, help="IdP client ID")
+    m2m_get_parser.add_argument(
+        "--json", action="store_true", help="Output raw JSON instead of formatted text"
+    )
+
+    m2m_update_parser = subparsers.add_parser(
+        "m2m-client-update",
+        help="Partially update an M2M client (manual records only)",
+    )
+    m2m_update_parser.add_argument("--client-id", required=True, help="IdP client ID")
+    m2m_update_parser.add_argument(
+        "--client-name", help="New client name (omit to leave unchanged)"
+    )
+    m2m_update_parser.add_argument(
+        "--groups",
+        help="Comma-separated new groups list; empty string clears groups; omit to leave unchanged",
+    )
+    m2m_update_parser.add_argument(
+        "--description", help="New description (omit to leave unchanged)"
+    )
+    m2m_update_parser.add_argument(
+        "--enabled",
+        choices=["true", "false"],
+        help="Set enabled flag (omit to leave unchanged)",
+    )
+
+    m2m_delete_parser = subparsers.add_parser(
+        "m2m-client-delete",
+        help="Delete an M2M client (manual records only)",
+    )
+    m2m_delete_parser.add_argument("--client-id", required=True, help="IdP client ID")
+    m2m_delete_parser.add_argument(
+        "--force", action="store_true", help="Skip confirmation prompt"
+    )
+
     # Create IAM group command
     group_create_parser = subparsers.add_parser("group-create", help="Create a new IAM group")
     group_create_parser.add_argument("--name", required=True, help="Group name")
@@ -5374,6 +5612,12 @@ Examples:
         "user-create-m2m": cmd_user_create_m2m,
         "user-create-human": cmd_user_create_human,
         "user-delete": cmd_user_delete,
+        # Direct M2M client registration (issue #851)
+        "m2m-client-create": cmd_m2m_client_create,
+        "m2m-client-list": cmd_m2m_client_list,
+        "m2m-client-get": cmd_m2m_client_get,
+        "m2m-client-update": cmd_m2m_client_update,
+        "m2m-client-delete": cmd_m2m_client_delete,
         "group-create": cmd_group_create,
         "group-delete": cmd_group_delete,
         "group-list": cmd_group_list,

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -212,6 +212,11 @@ registry:
     skillSecurityScanEnabled: true  # Enable/disable skill security scanning
     skillSecurityAnalyzers: "static"  # Comma-separated: static, behavioral, llm, meta, virustotal, ai-defense
 
+    # M2M direct client registration (issue #851)
+    # Exposes /api/iam/m2m-clients admin API for registering M2M client_ids and
+    # their group mappings directly, without requiring an IdP Admin API token.
+    m2mDirectRegistrationEnabled: true
+
     # OpenTelemetry direct OTLP push export configuration
     otelOtlpEndpoint: ""  # OTLP endpoint URL (e.g., https://otlp.datadoghq.com)
     otelExporterOtlpHeaders: ""  # OTLP headers (e.g., dd-api-key=YOUR_KEY)

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -149,6 +149,8 @@ data:
   {{- end }}
   SKILL_SECURITY_SCAN_ENABLED: {{ .Values.app.skillSecurityScanEnabled | toString | b64enc | quote }}
   SKILL_SECURITY_ANALYZERS: {{ .Values.app.skillSecurityAnalyzers | b64enc | quote }}
+  # M2M direct client registration (issue #851)
+  M2M_DIRECT_REGISTRATION_ENABLED: {{ .Values.app.m2mDirectRegistrationEnabled | toString | b64enc | quote }}
   # ANS (Agent Name Service) Integration
   {{- if .Values.ans.enabled }}
   ANS_INTEGRATION_ENABLED: {{ "true" | b64enc | quote }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -39,6 +39,11 @@ app:
   skillSecurityScanEnabled: true  # Enable/disable skill security scanning
   skillSecurityAnalyzers: "static"  # Comma-separated: static, behavioral, llm, meta, virustotal, ai-defense
 
+  # M2M direct client registration (issue #851)
+  # Exposes /api/iam/m2m-clients admin API for registering M2M client_ids and
+  # their group mappings directly, without requiring an IdP Admin API token.
+  m2mDirectRegistrationEnabled: true
+
   # OpenTelemetry direct OTLP push export configuration
   otelOtlpEndpoint: ""  # OTLP endpoint URL (e.g., https://otlp.datadoghq.com)
   otelExporterOtlpHeaders: ""  # OTLP headers (e.g., dd-api-key=YOUR_KEY)

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -30,3 +30,4 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [How do I register and manage MCP servers that require authentication?](registering-auth-protected-servers.md)
 - [Can I use an Entra ID token to call the registry API instead of the UI-generated token?](use-entra-token-for-registry-api.md)
+- [How do I register an M2M client and assign it groups without an IdP Admin API token?](registering-m2m-client-without-idp-admin-token.md)

--- a/docs/faq/registering-m2m-client-without-idp-admin-token.md
+++ b/docs/faq/registering-m2m-client-without-idp-admin-token.md
@@ -1,0 +1,152 @@
+# How do I register an M2M client and assign it groups without an IdP Admin API token?
+
+**Short answer**: use the direct M2M client registration API at `/api/iam/m2m-clients`. Create the M2M client in your IdP (Keycloak, Okta, Entra, Auth0) as you normally would, then register its `client_id` with the registry and assign groups. The registry writes directly to its own `idp_m2m_clients` collection -- no `OKTA_API_TOKEN` or equivalent IdP Admin API credentials required.
+
+## When to use this
+
+- Your enterprise gates IdP Admin API tokens (e.g. Okta requires approval for Admin API access) and getting one is disproportionate overhead.
+- You already know the M2M `client_id` you want to register (it lives in the IdP).
+- You want to assign groups so the registry's auth server can enrich M2M tokens with those groups during authorization.
+
+If `OKTA_API_TOKEN` / `AUTH0_M2M_CLIENT_ID` etc. are available, the existing `/api/iam/okta/m2m/*` or `/api/iam/auth0/m2m/*` sync endpoints cover the same ground. This FAQ is for the case where those credentials are not available.
+
+## Prerequisites
+
+- A user JWT (or static API token) with **admin** scope on the registry.
+- The `client_id` of an M2M client you have already created in your IdP.
+- `M2M_DIRECT_REGISTRATION_ENABLED=true` on the registry (this is the default).
+
+## Step 1: Create the M2M client in your IdP
+
+In Keycloak Admin UI (example; equivalent steps apply in Okta/Entra/Auth0):
+
+1. Navigate to **Clients > Create client**.
+2. Client type: **OpenID Connect**. Client ID: e.g. `my-automation-pipeline`. **Save**.
+3. Enable **Client authentication** and **Service accounts roles**. Disable standard/direct flows. **Save**.
+4. Copy the **Client Secret** from the `Credentials` tab. Your application will use this pair to request tokens from Keycloak.
+
+You do **not** need to assign groups inside the IdP. The registry resolves groups from its own `idp_m2m_clients` collection, which you will populate in the next step.
+
+## Step 2: Register the client with the registry
+
+Using the bundled CLI (`api/registry_management.py`):
+
+```bash
+export REGISTRY_URL=http://localhost
+export TOKEN_FILE=~/repos/mcp-gateway-registry/.token   # admin user token
+
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-create \
+  --client-id my-automation-pipeline \
+  --client-name "My Automation Pipeline" \
+  --groups pipeline-operators,registry-readonly \
+  --description "CI/CD pipeline service account"
+```
+
+Expected output:
+
+```
+M2M client registered successfully
+
+Client ID:    my-automation-pipeline
+Name:         My Automation Pipeline
+Provider:     manual
+Enabled:      True
+Groups:       pipeline-operators, registry-readonly
+Description:  CI/CD pipeline service account
+Created by:   admin
+Created at:   ...
+Updated at:   ...
+```
+
+`Provider: manual` means the record was created via this API (rather than synced from an IdP). Manual records are the only ones this API can modify or delete later.
+
+## Step 3: Verify from your application
+
+1. Request an M2M access token from Keycloak using client credentials:
+
+   ```bash
+   curl -X POST \
+     "http://localhost:8080/realms/mcp-gateway/protocol/openid-connect/token" \
+     -d "grant_type=client_credentials" \
+     -d "client_id=my-automation-pipeline" \
+     -d "client_secret=<from-keycloak-ui>"
+   ```
+
+2. Call the registry with that token. The registry's auth server looks up `client_id=my-automation-pipeline` in `idp_m2m_clients`, enriches the token with groups `["pipeline-operators", "registry-readonly"]`, and authorization proceeds based on those groups.
+
+   ```bash
+   curl -H "Authorization: Bearer $M2M_TOKEN" "$REGISTRY_URL/api/servers"
+   ```
+
+## Managing registered clients
+
+All commands below use the same `--registry-url`/`--token-file` prefix as above.
+
+**List**:
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-list --provider manual
+```
+
+Supports `--limit`, `--skip`, `--json`.
+
+**Get one**:
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-get --client-id my-automation-pipeline
+```
+
+**Update** (partial -- fields you omit are left unchanged; pass `--groups ""` to clear groups):
+
+```bash
+# Change groups only
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-update \
+  --client-id my-automation-pipeline \
+  --groups registry-readonly
+
+# Disable the client (kill switch)
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-update \
+  --client-id my-automation-pipeline \
+  --enabled false
+```
+
+**Delete**:
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url $REGISTRY_URL --token-file $TOKEN_FILE \
+  m2m-client-delete --client-id my-automation-pipeline --force
+```
+
+## HTTP endpoints (for reference)
+
+| Method | Path | Auth |
+|--------|------|------|
+| POST | `/api/iam/m2m-clients` | admin |
+| GET | `/api/iam/m2m-clients` | any authenticated user (paginated) |
+| GET | `/api/iam/m2m-clients/{client_id}` | any authenticated user |
+| PATCH | `/api/iam/m2m-clients/{client_id}` | admin |
+| DELETE | `/api/iam/m2m-clients/{client_id}` | admin |
+
+## Things to know
+
+- **Ownership guard**: records created by this API have `provider: "manual"`. Records written by the existing Okta/Auth0 sync services (`provider: "okta"`, `provider: "auth0"`) are visible via `GET` but return `HTTP 403` on `PATCH` or `DELETE` from this API, to prevent conflicts with IdP sync.
+- **Duplicate `client_id`**: returns `HTTP 409 Conflict`. One `client_id` can only have one record across all providers.
+- **Admins grant privilege directly**: any admin calling this API can assign any group to any `client_id`. The audit log records every mutation with the calling admin's identity for accountability. Treat the registry admin role accordingly.
+- **Feature flag**: `M2M_DIRECT_REGISTRATION_ENABLED` (default `true`) disables the whole router if set to `false`. Surface the flag on the System Config page under **Authentication**.
+
+## Related FAQs
+
+- [How do I restrict which MCP servers a user can see based on their Entra ID group?](restrict-server-visibility-by-entra-group.md)
+- [Can I use an Entra ID token to call the registry API instead of the UI-generated token?](use-entra-token-for-registry-api.md)
+- [How do I register and manage MCP servers that require authentication?](registering-auth-protected-servers.md)

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -75,6 +75,7 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("registry_static_token_auth_enabled", "Static Token Auth Enabled", False),
             ("registry_api_token", "Registry API Token", True),
             ("max_tokens_per_user_per_hour", "JWT Token Vending Rate Limit (per user/hour)", False),
+            ("m2m_direct_registration_enabled", "M2M Direct Registration Enabled", False),
             ("secret_key", "Secret Key", True),
         ],
     },

--- a/registry/api/m2m_management_routes.py
+++ b/registry/api/m2m_management_routes.py
@@ -1,0 +1,210 @@
+"""Direct CRUD endpoints for M2M client registration.
+
+These endpoints write directly to the ``idp_m2m_clients`` MongoDB collection
+without calling any IdP Admin API. Operators without ``OKTA_API_TOKEN`` (or
+equivalent) can register M2M ``client_id`` values and their group mappings so
+the auth server can enrich M2M tokens during authorization.
+
+Tracked by issue #851.
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from prometheus_client import Counter
+
+from registry.audit.context import set_audit_action
+from registry.auth.dependencies import nginx_proxied_auth
+from registry.repositories.documentdb.client import get_documentdb_client
+from registry.schemas.idp_m2m_client import (
+    IdPM2MClient,
+    IdPM2MClientCreate,
+    IdPM2MClientPatch,
+    M2MClientListResponse,
+)
+from registry.services.m2m_management_service import (
+    M2MClientConflict,
+    M2MClientImmutable,
+    M2MClientNotFound,
+    M2MManagementService,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_RESOURCE_TYPE: str = "m2m_client"
+_LIST_DEFAULT_LIMIT: int = 500
+_LIST_MAX_LIMIT: int = 1000
+
+
+m2m_management_requests_total = Counter(
+    "m2m_management_requests_total",
+    "Count of direct M2M client registration API calls",
+    ["operation", "outcome"],
+)
+
+
+def _require_admin(
+    user_context: dict | None,
+    operation: str,
+) -> None:
+    """Enforce admin permission or raise 401/403 and increment metrics."""
+    if not user_context:
+        m2m_management_requests_total.labels(operation=operation, outcome="auth_error").inc()
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if not user_context.get("is_admin"):
+        m2m_management_requests_total.labels(operation=operation, outcome="forbidden").inc()
+        raise HTTPException(status_code=403, detail="Administrator permissions are required")
+
+
+async def _get_service() -> M2MManagementService:
+    db = await get_documentdb_client()
+    return M2MManagementService(db)
+
+
+@router.post(
+    "/iam/m2m-clients",
+    response_model=IdPM2MClient,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_m2m_client(
+    payload: IdPM2MClientCreate,
+    request: Request,
+    user_context: Annotated[dict | None, Depends(nginx_proxied_auth)] = None,
+) -> IdPM2MClient:
+    """Register a new M2M client with its group mappings (admin only)."""
+    _require_admin(user_context, operation="create")
+    service = await _get_service()
+    created_by = user_context.get("username") if user_context else None
+    try:
+        result = await service.create(payload, created_by=created_by)
+    except M2MClientConflict:
+        m2m_management_requests_total.labels(operation="create", outcome="conflict").inc()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"M2M client {payload.client_id} already exists",
+        )
+    set_audit_action(
+        request,
+        "create",
+        _RESOURCE_TYPE,
+        resource_id=payload.client_id,
+        description=f"Created M2M client {payload.client_name}",
+    )
+    m2m_management_requests_total.labels(operation="create", outcome="success").inc()
+    return result
+
+
+@router.get("/iam/m2m-clients", response_model=M2MClientListResponse)
+async def list_m2m_clients(
+    provider: str | None = None,
+    limit: int = Query(default=_LIST_DEFAULT_LIMIT, ge=1, le=_LIST_MAX_LIMIT),
+    skip: int = Query(default=0, ge=0),
+    user_context: Annotated[dict | None, Depends(nginx_proxied_auth)] = None,
+) -> M2MClientListResponse:
+    """List M2M clients (any authenticated user)."""
+    if not user_context:
+        m2m_management_requests_total.labels(operation="list", outcome="auth_error").inc()
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    service = await _get_service()
+    items, total = await service.list_paged(provider=provider, limit=limit, skip=skip)
+    m2m_management_requests_total.labels(operation="list", outcome="success").inc()
+    return M2MClientListResponse(total=total, limit=limit, skip=skip, items=items)
+
+
+@router.get("/iam/m2m-clients/{client_id}", response_model=IdPM2MClient)
+async def get_m2m_client(
+    client_id: str,
+    user_context: Annotated[dict | None, Depends(nginx_proxied_auth)] = None,
+) -> IdPM2MClient:
+    """Get a specific M2M client (any authenticated user)."""
+    if not user_context:
+        m2m_management_requests_total.labels(operation="get", outcome="auth_error").inc()
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    service = await _get_service()
+    try:
+        result = await service.get(client_id)
+    except M2MClientNotFound:
+        m2m_management_requests_total.labels(operation="get", outcome="not_found").inc()
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"M2M client {client_id} not found",
+        )
+    m2m_management_requests_total.labels(operation="get", outcome="success").inc()
+    return result
+
+
+@router.patch("/iam/m2m-clients/{client_id}", response_model=IdPM2MClient)
+async def patch_m2m_client(
+    client_id: str,
+    payload: IdPM2MClientPatch,
+    request: Request,
+    user_context: Annotated[dict | None, Depends(nginx_proxied_auth)] = None,
+) -> IdPM2MClient:
+    """Update fields of an existing manual M2M client (admin only)."""
+    _require_admin(user_context, operation="patch")
+    service = await _get_service()
+    try:
+        result = await service.patch(client_id, payload)
+    except M2MClientNotFound:
+        m2m_management_requests_total.labels(operation="patch", outcome="not_found").inc()
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"M2M client {client_id} not found",
+        )
+    except M2MClientImmutable:
+        m2m_management_requests_total.labels(operation="patch", outcome="forbidden").inc()
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"M2M client {client_id} was registered by IdP sync and "
+                "cannot be modified via this API"
+            ),
+        )
+    set_audit_action(
+        request,
+        "update",
+        _RESOURCE_TYPE,
+        resource_id=client_id,
+        description=f"Updated M2M client {client_id}",
+    )
+    m2m_management_requests_total.labels(operation="patch", outcome="success").inc()
+    return result
+
+
+@router.delete("/iam/m2m-clients/{client_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_m2m_client(
+    client_id: str,
+    request: Request,
+    user_context: Annotated[dict | None, Depends(nginx_proxied_auth)] = None,
+) -> None:
+    """Delete a manual M2M client (admin only)."""
+    _require_admin(user_context, operation="delete")
+    service = await _get_service()
+    try:
+        await service.delete(client_id)
+    except M2MClientNotFound:
+        m2m_management_requests_total.labels(operation="delete", outcome="not_found").inc()
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"M2M client {client_id} not found",
+        )
+    except M2MClientImmutable:
+        m2m_management_requests_total.labels(operation="delete", outcome="forbidden").inc()
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"M2M client {client_id} was registered by IdP sync and "
+                "cannot be deleted via this API"
+            ),
+        )
+    set_audit_action(
+        request,
+        "delete",
+        _RESOURCE_TYPE,
+        resource_id=client_id,
+        description=f"Deleted M2M client {client_id}",
+    )
+    m2m_management_requests_total.labels(operation="delete", outcome="success").inc()

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -285,6 +285,16 @@ class Settings(BaseSettings):
         description="Comma-separated prefixes to filter IdP groups in IAM > Groups page",
     )
 
+    # M2M direct registration (issue #851)
+    m2m_direct_registration_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable direct M2M client registration API at /api/iam/m2m-clients. "
+            "This feature lets admins register M2M client_ids and group mappings "
+            "without an IdP Admin API token."
+        ),
+    )
+
     # ANS Integration
     ans_integration_enabled: bool = Field(
         default=False,

--- a/registry/main.py
+++ b/registry/main.py
@@ -30,6 +30,7 @@ from registry.api.config_routes import router as config_router
 from registry.api.federation_export_routes import router as federation_export_router
 from registry.api.federation_routes import router as federation_router
 from registry.api.internal_routes import router as internal_router
+from registry.api.m2m_management_routes import router as m2m_management_router
 from registry.api.management_routes import router as management_router
 from registry.api.okta_m2m_routes import router as okta_m2m_router
 from registry.api.peer_management_routes import router as peer_management_router
@@ -686,6 +687,22 @@ async def lifespan(app: FastAPI):
             await ans_scheduler.start()
             logger.info("ANS sync scheduler started")
 
+        # Ensure unique index on idp_m2m_clients.client_id for the direct
+        # M2M registration API (issue #851). Only when feature is enabled.
+        if settings.m2m_direct_registration_enabled:
+            try:
+                from registry.repositories.documentdb.client import get_documentdb_client
+                from registry.services.m2m_management_service import (
+                    M2MManagementService,
+                )
+
+                m2m_db = await get_documentdb_client()
+                await M2MManagementService(m2m_db).ensure_indexes()
+            except Exception as e:
+                logger.warning(
+                    f"Failed to ensure idp_m2m_clients index (continuing with startup): {e}",
+                )
+
         # Initialize built-in demo servers (airegistry-tools)
         # Skipped when DISABLE_AI_REGISTRY_TOOLS_SERVER=true (e.g. GitOps/production deployments)
         if not settings.disable_ai_registry_tools_server:
@@ -891,6 +908,11 @@ app.include_router(registry_management_router, prefix="/api")
 # Register IdP M2M management routers (Okta and Auth0)
 app.include_router(okta_m2m_router, prefix="/api", tags=["Okta M2M"])
 app.include_router(auth0_m2m_router, prefix="/api", tags=["Auth0 M2M"])
+
+# Direct M2M client registration API (issue #851)
+# Does not require IdP Admin API token. Gated by feature flag.
+if settings.m2m_direct_registration_enabled:
+    app.include_router(m2m_management_router, prefix="/api", tags=["M2M Management"])
 
 # Register Anthropic MCP Registry API (public API for MCP servers only)
 app.include_router(registry_router, prefix="/api/registry", tags=["Registry Card"])

--- a/registry/schemas/idp_m2m_client.py
+++ b/registry/schemas/idp_m2m_client.py
@@ -8,9 +8,24 @@ without hardcoding them in authorization server expressions.
 This collection serves as the authorization database for M2M clients.
 """
 
+import re
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+MANUAL_PROVIDER: str = "manual"
+
+_CLIENT_ID_PATTERN: re.Pattern = re.compile(r"^[A-Za-z0-9_\-.:]{1,256}$")
+
+
+def _validate_client_id(value: str) -> str:
+    """Validate that client_id matches the allowed character set."""
+    if not _CLIENT_ID_PATTERN.match(value):
+        raise ValueError(
+            "client_id must match ^[A-Za-z0-9_\\-.:]{1,256}$ "
+            "(alphanumerics, dash, underscore, dot, colon only)"
+        )
+    return value
 
 
 class IdPM2MClient(BaseModel):
@@ -26,7 +41,7 @@ class IdPM2MClient(BaseModel):
     description: str | None = Field(None, description="Application description")
     groups: list[str] = Field(default_factory=list, description="Groups this client belongs to")
     enabled: bool = Field(default=True, description="Whether client is active")
-    provider: str = Field(..., description="Identity provider (okta, keycloak, entra)")
+    provider: str = Field(..., description="Identity provider (okta, keycloak, entra, manual)")
     created_at: datetime = Field(
         default_factory=datetime.utcnow, description="When record was created"
     )
@@ -34,6 +49,13 @@ class IdPM2MClient(BaseModel):
         default_factory=datetime.utcnow, description="When record was last updated"
     )
     idp_app_id: str | None = Field(None, description="IdP internal app ID")
+    created_by: str | None = Field(
+        default=None,
+        description=(
+            "Username of operator who registered this M2M client. "
+            "Populated only for records with provider=manual."
+        ),
+    )
 
     class Config:
         """Pydantic model configuration."""
@@ -52,7 +74,78 @@ class IdPM2MClient(BaseModel):
 
 
 class IdPM2MClientUpdate(BaseModel):
-    """Payload for updating an IdP M2M client's group mappings."""
+    """Payload for updating an IdP M2M client's group mappings (legacy)."""
 
     groups: list[str] = Field(..., description="New list of groups for this client", min_length=1)
     description: str | None = Field(None, description="Updated description")
+
+
+class IdPM2MClientCreate(BaseModel):
+    """Request body for POST /api/iam/m2m-clients.
+
+    Creates a new M2M client record with provider=manual. Does not require
+    any IdP Admin API token.
+    """
+
+    client_id: str = Field(
+        ...,
+        description="IdP application client ID",
+        min_length=1,
+        max_length=256,
+    )
+    client_name: str = Field(
+        ...,
+        description="Human-readable name for the client",
+        min_length=1,
+        max_length=256,
+    )
+    groups: list[str] = Field(
+        default_factory=list,
+        description="Groups this client belongs to (may be empty)",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Optional human-readable description",
+        max_length=1024,
+    )
+
+    @field_validator("client_id")
+    @classmethod
+    def _validate_client_id_format(cls, v: str) -> str:
+        return _validate_client_id(v)
+
+
+class IdPM2MClientPatch(BaseModel):
+    """Request body for PATCH /api/iam/m2m-clients/{client_id}.
+
+    Patch semantics use Pydantic v2's `model_dump(exclude_unset=True)` in the
+    service, so fields not present in the request body are NOT written. Fields
+    explicitly present (including None or empty list) ARE written.
+    """
+
+    client_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=256,
+    )
+    groups: list[str] | None = Field(
+        default=None,
+        description="New groups list. Empty list clears groups.",
+    )
+    description: str | None = Field(
+        default=None,
+        max_length=1024,
+    )
+    enabled: bool | None = Field(default=None)
+
+
+class M2MClientListResponse(BaseModel):
+    """Paginated response envelope for GET /api/iam/m2m-clients."""
+
+    total: int = Field(..., description="Total number of matching records")
+    limit: int = Field(..., description="Limit applied to this page")
+    skip: int = Field(..., description="Offset applied to this page")
+    items: list[IdPM2MClient] = Field(
+        default_factory=list,
+        description="Records on this page",
+    )

--- a/registry/services/m2m_management_service.py
+++ b/registry/services/m2m_management_service.py
@@ -1,0 +1,216 @@
+"""Direct CRUD service for manually-registered M2M clients.
+
+This service writes to the shared ``idp_m2m_clients`` collection without
+calling any IdP Admin API. Records written by this service are tagged with
+``provider == "manual"`` so they are distinguishable from IdP-synced records,
+and only ``manual`` records can be modified or deleted via this API.
+
+Tracked by issue #851.
+"""
+
+import logging
+from datetime import datetime
+
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo.errors import DuplicateKeyError
+
+from registry.schemas.idp_m2m_client import (
+    MANUAL_PROVIDER,
+    IdPM2MClient,
+    IdPM2MClientCreate,
+    IdPM2MClientPatch,
+)
+
+logger = logging.getLogger(__name__)
+
+
+COLLECTION_NAME: str = "idp_m2m_clients"
+
+
+class M2MClientConflict(Exception):
+    """Raised when a client_id already exists in the collection."""
+
+
+class M2MClientNotFound(Exception):
+    """Raised when the requested client_id does not exist."""
+
+
+class M2MClientImmutable(Exception):
+    """Raised when attempting to mutate a record owned by IdP sync."""
+
+
+class M2MManagementService:
+    """CRUD service for manually-registered M2M clients."""
+
+    def __init__(
+        self,
+        db: AsyncIOMotorDatabase,
+    ) -> None:
+        self._collection = db[COLLECTION_NAME]
+
+    async def ensure_indexes(self) -> None:
+        """Create required indexes (idempotent).
+
+        Creates a unique index on ``client_id`` to prevent duplicate registrations
+        under concurrent POSTs.
+        """
+        await self._collection.create_index("client_id", unique=True)
+        logger.info(
+            "Ensured unique index on %s.client_id",
+            COLLECTION_NAME,
+        )
+
+    async def create(
+        self,
+        payload: IdPM2MClientCreate,
+        created_by: str | None,
+    ) -> IdPM2MClient:
+        """Insert a new manual M2M client record.
+
+        Args:
+            payload: Validated create request body.
+            created_by: Username of the operator performing the action
+                (captured from the authenticated user context).
+
+        Returns:
+            The persisted :class:`IdPM2MClient`.
+
+        Raises:
+            M2MClientConflict: If ``client_id`` already exists (unique index
+                violation).
+        """
+        now = datetime.utcnow()
+        doc: dict = {
+            "client_id": payload.client_id,
+            "name": payload.client_name,
+            "description": payload.description,
+            "groups": list(payload.groups),
+            "enabled": True,
+            "provider": MANUAL_PROVIDER,
+            "idp_app_id": None,
+            "created_by": created_by,
+            "created_at": now,
+            "updated_at": now,
+        }
+        try:
+            await self._collection.insert_one(doc)
+        except DuplicateKeyError as e:
+            raise M2MClientConflict(payload.client_id) from e
+
+        logger.info(
+            "Registered manual M2M client client_id=%s name=%s groups=%s created_by=%s",
+            payload.client_id,
+            payload.client_name,
+            payload.groups,
+            created_by,
+        )
+        return IdPM2MClient(**doc)
+
+    async def list_paged(
+        self,
+        provider: str | None = None,
+        limit: int = 500,
+        skip: int = 0,
+    ) -> tuple[list[IdPM2MClient], int]:
+        """Return a paginated slice of the collection.
+
+        Args:
+            provider: Optional filter on the ``provider`` field.
+            limit: Maximum number of records to return on this page.
+            skip: Number of records to skip (offset).
+
+        Returns:
+            Tuple of (items_on_page, total_matching_count).
+        """
+        query: dict = {}
+        if provider is not None:
+            query["provider"] = provider
+        total = await self._collection.count_documents(query)
+        cursor = self._collection.find(query).skip(skip).limit(limit)
+        docs = await cursor.to_list(length=limit)
+        return [IdPM2MClient(**d) for d in docs], total
+
+    async def get(
+        self,
+        client_id: str,
+    ) -> IdPM2MClient:
+        """Fetch a single client by ``client_id``.
+
+        Raises:
+            M2MClientNotFound: If the record does not exist.
+        """
+        doc = await self._collection.find_one({"client_id": client_id})
+        if doc is None:
+            raise M2MClientNotFound(client_id)
+        return IdPM2MClient(**doc)
+
+    async def patch(
+        self,
+        client_id: str,
+        payload: IdPM2MClientPatch,
+    ) -> IdPM2MClient:
+        """Update a manual M2M client record.
+
+        Only records with ``provider == "manual"`` can be modified.
+
+        Raises:
+            M2MClientNotFound: If the record does not exist.
+            M2MClientImmutable: If the record was written by IdP sync.
+        """
+        existing = await self._collection.find_one({"client_id": client_id})
+        if existing is None:
+            raise M2MClientNotFound(client_id)
+        if existing.get("provider") != MANUAL_PROVIDER:
+            raise M2MClientImmutable(client_id)
+
+        # Pydantic v2: only fields explicitly set in the request body appear
+        # in the dump. Callers clearing groups pass [] and it lands here too.
+        provided = payload.model_dump(exclude_unset=True)
+
+        field_map: dict[str, str] = {
+            "client_name": "name",
+            "groups": "groups",
+            "description": "description",
+            "enabled": "enabled",
+        }
+        updates: dict = {"updated_at": datetime.utcnow()}
+        for request_field, storage_field in field_map.items():
+            if request_field in provided:
+                updates[storage_field] = provided[request_field]
+
+        if len(updates) == 1:
+            # No meaningful changes requested; return existing doc unchanged.
+            return IdPM2MClient(**existing)
+
+        await self._collection.update_one(
+            {"client_id": client_id},
+            {"$set": updates},
+        )
+
+        logger.info(
+            "Updated manual M2M client client_id=%s fields=%s",
+            client_id,
+            sorted(updates.keys()),
+        )
+        return await self.get(client_id)
+
+    async def delete(
+        self,
+        client_id: str,
+    ) -> None:
+        """Delete a manual M2M client record.
+
+        Only records with ``provider == "manual"`` can be deleted.
+
+        Raises:
+            M2MClientNotFound: If the record does not exist.
+            M2MClientImmutable: If the record was written by IdP sync.
+        """
+        existing = await self._collection.find_one({"client_id": client_id})
+        if existing is None:
+            raise M2MClientNotFound(client_id)
+        if existing.get("provider") != MANUAL_PROVIDER:
+            raise M2MClientImmutable(client_id)
+
+        await self._collection.delete_one({"client_id": client_id})
+        logger.info("Deleted manual M2M client client_id=%s", client_id)

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -125,11 +125,11 @@ module "mcp_gateway" {
   security_add_pending_tag      = var.security_add_pending_tag
 
   # Microsoft Entra ID configuration
-  entra_enabled              = var.entra_enabled
-  entra_tenant_id            = var.entra_tenant_id
-  entra_client_id            = var.entra_client_id
-  entra_client_secret        = var.entra_client_secret
-  idp_group_filter_prefix    = var.idp_group_filter_prefix
+  entra_enabled           = var.entra_enabled
+  entra_tenant_id         = var.entra_tenant_id
+  entra_client_id         = var.entra_client_id
+  entra_client_secret     = var.entra_client_secret
+  idp_group_filter_prefix = var.idp_group_filter_prefix
 
   # Okta configuration
   okta_enabled           = var.okta_enabled
@@ -142,15 +142,15 @@ module "mcp_gateway" {
   okta_auth_server_id    = var.okta_auth_server_id
 
   # Auth0 configuration
-  auth0_enabled                = var.auth0_enabled
-  auth0_domain                 = var.auth0_domain
-  auth0_client_id              = var.auth0_client_id
-  auth0_client_secret          = var.auth0_client_secret
-  auth0_audience               = var.auth0_audience
-  auth0_groups_claim           = var.auth0_groups_claim
-  auth0_m2m_client_id          = var.auth0_m2m_client_id
-  auth0_m2m_client_secret      = var.auth0_m2m_client_secret
-  auth0_management_api_token   = var.auth0_management_api_token
+  auth0_enabled              = var.auth0_enabled
+  auth0_domain               = var.auth0_domain
+  auth0_client_id            = var.auth0_client_id
+  auth0_client_secret        = var.auth0_client_secret
+  auth0_audience             = var.auth0_audience
+  auth0_groups_claim         = var.auth0_groups_claim
+  auth0_m2m_client_id        = var.auth0_m2m_client_id
+  auth0_m2m_client_secret    = var.auth0_m2m_client_secret
+  auth0_management_api_token = var.auth0_management_api_token
 
   # OAuth token storage
   oauth_store_tokens_in_session = var.oauth_store_tokens_in_session
@@ -159,6 +159,9 @@ module "mcp_gateway" {
   registry_static_token_auth_enabled = var.registry_static_token_auth_enabled
   registry_api_token                 = var.registry_api_token
   max_tokens_per_user_per_hour       = var.max_tokens_per_user_per_hour
+
+  # M2M direct client registration (issue #851)
+  m2m_direct_registration_enabled = var.m2m_direct_registration_enabled
 
   # Federation configuration (peer-to-peer registry sync)
   registry_id                          = var.registry_id

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -219,6 +219,11 @@ module "ecs_service_auth" {
           name  = "REGISTRY_API_TOKEN"
           value = var.registry_api_token
         },
+        # M2M direct client registration (issue #851)
+        {
+          name  = "M2M_DIRECT_REGISTRATION_ENABLED"
+          value = tostring(var.m2m_direct_registration_enabled)
+        },
         # Federation configuration (peer-to-peer registry sync)
         {
           name  = "REGISTRY_ID"
@@ -862,6 +867,11 @@ module "ecs_service_registry" {
         {
           name  = "MAX_TOKENS_PER_USER_PER_HOUR"
           value = tostring(var.max_tokens_per_user_per_hour)
+        },
+        # M2M direct client registration (issue #851)
+        {
+          name  = "M2M_DIRECT_REGISTRATION_ENABLED"
+          value = tostring(var.m2m_direct_registration_enabled)
         },
         # Telemetry configuration
         {

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -651,6 +651,12 @@ variable "max_tokens_per_user_per_hour" {
   default     = 100
 }
 
+variable "m2m_direct_registration_enabled" {
+  description = "Enable the admin API at /api/iam/m2m-clients for direct M2M client registration (issue #851). Default: true."
+  type        = bool
+  default     = true
+}
+
 # =============================================================================
 # FEDERATION CONFIGURATION (Peer-to-Peer Registry Sync)
 # =============================================================================

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -280,6 +280,17 @@ registry_api_token = "m3zT65wREARMVDToKosg_DgNkKqS_434hNxy3sslGPY"
 # max_tokens_per_user_per_hour = 100
 
 # ============================================================================
+# M2M DIRECT CLIENT REGISTRATION (Issue #851)
+# ============================================================================
+
+# Enable the admin API at /api/iam/m2m-clients that writes M2M client_ids
+# and their group mappings directly to the idp_m2m_clients collection,
+# without requiring an IdP Admin API token (e.g. OKTA_API_TOKEN).
+# Records created via this API are tagged provider="manual".
+# Default: true
+# m2m_direct_registration_enabled = true
+
+# ============================================================================
 # REGISTRY CARD CONFIGURATION (Federation Metadata)
 # ============================================================================
 

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -597,6 +597,16 @@ variable "max_tokens_per_user_per_hour" {
 }
 
 # =============================================================================
+# M2M DIRECT CLIENT REGISTRATION (Issue #851)
+# =============================================================================
+
+variable "m2m_direct_registration_enabled" {
+  description = "Enable the admin API at /api/iam/m2m-clients that writes M2M client_ids and groups directly to the idp_m2m_clients collection without an IdP Admin API token. Default: true."
+  type        = bool
+  default     = true
+}
+
+# =============================================================================
 # FEDERATION CONFIGURATION (Peer-to-Peer Registry Sync)
 # =============================================================================
 

--- a/tests/unit/api/test_m2m_management_routes.py
+++ b/tests/unit/api/test_m2m_management_routes.py
@@ -1,0 +1,392 @@
+"""Unit tests for registry/api/m2m_management_routes.py (issue #851).
+
+Tests the direct M2M client registration endpoints:
+- POST   /api/iam/m2m-clients
+- GET    /api/iam/m2m-clients
+- GET    /api/iam/m2m-clients/{client_id}
+- PATCH  /api/iam/m2m-clients/{client_id}
+- DELETE /api/iam/m2m-clients/{client_id}
+"""
+
+import logging
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from registry.schemas.idp_m2m_client import MANUAL_PROVIDER, IdPM2MClient
+from registry.services.m2m_management_service import (
+    M2MClientConflict,
+    M2MClientImmutable,
+    M2MClientNotFound,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def admin_user_context() -> dict[str, Any]:
+    return {
+        "username": "admin",
+        "is_admin": True,
+        "groups": ["mcp-registry-admin"],
+        "scopes": ["mcp-servers-unrestricted/read"],
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "accessible_agents": ["all"],
+        "ui_permissions": {"register_service": ["all"]},
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def regular_user_context() -> dict[str, Any]:
+    return {
+        "username": "user",
+        "is_admin": False,
+        "groups": ["test-group"],
+        "scopes": [],
+        "accessible_servers": [],
+        "accessible_services": [],
+        "accessible_agents": [],
+        "ui_permissions": {},
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def sample_client() -> IdPM2MClient:
+    now = datetime.utcnow()
+    return IdPM2MClient(
+        client_id="test-client-id",
+        name="Test Client",
+        description="desc",
+        groups=["group-a"],
+        enabled=True,
+        provider=MANUAL_PROVIDER,
+        idp_app_id=None,
+        created_by="admin",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _override_auth(user_context: dict | None) -> None:
+    """Override the nginx_proxied_auth FastAPI dependency."""
+    from registry.auth.dependencies import nginx_proxied_auth
+    from registry.main import app
+
+    def _override() -> dict | None:
+        return user_context
+
+    app.dependency_overrides[nginx_proxied_auth] = _override
+
+
+@pytest.fixture
+def mock_service() -> MagicMock:
+    service = MagicMock()
+    service.create = AsyncMock()
+    service.list_paged = AsyncMock()
+    service.get = AsyncMock()
+    service.patch = AsyncMock()
+    service.delete = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def client_admin(mock_settings, admin_user_context, mock_service):
+    from registry.main import app
+
+    _override_auth(admin_user_context)
+    with patch(
+        "registry.api.m2m_management_routes._get_service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+        yield client, mock_service
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_regular(mock_settings, regular_user_context, mock_service):
+    from registry.main import app
+
+    _override_auth(regular_user_context)
+    with patch(
+        "registry.api.m2m_management_routes._get_service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+        yield client, mock_service
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_anon(mock_settings, mock_service):
+    from registry.main import app
+
+    _override_auth(None)
+    with patch(
+        "registry.api.m2m_management_routes._get_service",
+        new=AsyncMock(return_value=mock_service),
+    ):
+        client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+        yield client, mock_service
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestCreateM2MClient:
+    """Tests for POST /api/iam/m2m-clients."""
+
+    def test_unauthenticated_returns_401(self, client_anon):
+        client, _ = client_anon
+
+        response = client.post(
+            "/api/iam/m2m-clients",
+            json={"client_id": "abc", "client_name": "x"},
+        )
+
+        assert response.status_code == 401
+
+    def test_non_admin_returns_403(self, client_regular):
+        client, _ = client_regular
+
+        response = client.post(
+            "/api/iam/m2m-clients",
+            json={"client_id": "abc", "client_name": "x"},
+        )
+
+        assert response.status_code == 403
+
+    def test_happy_path_returns_201(
+        self,
+        client_admin,
+        sample_client,
+    ):
+        client, service = client_admin
+        service.create.return_value = sample_client
+
+        response = client.post(
+            "/api/iam/m2m-clients",
+            json={
+                "client_id": "test-client-id",
+                "client_name": "Test Client",
+                "groups": ["group-a"],
+                "description": "desc",
+            },
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["client_id"] == "test-client-id"
+        assert body["provider"] == MANUAL_PROVIDER
+        service.create.assert_awaited_once()
+        create_kwargs = service.create.await_args.kwargs
+        assert create_kwargs["created_by"] == "admin"
+
+    def test_conflict_returns_409(self, client_admin):
+        client, service = client_admin
+        service.create.side_effect = M2MClientConflict("dup")
+
+        response = client.post(
+            "/api/iam/m2m-clients",
+            json={"client_id": "dup", "client_name": "x"},
+        )
+
+        assert response.status_code == 409
+
+    def test_invalid_client_id_returns_422(self, client_admin):
+        client, _ = client_admin
+
+        response = client.post(
+            "/api/iam/m2m-clients",
+            json={"client_id": "bad id with space", "client_name": "x"},
+        )
+
+        assert response.status_code == 422
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestListM2MClients:
+    """Tests for GET /api/iam/m2m-clients."""
+
+    def test_unauthenticated_returns_401(self, client_anon):
+        client, _ = client_anon
+
+        response = client.get("/api/iam/m2m-clients")
+
+        assert response.status_code == 401
+
+    def test_returns_paginated_envelope(
+        self,
+        client_admin,
+        sample_client,
+    ):
+        client, service = client_admin
+        service.list_paged.return_value = ([sample_client], 1)
+
+        response = client.get("/api/iam/m2m-clients")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1
+        assert body["limit"] == 500
+        assert body["skip"] == 0
+        assert len(body["items"]) == 1
+        assert body["items"][0]["client_id"] == "test-client-id"
+
+    def test_passes_provider_filter(self, client_admin):
+        client, service = client_admin
+        service.list_paged.return_value = ([], 0)
+
+        client.get("/api/iam/m2m-clients?provider=manual")
+
+        kwargs = service.list_paged.await_args.kwargs
+        assert kwargs["provider"] == "manual"
+
+    def test_enforces_limit_cap(self, client_admin):
+        client, service = client_admin
+        service.list_paged.return_value = ([], 0)
+
+        response = client.get("/api/iam/m2m-clients?limit=5000")
+
+        assert response.status_code == 422  # exceeds le=1000
+
+    def test_passes_skip_and_limit(self, client_admin):
+        client, service = client_admin
+        service.list_paged.return_value = ([], 0)
+
+        client.get("/api/iam/m2m-clients?limit=25&skip=10")
+
+        kwargs = service.list_paged.await_args.kwargs
+        assert kwargs["limit"] == 25
+        assert kwargs["skip"] == 10
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestGetM2MClient:
+    """Tests for GET /api/iam/m2m-clients/{client_id}."""
+
+    def test_unauthenticated_returns_401(self, client_anon):
+        client, _ = client_anon
+
+        response = client.get("/api/iam/m2m-clients/x")
+
+        assert response.status_code == 401
+
+    def test_returns_200_on_found(
+        self,
+        client_admin,
+        sample_client,
+    ):
+        client, service = client_admin
+        service.get.return_value = sample_client
+
+        response = client.get("/api/iam/m2m-clients/test-client-id")
+
+        assert response.status_code == 200
+        assert response.json()["client_id"] == "test-client-id"
+
+    def test_returns_404_on_missing(self, client_admin):
+        client, service = client_admin
+        service.get.side_effect = M2MClientNotFound("missing")
+
+        response = client.get("/api/iam/m2m-clients/missing")
+
+        assert response.status_code == 404
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestPatchM2MClient:
+    """Tests for PATCH /api/iam/m2m-clients/{client_id}."""
+
+    def test_non_admin_returns_403(self, client_regular):
+        client, _ = client_regular
+
+        response = client.patch(
+            "/api/iam/m2m-clients/x",
+            json={"groups": ["g1"]},
+        )
+
+        assert response.status_code == 403
+
+    def test_happy_path_returns_200(
+        self,
+        client_admin,
+        sample_client,
+    ):
+        client, service = client_admin
+        service.patch.return_value = sample_client
+
+        response = client.patch(
+            "/api/iam/m2m-clients/test-client-id",
+            json={"groups": ["new-group"]},
+        )
+
+        assert response.status_code == 200
+
+    def test_not_found_returns_404(self, client_admin):
+        client, service = client_admin
+        service.patch.side_effect = M2MClientNotFound("missing")
+
+        response = client.patch(
+            "/api/iam/m2m-clients/missing",
+            json={"groups": ["g1"]},
+        )
+
+        assert response.status_code == 404
+
+    def test_immutable_returns_403(self, client_admin):
+        client, service = client_admin
+        service.patch.side_effect = M2MClientImmutable("sync-id")
+
+        response = client.patch(
+            "/api/iam/m2m-clients/sync-id",
+            json={"groups": ["g1"]},
+        )
+
+        assert response.status_code == 403
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestDeleteM2MClient:
+    """Tests for DELETE /api/iam/m2m-clients/{client_id}."""
+
+    def test_non_admin_returns_403(self, client_regular):
+        client, _ = client_regular
+
+        response = client.delete("/api/iam/m2m-clients/x")
+
+        assert response.status_code == 403
+
+    def test_happy_path_returns_204(self, client_admin):
+        client, service = client_admin
+        service.delete.return_value = None
+
+        response = client.delete("/api/iam/m2m-clients/test-client-id")
+
+        assert response.status_code == 204
+
+    def test_not_found_returns_404(self, client_admin):
+        client, service = client_admin
+        service.delete.side_effect = M2MClientNotFound("missing")
+
+        response = client.delete("/api/iam/m2m-clients/missing")
+
+        assert response.status_code == 404
+
+    def test_immutable_returns_403(self, client_admin):
+        client, service = client_admin
+        service.delete.side_effect = M2MClientImmutable("sync-id")
+
+        response = client.delete("/api/iam/m2m-clients/sync-id")
+
+        assert response.status_code == 403

--- a/tests/unit/services/test_m2m_management_service.py
+++ b/tests/unit/services/test_m2m_management_service.py
@@ -1,0 +1,395 @@
+"""Unit tests for registry.services.m2m_management_service.
+
+These tests mock the Motor collection so the service logic can be exercised
+without a live MongoDB.
+"""
+
+import logging
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from registry.schemas.idp_m2m_client import (
+    MANUAL_PROVIDER,
+    IdPM2MClientCreate,
+    IdPM2MClientPatch,
+)
+from registry.services.m2m_management_service import (
+    COLLECTION_NAME,
+    M2MClientConflict,
+    M2MClientImmutable,
+    M2MClientNotFound,
+    M2MManagementService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _make_collection_mock() -> MagicMock:
+    """Return a MagicMock that mimics an AsyncIOMotorCollection."""
+    collection = MagicMock()
+    collection.insert_one = AsyncMock()
+    collection.find_one = AsyncMock()
+    collection.update_one = AsyncMock()
+    collection.delete_one = AsyncMock()
+    collection.count_documents = AsyncMock()
+    collection.create_index = AsyncMock()
+
+    # find() returns a chainable cursor stub.
+    cursor = MagicMock()
+    cursor.skip = MagicMock(return_value=cursor)
+    cursor.limit = MagicMock(return_value=cursor)
+    cursor.to_list = AsyncMock()
+    collection.find = MagicMock(return_value=cursor)
+    collection._cursor = cursor
+    return collection
+
+
+@pytest.fixture
+def mock_collection() -> MagicMock:
+    return _make_collection_mock()
+
+
+@pytest.fixture
+def mock_db(mock_collection: MagicMock) -> MagicMock:
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=mock_collection)
+    return db
+
+
+@pytest.fixture
+def service(mock_db: MagicMock) -> M2MManagementService:
+    return M2MManagementService(mock_db)
+
+
+@pytest.fixture
+def sample_manual_doc() -> dict:
+    """A manual-provider document as stored in MongoDB."""
+    now = datetime.utcnow()
+    return {
+        "client_id": "test-client-id",
+        "name": "Test Client",
+        "description": "A test client",
+        "groups": ["group-a"],
+        "enabled": True,
+        "provider": MANUAL_PROVIDER,
+        "idp_app_id": None,
+        "created_by": "alice",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+@pytest.fixture
+def sample_synced_doc() -> dict:
+    """An IdP-synced document; must be immutable to this API."""
+    now = datetime.utcnow()
+    return {
+        "client_id": "synced-client-id",
+        "name": "Synced Client",
+        "description": None,
+        "groups": ["group-b"],
+        "enabled": True,
+        "provider": "okta",
+        "idp_app_id": "0oa1100",
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+class TestEnsureIndexes:
+    """Tests for ensure_indexes."""
+
+    @pytest.mark.asyncio
+    async def test_creates_unique_index_on_client_id(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        await service.ensure_indexes()
+
+        mock_collection.create_index.assert_awaited_once_with("client_id", unique=True)
+
+
+class TestCreate:
+    """Tests for M2MManagementService.create."""
+
+    @pytest.mark.asyncio
+    async def test_inserts_document_with_manual_provider(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        payload = IdPM2MClientCreate(
+            client_id="new-client-id",
+            client_name="New Client",
+            groups=["g1", "g2"],
+            description="desc",
+        )
+        mock_collection.insert_one = AsyncMock()
+
+        result = await service.create(payload, created_by="alice")
+
+        mock_collection.insert_one.assert_awaited_once()
+        inserted_doc = mock_collection.insert_one.await_args.args[0]
+        assert inserted_doc["client_id"] == "new-client-id"
+        assert inserted_doc["name"] == "New Client"
+        assert inserted_doc["groups"] == ["g1", "g2"]
+        assert inserted_doc["description"] == "desc"
+        assert inserted_doc["provider"] == MANUAL_PROVIDER
+        assert inserted_doc["created_by"] == "alice"
+        assert inserted_doc["enabled"] is True
+        assert inserted_doc["idp_app_id"] is None
+        assert isinstance(inserted_doc["created_at"], datetime)
+        assert isinstance(inserted_doc["updated_at"], datetime)
+        assert result.client_id == "new-client-id"
+        assert result.provider == MANUAL_PROVIDER
+
+    @pytest.mark.asyncio
+    async def test_raises_conflict_on_duplicate_key(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.insert_one = AsyncMock(side_effect=DuplicateKeyError("dup"))
+        payload = IdPM2MClientCreate(
+            client_id="dup-id",
+            client_name="Dup",
+        )
+
+        with pytest.raises(M2MClientConflict):
+            await service.create(payload, created_by=None)
+
+
+class TestListPaged:
+    """Tests for M2MManagementService.list_paged."""
+
+    @pytest.mark.asyncio
+    async def test_returns_items_and_total(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.count_documents = AsyncMock(return_value=1)
+        mock_collection._cursor.to_list = AsyncMock(return_value=[sample_manual_doc])
+
+        items, total = await service.list_paged(limit=10, skip=0)
+
+        assert total == 1
+        assert len(items) == 1
+        assert items[0].client_id == "test-client-id"
+        mock_collection.count_documents.assert_awaited_once_with({})
+
+    @pytest.mark.asyncio
+    async def test_filters_by_provider(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.count_documents = AsyncMock(return_value=0)
+        mock_collection._cursor.to_list = AsyncMock(return_value=[])
+
+        items, total = await service.list_paged(provider="manual", limit=10, skip=0)
+
+        assert items == []
+        assert total == 0
+        mock_collection.count_documents.assert_awaited_once_with({"provider": "manual"})
+        mock_collection.find.assert_called_once_with({"provider": "manual"})
+
+    @pytest.mark.asyncio
+    async def test_applies_skip_and_limit(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.count_documents = AsyncMock(return_value=0)
+        mock_collection._cursor.to_list = AsyncMock(return_value=[])
+
+        await service.list_paged(limit=25, skip=100)
+
+        mock_collection._cursor.skip.assert_called_once_with(100)
+        mock_collection._cursor.limit.assert_called_once_with(25)
+
+
+class TestGet:
+    """Tests for M2MManagementService.get."""
+
+    @pytest.mark.asyncio
+    async def test_returns_client_when_found(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_manual_doc)
+
+        result = await service.get("test-client-id")
+
+        assert result.client_id == "test-client-id"
+        mock_collection.find_one.assert_awaited_once_with({"client_id": "test-client-id"})
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_missing(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=None)
+
+        with pytest.raises(M2MClientNotFound):
+            await service.get("missing")
+
+
+class TestPatch:
+    """Tests for M2MManagementService.patch."""
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_missing(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=None)
+
+        with pytest.raises(M2MClientNotFound):
+            await service.patch("missing", IdPM2MClientPatch(client_name="x"))
+
+    @pytest.mark.asyncio
+    async def test_raises_immutable_for_non_manual(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_synced_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_synced_doc)
+
+        with pytest.raises(M2MClientImmutable):
+            await service.patch("synced-client-id", IdPM2MClientPatch(groups=["new-group"]))
+
+    @pytest.mark.asyncio
+    async def test_updates_only_provided_fields(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_manual_doc)
+
+        await service.patch(
+            "test-client-id",
+            IdPM2MClientPatch(groups=["new-group"]),
+        )
+
+        mock_collection.update_one.assert_awaited_once()
+        filter_arg, update_arg = mock_collection.update_one.await_args.args
+        assert filter_arg == {"client_id": "test-client-id"}
+        assert update_arg["$set"]["groups"] == ["new-group"]
+        # client_name and description were not provided, must not be in $set.
+        assert "name" not in update_arg["$set"]
+        assert "description" not in update_arg["$set"]
+        assert "enabled" not in update_arg["$set"]
+
+    @pytest.mark.asyncio
+    async def test_allows_clearing_groups_with_empty_list(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_manual_doc)
+
+        await service.patch(
+            "test-client-id",
+            IdPM2MClientPatch(groups=[]),
+        )
+
+        _, update_arg = mock_collection.update_one.await_args.args
+        assert update_arg["$set"]["groups"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_op_patch_skips_update_call(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_manual_doc)
+
+        # Empty patch (no fields set) should not call update_one.
+        await service.patch("test-client-id", IdPM2MClientPatch())
+
+        mock_collection.update_one.assert_not_awaited()
+
+
+class TestDelete:
+    """Tests for M2MManagementService.delete."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_manual_record(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_manual_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_manual_doc)
+
+        await service.delete("test-client-id")
+
+        mock_collection.delete_one.assert_awaited_once_with({"client_id": "test-client-id"})
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_when_missing(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=None)
+
+        with pytest.raises(M2MClientNotFound):
+            await service.delete("missing")
+
+    @pytest.mark.asyncio
+    async def test_raises_immutable_for_non_manual(
+        self,
+        service: M2MManagementService,
+        mock_collection: MagicMock,
+        sample_synced_doc: dict,
+    ) -> None:
+        mock_collection.find_one = AsyncMock(return_value=sample_synced_doc)
+
+        with pytest.raises(M2MClientImmutable):
+            await service.delete("synced-client-id")
+
+        mock_collection.delete_one.assert_not_awaited()
+
+
+class TestClientIdValidation:
+    """Tests for the IdPM2MClientCreate client_id validator."""
+
+    def test_accepts_alphanumerics(self) -> None:
+        IdPM2MClientCreate(client_id="abc123", client_name="x")
+
+    def test_accepts_dash_underscore_dot_colon(self) -> None:
+        IdPM2MClientCreate(client_id="abc-def_ghi.jkl:mno", client_name="x")
+
+    def test_rejects_whitespace(self) -> None:
+        with pytest.raises(ValueError):
+            IdPM2MClientCreate(client_id="abc 123", client_name="x")
+
+    def test_rejects_special_chars(self) -> None:
+        with pytest.raises(ValueError):
+            IdPM2MClientCreate(client_id="abc$123", client_name="x")
+
+    def test_rejects_control_chars(self) -> None:
+        with pytest.raises(ValueError):
+            IdPM2MClientCreate(client_id="abc\x00123", client_name="x")
+
+
+class TestCollectionName:
+    """Sanity check that service writes to the right collection."""
+
+    def test_collection_name_is_idp_m2m_clients(self) -> None:
+        assert COLLECTION_NAME == "idp_m2m_clients"


### PR DESCRIPTION
## Summary

Closes #851. Adds admin endpoints under `/api/iam/m2m-clients` that let operators register M2M `client_id` values and their group mappings by writing directly to the `idp_m2m_clients` collection, without requiring an IdP Admin API token (e.g., `OKTA_API_TOKEN`).

This closes the gap where every existing M2M management route returns 503 when `OKTA_API_TOKEN` / `AUTH0_*` credentials are unavailable, which is common in enterprise IdP tenants where Admin API access is gated behind approval processes.

## What changed

New endpoints:

| Method | Path | Auth | Behavior |
|--------|------|------|----------|
| POST   | `/api/iam/m2m-clients` | admin | 201 on success, 409 on duplicate `client_id` |
| GET    | `/api/iam/m2m-clients` | any authenticated | Paginated (`limit`/`skip`/`provider`) |
| GET    | `/api/iam/m2m-clients/{id}` | any authenticated | 404 on missing |
| PATCH  | `/api/iam/m2m-clients/{id}` | admin | 403 for IdP-synced records, partial update via `exclude_unset` |
| DELETE | `/api/iam/m2m-clients/{id}` | admin | 403 for IdP-synced records |

Key design decisions:

- **`provider: \"manual\"` ownership guard**: records created by this API are tagged manual and cannot be overwritten by IdP sync. Mutations only succeed on manual records; IdP-synced records return 403.
- **Unique index on `client_id`** created on startup to prevent races on concurrent POSTs.
- **Admin check**: reuses `is_admin` from the shared `nginx_proxied_auth` dependency (permission-based, consistent with `management_routes.py`).
- **Audit logging** on all mutations via `set_audit_action`.
- **Feature flag** `M2M_DIRECT_REGISTRATION_ENABLED` (default `true`) gates both router registration and startup index creation.
- **Prometheus counter** `m2m_management_requests_total{operation, outcome}` for dashboarding and abuse detection.
- **`client_id` regex validator** (`^[A-Za-z0-9_\-.:]{1,256}$`) rejects whitespace / control chars.
- **`created_by` field** captured from the authenticated user for post-hoc accountability.

Design docs: [.scratchpad/issue-851/lld.md](.scratchpad/issue-851/lld.md), [.scratchpad/issue-851/review.md](.scratchpad/issue-851/review.md) (not included in PR).

## Files

**New:**
- `registry/api/m2m_management_routes.py`
- `registry/services/m2m_management_service.py`
- `tests/unit/api/test_m2m_management_routes.py` (21 tests)
- `tests/unit/services/test_m2m_management_service.py` (22 tests)

**Modified:**
- `registry/schemas/idp_m2m_client.py` — added `IdPM2MClientCreate`, `IdPM2MClientPatch`, `M2MClientListResponse`, `MANUAL_PROVIDER`, `created_by` field
- `registry/core/config.py` — added `m2m_direct_registration_enabled` setting
- `registry/main.py` — router registration + startup index creation (both flag-gated)

## Threat model

An admin with access to this API can grant any group name to any `client_id`. The auth server trusts `idp_m2m_clients` during group enrichment, so this equals group-assignment authority for all M2M service accounts. This matches existing risk from `/api/iam/okta/m2m/clients/{id}/groups` PATCH. Mitigations: admin-only mutations, audit log on every mutation with calling identity, `created_by` field, `provider == \"manual\"` guard to prevent overwriting IdP-synced records.

## Test plan

- [x] Unit tests (service): 22 cases covering happy paths, conflict, not-found, immutable, pagination, partial update via `exclude_unset`, `client_id` validation
- [x] Unit tests (router): 21 cases covering auth/admin enforcement, success/error paths, pagination limits, audit side-effects
- [x] Full unit suite: 2081 passed, 11 skipped (no regressions)
- [x] `ruff check` + `ruff format` clean
- [x] `bandit` clean (0 low/med/high)
- [x] `py_compile` clean
- [ ] Manual end-to-end: start stack without `OKTA_API_TOKEN`, POST an M2M client, confirm the record appears in `idp_m2m_clients` and the auth server enriches groups for a token issued against that `client_id`.
- [ ] Integration test against real MongoDB (follow-up recommended)

## Follow-ups (out of scope)

- UI story for an \"M2M Clients\" admin panel
- Migrate older `/api/iam/okta/m2m/*` and `/api/iam/auth0/m2m/*` admin check from the `registry-admins` group literal to `is_admin` for consistency
- Cron-backed reconciliation between `idp_m2m_clients` and the IdP
- `api/registry_client.py` + `api/registry_management.py` CLI wrappers