### PR TITLE
docs: add security preflight admission pattern

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ mkdocs build
 - `complete-setup-guide.md` - Step-by-step setup from scratch
 - `installation.md` - Complete installation guide
 - `auth.md` - Authentication and OAuth setup
+- `registration-webhooks.md` - Registration notifications and admission-control gate integrations
 - `cognito.md` - Amazon Cognito configuration
 - `keycloak-integration.md` - Keycloak integration guide
 - `scopes.md` - Access control and permissions

--- a/docs/registration-webhooks.md
+++ b/docs/registration-webhooks.md
@@ -304,6 +304,35 @@ The gate is checked on the following operations:
 | Skill | Register | `POST /api/skills` |
 | Skill | Update | `PUT /api/skills/{path}` |
 
+### Pattern: External Trust Preflight Before Admission
+
+The registration gate can be used as a security preflight step before a newly discovered MCP server, A2A agent, or skill becomes an executable dependency for users and AI agents. This complements the built-in security scanner: the registry still owns admission, access control, and auditability, while the gate can call external risk services for additional signals.
+
+A typical server admission flow is:
+
+1. Discover or propose a remote MCP server for registration.
+2. Send the sanitized registration payload to the registration gate before persistence.
+3. Have the gate evaluate policy, using internal rules and optional external trust checks.
+4. Store the decision and relevant preflight summary in the operator's approval/audit system.
+5. Return `200` only when policy passes; otherwise return `403` with a clear human-review reason.
+
+When designing a trust preflight, prefer deterministic policy over a single vendor verdict. Useful inputs include endpoint allow/deny lists, transport type, domain ownership, scanner severity, prior approval status, and whether the endpoint requires privileged credentials. If the preflight depends on a third-party service, keep the gate fail-closed for production and define a manual review process for outages or inconclusive results.
+
+Optional external check example:
+
+```bash
+# Trust metadata check for a proposed MCP endpoint.
+agentcash fetch 'https://shield.vainplex.dev/api/cdp/check/mcp/trust?shieldapi_source=mcp-gateway-registry' \
+  -m POST \
+  -H 'content-type: application/json' \
+  -b '{"endpoint":"https://mcp.example.com"}'
+
+# Deeper endpoint scan when policy requires more context.
+agentcash fetch 'https://shield.vainplex.dev/api/cdp/full/scan?target=mcp.example.com&shieldapi_source=mcp-gateway-registry'
+```
+
+Treat external preflight results as one admission signal, not as a replacement for registry governance. The gate should return a concise denial reason such as `External trust preflight requires human review` and avoid storing raw credentials or sensitive headers in external systems.
+
 ### Example: Simple Gate Endpoint
 
 A minimal Python gate endpoint that approves all registrations:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
   - Authentication & Security:
     - Authentication Guide: auth.md
     - Registry API Authentication: registry-api-auth.md
+    - Registration Webhooks and Gate: registration-webhooks.md
     - IAM Settings UI: iam-settings-ui.md
     - Amazon Cognito Setup: cognito.md
     - Access Control & Scopes: scopes.md


### PR DESCRIPTION
## Summary

- Adds an external trust preflight pattern to the Registration Gate documentation
- Frames third-party trust checks as one admission signal, not a replacement for registry governance
- Adds the registration gate guide to the MkDocs navigation and docs README index

Closes #911

## Validation

- `uv run --extra docs mkdocs build --strict` (blocked: dependency installation ran out of disk space while extracting `torch`)
- `python3` markdown sanity check for balanced fences and MkDocs/docs references
