### PR TITLE
fix(scopes): scope server_access writes to target group only

### DIFF
--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -170,8 +170,8 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
 
             server_entry = {"server": server_name, "methods": methods, "tools": tools}
 
-            result = await collection.update_many(
-                {},
+            result = await collection.update_one(
+                {"_id": scope_name},
                 {
                     "$push": {
                         "server_access": {
@@ -181,6 +181,10 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                     "$set": {"updated_at": datetime.utcnow()},
                 },
             )
+
+            if result.matched_count == 0:
+                logger.error(f"Scope '{scope_name}' not found")
+                return False
 
             self._scopes_cache.setdefault(scope_name, []).append(server_entry)
 
@@ -200,8 +204,8 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             collection = await self._get_collection()
             server_name = server_path.lstrip("/")
 
-            result = await collection.update_many(
-                {},
+            result = await collection.update_one(
+                {"_id": scope_name},
                 {
                     "$pull": {
                         "server_access": {
@@ -212,6 +216,10 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                     "$set": {"updated_at": datetime.utcnow()},
                 },
             )
+
+            if result.matched_count == 0:
+                logger.error(f"Scope '{scope_name}' not found")
+                return False
 
             if scope_name in self._scopes_cache:
                 self._scopes_cache[scope_name] = [


### PR DESCRIPTION
## Summary
- Fixed `add_server_scope()` and `remove_server_scope()` in `DocumentDBScopeRepository` to use `update_one({"_id": scope_name})` instead of `update_many({})`.
- The previous `update_many({})` with an empty filter pushed/pulled `server_access` entries to every group document in the collection, causing inflated `server_count` values (e.g. 1486 instead of the actual 1-3 servers assigned to a group).
- Added `matched_count == 0` guard to return `False` when the target scope does not exist, consistent with other methods in the class.
- Note: `remove_server_from_all_scopes()` correctly uses `update_many({})` and was left unchanged.
- Actual UI access control was not affected because it is driven by `ui_permissions.list_service` (which was correctly scoped), but the inflated `server_access` array caused misleading server counts in the admin UI and data exports.

## Test plan
- [x] All 2245 unit tests pass (11 skipped)
- [ ] Verify scopes listing shows correct server_count after deploying
- [ ] Verify adding a server to a scope only adds it to the target group (not all groups)
- [ ] Verify removing a server from a scope only removes it from the target group