### PR TITLE
fix(skills): post-PR-849 follow-ups for auth, service layering, and env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -323,6 +323,43 @@ INITIAL_ADMIN_PASSWORD=your-secure-keycloak-admin-password
 INITIAL_USER_PASSWORD=your-secure-keycloak-user-password
 
 # =============================================================================
+# MCPGW (MCP GATEWAY SERVER) CONFIGURATION
+# =============================================================================
+# These settings configure the MCPGW MCP server that provides tool access
+# to the registry. Required only when running the MCPGW server component.
+
+# **WARNING**: Before enabling OIDC, review the security gaps documented in
+# GitHub issue #895. The M2M token flow does NOT propagate user identity to
+# the registry, which bypasses per-user authorization and audit logging.
+# Do NOT set OIDC_ENABLED=true in any environment until issue #895 is resolved.
+
+# Enable OIDC/OAuth2 authentication for the MCPGW server
+# When true, MCPGW uses Keycloak OAuthProxy for client authentication
+# When false (default), MCPGW uses bearer-token passthrough
+# OIDC_ENABLED=false
+
+# OIDC client credentials (used when OIDC_ENABLED=true)
+# These should match a Keycloak client configured for the MCPGW server
+# OIDC_CLIENT_ID=mcp-gateway-web
+# OIDC_CLIENT_SECRET=your-oidc-client-secret-here
+
+# Keycloak internal URL for server-to-server OIDC communication
+# Used by MCPGW to reach Keycloak within the Docker network
+# KEYCLOAK_INTERNAL_URL=http://keycloak:8080
+
+# M2M (machine-to-machine) client credentials for MCPGW to call registry APIs
+# MCPGW uses these to obtain tokens for authenticated registry API calls
+# M2M_CLIENT_ID=mcp-gateway-m2m
+# M2M_CLIENT_SECRET=your-m2m-client-secret-here
+
+# Base URL where the MCPGW server is reachable (for OAuth redirect URIs)
+# MCPGW_BASE_URL=http://localhost:18003
+
+# Bind host for the MCPGW server
+# Use 127.0.0.1 for local-only access (default), 0.0.0.0 for containers
+# HOST=127.0.0.1
+
+# =============================================================================
 # GATEWAY HOST CONFIGURATION
 # =============================================================================
 

--- a/frontend/src/hooks/useSkills.ts
+++ b/frontend/src/hooks/useSkills.ts
@@ -49,6 +49,8 @@ export const useSkills = (): UseSkillsReturn => {
         allowed_tools: skillInfo.allowed_tools || [],
         requirements: skillInfo.requirements || [],
         metadata: skillInfo.metadata || null,
+        auth_scheme: skillInfo.auth_scheme || 'none',
+        auth_header_name: skillInfo.auth_header_name || undefined,
         num_stars: skillInfo.num_stars || 0,
         status: skillInfo.status || 'active',
         health_status: skillInfo.health_status || 'unknown',

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -301,6 +301,9 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     target_agents: '',  // Raw string, parsed on save
     metadata: '',  // JSON string for custom metadata
     status: 'draft' as 'active' | 'draft' | 'deprecated' | 'beta',
+    auth_scheme: 'none' as 'none' | 'global_credentials' | 'bearer' | 'api_key',
+    auth_credential: '',
+    auth_header_name: '',
   });
   const [skillFormLoading, setSkillFormLoading] = useState(false);
   const [showDeleteSkillConfirm, setShowDeleteSkillConfirm] = useState<string | null>(null);
@@ -1391,6 +1394,9 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         target_agents: (skill.target_agents || []).join(', '),
         metadata: skill.metadata?.extra ? JSON.stringify(skill.metadata.extra, null, 2) : '',
         status: (skill.status || 'active') as 'active' | 'draft' | 'deprecated' | 'beta',
+        auth_scheme: (skill.auth_scheme || 'none') as 'none' | 'global_credentials' | 'bearer' | 'api_key',
+        auth_credential: '',
+        auth_header_name: skill.auth_header_name || '',
       });
     } else {
       // Create mode - reset form
@@ -1407,6 +1413,9 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         target_agents: '',
         metadata: '',
         status: 'draft',
+        auth_scheme: 'none',
+        auth_credential: '',
+        auth_header_name: '',
       });
     }
     setShowSkillModal(true);
@@ -1422,7 +1431,17 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
 
     try {
       setSkillParseLoading(true);
-      const response = await axios.post(`/api/skills/parse-skill-md?url=${encodeURIComponent(skillForm.skill_md_url)}`);
+      const params = new URLSearchParams({ url: skillForm.skill_md_url });
+      if (skillForm.auth_scheme !== 'none') {
+        params.set('auth_scheme', skillForm.auth_scheme);
+      }
+      if (skillForm.auth_credential && skillForm.auth_scheme !== 'none' && skillForm.auth_scheme !== 'global_credentials') {
+        params.set('auth_credential', skillForm.auth_credential);
+      }
+      if (skillForm.auth_header_name && skillForm.auth_scheme === 'api_key') {
+        params.set('auth_header_name', skillForm.auth_header_name);
+      }
+      const response = await axios.post(`/api/skills/parse-skill-md?${params.toString()}`);
       const data = response.data;
 
       if (data.success) {
@@ -1444,7 +1463,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     } finally {
       setSkillParseLoading(false);
     }
-  }, [skillForm.skill_md_url, skillParseLoading, showToast]);
+  }, [skillForm.skill_md_url, skillForm.auth_scheme, skillForm.auth_credential, skillForm.auth_header_name, skillParseLoading, showToast]);
 
   const handleSaveSkill = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
@@ -1476,7 +1495,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         }
       }
 
