### PR TITLE
fix(agents): add bulk get_all_states() and align get_state() signatures

### DIFF
--- a/registry/api/federation_export_routes.py
+++ b/registry/api/federation_export_routes.py
@@ -53,11 +53,8 @@ async def _get_current_sync_generation() -> int:
             if await server_service.is_service_enabled(path):
                 enabled_server_count += 1
 
-        all_agents = await agent_service.get_all_agents()
-        enabled_agent_count = 0
-        for a in all_agents:
-            if await agent_service.is_agent_enabled(a.path):
-                enabled_agent_count += 1
+        agent_states = await agent_service.get_all_agent_states()
+        enabled_agent_count = sum(1 for enabled in agent_states.values() if enabled)
 
         generation = max(1, enabled_server_count + enabled_agent_count)
         return generation
@@ -545,11 +542,9 @@ async def export_agents(
     # Get all agents (enabled and disabled)
     all_agents = await agent_service.get_all_agents()
 
-    # Filter out disabled agents - never sync disabled agents
-    enabled_agents = []
-    for a in all_agents:
-        if await agent_service.is_agent_enabled(a.path):
-            enabled_agents.append(a)
+    # Filter out disabled agents, never sync disabled agents
+    agent_states = await agent_service.get_all_agent_states()
+    enabled_agents = [a for a in all_agents if agent_states.get(a.path, False)]
 
     # Extract peer groups from JWT for visibility filtering
     peer_groups = user_context.get("groups", [])

--- a/registry/repositories/documentdb/agent_repository.py
+++ b/registry/repositories/documentdb/agent_repository.py
@@ -198,31 +198,29 @@ class DocumentDBAgentRepository(AgentRepositoryBase):
 
     async def get_state(
         self,
-        path: str = None,
-    ) -> dict[str, list[str]] | bool:
-        """Get agent state."""
-        if path is None:
-            collection = await self._get_collection()
-
-            try:
-                cursor = collection.find({})
-                state = {"enabled": [], "disabled": []}
-                async for doc in cursor:
-                    agent_path = doc.get("_id")
-                    if agent_path:
-                        if doc.get("is_enabled", False):
-                            state["enabled"].append(agent_path)
-                        else:
-                            state["disabled"].append(agent_path)
-                return state
-            except Exception as e:
-                logger.error(f"Error getting all agent state from DocumentDB: {e}", exc_info=True)
-                return {"enabled": [], "disabled": []}
-
+        path: str,
+    ) -> bool:
+        """Get enabled/disabled state for a single agent."""
         agent = await self.get(path)
         if agent:
             return getattr(agent, "is_enabled", False)
         return False
+
+    async def get_all_states(self) -> dict[str, bool]:
+        """Get enabled/disabled state for all agents in a single query."""
+        collection = await self._get_collection()
+
+        try:
+            cursor = collection.find({}, {"_id": 1, "is_enabled": 1})
+            states: dict[str, bool] = {}
+            async for doc in cursor:
+                agent_path = doc.get("_id")
+                if agent_path:
+                    states[agent_path] = doc.get("is_enabled", False)
+            return states
+        except Exception as e:
+            logger.error(f"Error getting all agent states from DocumentDB: {e}", exc_info=True)
+            return {}
 
     async def set_state(
         self,

--- a/registry/repositories/file/agent_repository.py
+++ b/registry/repositories/file/agent_repository.py
@@ -95,17 +95,20 @@ class FileAgentRepository(AgentRepositoryBase):
 
         return {"enabled": [], "disabled": []}
 
-    async def get_state(self, path: str | None = None) -> bool | dict[str, list[str]]:
-        """Get agent enabled state.
-
-        Args:
-            path: If provided, return True/False for that agent. If None,
-                return the full {"enabled": [...], "disabled": [...]} dict.
-        """
+    async def get_state(self, path: str) -> bool:
+        """Get enabled/disabled state for a single agent."""
         state = await self._load_state_file()
-        if path is None:
-            return state
         return path in state["enabled"]
+
+    async def get_all_states(self) -> dict[str, bool]:
+        """Get enabled/disabled state for all agents in a single read."""
+        state = await self._load_state_file()
+        states: dict[str, bool] = {}
+        for path in state.get("enabled", []):
+            states[path] = True
+        for path in state.get("disabled", []):
+            states[path] = False
+        return states
 
     async def save_state(self, state: dict[str, list[str]]) -> None:
         """Save agent state to disk."""

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -247,6 +247,15 @@ class AgentRepositoryBase(ABC):
         pass
 
     @abstractmethod
+    async def get_all_states(self) -> dict[str, bool]:
+        """Get enabled/disabled state for all agents in a single query.
+
+        Returns:
+            Dict mapping agent path to enabled (True) or disabled (False).
+        """
+        pass
+
+    @abstractmethod
     async def set_state(
         self,
         path: str,
@@ -495,7 +504,7 @@ class ScopeRepositoryBase(ABC):
                 }
             }
         """
-        pass
+        return {}
 
     @abstractmethod
     async def group_exists(
@@ -918,7 +927,7 @@ class SearchRepositoryBase(ABC):
             skill: SkillCard object
             is_enabled: Whether skill is enabled
         """
