### PR TITLE
fix(iam): default 'Create in identity provider' checkbox to unchecked

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1987,7 +1987,7 @@ class RegistryClient:
                 - server_access (optional): List of server access definitions
                 - group_mappings (optional): List of group mappings
                 - ui_permissions (optional): Dictionary of UI permissions
-                - create_in_idp (optional): Whether to create in IdP (default: true)
+                - create_in_idp (optional): Whether to create in IdP (default: false)
 
         Returns:
             Response data

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -85,7 +85,7 @@ const EXAMPLE_SCOPE_JSON = {
     list_service: ['currenttime'],
     health_check_service: ['currenttime'],
   },
-  create_in_idp: true,
+  create_in_idp: false,
 };
 
 // Default entry has all methods selected
@@ -338,7 +338,7 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
   const [groupMappings, setGroupMappings] = useState('');
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [uiPermissions, setUiPermissions] = useState<Record<string, string>>({});
-  const [createInIdp, setCreateInIdp] = useState(true);
+  const [createInIdp, setCreateInIdp] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [showUiPermissions, setShowUiPermissions] = useState(false);
 

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -410,7 +410,7 @@ async def management_create_group(
     """
     Create a new group in the identity provider and/or MongoDB (admin only).
 
-    When create_in_idp is True (default), creates in both the configured
+    When create_in_idp is True, creates in both the configured
     identity provider and MongoDB scopes collection.
     When create_in_idp is False, creates only in MongoDB scopes collection.
     """
@@ -419,7 +419,7 @@ async def management_create_group(
     iam = get_iam_manager()
 
     # Extract create_in_idp from scope_config (frontend sends it there)
-    create_in_idp = True  # default: create in IdP
+    create_in_idp = False  # default: do not create in IdP
     if payload.scope_config and "create_in_idp" in payload.scope_config:
         create_in_idp = bool(payload.scope_config["create_in_idp"])
     logger.debug(

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -2245,7 +2245,7 @@ async def internal_create_group(
     caller: Annotated[str, Depends(validate_internal_auth)],
     group_name: Annotated[str, Form()],
     description: Annotated[str, Form()] = "",
-    create_in_idp: Annotated[bool, Form()] = True,
+    create_in_idp: Annotated[bool, Form()] = False,
 ):
     """Internal endpoint to create a new group in both IdP and scopes.yml (requires admin authentication)."""
     logger.info(f"Creating group '{group_name}' via internal endpoint by caller '{caller}'")
@@ -3386,7 +3386,7 @@ async def remove_server_from_groups_api(
 async def _create_group_impl(
     group_name: str,
     description: str = "",
-    create_in_idp: bool = True,
+    create_in_idp: bool = False,
 ) -> JSONResponse:
     """
     Internal implementation for group creation.
@@ -3461,7 +3461,7 @@ async def create_group_api(
     request: Request,
     group_name: Annotated[str, Form()],
     description: Annotated[str, Form()] = "",
-    create_in_idp: Annotated[bool, Form()] = True,
+    create_in_idp: Annotated[bool, Form()] = False,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
@@ -3476,7 +3476,7 @@ async def create_group_api(
     **Request body (form data):**
     - `group_name` (required): Name of the new group
     - `description` (optional): Group description
-    - `create_in_idp` (optional): Whether to create in IdP (default: true)
+    - `create_in_idp` (optional): Whether to create in IdP (default: false)
 
     **Response:**
     Returns confirmation of group creation.

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -407,7 +407,11 @@ class TestManagementCreateGroup:
             # Act
             response = client.post(
                 "/api/management/iam/groups",
-                json={"name": "new-group", "description": "A new test group"},
+                json={
+                    "name": "new-group",
+                    "description": "A new test group",
+                    "scope_config": {"create_in_idp": True},
+                },
             )
 
             # Assert
@@ -453,7 +457,11 @@ class TestManagementCreateGroup:
             # Act
             response = client.post(
                 "/api/management/iam/groups",
-                json={"name": "new-group", "description": "Entra test group"},
+                json={
+                    "name": "new-group",
+                    "description": "Entra test group",
+                    "scope_config": {"create_in_idp": True},
+                },
             )
 
             # Assert
@@ -500,7 +508,10 @@ class TestManagementCreateGroup:
         # Act
         response = client.post(
             "/api/management/iam/groups",
-            json={"name": "existing-group"},
+            json={
+                "name": "existing-group",
+                "scope_config": {"create_in_idp": True},
+            },
         )
 
         # Assert
@@ -516,7 +527,10 @@ class TestManagementCreateGroup:
         # Act
         response = client.post(
             "/api/management/iam/groups",
-            json={"name": "new-group"},
+            json={
+                "name": "new-group",
+                "scope_config": {"create_in_idp": True},
+            },
         )
 
         # Assert
@@ -545,7 +559,10 @@ class TestManagementCreateGroup:
             # Act
             response = client.post(
                 "/api/management/iam/groups",
-                json={"name": "partial-group"},
+                json={
+                    "name": "partial-group",
+                    "scope_config": {"create_in_idp": True},
+                },
             )
 
             # Assert - should still succeed (IdP creation succeeded)
@@ -575,7 +592,10 @@ class TestManagementCreateGroup:
             # Act
             response = client.post(
                 "/api/management/iam/groups",
-                json={"name": "minimal-group"},
+                json={
+                    "name": "minimal-group",
+                    "scope_config": {"create_in_idp": True},
+                },
             )
 
             # Assert
@@ -695,23 +715,17 @@ class TestManagementCreateGroupCreateInIdp:
                 agent_access=[],
             )
 
-    def test_create_group_default_creates_in_idp(self, test_client_admin):
-        """When create_in_idp not in scope_config, default to creating in IdP."""
+    def test_create_group_default_does_not_create_in_idp(self, test_client_admin):
+        """When create_in_idp not in scope_config, default to NOT creating in IdP."""
         # Arrange
         client, mock_iam = test_client_admin
-        mock_iam.create_group.return_value = {
-            "id": "default-group-id",
-            "name": "default-group",
-            "path": "/default-group",
-            "attributes": None,
-        }
 
         with (
             patch(
                 "registry.api.management_routes.scope_service.import_group",
                 new_callable=AsyncMock,
                 return_value=True,
-            ),
+            ) as mock_import_group,
             patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
         ):
             # Act
@@ -722,7 +736,21 @@ class TestManagementCreateGroupCreateInIdp:
 
             # Assert
             assert response.status_code == 200
-            mock_iam.create_group.assert_called_once()
+            data = response.json()
+            assert data["name"] == "default-group"
+
+            # IdP create_group should NOT be called (default is False)
+            mock_iam.create_group.assert_not_called()
+
+            # MongoDB scope should still be created with group name as mapping
+            mock_import_group.assert_called_once_with(
+                scope_name="default-group",
+                description="",
+                group_mappings=["default-group"],
+                server_access=[],
+                ui_permissions={},
+                agent_access=[],
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Default the "Create in identity provider" checkbox to unchecked when creating a new group under IAM > Groups

Fixes #916

## Test plan

- [ ] Navigate to IAM > Groups > Create Group
- [ ] Verify the "Create in identity provider" checkbox is unchecked by default
- [ ] Verify the checkbox can still be toggled on when needed
- [ ] Verify editing an existing group with `create_in_idp: true` still loads as checked