-      const payload = {
+      const payload: Record<string, any> = {
         name: skillForm.name,
         description: skillForm.description,
         skill_md_url: skillForm.skill_md_url,
@@ -1487,7 +1506,17 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         target_agents: parseTags(skillForm.target_agents),
         metadata: parsedMetadata,
         status: skillForm.status,
+        auth_scheme: skillForm.auth_scheme,
       };
+
+      if (skillForm.auth_scheme !== 'none' && skillForm.auth_scheme !== 'global_credentials') {
+        if (skillForm.auth_credential) {
+          payload.auth_credential = skillForm.auth_credential;
+        }
+        if (skillForm.auth_scheme === 'api_key' && skillForm.auth_header_name) {
+          payload.auth_header_name = skillForm.auth_header_name;
+        }
+      }
 
       if (editingSkill) {
         // Update existing skill
@@ -3486,6 +3515,92 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                   Comma-separated list of compatible coding assistants
                 </p>
               </div>
+
+              {/* Source Authentication */}
+              <div className="border-t border-gray-200 dark:border-gray-600 pt-4 mt-4">
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                  Source Authentication
+                </label>
+                <select
+                  value={skillForm.auth_scheme}
+                  onChange={(e) => {
+                    const newScheme = e.target.value as 'none' | 'global_credentials' | 'bearer' | 'api_key';
+                    setSkillForm(prev => ({
+                      ...prev,
+                      auth_scheme: newScheme,
+                      auth_credential: (newScheme === 'none' || newScheme === 'global_credentials') ? '' : prev.auth_credential,
+                      auth_header_name: newScheme === 'api_key' ? prev.auth_header_name : '',
+                    }));
+                  }}
+                  className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-amber-500 focus:border-amber-500"
+                >
+                  <option value="none">None (public repo, no auth)</option>
+                  <option value="global_credentials">Use global credentials (registry PAT)</option>
+                  <option value="bearer">Bearer token (per-skill)</option>
+                  <option value="api_key">API key (per-skill, custom header)</option>
+                </select>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  How the registry authenticates when fetching SKILL.md from the source
+                </p>
+                {skillAutoFill && skillForm.auth_scheme === 'global_credentials' && skillForm.skill_md_url && (
+                  <button
+                    type="button"
+                    onClick={handleParseSkillMd}
+                    disabled={skillParseLoading}
+                    className="mt-2 px-3 py-1.5 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-md transition-colors"
+                  >
+                    {skillParseLoading ? 'Parsing...' : 'Re-parse with global credentials'}
+                  </button>
+                )}
+              </div>
+
+              {(skillForm.auth_scheme === 'bearer' || skillForm.auth_scheme === 'api_key') && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                    {skillForm.auth_scheme === 'bearer' ? 'Bearer Token' : 'API Key'} *
+                  </label>
+                  <div className="flex space-x-2">
+                    <input
+                      type="password"
+                      value={skillForm.auth_credential}
+                      onChange={(e) => setSkillForm(prev => ({ ...prev, auth_credential: e.target.value }))}
+                      className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-amber-500 focus:border-amber-500"
+                      placeholder={editingSkill ? 'Leave blank to keep existing credential' : (skillForm.auth_scheme === 'bearer' ? 'Enter bearer token (e.g., ghp_...)' : 'Enter API key')}
+                    />
+                    {skillAutoFill && skillForm.skill_md_url && skillForm.auth_credential && (
+                      <button
+                        type="button"
+                        onClick={handleParseSkillMd}
+                        disabled={skillParseLoading}
+                        className="px-3 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed rounded-md transition-colors whitespace-nowrap"
+                      >
+                        {skillParseLoading ? 'Parsing...' : 'Re-parse'}
+                      </button>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    Encrypted before storage. Never displayed after saving.
+                  </p>
+                </div>
+              )}
+
+              {skillForm.auth_scheme === 'api_key' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+                    Header Name
+                  </label>
+                  <input
+                    type="text"
+                    value={skillForm.auth_header_name}
+                    onChange={(e) => setSkillForm(prev => ({ ...prev, auth_header_name: e.target.value }))}
+                    className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-amber-500 focus:border-amber-500"
+                    placeholder="PRIVATE-TOKEN"
+                  />
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    HTTP header name for the API key (default: PRIVATE-TOKEN)
+                  </p>
+                </div>
+              )}
 
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -54,6 +54,8 @@ export interface Skill {
   requirements?: SkillRequirement[];
   metadata?: SkillMetadata | null;
   repository_url?: string;
+  auth_scheme?: 'none' | 'global_credentials' | 'bearer' | 'api_key';
+  auth_header_name?: string;
   num_stars?: number;
   status?: 'active' | 'draft' | 'deprecated' | 'beta';
   health_status?: 'healthy' | 'unhealthy' | 'unknown';

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -49,10 +49,17 @@ from ..schemas.skill_models import (
     ToolValidationResult,
     VisibilityEnum,
 )
-from ..services.github_auth import github_auth_provider as _github_auth
+from ..exceptions import (
+    SkillContentFetchError,
+    SkillContentSSRFError,
+    SkillContentTooLargeError,
+)
 from ..services.skill_service import (
     _build_fetch_headers,
+    _check_drift_inline,
+    _decrypt_skill_auth,
     _discover_skill_resources,
+    _fetch_authenticated_content,
     _is_safe_url,
     get_skill_service,
 )
@@ -492,56 +499,73 @@ async def get_skill_content(
             detail="No SKILL.md URL configured for this skill",
         )
 
-    if resource is not None:
-        manifest = skill.resource_manifest
-        if not manifest:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="No resource manifest available for this skill",
-            )
-        all_resources = manifest.references + manifest.scripts + manifest.agents + manifest.assets
-        matched = [r for r in all_resources if r.path == resource]
-        if not matched:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Resource '{resource}' not found in manifest",
+    try:
+        if resource is not None:
+            manifest = skill.resource_manifest
+            if not manifest:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="No resource manifest available for this skill",
+                )
+            all_resources = manifest.references + manifest.scripts + manifest.agents + manifest.assets
+            matched = [r for r in all_resources if r.path == resource]
+            if not matched:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Resource '{resource}' not found in manifest",
+                )
+
+            from ..utils.url_utils import derive_resource_url
+
+            resource_url = derive_resource_url(str(raw_url), resource)
+            response = await _fetch_authenticated_content(
+                resource_url, skill, max_size=MAX_RESOURCE_SIZE,
             )
 
