### PR TITLE
fix: skip CSRF validation for Bearer token clients on toggle endpoints

### DIFF
--- a/registry/api/virtual_server_routes.py
+++ b/registry/api/virtual_server_routes.py
@@ -21,6 +21,7 @@ from fastapi import (
 from pydantic import BaseModel
 
 from ..audit.context import set_audit_action
+from ..auth.csrf import verify_csrf_token_flexible
 from ..auth.dependencies import nginx_proxied_auth
 from ..exceptions import (
     VirtualServerAlreadyExistsError,
@@ -460,6 +461,7 @@ async def toggle_virtual_server(
     request: ToggleVirtualServerRequest,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     vs_path: str = Path(..., description="Virtual server path"),
+    _csrf: Annotated[None, Depends(verify_csrf_token_flexible)] = None,
 ) -> dict:
     """Enable or disable a virtual MCP server.
 

--- a/registry/auth/csrf.py
+++ b/registry/auth/csrf.py
@@ -113,13 +113,21 @@ async def verify_csrf_token_flexible(
     - Form data (for traditional HTML forms)
     - X-CSRF-Token header (for React/SPA applications)
 
+    Skips CSRF validation when no session cookie is present, as the request
+    is from a non-browser client (e.g. Bearer token auth) and CSRF attacks
+    require a browser session with cookies.
+
     Args:
         request: The incoming FastAPI request.
 
     Raises:
-        HTTPException: If the CSRF token is missing, invalid, or the session
-            cookie is not present.
+        HTTPException: If CSRF token is missing or invalid for session-based requests.
     """
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if not session_id:
+        logger.debug("No session cookie present, skipping CSRF check (non-browser client)")
+        return
+
     # Try to get token from header first (for JSON requests)
     csrf_token = request.headers.get("X-CSRF-Token")
 
@@ -129,22 +137,13 @@ async def verify_csrf_token_flexible(
             form_data = await request.form()
             csrf_token = form_data.get("csrf_token")
         except Exception:
-            # Not form data, continue without token
             pass
 
     if not csrf_token:
-        logger.warning("CSRF validation failed: no token provided")
+        logger.warning("CSRF validation failed: no token provided (session-based request)")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="CSRF validation failed: no token provided",
-        )
-
-    session_id = request.cookies.get(settings.session_cookie_name)
-    if not session_id:
-        logger.warning("CSRF validation failed: no session cookie present")
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="CSRF validation failed: no session",
         )
 
     if not validate_csrf_token(csrf_token, session_id):

--- a/tests/unit/auth/test_csrf.py
+++ b/tests/unit/auth/test_csrf.py
@@ -1,0 +1,120 @@
+"""Tests for CSRF token validation with Bearer token bypass."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import HTTPException
+
+from registry.auth.csrf import (
+    generate_csrf_token,
+    verify_csrf_token_flexible,
+)
+
+
+def _make_request(
+    cookies: dict | None = None,
+    headers: dict | None = None,
+    form_data: dict | None = None,
+):
+    """Create a mock Request object with optional cookies, headers, and form data."""
+    request = MagicMock()
+    request.cookies = cookies or {}
+
+    header_dict = headers or {}
+    request.headers = MagicMock()
+    request.headers.get = lambda key, default=None: header_dict.get(key, default)
+
+    request.form = AsyncMock(return_value=form_data or {})
+    return request
+
+
+class TestVerifyCsrfTokenFlexibleBypass:
+    """Tests for the session-cookie-based CSRF bypass."""
+
+    @pytest.mark.asyncio
+    async def test_skip_csrf_when_no_session_cookie(self):
+        """No session cookie means non-browser client, CSRF check is skipped."""
+        request = _make_request(cookies={}, headers={})
+        await verify_csrf_token_flexible(request)
+
+    @pytest.mark.asyncio
+    async def test_skip_csrf_for_bearer_token_client(self):
+        """Bearer token client with no cookies should skip CSRF."""
+        request = _make_request(
+            cookies={},
+            headers={"Authorization": "Bearer eyJhbGciOiJSUzI1NiJ9.test"},
+        )
+        await verify_csrf_token_flexible(request)
+
+
+class TestVerifyCsrfTokenFlexibleEnforcement:
+    """Tests for CSRF enforcement when session cookie is present."""
+
+    @pytest.mark.asyncio
+    async def test_reject_when_session_cookie_but_no_csrf_token(self):
+        """Session cookie present but no CSRF token should return 403."""
+        request = _make_request(
+            cookies={"mcp_gateway_session": "test-session"},
+            headers={},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_csrf_token_flexible(request)
+
+        assert exc_info.value.status_code == 403
+        assert "no token provided" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_reject_when_session_cookie_and_invalid_csrf_token(self):
+        """Session cookie + invalid CSRF token should return 403."""
+        request = _make_request(
+            cookies={"mcp_gateway_session": "test-session"},
+            headers={"X-CSRF-Token": "invalid-token-value"},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_csrf_token_flexible(request)
+
+        assert exc_info.value.status_code == 403
+        assert "invalid token" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_pass_when_session_cookie_and_valid_csrf_header(self):
+        """Session cookie + valid CSRF token in header should pass."""
+        session_id = "test-session-id"
+        csrf_token = generate_csrf_token(session_id)
+
+        request = _make_request(
+            cookies={"mcp_gateway_session": session_id},
+            headers={"X-CSRF-Token": csrf_token},
+        )
+
+        await verify_csrf_token_flexible(request)
+
+    @pytest.mark.asyncio
+    async def test_pass_when_session_cookie_and_valid_csrf_form(self):
+        """Session cookie + valid CSRF token in form data should pass."""
+        session_id = "test-session-id"
+        csrf_token = generate_csrf_token(session_id)
+
+        request = _make_request(
+            cookies={"mcp_gateway_session": session_id},
+            headers={},
+            form_data={"csrf_token": csrf_token},
+        )
+
+        await verify_csrf_token_flexible(request)
+
+    @pytest.mark.asyncio
+    async def test_header_token_takes_precedence_over_form(self):
+        """X-CSRF-Token header should be checked before form data."""
+        session_id = "test-session-id"
+        valid_token = generate_csrf_token(session_id)
+
+        request = _make_request(
+            cookies={"mcp_gateway_session": session_id},
+            headers={"X-CSRF-Token": valid_token},
+            form_data={"csrf_token": "wrong-token"},
+        )
+
+        await verify_csrf_token_flexible(request)


### PR DESCRIPTION
## Summary

Resolves #891

- Skip CSRF validation in `verify_csrf_token_flexible` when no session cookie is present (non-browser clients)
- Add CSRF dependency to virtual server toggle endpoint for consistency across all user-facing toggle endpoints
- Add 7 unit tests covering both the bypass path and enforcement path

## Problem

OAuth M2M Bearer token clients could register agents and skills but could not enable them, because the toggle endpoints required a CSRF token bound to a session cookie that Bearer clients do not have. This blocked any programmatic registration pipeline.

## Fix

Move the session cookie check to the top of `verify_csrf_token_flexible`. If no session cookie is present, the request is from a non-browser client and CSRF protection does not apply (CSRF attacks require a browser session with automatic cookie attachment). Browser/SPA sessions retain full CSRF enforcement.

## Files Changed

| File | Change |
|------|--------|
| `registry/auth/csrf.py` | Early return when no session cookie (core fix) |
| `registry/api/virtual_server_routes.py` | Add CSRF dependency for consistency |
| `tests/unit/auth/test_csrf.py` | 7 new unit tests |

## CSRF Coverage After Fix

| Endpoint | CSRF Depends | Bearer Token Works |
|----------|-------------|-------------------|
| `POST /api/toggle/{service_path}` | Yes | Yes (bypass) |
| `POST /api/servers/toggle` | No | Yes (no CSRF) |
| `POST /api/internal/toggle` | No | N/A (internal auth) |
| `POST /api/agents/{path}/toggle` | Yes | Yes (bypass) |
| `POST /api/skills/{path}/toggle` | Yes | Yes (bypass) |
| `POST /api/virtual-servers/{vs_path}/toggle` | Yes (new) | Yes (bypass) |

## Design Documents

Full design documentation in `.scratchpad/issue-891/`:
- [LLD](.scratchpad/issue-891/lld.md)
- [Expert Review](.scratchpad/issue-891/review.md)
- [Testing Plan](.scratchpad/issue-891/testing.md)

## Test plan

- [x] All 7 new CSRF unit tests pass
- [x] Full test suite passes (2522 passed, 67 skipped, 47.80% coverage)
- [ ] Verify Bearer token toggle works for agents on a live instance
- [ ] Verify Bearer token toggle works for skills on a live instance
- [ ] Verify browser UI toggle still works (CSRF enforced with session cookie)
- [ ] Verify virtual server toggle works for both Bearer and browser clients