-        pass
+        return None
 
     async def index_virtual_server(
         self,
@@ -936,7 +945,7 @@ class SearchRepositoryBase(ABC):
             virtual_server: VirtualServerConfig object
             is_enabled: Whether virtual server is enabled
         """
-        pass
+        return None
 
     async def search_by_tags(
         self,

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -322,12 +322,8 @@ class AgentService:
         Returns:
             List of enabled agent paths
         """
-        agents = await self._repo.list_all()
-        enabled = []
-        for a in agents:
-            if await self._repo.get_state(a.path):
-                enabled.append(a.path)
-        return enabled
+        all_states = await self._repo.get_all_states()
+        return [path for path, enabled in all_states.items() if enabled]
 
     async def get_disabled_agents(self) -> list[str]:
         """
@@ -336,12 +332,17 @@ class AgentService:
         Returns:
             List of disabled agent paths
         """
-        agents = await self._repo.list_all()
-        disabled = []
-        for a in agents:
-            if not await self._repo.get_state(a.path):
-                disabled.append(a.path)
-        return disabled
+        all_states = await self._repo.get_all_states()
+        return [path for path, enabled in all_states.items() if not enabled]
+
+    async def get_all_agent_states(self) -> dict[str, bool]:
+        """
+        Get enabled/disabled state for all agents in a single query.
+
+        Returns:
+            Dict mapping agent path to enabled (True) or disabled (False).
+        """
+        return await self._repo.get_all_states()
 
     async def index_agent(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -341,9 +341,9 @@ def mock_agent_repository():
     mock.create.return_value = True
     mock.update.return_value = True
     mock.get_state.return_value = False
+    mock.get_all_states.return_value = {}
     mock.save_state.return_value = True
     mock.set_state.return_value = True
-    mock.get_all_state.return_value = {}
     return mock
 
 

--- a/tests/unit/api/test_federation_export_routes.py
+++ b/tests/unit/api/test_federation_export_routes.py
@@ -800,8 +800,8 @@ class TestAgentsEndpoint:
             ),
             patch.object(
                 agent_service,
-                "is_agent_enabled",
-                return_value=True,
+                "get_all_agent_states",
+                return_value={"/agents/public-agent": True},
             ),
         ):
             client = TestClient(app)
@@ -850,8 +850,11 @@ class TestAgentsEndpoint:
             ),
             patch.object(
                 agent_service,
-                "is_agent_enabled",
-                return_value=True,
+                "get_all_agent_states",
+                return_value={
+                    "/agents/public-agent": True,
+                    "/agents/engineering-agent": True,
+                },
             ),
         ):
             client = TestClient(app)
@@ -1152,8 +1155,8 @@ class TestDisabledItemsFiltering:
             ),
             patch.object(
                 agent_service,
-                "is_agent_enabled",
-                return_value=False,  # Agent is disabled
+                "get_all_agent_states",
+                return_value={"/agents/public-agent": False},
             ),
         ):
             client = TestClient(app)
@@ -1402,8 +1405,11 @@ class TestChainPrevention:
             ),
             patch.object(
                 agent_service,
-                "is_agent_enabled",
-                return_value=True,
+                "get_all_agent_states",
+                return_value={
+                    "/agents/local-agent": True,
+                    "/agents/peer-a/synced-agent": True,
+                },
             ),
         ):
             client = TestClient(app)

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -95,6 +95,9 @@ class InMemoryAgentRepository(AgentRepositoryBase):
     async def get_state(self, path: str) -> bool:
         return self._enabled.get(path, False)
 
+    async def get_all_states(self) -> dict[str, bool]:
+        return dict(self._enabled)
+
     async def set_state(self, path: str, enabled: bool) -> bool:
         if path not in self._agents:
             return False


### PR DESCRIPTION
## Summary

Follow-up to PR #907 (remove in-memory agent cache). Addresses two items from the post-merge review:

- **N+1 fix**: `get_enabled_agents()`, `get_disabled_agents()`, and federation export loops were making one DB round-trip per agent to check enabled state. Added `get_all_states()` that fetches all states in a single query (DocumentDB projection on `_id` + `is_enabled`; single file read for file backend).
- **Interface alignment**: `FileAgentRepository.get_state()` and `DocumentDBAgentRepository.get_state()` accepted `path=None` with a union return type, diverging from the `AgentRepositoryBase` abstract interface. Removed the dead `None` overload; the bulk logic now lives in the dedicated `get_all_states()` method.
- **Ruff B027 fixes**: Three pre-existing warnings in `interfaces.py` for non-abstract empty methods in ABCs.

## Test plan

- [x] Full test suite: 2596 passed, 67 skipped, 0 failed
- [x] Coverage: 48.19% (above 35% threshold)
- [x] Ruff: clean (including pre-existing B027 fixes)
- [x] Bandit: clean