-        from ..utils.url_utils import derive_resource_url
+            drift_task = asyncio.create_task(
+                _check_drift_inline(service, normalized_path, skill, resource, response.content)
+            )
+            drift_task.add_done_callback(_log_task_exception)
 
-        resource_url = derive_resource_url(str(raw_url), resource)
-        response = await _fetch_authenticated_content(
-            resource_url, skill, max_size=MAX_RESOURCE_SIZE,
-        )
+            return {
+                "content": response.text,
+                "path": resource,
+                "type": matched[0].type,
+                "url": resource_url,
+            }
+
+        response = await _fetch_authenticated_content(str(raw_url), skill)
 
         drift_task = asyncio.create_task(
-            _check_drift_inline(service, normalized_path, skill, resource, response.content)
+            _check_drift_inline(service, normalized_path, skill, "SKILL.md", response.content)
         )
         drift_task.add_done_callback(_log_task_exception)
 
-        return {
+        result: dict[str, Any] = {
             "content": response.text,
-            "path": resource,
-            "type": matched[0].type,
-            "url": resource_url,
+            "url": str(raw_url),
         }
+        if skill.resource_manifest:
+            result["resource_manifest"] = skill.resource_manifest.model_dump()
+        if skill.content_integrity:
+            result["drift_detected"] = skill.content_integrity.drift_detected
+        return result
 
-    response = await _fetch_authenticated_content(str(raw_url), skill)
-
-    drift_task = asyncio.create_task(
-        _check_drift_inline(service, normalized_path, skill, "SKILL.md", response.content)
-    )
-    drift_task.add_done_callback(_log_task_exception)
-
-    result: dict[str, Any] = {
-        "content": response.text,
-        "url": str(raw_url),
-    }
-    if skill.resource_manifest:
-        result["resource_manifest"] = skill.resource_manifest.model_dump()
-    if skill.content_integrity:
-        result["drift_detected"] = skill.content_integrity.drift_detected
-    return result
+    except SkillContentSSRFError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"URL failed SSRF validation: {e.url}",
+        )
+    except SkillContentTooLargeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=str(e),
+        )
+    except SkillContentFetchError as e:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(e),
+        )
 
 
 @router.get(
@@ -914,12 +938,12 @@ async def update_skill(
     # Encrypt credential if provided on update
     auth_credential = updates.pop("auth_credential", None)
     auth_scheme = updates.get("auth_scheme", existing.auth_scheme)
-    if auth_credential and auth_scheme != "none":
+    if auth_credential and auth_scheme not in ("none", "global_credentials"):
         from ..utils.credential_encryption import encrypt_credential
 
         updates["auth_credential_encrypted"] = encrypt_credential(auth_credential)
         updates["credential_updated_at"] = datetime.now(UTC).isoformat()
-    elif auth_scheme == "none":
+    elif auth_scheme in ("none", "global_credentials"):
         updates["auth_credential_encrypted"] = None
         updates["auth_header_name"] = None
         updates["credential_updated_at"] = None
@@ -1096,87 +1120,6 @@ def _log_task_exception(task: asyncio.Task) -> None:
         logger.error("Background task failed: %s", exc, exc_info=exc)
 
 
-def _decrypt_skill_auth(
-    skill: SkillCard,
-) -> tuple[str, str | None, str | None]:
-    """Extract and decrypt authentication details from a skill.
-
-    Returns (auth_scheme, plaintext_credential_or_none, auth_header_name).
-    """
-    auth_scheme = getattr(skill, "auth_scheme", "none")
-    encrypted_cred = getattr(skill, "auth_credential_encrypted", None)
-    credential = None
-    if auth_scheme != "none" and encrypted_cred:
-        from ..utils.credential_encryption import decrypt_credential
-
-        credential = decrypt_credential(encrypted_cred)
-    return auth_scheme, credential, getattr(skill, "auth_header_name", None)
-
-
-async def _fetch_authenticated_content(
-    url: str,
-    skill: SkillCard,
-    *,
-    max_size: int | None = None,
-    timeout: float = 30.0,
-) -> "httpx.Response":
-    """Fetch content from a URL using the skill's encrypted credentials.
-
-    Handles SSRF validation, credential decryption, header building,
-    and redirect safety checks. Raises HTTPException on failure.
-    """
-    import httpx as _httpx
-
-    if not _is_safe_url(url):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="URL failed SSRF validation - private/internal addresses are not allowed",
-        )
-
-    auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
-    fetch_url, fetch_headers = _build_fetch_headers(url, auth_scheme, credential, auth_header_name)
-
-    # Merge in GitHub App / token auth headers so public-repo fetches
-    # benefit from the higher rate-limit ceiling.  Per-skill credentials
-    # take precedence on key collisions because they are explicitly
-    # configured for this skill's source.
-    github_headers = await _github_auth.get_auth_headers(fetch_url)
-    merged_headers = {**github_headers, **fetch_headers}
-
-    try:
-        async with _httpx.AsyncClient() as client:
-            response = await client.get(
-                fetch_url, headers=merged_headers, follow_redirects=True, timeout=timeout,
-            )
-
-            final_url = str(response.url)
-            if final_url != fetch_url and not _is_safe_url(final_url):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Redirect to unsafe URL blocked: {final_url}",
-                )
-
-            if response.status_code >= 400:
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"Failed to fetch content: HTTP {response.status_code}",
-                )
-
-            if max_size and len(response.content) > max_size:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=f"Content exceeds {max_size // 1024} KB limit",
-                )
-
-            return response
-    except _httpx.RequestError as e:
-        logger.error("Failed to fetch from %s: %s", url, e)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Failed to fetch content: {e}",
-        )
-
-
 def _user_can_access_skill(
     skill: SkillCard,
     user_context: dict,
@@ -1277,82 +1220,3 @@ async def _perform_skill_security_scan_on_registration(
                 logger.error(f"Failed to add security-pending tag: {tag_err}")
 
 
-async def _check_drift_inline(
-    service: "SkillService",
-    skill_path: str,
-    skill: SkillCard,
-    file_path: str,
-    content_bytes: bytes,
-) -> None:
-    """Compare fetched content against the stored integrity baseline.
-
-    Runs as a fire-and-forget background task so it never blocks the
-    content response.  Updates the DB only when a change is detected
-    (or when a previously-drifted file returns to its baseline).
-    """
-    import hashlib
-    from datetime import UTC, datetime
-
-    integrity = skill.content_integrity
-    if not integrity or not integrity.file_hashes:
-        return
-
-    baseline = {fh.path: fh.sha256 for fh in integrity.file_hashes}
-    expected = baseline.get(file_path)
-    if expected is None:
-        return
-
-    actual = hashlib.sha256(content_bytes).hexdigest()
-    file_drifted = actual != expected
-
-    previously_drifted = file_path in (integrity.drifted_files or [])
-    now = datetime.now(UTC).isoformat()
-
-    try:
-        # Fast path: drift state for this file did not change.  Persist
-        # only the last-checked timestamp in a single update so we still
-        # have an audit trail of the verification.
-        if file_drifted == previously_drifted:
-            await service.update_skill(
-                skill_path,
-                {"content_integrity.last_drift_check": now},
-            )
-            return
-
-        current_drifted = list(integrity.drifted_files or [])
-        if file_drifted and file_path not in current_drifted:
-            current_drifted.append(file_path)
-        elif not file_drifted and file_path in current_drifted:
-            current_drifted.remove(file_path)
-
-        # Batch all field-level changes (integrity state + tags) into a
-        # single update_skill() call.  This halves DB round-trips and
-        # avoids interleaving where another task could observe a
-        # half-applied state.  Enable/disable is a separate persistence
-        # path (set_state vs update) and must remain its own call.
-        current_tags = list(skill.tags or [])
-        drift_tag = "content-drifted"
-        if current_drifted and drift_tag not in current_tags:
-            current_tags.append(drift_tag)
-        elif not current_drifted and drift_tag in current_tags:
-            current_tags.remove(drift_tag)
-
-        combined_updates: dict[str, Any] = {
-            "content_integrity.drift_detected": bool(current_drifted),
-            "content_integrity.last_drift_check": now,
-            "content_integrity.drifted_files": current_drifted,
-            "tags": current_tags,
-        }
-        await service.update_skill(skill_path, combined_updates)
-
-        if current_drifted:
-            await service.toggle_skill(skill_path, enabled=False)
-            logger.warning(
-                "Drift detected for %s in skill %s — skill disabled",
-                file_path, skill_path,
-            )
-        else:
-            await service.toggle_skill(skill_path, enabled=True)
-            logger.info("Drift cleared for skill %s — skill re-enabled", skill_path)
-    except Exception:
-        logger.debug("Failed to persist drift state for %s", skill_path, exc_info=True)

--- a/registry/api/skill_routes.py
+++ b/registry/api/skill_routes.py
@@ -210,6 +210,8 @@ async def list_skills(
                 allowed_groups=s.allowed_groups,
                 registry_name=s.registry_name,
                 owner=s.owner,
+                auth_scheme=s.auth_scheme,
+                auth_header_name=s.auth_header_name,
                 num_stars=s.num_stars,
                 health_status=s.health_status,
                 last_checked_time=s.last_checked_time,
@@ -249,15 +251,24 @@ async def list_skills(
 async def parse_skill_md(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     url: str = Query(..., description="URL to SKILL.md file"),
+    auth_scheme: str = Query("none", description="Auth scheme: none, global_credentials, bearer, api_key"),
+    auth_credential: str | None = Query(None, description="Plaintext credential for bearer/api_key"),
+    auth_header_name: str | None = Query(None, description="Custom header name for api_key scheme"),
 ) -> dict:
     """Parse SKILL.md content and extract metadata.
 
     Returns name, description, version, and tags from the SKILL.md file.
     Useful for auto-populating the skill registration form.
+    Accepts optional auth parameters for parsing private repo SKILL.md files.
     """
     service = get_skill_service()
     try:
-        result = await service.parse_skill_md(url)
+        result = await service.parse_skill_md(
+            url,
+            auth_scheme=auth_scheme,
+            auth_credential=auth_credential,
+            auth_header_name=auth_header_name,
+        )
         return {
             "success": True,
             "name": result.get("name"),

--- a/registry/exceptions.py
+++ b/registry/exceptions.py
@@ -173,6 +173,50 @@ class VirtualServerServiceError(VirtualServerRegistryError):
     pass
 
 
+# Skill content fetch exceptions
+
+
+class SkillContentFetchError(SkillRegistryError):
+    """Failed to fetch skill content from a remote URL."""
+
+    def __init__(
+        self,
+        url: str,
+        reason: str,
+        status_code: int = 502,
+    ):
+        self.url = url
+        self.reason = reason
+        self.status_code = status_code
+        super().__init__(f"Failed to fetch content from '{url}': {reason}")
+
+
+class SkillContentSSRFError(SkillRegistryError):
+    """URL failed SSRF validation."""
+
+    def __init__(
+        self,
+        url: str,
+    ):
+        self.url = url
+        super().__init__(
+            f"URL failed SSRF validation: {url}"
+        )
+
+
+class SkillContentTooLargeError(SkillRegistryError):
+    """Fetched content exceeds the size limit."""
+
+    def __init__(
+        self,
+        max_size: int,
+    ):
+        self.max_size = max_size
+        super().__init__(
+            f"Content exceeds {max_size // 1024} KB limit"
+        )
+
+
 # Registration Gate exceptions
 
 

--- a/registry/schemas/skill_models.py
+++ b/registry/schemas/skill_models.py
@@ -332,6 +332,14 @@ class SkillInfo(BaseModel):
     owner: str | None = Field(
         None, description="Owner email/username for private visibility access control"
     )
+    auth_scheme: Literal["none", "global_credentials", "bearer", "api_key"] = Field(
+        default="none",
+        description="Auth scheme for fetching SKILL.md: none, global_credentials, bearer, api_key",
+    )
+    auth_header_name: str | None = Field(
+        None,
+        description="Custom header name for credential (default: Authorization for bearer, PRIVATE-TOKEN for api_key)",
+    )
     num_stars: float = Field(default=0.0, ge=0.0, le=5.0, description="Average rating (1-5 stars)")
     health_status: Literal["healthy", "unhealthy", "unknown"] = Field(
         default="unknown", description="Health status from last SKILL.md accessibility check"

--- a/registry/schemas/skill_models.py
+++ b/registry/schemas/skill_models.py
@@ -211,9 +211,9 @@ class SkillCard(BaseModel):
     # Literal keeps the wire-format strings compatible with existing clients
     # while rejecting unsupported schemes at validation time.  Adding a new
     # scheme requires updating both this list and SkillRegistrationRequest.
-    auth_scheme: Literal["none", "bearer", "api_key"] = Field(
+    auth_scheme: Literal["none", "global_credentials", "bearer", "api_key"] = Field(
         default="none",
-        description="Auth scheme for fetching SKILL.md: none, bearer, api_key",
+        description="Auth scheme for fetching SKILL.md: none, global_credentials, bearer, api_key",
     )
     auth_credential_encrypted: str | None = Field(
         None,
@@ -377,9 +377,9 @@ class SkillRegistrationRequest(BaseModel):
         default="draft",
         description="Lifecycle status (default: draft). Allowed: active, deprecated, draft, beta",
     )
-    auth_scheme: Literal["none", "bearer", "api_key"] = Field(
+    auth_scheme: Literal["none", "global_credentials", "bearer", "api_key"] = Field(
         default="none",
-        description="Auth scheme for fetching SKILL.md from private repos: none, bearer, api_key",
+        description="Auth scheme for fetching SKILL.md from private repos: none, global_credentials, bearer, api_key",
     )
     auth_credential: str | None = Field(
         None,

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -383,6 +383,9 @@ async def _validate_skill_md_url(
 
 async def _parse_skill_md_content(
     url: str,
+    auth_scheme: str = "none",
+    auth_credential: str | None = None,
+    auth_header_name: str | None = None,
 ) -> dict[str, Any]:
     """Parse SKILL.md content and extract metadata.
 
@@ -429,10 +432,18 @@ async def _parse_skill_md_content(
 
     try:
         async with httpx.AsyncClient() as client:
-            # Fetch from raw URL with GitHub auth if applicable
-            headers = await _github_auth.get_auth_headers(raw_url_str)
+            fetch_url, fetch_headers = _build_fetch_headers(
+                raw_url_str, auth_scheme, auth_credential, auth_header_name,
+            )
+            if auth_scheme == "none":
+                headers = fetch_headers
+            elif auth_scheme == "global_credentials":
+                headers = await _github_auth.get_auth_headers(fetch_url)
+            else:
+                github_headers = await _github_auth.get_auth_headers(fetch_url)
+                headers = {**github_headers, **fetch_headers}
             response = await client.get(
-                raw_url_str, headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
+                fetch_url, headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
 
             # SSRF protection: validate final URL after redirects
@@ -1139,6 +1150,8 @@ class SkillService:
                 allowed_groups=s.allowed_groups,
                 registry_name=s.registry_name,
                 owner=s.owner,
+                auth_scheme=s.auth_scheme,
+                auth_header_name=s.auth_header_name,
                 num_stars=s.num_stars,
                 health_status=s.health_status,
                 last_checked_time=s.last_checked_time,
@@ -1293,16 +1306,27 @@ class SkillService:
     async def parse_skill_md(
         self,
         url: str,
+        auth_scheme: str = "none",
+        auth_credential: str | None = None,
+        auth_header_name: str | None = None,
     ) -> dict[str, Any]:
         """Parse SKILL.md content and extract metadata.
 
         Args:
             url: URL to SKILL.md file
+            auth_scheme: Auth scheme (none, global_credentials, bearer, api_key)
+            auth_credential: Plaintext credential for bearer/api_key
+            auth_header_name: Custom header name for api_key scheme
 
         Returns:
             Dict with parsed metadata (name, description, version, tags)
         """
-        return await _parse_skill_md_content(url)
+        return await _parse_skill_md_content(
+            url,
+            auth_scheme=auth_scheme,
+            auth_credential=auth_credential,
+            auth_header_name=auth_header_name,
+        )
 
     async def check_skill_health(
         self,

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -182,7 +182,7 @@ def _build_fetch_headers(
     headers: dict[str, str] = {}
     fetch_url = url
 
-    if auth_scheme == "none" or not auth_credential:
+    if auth_scheme in ("none", "global_credentials") or not auth_credential:
         return fetch_url, headers
 
     if auth_scheme == "bearer":
@@ -606,7 +606,7 @@ async def _check_skill_health(
 
     # Build auth headers for private repos
     credential = None
-    if auth_scheme != "none" and auth_credential_encrypted:
+    if auth_scheme not in ("none", "global_credentials") and auth_credential_encrypted:
         from ..utils.credential_encryption import decrypt_credential
 
         credential = decrypt_credential(auth_credential_encrypted)
@@ -618,7 +618,7 @@ async def _check_skill_health(
     try:
         async with httpx.AsyncClient() as client:
             github_headers = await _github_auth.get_auth_headers(str(url))
-            merged_headers = {**fetch_headers, **github_headers}
+            merged_headers = {**github_headers, **fetch_headers}
             response = await client.head(
                 fetch_url, headers=merged_headers,
                 follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
@@ -673,44 +673,48 @@ async def _compute_content_integrity(
     """
     file_hashes: list[FileHash] = []
 
-    async def _hash_url(url: str, rel_path: str) -> FileHash | None:
+    async def _hash_url(
+        client: httpx.AsyncClient,
+        url: str,
+        rel_path: str,
+    ) -> FileHash | None:
         fetch_url, fetch_headers = _build_fetch_headers(
             url, auth_scheme, auth_credential, auth_header_name,
         )
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(
-                    fetch_url, headers=fetch_headers,
-                    follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
-                )
-                if resp.status_code >= 400:
-                    logger.warning("Integrity fetch failed for %s: HTTP %s", rel_path, resp.status_code)
-                    return None
-                digest = hashlib.sha256(resp.content).hexdigest()
-                return FileHash(path=rel_path, sha256=digest, size_bytes=len(resp.content))
+            resp = await client.get(
+                fetch_url, headers=fetch_headers,
+                follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
+            )
+            if resp.status_code >= 400:
+                logger.warning("Integrity fetch failed for %s: HTTP %s", rel_path, resp.status_code)
+                return None
+            digest = hashlib.sha256(resp.content).hexdigest()
+            return FileHash(path=rel_path, sha256=digest, size_bytes=len(resp.content))
         except httpx.RequestError as e:
             logger.warning("Integrity fetch error for %s: %s", rel_path, e)
             return None
 
-    skill_md_hash = await _hash_url(skill_md_url, "SKILL.md")
-    if not skill_md_hash:
-        return None
-    file_hashes.append(skill_md_hash)
+    async with httpx.AsyncClient() as client:
+        skill_md_hash = await _hash_url(client, skill_md_url, "SKILL.md")
+        if not skill_md_hash:
+            return None
+        file_hashes.append(skill_md_hash)
 
-    if resource_manifest:
-        from ..utils.url_utils import derive_resource_url
+        if resource_manifest:
+            from ..utils.url_utils import derive_resource_url
 
-        all_resources = (
-            resource_manifest.references
-            + resource_manifest.scripts
-            + resource_manifest.agents
-            + resource_manifest.assets
-        )
-        for res in all_resources:
-            res_url = derive_resource_url(skill_md_url, res.path)
-            fh = await _hash_url(res_url, res.path)
-            if fh:
-                file_hashes.append(fh)
+            all_resources = (
+                resource_manifest.references
+                + resource_manifest.scripts
+                + resource_manifest.agents
+                + resource_manifest.assets
+            )
+            for res in all_resources:
+                res_url = derive_resource_url(skill_md_url, res.path)
+                fh = await _hash_url(client, res_url, res.path)
+                if fh:
+                    file_hashes.append(fh)
 
     sorted_entries = sorted(file_hashes, key=lambda h: h.path)
     composite_input = "".join(f"{h.path}:{h.sha256}" for h in sorted_entries)
@@ -721,6 +725,159 @@ async def _compute_content_integrity(
         file_hashes=file_hashes,
         computed_at=datetime.now(UTC),
     )
+
+
+def _decrypt_skill_auth(
+    skill: SkillCard,
+) -> tuple[str, str | None, str | None]:
+    """Extract and decrypt authentication details from a skill.
+
+    Returns (auth_scheme, plaintext_credential_or_none, auth_header_name).
+    """
+    auth_scheme = getattr(skill, "auth_scheme", "none")
+    encrypted_cred = getattr(skill, "auth_credential_encrypted", None)
+    credential = None
+    if auth_scheme not in ("none", "global_credentials") and encrypted_cred:
+        from ..utils.credential_encryption import decrypt_credential
+
+        credential = decrypt_credential(encrypted_cred)
+    return auth_scheme, credential, getattr(skill, "auth_header_name", None)
+
+
+async def _fetch_authenticated_content(
+    url: str,
+    skill: SkillCard,
+    *,
+    max_size: int | None = None,
+    timeout: float = 30.0,
+) -> "httpx.Response":
+    """Fetch content from a URL using the skill's encrypted credentials.
+
+    Handles SSRF validation, credential decryption, header building,
+    and redirect safety checks.
+
+    Raises:
+        SkillContentSSRFError: URL or redirect target fails SSRF check.
+        SkillContentFetchError: Upstream returned an HTTP error or was unreachable.
+        SkillContentTooLargeError: Response body exceeds max_size.
+    """
+    from ..exceptions import (
+        SkillContentFetchError,
+        SkillContentSSRFError,
+        SkillContentTooLargeError,
+    )
+
+    if not _is_safe_url(url):
+        raise SkillContentSSRFError(url)
+
+    auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
+    fetch_url, fetch_headers = _build_fetch_headers(
+        url, auth_scheme, credential, auth_header_name,
+    )
+
+    if auth_scheme == "none":
+        merged_headers = fetch_headers
+    elif auth_scheme == "global_credentials":
+        merged_headers = await _github_auth.get_auth_headers(fetch_url)
+    else:
+        github_headers = await _github_auth.get_auth_headers(fetch_url)
+        merged_headers = {**github_headers, **fetch_headers}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                fetch_url,
+                headers=merged_headers,
+                follow_redirects=True,
+                timeout=timeout,
+            )
+
+            final_url = str(response.url)
+            if final_url != fetch_url and not _is_safe_url(final_url):
+                raise SkillContentSSRFError(final_url)
+
+            if response.status_code >= 400:
+                raise SkillContentFetchError(
+                    url, f"HTTP {response.status_code}",
+                )
+
+            if max_size and len(response.content) > max_size:
+                raise SkillContentTooLargeError(max_size)
+
+            return response
+    except httpx.RequestError as e:
+        logger.error("Failed to fetch from %s: %s", url, e)
+        raise SkillContentFetchError(url, str(e))
+
+
+async def _check_drift_inline(
+    service: "SkillService",
+    skill_path: str,
+    skill: SkillCard,
+    file_path: str,
+    content_bytes: bytes,
+) -> None:
+    """Compare fetched content against the stored integrity baseline.
+
+    Runs as a fire-and-forget background task so it never blocks the
+    content response.  Updates the DB only when a change is detected
+    (or when a previously-drifted file returns to its baseline).
+    """
+    integrity = skill.content_integrity
+    if not integrity or not integrity.file_hashes:
+        return
+
+    baseline = {fh.path: fh.sha256 for fh in integrity.file_hashes}
+    expected = baseline.get(file_path)
+    if expected is None:
+        return
+
+    actual = hashlib.sha256(content_bytes).hexdigest()
+    file_drifted = actual != expected
+
+    previously_drifted = file_path in (integrity.drifted_files or [])
+    now = datetime.now(UTC).isoformat()
+
+    try:
+        if file_drifted == previously_drifted:
+            await service.update_skill(
+                skill_path,
+                {"content_integrity.last_drift_check": now},
+            )
+            return
+
+        current_drifted = list(integrity.drifted_files or [])
+        if file_drifted and file_path not in current_drifted:
+            current_drifted.append(file_path)
+        elif not file_drifted and file_path in current_drifted:
+            current_drifted.remove(file_path)
+
+        current_tags = list(skill.tags or [])
+        drift_tag = "content-drifted"
+        if current_drifted and drift_tag not in current_tags:
+            current_tags.append(drift_tag)
+        elif not current_drifted and drift_tag in current_tags:
+            current_tags.remove(drift_tag)
+
+        combined_updates: dict[str, Any] = {
+            "content_integrity.drift_detected": bool(current_drifted),
+            "content_integrity.last_drift_check": now,
+            "content_integrity.drifted_files": current_drifted,
+            "tags": current_tags,
+        }
+        await service.update_skill(skill_path, combined_updates)
+
+        if current_drifted:
+            await service.toggle_skill(skill_path, enabled=False)
+            logger.warning(
+                "Drift detected for %s in skill %s, skill disabled",
+                file_path, skill_path,
+            )
+        else:
+            await service.toggle_skill(skill_path, enabled=True)
+            logger.info("Drift cleared for skill %s, skill re-enabled", skill_path)
+    except Exception:
+        logger.debug("Failed to persist drift state for %s", skill_path, exc_info=True)
 
 
 def _build_skill_card(
@@ -768,7 +925,7 @@ def _build_skill_card(
     credential_updated_at = None
     if (
         getattr(request, "auth_credential", None)
-        and getattr(request, "auth_scheme", "none") != "none"
+        and getattr(request, "auth_scheme", "none") not in ("none", "global_credentials")
     ):
         from ..utils.credential_encryption import encrypt_credential
 

--- a/tests/unit/api/test_skill_inline_content.py
+++ b/tests/unit/api/test_skill_inline_content.py
@@ -236,7 +236,7 @@ class TestSkillInlineContent:
         mock_async_client.get = AsyncMock(return_value=mock_response)
 
         with (
-            patch("registry.api.skill_routes._is_safe_url", return_value=True),
+            patch("registry.services.skill_service._is_safe_url", return_value=True),
             patch("httpx.AsyncClient", return_value=mock_async_client),
         ):
             # Act
@@ -271,7 +271,7 @@ class TestSkillInlineContent:
         mock_async_client.get = AsyncMock(return_value=mock_response)
 
         with (
-            patch("registry.api.skill_routes._is_safe_url", return_value=True),
+            patch("registry.services.skill_service._is_safe_url", return_value=True),
             patch("httpx.AsyncClient", return_value=mock_async_client),
         ):
             # Act

--- a/tests/unit/test_skill_routes_github_auth.py
+++ b/tests/unit/test_skill_routes_github_auth.py
@@ -3,33 +3,39 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+def _make_mock_skill(
+    auth_scheme: str = "none",
+) -> MagicMock:
+    """Create a mock SkillCard with sensible defaults."""
+    mock_skill = MagicMock()
+    mock_skill.skill_md_raw_url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+    mock_skill.skill_md_url = "https://github.com/o/r/blob/main/SKILL.md"
+    mock_skill.skill_md_content = None
+    mock_skill.content_integrity = None
+    mock_skill.resource_manifest = None
+    mock_skill.tags = []
+    mock_skill.auth_scheme = auth_scheme
+    mock_skill.auth_credential_encrypted = None
+    mock_skill.auth_header_name = None
+    return mock_skill
+
+
 class TestGetSkillContentAuth:
     """Tests for auth header injection in get_skill_content."""
 
-    @patch("registry.api.skill_routes._github_auth")
-    @patch("registry.api.skill_routes._is_safe_url", return_value=True)
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
     @patch("registry.api.skill_routes._user_can_access_skill", return_value=True)
     @patch("registry.api.skill_routes.get_skill_service")
-    async def test_auth_headers_passed_to_get(
+    async def test_global_credentials_sends_github_headers(
         self, mock_get_service, mock_access, mock_safe_url, mock_auth
     ):
-        """Auth headers from GitHubAuthProvider are passed to httpx.get."""
-        mock_auth.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer ghp_test"})
+        """auth_scheme=global_credentials sends global GitHub auth headers."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_test"},
+        )
 
-        # Mock skill service to return a skill with raw URL
-        mock_skill = MagicMock()
-        mock_skill.skill_md_raw_url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
-        mock_skill.skill_md_url = "https://github.com/o/r/blob/main/SKILL.md"
-        mock_skill.skill_md_content = None  # Force httpx path, not inline content
-        # Drift-detection guard in get_skill_content() reads .content_integrity;
-        # MagicMock's default truthy attribute would otherwise trigger 409.
-        mock_skill.content_integrity = None
-        mock_skill.resource_manifest = None
-        mock_skill.tags = []
-        mock_skill.auth_scheme = "none"
-        mock_skill.auth_credential_encrypted = None
-        mock_skill.auth_header_name = None
-
+        mock_skill = _make_mock_skill(auth_scheme="global_credentials")
         mock_service = AsyncMock()
         mock_service.get_skill.return_value = mock_skill
         mock_get_service.return_value = mock_service
@@ -51,8 +57,50 @@ class TestGetSkillContentAuth:
             result = await get_skill_content(
                 user_context={"sub": "test-user"},
                 skill_path="test/skill",
+                resource=None,
             )
 
             call_kwargs = mock_client.get.call_args
             assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
             assert result["content"] == "# My Skill"
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    @patch("registry.api.skill_routes._user_can_access_skill", return_value=True)
+    @patch("registry.api.skill_routes.get_skill_service")
+    async def test_none_scheme_sends_no_auth_headers(
+        self, mock_get_service, mock_access, mock_safe_url, mock_auth
+    ):
+        """auth_scheme=none sends no auth headers at all."""
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_should_not_appear"},
+        )
+
+        mock_skill = _make_mock_skill(auth_scheme="none")
+        mock_service = AsyncMock()
+        mock_service.get_skill.return_value = mock_skill
+        mock_get_service.return_value = mock_service
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "# Public Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.api.skill_routes import get_skill_content
+
+            result = await get_skill_content(
+                user_context={"sub": "test-user"},
+                skill_path="test/skill",
+                resource=None,
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {}
+            assert result["content"] == "# Public Skill"

--- a/tests/unit/test_skill_service_github_auth.py
+++ b/tests/unit/test_skill_service_github_auth.py
@@ -67,7 +67,7 @@ class TestParseSkillMdContentAuth:
     @patch("registry.services.skill_service._is_safe_url", return_value=True)
     @patch("registry.services.skill_service.translate_skill_url")
     async def test_auth_headers_passed_to_get(self, mock_translate, mock_safe_url, mock_auth):
-        """Auth headers are passed to httpx.get when fetching SKILL.md content."""
+        """global_credentials sends GitHub auth headers when parsing SKILL.md."""
         mock_auth.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer ghp_test"})
         mock_translate.return_value = (
             "https://github.com/o/r/blob/main/SKILL.md",
@@ -89,10 +89,48 @@ class TestParseSkillMdContentAuth:
 
             from registry.services.skill_service import _parse_skill_md_content
 
-            result = await _parse_skill_md_content("https://github.com/o/r/blob/main/SKILL.md")
+            result = await _parse_skill_md_content(
+                "https://github.com/o/r/blob/main/SKILL.md",
+                auth_scheme="global_credentials",
+            )
 
             call_kwargs = mock_client.get.call_args
             assert call_kwargs.kwargs.get("headers") == {"Authorization": "Bearer ghp_test"}
+            assert result["name"] == "test"
+
+    @patch("registry.services.skill_service._github_auth")
+    @patch("registry.services.skill_service._is_safe_url", return_value=True)
+    @patch("registry.services.skill_service.translate_skill_url")
+    async def test_none_scheme_sends_no_headers(self, mock_translate, mock_safe_url, mock_auth):
+        """auth_scheme=none sends no auth headers when parsing SKILL.md."""
+        mock_auth.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer ghp_should_not_appear"})
+        mock_translate.return_value = (
+            "https://github.com/o/r/blob/main/SKILL.md",
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"---\nname: test\n---\n# Test Skill"
+        mock_response.text = "---\nname: test\n---\n# Test Skill"
+        mock_response.url = "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md"
+
+        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.get.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            from registry.services.skill_service import _parse_skill_md_content
+
+            result = await _parse_skill_md_content(
+                "https://github.com/o/r/blob/main/SKILL.md",
+                auth_scheme="none",
+            )
+
+            call_kwargs = mock_client.get.call_args
+            assert call_kwargs.kwargs.get("headers") == {}
             assert result["name"] == "test"
 
 


### PR DESCRIPTION
## Summary

Post-merge follow-up items from PR #849 (auth credentials, multi-file support, drift detection):

- Fix failing `test_skill_routes_github_auth.py` (missing `resource=None` in direct function call)
- Share single `httpx.AsyncClient` in `_compute_content_integrity()` instead of creating one per file
- Document MCPGW OIDC env vars in `.env.example` with security warning pointing to #895
- Move business logic (`_decrypt_skill_auth`, `_fetch_authenticated_content`, `_check_drift_inline`) from routes to service layer with new service exceptions (`SkillContentFetchError`, `SkillContentSSRFError`, `SkillContentTooLargeError`)
- Add `global_credentials` auth scheme so `auth_scheme=none` truly sends no auth (fixes global PAT leak to non-GitHub hosts)
- Add per-skill auth UI to the skill registration/edit form (Source Authentication dropdown, conditional credential/header fields, Re-parse button for private repos)
- Make `parse-skill-md` endpoint credential-aware so private repo SKILL.md files can be auto-parsed during registration
- Add `auth_scheme` and `auth_header_name` to `SkillInfo` so the list API returns them for edit modal population

## Changes by file

| File | What changed |
|------|-------------|
| `.env.example` | Added MCPGW OIDC env vars with security warning about #895 |
| `registry/exceptions.py` | Added `SkillContentFetchError`, `SkillContentSSRFError`, `SkillContentTooLargeError` |
| `registry/schemas/skill_models.py` | Added `global_credentials` to auth_scheme Literal, added auth fields to `SkillInfo` |
| `registry/services/skill_service.py` | Moved `_decrypt_skill_auth`, `_fetch_authenticated_content`, `_check_drift_inline` from routes; shared httpx client in integrity computation; credential-aware `_parse_skill_md_content`; auth fields in SkillInfo construction |
| `registry/api/skill_routes.py` | Removed moved functions, added service exception handling, auth fields in SkillInfo fast path, auth params on parse endpoint |
| `frontend/src/pages/Dashboard.tsx` | Source Authentication section in skill form (dropdown, credential field, Re-parse button) |
| `frontend/src/types/skill.ts` | Added `auth_scheme`, `auth_header_name` to Skill interface |
| `frontend/src/hooks/useSkills.ts` | Map `auth_scheme`, `auth_header_name` from API response |
| `tests/unit/test_skill_routes_github_auth.py` | Rewritten: `global_credentials` sends headers, `none` sends nothing |
| `tests/unit/test_skill_service_github_auth.py` | Updated parse test for `global_credentials`, added `none` scheme test |
| `tests/unit/api/test_skill_inline_content.py` | Updated patch targets from routes to service layer |

## Related issues

- Closes follow-up items from #849
- References #895 (MCPGW OAuth security gaps, not fixed here, env warning added)
- References #896 (infrastructure wiring, blocked by #895)
- References #897 (frontend per-skill auth UI, addressed in this PR)

## Test plan

- [x] All 12 unit tests pass (auth headers, inline content, service github auth)
- [x] Manual integration tests: BC.1, BC.2, 1.1-1.9, 2.3, 2.4, 3.1, 3.2, 3.6, 3.7 all pass
- [x] Test 1.6b confirms `auth_scheme=none` returns 502 for private repos (no PAT leak)
- [x] `parse-skill-md` with `auth_scheme=bearer` + credential succeeds for private repo
- [x] `parse-skill-md` with `auth_scheme=none` fails for private repo (404)
- [x] Edit modal correctly shows stored `auth_scheme` from list API
- [x] Frontend builds without new TypeScript errors