### PR TITLE
fix(keycloak): honor .env config in setup-agent-service-account.sh

### DIFF
--- a/keycloak/setup/setup-agent-service-account.sh
+++ b/keycloak/setup/setup-agent-service-account.sh
@@ -5,10 +5,12 @@
 set -e
 
 # Configuration
-ADMIN_URL="http://localhost:8080"
-REALM="mcp-gateway"
-ADMIN_USER="admin"
+ADMIN_URL="${KEYCLOAK_ADMIN_URL:-http://localhost:8080}"
+REALM="${KEYCLOAK_REALM:-mcp-gateway}"
+ADMIN_USER="${KEYCLOAK_ADMIN:-admin}"
 ADMIN_PASS="${KEYCLOAK_ADMIN_PASSWORD}"
+
+echo "Using Keycloak admin URL: $ADMIN_URL (realm: $REALM, user: $ADMIN_USER)"
 
 # Check required environment variables
 if [ -z "$ADMIN_PASS" ]; then


### PR DESCRIPTION
## Summary

Aligns `keycloak/setup/setup-agent-service-account.sh` with the `.env` contract that the rest of the codebase already follows. Three values were hardcoded; this PR makes them honor the same `KEYCLOAK_*` env vars used by `init-keycloak.sh`, `docker-compose.yml`, and `.env.example`:

| Line | Now honors | Default (preserved when env unset) |
|------|-----------|--------------------------------------|
| 8    | `KEYCLOAK_ADMIN_URL` | `http://localhost:8080` |
| 9    | `KEYCLOAK_REALM`     | `mcp-gateway` |
| 10   | `KEYCLOAK_ADMIN`     | `admin` |

All defaults are unchanged, so behavior on a stock single-host docker-compose deployment is identical to `main`.

A one-line startup `echo` was added so the resolved configuration is visible at run time, matching the pattern used by `init-keycloak.sh:637`.

## Repro

```bash
# Run Keycloak somewhere other than localhost:8080,
# in a non-default realm, with a non-default admin user
export KEYCLOAK_ADMIN_PASSWORD=...
export KEYCLOAK_ADMIN_URL=http://10.0.0.2:8091
export KEYCLOAK_REALM=acme-prod
export KEYCLOAK_ADMIN=keycloak-admin

./keycloak/setup/setup-agent-service-account.sh \
  --agent-id test-agent --group mcp-servers-unrestricted

# Without this PR: "Failed to get admin token"
# With this PR:    Using Keycloak admin URL: http://10.0.0.2:8091 (realm: acme-prod, user: keycloak-admin)
#                  ✓ Admin token obtained
```

## Test plan

```bash
cd keycloak/setup

# 1. Defaults preserved when env unset
( unset KEYCLOAK_ADMIN_URL KEYCLOAK_REALM KEYCLOAK_ADMIN
  eval "$(grep -E '^(ADMIN_URL|REALM|ADMIN_USER)=' setup-agent-service-account.sh)"
  echo "$ADMIN_URL | $REALM | $ADMIN_USER" )
# Expected: http://localhost:8080 | mcp-gateway | admin

# 2. Env vars honored when set
( export KEYCLOAK_ADMIN_URL=http://10.0.0.2:8091 KEYCLOAK_REALM=acme-prod KEYCLOAK_ADMIN=keycloak-admin
  eval "$(grep -E '^(ADMIN_URL|REALM|ADMIN_USER)=' setup-agent-service-account.sh)"
  echo "$ADMIN_URL | $REALM | $ADMIN_USER" )
# Expected: http://10.0.0.2:8091 | acme-prod | keycloak-admin

# 3. Bash syntax check
bash -n setup-agent-service-account.sh

# 4. End-to-end: see Repro above (verified locally on a LAN-bound Keycloak)
```
