### PR TITLE
remove in-memory agent registry and state cache

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -522,7 +522,7 @@ async def register_agent(
 
     from ..search.service import faiss_service
 
-    is_enabled = agent_service.is_agent_enabled(path)
+    is_enabled = await agent_service.is_agent_enabled(path)
     await faiss_service.add_or_update_entity(
         path,
         agent_card.model_dump(),
@@ -672,7 +672,7 @@ async def list_agents(
     search_query = query.lower() if query else ""
 
     for agent in accessible_agents:
-        if enabled_only and not agent_service.is_agent_enabled(agent.path):
+        if enabled_only and not await agent_service.is_agent_enabled(agent.path):
             continue
 
         if visibility and agent.visibility != visibility:
@@ -701,7 +701,7 @@ async def list_agents(
                 skills=[s.name for s in agent.skills],
                 num_skills=len(agent.skills),
                 num_stars=agent.num_stars,
-                is_enabled=agent_service.is_agent_enabled(agent.path),
+                is_enabled=await agent_service.is_agent_enabled(agent.path),
                 provider=provider_name,
                 streaming=streaming,
                 trust_level=agent.trust_level,
@@ -790,7 +790,7 @@ async def check_agent_health(
             detail="You do not have access to this agent",
         )
 
-    if not agent_service.is_agent_enabled(path):
+    if not await agent_service.is_agent_enabled(path):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot perform health check on a disabled agent",
@@ -1375,7 +1375,7 @@ async def update_agent(
 
     from ..search.service import faiss_service
 
-    is_enabled = agent_service.is_agent_enabled(path)
+    is_enabled = await agent_service.is_agent_enabled(path)
     await faiss_service.add_or_update_entity(
         path,
         updated_agent.model_dump(),
@@ -1521,7 +1521,7 @@ async def discover_agents_by_skills(
     required_tags = set(t.lower() for t in tags) if tags else set()
 
     for agent in accessible_agents:
-        if not agent_service.is_agent_enabled(agent.path):
+        if not await agent_service.is_agent_enabled(agent.path):
             continue
 
         agent_skills = set(skill.id.lower() for skill in agent.skills) | set(

--- a/registry/api/federation_export_routes.py
+++ b/registry/api/federation_export_routes.py
@@ -54,7 +54,10 @@ async def _get_current_sync_generation() -> int:
                 enabled_server_count += 1
 
         all_agents = await agent_service.get_all_agents()
-        enabled_agent_count = len([a for a in all_agents if agent_service.is_agent_enabled(a.path)])
+        enabled_agent_count = 0
+        for a in all_agents:
+            if await agent_service.is_agent_enabled(a.path):
+                enabled_agent_count += 1
 
         generation = max(1, enabled_server_count + enabled_agent_count)
         return generation
@@ -543,7 +546,10 @@ async def export_agents(
     all_agents = await agent_service.get_all_agents()
 
     # Filter out disabled agents - never sync disabled agents
-    enabled_agents = [a for a in all_agents if agent_service.is_agent_enabled(a.path)]
+    enabled_agents = []
+    for a in all_agents:
+        if await agent_service.is_agent_enabled(a.path):
+            enabled_agents.append(a)
 
     # Extract peer groups from JWT for visibility filtering
     peer_groups = user_context.get("groups", [])

--- a/registry/api/federation_routes.py
+++ b/registry/api/federation_routes.py
@@ -1049,7 +1049,7 @@ async def sync_federation(
                         registered_at=datetime.now(UTC),
                     )
 
-                    if agent_path not in agent_service.registered_agents:
+                    if await agent_service.get_agent_info(agent_path) is None:
                         await agent_service.register_agent(agent_card)
                         logger.info(f"Synced ASOR agent: {agent_name}")
                         results["asor"]["agents"].append(agent_name)

--- a/registry/main.py
+++ b/registry/main.py
@@ -431,9 +431,9 @@ async def lifespan(app: FastAPI):
         await agent_service.load_agents_and_state()
 
         logger.info(f"📊 Updating {backend_name} index with all registered agents...")
-        all_agents = agent_service.list_agents()
+        all_agents = await agent_service.list_agents()
         for agent_card in all_agents:
-            is_enabled = agent_service.is_agent_enabled(agent_card.path)
+            is_enabled = await agent_service.is_agent_enabled(agent_card.path)
             try:
                 await search_repo.index_agent(agent_card.path, agent_card, is_enabled)
                 logger.debug(f"Updated {backend_name} index for agent: {agent_card.path}")

--- a/registry/repositories/file/agent_repository.py
+++ b/registry/repositories/file/agent_repository.py
@@ -79,8 +79,8 @@ class FileAgentRepository(AgentRepositoryBase):
             return True
         return False
 
-    async def get_state(self) -> dict[str, list[str]]:
-        """Load agent state from disk."""
+    async def _load_state_file(self) -> dict[str, list[str]]:
+        """Load raw state dict from disk."""
         if self.state_file.exists():
             try:
                 with open(self.state_file) as f:
@@ -95,6 +95,18 @@ class FileAgentRepository(AgentRepositoryBase):
 
         return {"enabled": [], "disabled": []}
 
+    async def get_state(self, path: str | None = None) -> bool | dict[str, list[str]]:
+        """Get agent enabled state.
+
+        Args:
+            path: If provided, return True/False for that agent. If None,
+                return the full {"enabled": [...], "disabled": [...]} dict.
+        """
+        state = await self._load_state_file()
+        if path is None:
+            return state
+        return path in state["enabled"]
+
     async def save_state(self, state: dict[str, list[str]]) -> None:
         """Save agent state to disk."""
         with open(self.state_file, "w") as f:
@@ -102,12 +114,12 @@ class FileAgentRepository(AgentRepositoryBase):
 
     async def is_enabled(self, path: str) -> bool:
         """Check if agent is enabled."""
-        state = await self.get_state()
+        state = await self._load_state_file()
         return path in state["enabled"]
 
     async def set_enabled(self, path: str, enabled: bool) -> None:
         """Set agent enabled state."""
-        state = await self.get_state()
+        state = await self._load_state_file()
 
         if enabled:
             if path in state["disabled"]:

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -25,42 +25,13 @@ class AgentService:
         """Initialize agent service with repository."""
         self._repo: AgentRepositoryBase = get_agent_repository()
         self._search_repo: SearchRepositoryBase = get_search_repository()
-        self.registered_agents: dict[str, AgentCard] = {}
-        self.agent_state: dict[str, list[str]] = {"enabled": [], "disabled": []}
 
     async def load_agents_and_state(self) -> None:
-        """Load agent cards and persisted state from repository."""
+        """Load agent cards from the repository."""
         logger.info("Loading agent cards from repository...")
-
-        # Load agents from storage first (OpenSearch, file, etc.)
         await self._repo.load_all()
-
-        # Now get the list of loaded agents
-        agents_list = await self._repo.list_all()
-        self.registered_agents = {agent.path: agent for agent in agents_list}
-        logger.info(f"Successfully loaded {len(self.registered_agents)} agent cards")
-
-        await self._load_agent_state()
-
-    async def _load_agent_state(self) -> None:
-        """Load persisted agent state from repository."""
-        state_data = await self._repo.get_state()
-
-        # Initialize state for all registered agents
-        for path in self.registered_agents.keys():
-            if path not in state_data["enabled"] and path not in state_data["disabled"]:
-                state_data["disabled"].append(path)
-
-        self.agent_state = state_data
-        await self._repo.save_state(state_data)
-        logger.info(
-            f"Agent state initialized: {len(state_data['enabled'])} enabled, "
-            f"{len(state_data['disabled'])} disabled"
-        )
-
-    async def _persist_state(self) -> None:
-        """Persist agent state to repository."""
-        await self._repo.save_state(self.agent_state)
+        count = await self._repo.count()
+        logger.info(f"Repository reports {count} agents loaded")
 
     async def register_agent(
         self,
@@ -80,25 +51,18 @@ class AgentService:
         """
         path = agent_card.path
 
-        if path in self.registered_agents:
+        if await self._repo.get(path) is not None:
             logger.error(f"Agent registration failed: path '{path}' already exists")
             raise ValueError(f"Agent path '{path}' already exists")
 
-        # Save to repository
         agent_card = await self._repo.create(agent_card)
+        await self._repo.set_state(path, False)
 
-        # Add to in-memory registry and default to disabled
-        self.registered_agents[path] = agent_card
-        self.agent_state["disabled"].append(path)
-        await self._persist_state()
-
-        # Index in search backend
         try:
-            is_enabled = self.is_agent_enabled(path)
+            is_enabled = await self.is_agent_enabled(path)
             await self._search_repo.index_agent(path, agent_card, is_enabled)
         except Exception as e:
             logger.error(f"Failed to index agent {path}: {e}")
-            # Don't fail the primary operation
 
         logger.info(
             f"New agent registered: '{agent_card.name}' at path '{path}' (disabled by default)"
@@ -106,7 +70,7 @@ class AgentService:
 
         return agent_card
 
-    def get_agent(
+    async def get_agent(
         self,
         path: str,
     ) -> AgentCard:
@@ -122,30 +86,28 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        agent = self.registered_agents.get(path)
+        agent = await self._repo.get(path)
 
         if not agent:
-            # Try alternate form (with/without trailing slash)
             if path.endswith("/"):
                 alternate_path = path.rstrip("/")
             else:
                 alternate_path = path + "/"
-
-            agent = self.registered_agents.get(alternate_path)
+            agent = await self._repo.get(alternate_path)
 
         if not agent:
             raise ValueError(f"Agent not found at path: {path}")
 
         return agent
 
-    def list_agents(self) -> list[AgentCard]:
+    async def list_agents(self) -> list[AgentCard]:
         """
         List all registered agents.
 
         Returns:
             List of all agent cards
         """
-        return list(self.registered_agents.values())
+        return await self._repo.list_all()
 
     async def update_rating(
         self,
@@ -169,42 +131,28 @@ class AgentService:
         """
         from . import rating_service
 
-        # Query repository directly instead of using cache
         existing_agent = await self._repo.get(path)
         if not existing_agent:
             logger.error(f"Cannot update agent at path '{path}': not found")
             raise ValueError(f"Agent not found at path: {path}")
 
-        # Validate rating using shared service
         rating_service.validate_rating(rating)
 
-        # Convert to dict for modification
         agent_dict = existing_agent.model_dump()
 
-        # Ensure rating_details is a list
         if "rating_details" not in agent_dict or agent_dict["rating_details"] is None:
             agent_dict["rating_details"] = []
 
-        # Update rating details using shared service
         updated_details, is_new_rating = rating_service.update_rating_details(
             agent_dict["rating_details"], username, rating
         )
         agent_dict["rating_details"] = updated_details
 
-        # Calculate average rating using shared service
         agent_dict["num_stars"] = rating_service.calculate_average_rating(
             agent_dict["rating_details"]
         )
 
-        # Save to repository (this will handle AOSS eventual consistency)
         await self._repo.update(path, agent_dict)
-
-        # Update in-memory registry
-        try:
-            updated_agent = AgentCard(**agent_dict)
-            self.registered_agents[path] = updated_agent
-        except Exception as e:
-            logger.warning(f"Failed to update in-memory agent cache: {e}")
 
         logger.info(
             f"Updated rating for agent {path}: user {username} rated {rating}, "
@@ -231,33 +179,29 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        if path not in self.registered_agents:
+        existing_agent = await self._repo.get(path)
+        if existing_agent is None:
             logger.error(f"Cannot update agent at path '{path}': not found")
             raise ValueError(f"Agent not found at path: {path}")
 
-        existing_agent = self.registered_agents[path]
         agent_dict = existing_agent.model_dump()
         agent_dict.update(updates)
         agent_dict["path"] = path
         agent_dict["updated_at"] = datetime.now(UTC)
 
         try:
-            updated_agent = AgentCard(**agent_dict)
+            AgentCard(**agent_dict)
         except Exception as e:
             logger.error(f"Failed to validate updated agent: {e}")
             raise ValueError(f"Invalid agent update: {e}")
 
-        # Save to repository (pass full merged dict to repo for persistence)
         updated_agent = await self._repo.update(path, agent_dict)
-        self.registered_agents[path] = updated_agent
 
-        # Re-index in search backend
         try:
-            is_enabled = self.is_agent_enabled(path)
+            is_enabled = await self.is_agent_enabled(path)
             await self._search_repo.index_agent(path, updated_agent, is_enabled)
         except Exception as e:
             logger.error(f"Failed to re-index agent {path}: {e}")
-            # Don't fail the primary operation
 
         logger.info(f"Agent '{updated_agent.name}' ({path}) updated")
         return updated_agent
@@ -278,33 +222,20 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        if path not in self.registered_agents:
+        existing_agent = await self._repo.get(path)
+        if existing_agent is None:
             logger.error(f"Cannot delete agent at path '{path}': not found")
             raise ValueError(f"Agent not found at path: {path}")
 
         try:
-            agent_name = self.registered_agents[path].name
+            agent_name = existing_agent.name
 
-            # Delete from repository
             await self._repo.delete(path)
 
-            # Remove from in-memory registry
-            del self.registered_agents[path]
-
-            # Remove from state
-            if path in self.agent_state["enabled"]:
-                self.agent_state["enabled"].remove(path)
-            if path in self.agent_state["disabled"]:
-                self.agent_state["disabled"].remove(path)
-
-            await self._persist_state()
-
-            # Remove from search backend
             try:
                 await self._search_repo.remove_entity(path)
             except Exception as e:
                 logger.error(f"Failed to remove agent {path} from search: {e}")
-                # Don't fail the primary operation
 
             logger.info(f"Successfully deleted agent '{agent_name}' from path '{path}'")
             return True
@@ -312,23 +243,6 @@ class AgentService:
         except Exception as e:
             logger.error(f"Failed to delete agent at path '{path}': {e}", exc_info=True)
             raise ValueError(f"Failed to delete agent: {e}")
-
-    async def _ensure_agent_loaded(
-        self,
-        path: str,
-    ) -> None:
-        """Load agent from DB into in-memory dict if not already present.
-
-        Raises:
-            ValueError: If agent not found in DB either
-        """
-        if path in self.registered_agents:
-            return
-        agent = await self._repo.get(path)
-        if agent is None:
-            raise ValueError(f"Agent not found at path: {path}")
-        self.registered_agents[path] = agent
-        logger.info(f"Loaded agent '{agent.name}' ({path}) from database into memory")
 
     async def enable_agent(
         self,
@@ -343,21 +257,16 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        await self._ensure_agent_loaded(path)
+        agent = await self._repo.get(path)
+        if agent is None:
+            raise ValueError(f"Agent not found at path: {path}")
 
-        if path in self.agent_state["enabled"]:
+        if await self._repo.get_state(path):
             logger.info(f"Agent '{path}' is already enabled")
             return
 
-        if path in self.agent_state["disabled"]:
-            self.agent_state["disabled"].remove(path)
-        self.agent_state["enabled"].append(path)
-
         await self._repo.set_state(path, True)
-        await self._persist_state()
-
-        agent_name = self.registered_agents[path].name
-        logger.info(f"Enabled agent '{agent_name}' ({path})")
+        logger.info(f"Enabled agent '{agent.name}' ({path})")
 
     async def disable_agent(
         self,
@@ -372,23 +281,18 @@ class AgentService:
         Raises:
             ValueError: If agent not found
         """
-        await self._ensure_agent_loaded(path)
+        agent = await self._repo.get(path)
+        if agent is None:
+            raise ValueError(f"Agent not found at path: {path}")
 
-        if path in self.agent_state["disabled"]:
+        if not await self._repo.get_state(path):
             logger.info(f"Agent '{path}' is already disabled")
             return
 
-        if path in self.agent_state["enabled"]:
-            self.agent_state["enabled"].remove(path)
-        self.agent_state["disabled"].append(path)
-
         await self._repo.set_state(path, False)
-        await self._persist_state()
+        logger.info(f"Disabled agent '{agent.name}' ({path})")
 
-        agent_name = self.registered_agents[path].name
-        logger.info(f"Disabled agent '{agent_name}' ({path})")
-
-    def is_agent_enabled(
+    async def is_agent_enabled(
         self,
         path: str,
     ) -> bool:
@@ -401,35 +305,43 @@ class AgentService:
         Returns:
             True if enabled, False otherwise
         """
-        # Try exact match first
-        if path in self.agent_state["enabled"]:
+        if await self._repo.get_state(path):
             return True
 
-        # Try alternate form (with/without trailing slash)
         if path.endswith("/"):
             alternate_path = path.rstrip("/")
         else:
             alternate_path = path + "/"
 
-        return alternate_path in self.agent_state["enabled"]
+        return await self._repo.get_state(alternate_path)
 
-    def get_enabled_agents(self) -> list[str]:
+    async def get_enabled_agents(self) -> list[str]:
         """
         Get list of enabled agent paths.
 
         Returns:
             List of enabled agent paths
         """
-        return list(self.agent_state["enabled"])
+        agents = await self._repo.list_all()
+        enabled = []
+        for a in agents:
+            if await self._repo.get_state(a.path):
+                enabled.append(a.path)
+        return enabled
 
-    def get_disabled_agents(self) -> list[str]:
+    async def get_disabled_agents(self) -> list[str]:
         """
         Get list of disabled agent paths.
 
         Returns:
             List of disabled agent paths
         """
-        return list(self.agent_state["disabled"])
+        agents = await self._repo.list_all()
+        disabled = []
+        for a in agents:
+            if not await self._repo.get_state(a.path):
+                disabled.append(a.path)
+        return disabled
 
     async def index_agent(
         self,
@@ -443,11 +355,12 @@ class AgentService:
         """
         try:
             agent_data = agent_card.model_dump(mode="json")
+            is_enabled = await self.is_agent_enabled(agent_card.path)
             await self._search_repo.index_entity(
                 entity_path=agent_card.path,
                 entity_data=agent_data,
                 entity_type="a2a_agent",
-                is_enabled=self.is_agent_enabled(agent_card.path),
+                is_enabled=is_enabled,
             )
             logger.info(f"Indexed agent '{agent_card.name}' in search")
         except Exception as e:
@@ -475,7 +388,6 @@ class AgentService:
         Returns:
             List of all agent cards
         """
-        # Query repository directly instead of using cache
         return await self._repo.list_all()
 
     async def get_agents_paginated(

--- a/registry/services/peer_federation_service.py
+++ b/registry/services/peer_federation_service.py
@@ -1280,7 +1280,7 @@ class PeerFederationService:
         """
         try:
             search_repo = get_search_repository()
-            is_enabled = agent_service.is_agent_enabled(path)
+            is_enabled = await agent_service.is_agent_enabled(path)
             await search_repo.index_agent(path, agent_card, is_enabled)
             logger.debug(f"Indexed synced agent for search: {path}")
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,7 +340,7 @@ def mock_agent_repository():
     mock.delete.return_value = None
     mock.create.return_value = True
     mock.update.return_value = True
-    mock.get_state.return_value = {"enabled": [], "disabled": []}
+    mock.get_state.return_value = False
     mock.save_state.return_value = True
     mock.set_state.return_value = True
     mock.get_all_state.return_value = {}

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -484,7 +484,7 @@ class TestRegisterAgent:
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=None)
             mock_agent_service.register_agent = AsyncMock(return_value=True)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             mock_validation_result = MagicMock()
             mock_validation_result.is_valid = True
@@ -596,7 +596,7 @@ class TestListAgents:
             mock_agent_service.get_agents_paginated = AsyncMock(
                 return_value=([sample_agent_card], 1)
             )
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Act
             response = test_app.get("/agents")
@@ -623,7 +623,7 @@ class TestListAgents:
             mock_agent_service.get_all_agents = AsyncMock(
                 return_value=[enabled_agent, disabled_agent]
             )
-            mock_agent_service.is_agent_enabled.side_effect = lambda path: path == "/agents/enabled"
+            mock_agent_service.is_agent_enabled = AsyncMock(side_effect=lambda path: path == "/agents/enabled")
 
             # Act
             response = test_app.get("/agents?enabled_only=true")
@@ -648,7 +648,7 @@ class TestListAgents:
             mock_agent_service.get_all_agents = AsyncMock(
                 return_value=[public_agent, internal_agent]
             )
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Act
             response = test_app.get("/agents?visibility=public")
@@ -681,7 +681,7 @@ class TestListAgents:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[data_agent, image_agent])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Act
             response = test_app.get("/agents?query=data")
@@ -719,7 +719,7 @@ class TestListAgents:
             mock_agent_service.get_all_agents = AsyncMock(
                 return_value=[agent_with_meta, agent_without_meta]
             )
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=finance")
 
@@ -741,7 +741,7 @@ class TestListAgents:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[agent])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=department")
 
@@ -762,7 +762,7 @@ class TestListAgents:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[agent])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=golang")
 
@@ -783,7 +783,7 @@ class TestListAgents:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[agent])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=nonexistent")
 
@@ -804,7 +804,7 @@ class TestListAgents:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[agent])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=minimal")
 
@@ -840,7 +840,7 @@ class TestListAgents:
         agents = [AgentCardFactory(path=f"/agents/agent-{i}") for i in range(5)]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_agents_paginated = AsyncMock(return_value=(agents[2:4], 5))
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?limit=2&offset=2")
 
@@ -859,7 +859,7 @@ class TestListAgents:
         agents = [AgentCardFactory(path=f"/agents/agent-{i}") for i in range(3)]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_agents_paginated = AsyncMock(return_value=(agents, 3))
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?limit=20")
 
@@ -874,7 +874,7 @@ class TestListAgents:
         """Fast path: offset beyond total returns empty list."""
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_agents_paginated = AsyncMock(return_value=([], 3))
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?offset=100")
 
@@ -908,7 +908,7 @@ class TestListAgents:
         ]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=agents)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app.get("/agents?query=data&limit=10")
 
@@ -934,7 +934,7 @@ class TestListAgents:
         ]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=agents)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             response = test_app_limited.get("/agents?limit=5")
 
@@ -958,7 +958,7 @@ class TestListAgents:
         ]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=agents)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Limited user can only see /test-agent, offset=1 gives empty
             response = test_app_limited.get("/agents?limit=5&offset=1")
@@ -986,7 +986,7 @@ class TestCheckAgentHealth:
             patch("httpx.AsyncClient") as mock_httpx_client,
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Mock httpx response
             mock_response = MagicMock()
@@ -1019,7 +1019,7 @@ class TestCheckAgentHealth:
             patch("httpx.AsyncClient") as mock_httpx_client,
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Mock httpx timeout for both GET (health URLs) and HEAD (fallback)
             mock_client_instance = AsyncMock()
@@ -1061,7 +1061,7 @@ class TestCheckAgentHealth:
         # Arrange
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
-            mock_agent_service.is_agent_enabled.return_value = False
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=False)
 
             # Act
             response = test_app.post("/agents/test-agent/health")
@@ -1334,7 +1334,7 @@ class TestUpdateAgent:
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
             mock_agent_service.update_agent = AsyncMock(return_value=True)
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             mock_validation_result = MagicMock()
             mock_validation_result.is_valid = True
@@ -1501,7 +1501,7 @@ class TestDiscoverAgentsBySkills:
 
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_all_agents = AsyncMock(return_value=[agent_with_skill])
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Act - skills sent as body object, max_results as query param
             response = test_app.post("/agents/discover?max_results=10", json=request_body)
@@ -1564,7 +1564,7 @@ class TestDiscoverAgentsBySkills:
             mock_agent_service.get_all_agents = AsyncMock(
                 return_value=[agent_with_tags, agent_without_tags]
             )
-            mock_agent_service.is_agent_enabled.return_value = True
+            mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
 
             # Act
             response = test_app.post("/agents/discover?max_results=10", json=request_body)

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -1,18 +1,20 @@
 """
 Unit tests for registry.services.agent_service module.
 
-This module tests the AgentService class which manages A2A agent registration,
-state management, ratings, and file-based storage operations.
+These tests exercise AgentService against an in-memory fake implementation
+of AgentRepositoryBase so we test the real service-to-repo contract rather
+than MagicMock behavior.
 """
 
-import json
 import logging
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
+from registry.repositories.interfaces import AgentRepositoryBase
+from registry.schemas.agent_models import AgentCard
 from registry.services.agent_service import AgentService
 from tests.fixtures.constants import (
     TEST_AGENT_NAME_1,
@@ -30,42 +32,140 @@ logger = logging.getLogger(__name__)
 
 
 # =============================================================================
+# In-memory fake repository
+# =============================================================================
+
+
+class InMemoryAgentRepository(AgentRepositoryBase):
+    """In-memory AgentRepositoryBase implementation for tests.
+
+    Stores AgentCard objects keyed by path and a parallel enabled/disabled
+    map. Mirrors the persistence contract used by real repository
+    implementations.
+    """
+
+    def __init__(self) -> None:
+        self._agents: dict[str, AgentCard] = {}
+        self._enabled: dict[str, bool] = {}
+
+    async def get(self, path: str) -> AgentCard | None:
+        return self._agents.get(path)
+
+    async def list_all(self) -> list[AgentCard]:
+        return list(self._agents.values())
+
+    async def list_paginated(
+        self,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> list[AgentCard]:
+        return list(self._agents.values())[skip : skip + limit]
+
+    async def create(self, agent: AgentCard) -> AgentCard:
+        if agent.path in self._agents:
+            raise ValueError(f"Agent path '{agent.path}' already exists")
+        if not agent.registered_at:
+            agent.registered_at = datetime.now(UTC)
+        if not agent.updated_at:
+            agent.updated_at = datetime.now(UTC)
+        self._agents[agent.path] = agent
+        self._enabled.setdefault(agent.path, False)
+        return agent
+
+    async def update(self, path: str, updates: dict[str, Any]) -> AgentCard:
+        existing = self._agents.get(path)
+        if existing is None:
+            raise ValueError(f"Agent not found at path: {path}")
+
+        data = existing.model_dump()
+        data.update(updates)
+        data["path"] = path
+        data["updated_at"] = datetime.now(UTC)
+        new_agent = AgentCard(**data)
+        self._agents[path] = new_agent
+        return new_agent
+
+    async def delete(self, path: str) -> bool:
+        if path not in self._agents:
+            return False
+        del self._agents[path]
+        self._enabled.pop(path, None)
+        return True
+
+    async def get_state(self, path: str) -> bool:
+        return self._enabled.get(path, False)
+
+    async def set_state(self, path: str, enabled: bool) -> bool:
+        if path not in self._agents:
+            return False
+        self._enabled[path] = enabled
+        agent = self._agents[path]
+        data = agent.model_dump()
+        data["is_enabled"] = enabled
+        self._agents[path] = AgentCard(**data)
+        return True
+
+    async def load_all(self) -> None:
+        return None
+
+    async def count(self) -> int:
+        return len(self._agents)
+
+    async def update_field(self, path: str, field: str, value: Any) -> bool:
+        agent = self._agents.get(path)
+        if agent is None:
+            return False
+        data = agent.model_dump()
+        data[field] = value
+        self._agents[path] = AgentCard(**data)
+        return True
+
+    async def find_with_filter(
+        self, filter_dict: dict[str, Any]
+    ) -> dict[str, dict]:
+        results: dict[str, dict] = {}
+        for path, agent in self._agents.items():
+            data = agent.model_dump()
+            if all(data.get(k) == v for k, v in filter_dict.items()):
+                results[path] = data
+        return results
+
+
+# =============================================================================
 # FIXTURES
 # =============================================================================
 
 
 @pytest.fixture
+def fake_repo() -> InMemoryAgentRepository:
+    return InMemoryAgentRepository()
+
+
+@pytest.fixture
+def fake_search_repo() -> AsyncMock:
+    """Search repository is an integration boundary we don't exercise here."""
+    mock = AsyncMock()
+    mock.index_agent.return_value = None
+    mock.remove_entity.return_value = None
+    mock.index_entity.return_value = None
+    return mock
+
+
+@pytest.fixture
 def agent_service(
     mock_settings,
-    mock_agent_repository,
-    mock_search_repository,
+    fake_repo: InMemoryAgentRepository,
+    fake_search_repo: AsyncMock,
 ) -> AgentService:
-    """
-    Create a fresh AgentService instance with mocked dependencies.
-
-    Args:
-        mock_settings: Mocked settings fixture
-        mock_agent_repository: Mocked agent repository
-        mock_search_repository: Mocked search repository
-
-    Returns:
-        AgentService instance with injected mocks
-    """
+    """AgentService backed by an in-memory repository."""
     service = AgentService()
-    # Inject mocked singletons
-    service._repo = mock_agent_repository
-    service._search_repo = mock_search_repository
+    service._repo = fake_repo
+    service._search_repo = fake_search_repo
     return service
 
 
 @pytest.fixture
 def sample_agent_dict() -> dict[str, Any]:
-    """
-    Create a sample agent dictionary for testing.
-
-    Returns:
-        Dictionary with sample agent data
-    """
     return {
         "protocol_version": "1.0",
         "name": TEST_AGENT_NAME_1,
@@ -96,26 +196,20 @@ def sample_agent_dict() -> dict[str, Any]:
 
 @pytest.fixture
 def sample_agent_dict_2() -> dict[str, Any]:
-    """
-    Create a second sample agent dictionary for testing.
-
-    Returns:
-        Dictionary with sample agent data
-    """
     return {
         "protocol_version": "1.0",
         "name": TEST_AGENT_NAME_2,
         "description": "Another test agent",
         "url": TEST_AGENT_URL_2,
-        "version": "2.0",
+        "version": "1.0",
         "path": TEST_AGENT_PATH_2,
-        "capabilities": {"streaming": True},
+        "capabilities": {"streaming": True, "tools": False},
         "default_input_modes": ["text/plain"],
-        "default_output_modes": ["application/json"],
+        "default_output_modes": ["text/plain"],
         "skills": [],
         "tags": ["test"],
         "is_enabled": False,
-        "num_stars": 4.5,
+        "num_stars": 0.0,
         "rating_details": [],
         "license": "Apache-2.0",
         "visibility": VISIBILITY_PUBLIC,
@@ -123,250 +217,51 @@ def sample_agent_dict_2() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
-def agent_json_files(
-    tmp_path: Path,
-    sample_agent_dict: dict[str, Any],
-) -> Path:
-    """
-    Create sample JSON agent files in tmp_path.
-
-    Args:
-        tmp_path: Temporary directory path
-        sample_agent_dict: Sample agent data
-
-    Returns:
-        Path to agents directory with JSON files
-    """
-    agents_dir = tmp_path / "agents"
-    agents_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create a valid agent file
-    agent_file = agents_dir / "test_agent_1_agent.json"
-    with open(agent_file, "w") as f:
-        json.dump(sample_agent_dict, f, indent=2)
-
-    # Create another valid agent file
-    agent_2 = {
-        "protocol_version": "1.0",
-        "name": TEST_AGENT_NAME_2,
-        "description": "Another agent",
-        "url": TEST_AGENT_URL_2,
-        "version": "1.0",
-        "path": TEST_AGENT_PATH_2,
-        "capabilities": {},
-        "default_input_modes": ["text/plain"],
-        "default_output_modes": ["text/plain"],
-        "skills": [],
-        "tags": [],
-        "is_enabled": False,
-        "num_stars": 0.0,
-        "rating_details": [],
-    }
-    agent_file_2 = agents_dir / "test_agent_2_agent.json"
-    with open(agent_file_2, "w") as f:
-        json.dump(agent_2, f, indent=2)
-
-    # Create an invalid agent file (missing required fields)
-    invalid_file = agents_dir / "invalid_agent.json"
-    with open(invalid_file, "w") as f:
-        json.dump({"invalid": "data"}, f)
-
-    # Create a malformed JSON file
-    malformed_file = agents_dir / "malformed_agent.json"
-    with open(malformed_file, "w") as f:
-        f.write("{invalid json")
-
-    # Create agent_state.json (should be excluded from loading)
-    state_file = agents_dir / "agent_state.json"
-    with open(state_file, "w") as f:
-        json.dump({"enabled": [], "disabled": []}, f)
-
-    return agents_dir
-
-
-@pytest.fixture
-def agent_state_file(
-    tmp_path: Path,
-) -> Path:
-    """
-    Create an agent state file with test data.
-
-    Args:
-        tmp_path: Temporary directory path
-
-    Returns:
-        Path to agent_state.json
-    """
-    state_file = tmp_path / "agent_state.json"
-    state_data = {
-        "enabled": [TEST_AGENT_PATH_1],
-        "disabled": [TEST_AGENT_PATH_2],
-    }
-    with open(state_file, "w") as f:
-        json.dump(state_data, f, indent=2)
-
-    return state_file
-
-
 # =============================================================================
-# TEST: Helper Functions - Path to Filename Conversion
+# TEST: Register Agent
 # =============================================================================
 
 
 @pytest.mark.unit
-@pytest.mark.agents
-class TestAgentServiceInstantiation:
-    """Test AgentService initialization and basic properties."""
-
-    def test_init_creates_empty_registries(
-        self,
-        agent_service: AgentService,
-    ):
-        """Test that __init__ creates empty registries."""
-        # Assert
-        assert agent_service.registered_agents == {}
-        assert agent_service.agent_state == {"enabled": [], "disabled": []}
-
-    def test_init_does_not_load_agents(
-        self,
-        agent_service: AgentService,
-    ):
-        """Test that __init__ does not automatically load agents."""
-        # Assert - should be empty until load_agents_and_state is called
-        assert len(agent_service.registered_agents) == 0
-        assert len(agent_service.agent_state["enabled"]) == 0
-        assert len(agent_service.agent_state["disabled"]) == 0
-
-
-# =============================================================================
-# TEST: Loading Agents and State
-# =============================================================================
-
-
-@pytest.mark.unit
-@pytest.mark.agents
 @pytest.mark.agents
 class TestRegisterAgent:
-    """Test agent registration."""
-
     @pytest.mark.asyncio
     async def test_register_new_agent_successfully(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
+        fake_search_repo: AsyncMock,
     ):
-        """Test registering a new agent."""
-        # Arrange
         agent_card = AgentCardFactory(path="/new-agent")
-        mock_agent_repository.create.return_value = agent_card
-        mock_agent_repository.save_state.return_value = True
 
-        # Act
         result = await agent_service.register_agent(agent_card)
 
-        # Assert
-        assert result == agent_card
-        mock_agent_repository.create.assert_called_once()
-        mock_agent_repository.save_state.assert_called()
-        mock_search_repository.index_agent.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_register_agent_sets_timestamps(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test that registration sets registered_at and updated_at."""
-        # Arrange
-        agent_card = AgentCardFactory(
-            path="/test-agent",
-            registered_at=None,
-            updated_at=None,
-        )
-
-        # Mock create to set timestamps like real repository does
-        def mock_create(agent):
-            if not agent.registered_at:
-                agent.registered_at = datetime.now(UTC)
-            if not agent.updated_at:
-                agent.updated_at = datetime.now(UTC)
-            return agent
-
-        mock_agent_repository.create.side_effect = mock_create
-
-        # Act
-        result = await agent_service.register_agent(agent_card)
-
-        # Assert
-        assert result.registered_at is not None
-        assert result.updated_at is not None
-        assert isinstance(result.registered_at, datetime)
-        assert isinstance(result.updated_at, datetime)
-
-    @pytest.mark.asyncio
-    async def test_register_agent_preserves_existing_timestamps(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test that registration preserves existing timestamps."""
-        # Arrange
-        original_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
-        agent_card = AgentCardFactory(
-            path="/test-agent",
-            registered_at=original_time,
-            updated_at=original_time,
-        )
-        mock_agent_repository.create.return_value = agent_card
-
-        # Act
-        result = await agent_service.register_agent(agent_card)
-
-        # Assert
-        assert result.registered_at == original_time
-        assert result.updated_at == original_time
+        assert result.path == "/new-agent"
+        assert await fake_repo.get("/new-agent") is not None
+        fake_search_repo.index_agent.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_register_agent_fails_for_duplicate_path(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that registering duplicate path raises ValueError."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/duplicate")
-        # Simulate agent already in registry
-        agent_service.registered_agents["/duplicate"] = agent_card
+        await fake_repo.create(AgentCardFactory(path="/duplicate"))
 
-        # Act & Assert
         with pytest.raises(ValueError, match="already exists"):
-            await agent_service.register_agent(agent_card)
+            await agent_service.register_agent(AgentCardFactory(path="/duplicate"))
 
     @pytest.mark.asyncio
     async def test_register_agent_defaults_to_disabled(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that newly registered agents are disabled by default."""
-        # Arrange
         agent_card = AgentCardFactory(path="/new-agent")
-        mock_agent_repository.create.return_value = agent_card
-        mock_agent_repository.save_state.return_value = True
 
-        # Act
         await agent_service.register_agent(agent_card)
 
-        # Assert
-        # Verify the agent was added to disabled list via state persistence
-        assert mock_agent_repository.save_state.called
-        assert "/new-agent" in agent_service.agent_state["disabled"]
+        assert await fake_repo.get_state("/new-agent") is False
 
 
 # =============================================================================
@@ -377,73 +272,53 @@ class TestRegisterAgent:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestGetAgent:
-    """Test retrieving agents."""
-
-    def test_get_existing_agent(
+    @pytest.mark.asyncio
+    async def test_get_existing_agent(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test getting an existing agent."""
-        # Arrange
         agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
+        await fake_repo.create(agent_card)
 
-        # Act
-        result = agent_service.get_agent("/test-agent")
+        result = await agent_service.get_agent("/test-agent")
 
-        # Assert
         assert result.path == "/test-agent"
         assert result.name == agent_card.name
 
-    def test_get_agent_not_found(
+    @pytest.mark.asyncio
+    async def test_get_agent_not_found(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
     ):
-        """Test getting a non-existent agent raises ValueError."""
-        # Act & Assert
         with pytest.raises(ValueError, match="not found"):
-            agent_service.get_agent("/nonexistent")
+            await agent_service.get_agent("/nonexistent")
 
-    def test_get_agent_handles_trailing_slash(
+    @pytest.mark.asyncio
+    async def test_get_agent_handles_trailing_slash(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test getting agent with/without trailing slash."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act - try with trailing slash
-        result = agent_service.get_agent("/test-agent/")
+        result = await agent_service.get_agent("/test-agent/")
 
-        # Assert
         assert result.path == "/test-agent"
 
-    def test_get_agent_with_slash_registered_without(
+    @pytest.mark.asyncio
+    async def test_get_agent_falls_back_when_query_has_extra_slash(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test getting agent registered with slash when querying without."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        # Manually register with trailing slash to test edge case
-        agent_service.registered_agents["/test-agent/"] = agent_card
+        """A query with a trailing slash should still find an agent stored without one."""
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
-        result = agent_service.get_agent("/test-agent")
+        result = await agent_service.get_agent("/test-agent/")
 
-        # Assert
-        # Should find agent despite slash mismatch
         assert result is not None
-        assert result.name == agent_card.name
+        assert result.path == "/test-agent"
 
 
 # =============================================================================
@@ -454,66 +329,37 @@ class TestGetAgent:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestListAgents:
-    """Test listing all agents."""
-
-    def test_list_agents_empty(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test listing agents when none are registered."""
-        # Arrange
-        agent_service.registered_agents = {}
-
-        # Act
-        result = agent_service.list_agents()
-
-        # Assert
+    @pytest.mark.asyncio
+    async def test_list_agents_empty(self, agent_service: AgentService):
+        result = await agent_service.list_agents()
         assert result == []
 
-    def test_list_agents_returns_all(
+    @pytest.mark.asyncio
+    async def test_list_agents_returns_all(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test listing all registered agents."""
-        # Arrange
-        agent_1 = AgentCardFactory(path="/agent-1")
-        agent_2 = AgentCardFactory(path="/agent-2")
-        agent_service.registered_agents["/agent-1"] = agent_1
-        agent_service.registered_agents["/agent-2"] = agent_2
+        await fake_repo.create(AgentCardFactory(path="/agent-1"))
+        await fake_repo.create(AgentCardFactory(path="/agent-2"))
 
-        # Act
-        result = agent_service.list_agents()
+        result = await agent_service.list_agents()
 
-        # Assert
-        assert len(result) == 2
         paths = [a.path for a in result]
-        assert "/agent-1" in paths
-        assert "/agent-2" in paths
+        assert set(paths) == {"/agent-1", "/agent-2"}
 
     @pytest.mark.asyncio
     async def test_get_all_agents_alias(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that get_all_agents is an alias for list_agents."""
-        # Arrange
-        agent = AgentCardFactory(path="/test")
-        agent_service.registered_agents["/test"] = agent
-        mock_agent_repository.list_all.return_value = [agent]
+        await fake_repo.create(AgentCardFactory(path="/test"))
 
-        # Act
-        list_result = agent_service.list_agents()
+        list_result = await agent_service.list_agents()
         get_all_result = await agent_service.get_all_agents()
 
-        # Assert
-        assert len(list_result) == 1
-        assert len(get_all_result) == 1
+        assert len(list_result) == len(get_all_result) == 1
         assert list_result[0].path == get_all_result[0].path
 
 
@@ -525,79 +371,42 @@ class TestListAgents:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestUpdateAgent:
-    """Test updating agent information."""
-
     @pytest.mark.asyncio
     async def test_update_agent_successfully(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test updating an agent's information."""
-        # Arrange
-        agent_card = AgentCardFactory(
-            path="/test-agent",
-            description="Original description",
+        await fake_repo.create(
+            AgentCardFactory(path="/test-agent", description="Original description")
         )
-        # Pre-populate registered_agents
-        agent_service.registered_agents["/test-agent"] = agent_card
 
-        updated_card = AgentCardFactory(
-            path="/test-agent",
-            description="Updated description",
+        result = await agent_service.update_agent(
+            "/test-agent", {"description": "Updated description"}
         )
-        mock_agent_repository.update.return_value = updated_card
 
-        updates = {"description": "Updated description"}
-
-        # Act
-        result = await agent_service.update_agent("/test-agent", updates)
-
-        # Assert
         assert result.description == "Updated description"
         assert result.path == "/test-agent"
-        mock_agent_repository.update.assert_called_once()
+        persisted = await fake_repo.get("/test-agent")
+        assert persisted.description == "Updated description"
 
     @pytest.mark.asyncio
     async def test_update_agent_updates_timestamp(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that update sets updated_at timestamp."""
-        # Arrange
         original_time = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
-        agent_card = AgentCardFactory(
-            path="/test-agent",
-            updated_at=original_time,
+        await fake_repo.create(
+            AgentCardFactory(path="/test-agent", updated_at=original_time)
         )
-        agent_service.registered_agents["/test-agent"] = agent_card
 
-        updated_card = AgentCardFactory(
-            path="/test-agent",
-            updated_at=datetime.now(UTC),
-        )
-        mock_agent_repository.update.return_value = updated_card
-
-        # Act
         result = await agent_service.update_agent("/test-agent", {"description": "New"})
 
-        # Assert
         assert result.updated_at > original_time
 
     @pytest.mark.asyncio
-    async def test_update_agent_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test updating non-existent agent raises ValueError."""
-        # Arrange - don't add to registered_agents
-
-        # Act & Assert
+    async def test_update_agent_not_found(self, agent_service: AgentService):
         with pytest.raises(ValueError, match="not found"):
             await agent_service.update_agent("/nonexistent", {"description": "test"})
 
@@ -605,42 +414,27 @@ class TestUpdateAgent:
     async def test_update_agent_preserves_path(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that path cannot be changed via update."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/original-path")
-        agent_service.registered_agents["/original-path"] = agent_card
+        await fake_repo.create(AgentCardFactory(path="/original-path"))
 
-        updated_card = AgentCardFactory(path="/original-path", description="Updated")
-        mock_agent_repository.update.return_value = updated_card
-
-        # Act
         result = await agent_service.update_agent(
             "/original-path",
             {"path": "/new-path", "description": "Updated"},
         )
 
-        # Assert
-        # Path should remain unchanged
         assert result.path == "/original-path"
+        assert await fake_repo.get("/new-path") is None
 
     @pytest.mark.asyncio
     async def test_update_agent_with_invalid_data(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test updating with invalid data raises ValueError."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act & Assert
         with pytest.raises(ValueError, match="Invalid"):
-            # Try to set num_stars to invalid value
             await agent_service.update_agent("/test-agent", {"num_stars": 10.0})
 
 
@@ -652,60 +446,21 @@ class TestUpdateAgent:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestDeleteAgent:
-    """Test agent deletion."""
-
     @pytest.mark.asyncio
     async def test_delete_agent_successfully(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test deleting an agent."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["disabled"].append("/test-agent")
-        mock_agent_repository.delete.return_value = True
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
         result = await agent_service.delete_agent("/test-agent")
 
-        # Assert
         assert result is True
-        assert "/test-agent" not in agent_service.registered_agents
-        mock_agent_repository.delete.assert_called_once_with("/test-agent")
+        assert await fake_repo.get("/test-agent") is None
 
     @pytest.mark.asyncio
-    async def test_delete_agent_removes_from_state(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test that delete removes agent from state lists."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["enabled"].append("/test-agent")
-        mock_agent_repository.delete.return_value = True
-
-        # Act
-        await agent_service.delete_agent("/test-agent")
-
-        # Assert
-        assert "/test-agent" not in agent_service.agent_state["enabled"]
-        assert "/test-agent" not in agent_service.agent_state["disabled"]
-
-    @pytest.mark.asyncio
-    async def test_delete_agent_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test deleting non-existent agent raises ValueError."""
-        # Act & Assert
+    async def test_delete_agent_not_found(self, agent_service: AgentService):
         with pytest.raises(ValueError, match="not found"):
             await agent_service.delete_agent("/nonexistent")
 
@@ -713,35 +468,21 @@ class TestDeleteAgent:
     async def test_remove_agent_alias(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test that remove_agent is an alias for delete_agent."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["disabled"].append("/test-agent")
-        mock_agent_repository.delete.return_value = True
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
         result = await agent_service.remove_agent("/test-agent")
 
-        # Assert
         assert result is True
-        assert "/test-agent" not in agent_service.registered_agents
+        assert await fake_repo.get("/test-agent") is None
 
     @pytest.mark.asyncio
     async def test_remove_agent_returns_false_for_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        self, agent_service: AgentService
     ):
-        """Test that remove_agent returns False for non-existent agent."""
-        # Act
         result = await agent_service.remove_agent("/nonexistent")
 
-        # Assert
         assert result is False
 
 
@@ -753,59 +494,33 @@ class TestDeleteAgent:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestEnableDisableAgent:
-    """Test enabling and disabling agents."""
-
     @pytest.mark.asyncio
     async def test_enable_agent(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test enabling an agent."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["disabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
         await agent_service.enable_agent("/test-agent")
 
-        # Assert
-        assert "/test-agent" in agent_service.agent_state["enabled"]
-        assert "/test-agent" not in agent_service.agent_state["disabled"]
-        mock_agent_repository.set_state.assert_called_with("/test-agent", True)
+        assert await fake_repo.get_state("/test-agent") is True
 
     @pytest.mark.asyncio
     async def test_enable_already_enabled_agent(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test enabling an already enabled agent (idempotent)."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["enabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
 
-        # Act - enable again
         await agent_service.enable_agent("/test-agent")
 
-        # Assert
-        assert "/test-agent" in agent_service.agent_state["enabled"]
-        # Should only appear once
-        assert agent_service.agent_state["enabled"].count("/test-agent") == 1
+        assert await fake_repo.get_state("/test-agent") is True
 
     @pytest.mark.asyncio
-    async def test_enable_agent_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test enabling non-existent agent raises ValueError."""
-        # Act & Assert
+    async def test_enable_agent_not_found(self, agent_service: AgentService):
         with pytest.raises(ValueError, match="not found"):
             await agent_service.enable_agent("/nonexistent")
 
@@ -813,53 +528,29 @@ class TestEnableDisableAgent:
     async def test_disable_agent(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test disabling an agent."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["enabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
 
-        # Act
         await agent_service.disable_agent("/test-agent")
 
-        # Assert
-        assert "/test-agent" in agent_service.agent_state["disabled"]
-        assert "/test-agent" not in agent_service.agent_state["enabled"]
-        mock_agent_repository.set_state.assert_called_with("/test-agent", False)
+        assert await fake_repo.get_state("/test-agent") is False
 
     @pytest.mark.asyncio
     async def test_disable_already_disabled_agent(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test disabling an already disabled agent (idempotent)."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["disabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act - disable again (already disabled by default)
         await agent_service.disable_agent("/test-agent")
 
-        # Assert
-        assert "/test-agent" in agent_service.agent_state["disabled"]
-        # Should only appear once
-        assert agent_service.agent_state["disabled"].count("/test-agent") == 1
+        assert await fake_repo.get_state("/test-agent") is False
 
     @pytest.mark.asyncio
-    async def test_disable_agent_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test disabling non-existent agent raises ValueError."""
-        # Act & Assert
+    async def test_disable_agent_not_found(self, agent_service: AgentService):
         with pytest.raises(ValueError, match="not found"):
             await agent_service.disable_agent("/nonexistent")
 
@@ -867,54 +558,32 @@ class TestEnableDisableAgent:
     async def test_toggle_agent_enable(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test toggling agent to enabled state."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["disabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
         result = await agent_service.toggle_agent("/test-agent", enabled=True)
 
-        # Assert
         assert result is True
-        assert "/test-agent" in agent_service.agent_state["enabled"]
+        assert await fake_repo.get_state("/test-agent") is True
 
     @pytest.mark.asyncio
     async def test_toggle_agent_disable(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test toggling agent to disabled state."""
-        # Arrange
-        agent_card = AgentCardFactory(path="/test-agent")
-        agent_service.registered_agents["/test-agent"] = agent_card
-        agent_service.agent_state["enabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
 
-        # Act
         result = await agent_service.toggle_agent("/test-agent", enabled=False)
 
-        # Assert
         assert result is True
-        assert "/test-agent" in agent_service.agent_state["disabled"]
+        assert await fake_repo.get_state("/test-agent") is False
 
     @pytest.mark.asyncio
-    async def test_toggle_agent_not_found(
-        self,
-        agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
-    ):
-        """Test toggling non-existent agent returns False."""
-        # Act
+    async def test_toggle_agent_not_found(self, agent_service: AgentService):
         result = await agent_service.toggle_agent("/nonexistent", enabled=True)
-
-        # Assert
         assert result is False
 
 
@@ -926,90 +595,62 @@ class TestEnableDisableAgent:
 @pytest.mark.unit
 @pytest.mark.agents
 class TestAgentStateQueries:
-    """Test querying agent state."""
-
-    def test_is_agent_enabled_true(
+    @pytest.mark.asyncio
+    async def test_is_agent_enabled_true(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test checking if agent is enabled."""
-        # Arrange
-        agent_service.agent_state["enabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
 
-        # Act
-        result = agent_service.is_agent_enabled("/test-agent")
+        assert await agent_service.is_agent_enabled("/test-agent") is True
 
-        # Assert
-        assert result is True
-
-    def test_is_agent_enabled_false(
+    @pytest.mark.asyncio
+    async def test_is_agent_enabled_false(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test checking if agent is disabled."""
-        # Arrange
-        agent_service.agent_state["disabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
 
-        # Act
-        result = agent_service.is_agent_enabled("/test-agent")
+        assert await agent_service.is_agent_enabled("/test-agent") is False
 
-        # Assert
-        assert result is False
-
-    def test_is_agent_enabled_handles_trailing_slash(
+    @pytest.mark.asyncio
+    async def test_is_agent_enabled_handles_trailing_slash(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test is_agent_enabled with trailing slash."""
-        # Arrange
-        agent_service.agent_state["enabled"].append("/test-agent")
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
 
-        # Act
-        result = agent_service.is_agent_enabled("/test-agent/")
+        assert await agent_service.is_agent_enabled("/test-agent/") is True
 
-        # Assert
-        assert result is True
-
-    def test_get_enabled_agents(
+    @pytest.mark.asyncio
+    async def test_get_enabled_agents(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test getting list of enabled agents."""
-        # Arrange
-        agent_service.agent_state["enabled"].append("/agent-1")
-        agent_service.agent_state["disabled"].append("/agent-2")
+        await fake_repo.create(AgentCardFactory(path="/agent-1"))
+        await fake_repo.create(AgentCardFactory(path="/agent-2"))
+        await fake_repo.set_state("/agent-1", True)
 
-        # Act
-        result = agent_service.get_enabled_agents()
+        result = await agent_service.get_enabled_agents()
 
-        # Assert
-        assert len(result) == 1
-        assert "/agent-1" in result
-        assert "/agent-2" not in result
+        assert result == ["/agent-1"]
 
-    def test_get_disabled_agents(
+    @pytest.mark.asyncio
+    async def test_get_disabled_agents(
         self,
         agent_service: AgentService,
-        mock_agent_repository,
-        mock_search_repository,
+        fake_repo: InMemoryAgentRepository,
     ):
-        """Test getting list of disabled agents."""
-        # Arrange
-        agent_service.agent_state["enabled"].append("/agent-1")
-        agent_service.agent_state["disabled"].append("/agent-2")
+        await fake_repo.create(AgentCardFactory(path="/agent-1"))
+        await fake_repo.create(AgentCardFactory(path="/agent-2"))
+        await fake_repo.set_state("/agent-1", True)
 
-        # Act
-        result = agent_service.get_disabled_agents()
+        result = await agent_service.get_disabled_agents()
 
-        # Assert
-        assert len(result) == 1
-        assert "/agent-2" in result
-        assert "/agent-1" not in result
+        assert result == ["/agent-2"]


### PR DESCRIPTION
The registered_agents dict and agent_state dict in AgentService held per- replica copies of agent cards and enabled/disabled lists that drifted across replicas once one instance mutated state. Replace both with direct repository calls so every read/write hits the shared store.

- Drop registered_agents and agent_state from AgentService
- Convert get_agent, list_agents, is_agent_enabled, enable_agent, disable_agent, get_enabled_agents, get_disabled_agents to async; they now delegate to the agent repository
- register_agent/update_agent/delete_agent no longer maintain a cache
- Align FileAgentRepository.get_state signature with the interface (path: str | None) -> bool | dict
- Update callers in main.py, agent_routes, federation_routes, federation_export_routes, and peer_federation_service to await the now-async methods

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
