### PR TITLE
fix: multiple path-routing, logout, and OAuth redirect bugs on Helm deployments

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -452,6 +452,27 @@ def mask_token(token: str) -> str:
     return "***MASKED***"
 
 
+def _is_redirect_within_cookie_domain(
+    url: str,
+    cookie_domain: str,
+) -> bool:
+    """Check if an absolute redirect URL's host is within SESSION_COOKIE_DOMAIN.
+
+    SESSION_COOKIE_DOMAIN (e.g. ".example.com") defines the trust boundary —
+    the apex host and any subdomain sharing the session cookie are safe
+    redirect targets. The leading dot is conventional but not required.
+    """
+    if not cookie_domain:
+        return False
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    # urlparse().hostname is lowercased by Python; normalize apex to match.
+    hostname = parsed.hostname or ""
+    apex = cookie_domain.lstrip(".").lower()
+    return hostname == apex or hostname.endswith(f".{apex}")
+
+
 def _is_safe_redirect_url(
     url: str,
     allowed_hosts: set[str] | None = None,
@@ -2678,7 +2699,10 @@ async def oauth2_login(provider: str, request: Request, redirect_uri: str = None
         # The callback_uri MUST match exactly between authorization and token exchange
         auth_server_external_url = os.environ.get("AUTH_SERVER_EXTERNAL_URL", "").rstrip("/")
         if auth_server_external_url:
-            auth_server_url = f"{auth_server_external_url}{ROOT_PATH}"
+            # AUTH_SERVER_EXTERNAL_URL is the complete public base URL and
+            # already includes any path prefix (e.g. "/auth-server" in path
+            # routing mode); ROOT_PATH is only used in the host-fallback branch.
+            auth_server_url = auth_server_external_url
             scheme = "https" if auth_server_external_url.startswith("https") else "http"
             logger.info(f"OAuth2 login - using AUTH_SERVER_EXTERNAL_URL: {auth_server_url}")
         else:
@@ -3034,21 +3058,13 @@ async def oauth2_callback(
         redirect_url = temp_session_data.get(
             "redirect_uri", OAUTH2_CONFIG.get("registry", {}).get("success_redirect", "/")
         )
-        # Validate redirect_url to prevent open redirect attacks.
-        # Allow relative URLs and absolute URLs within the deployment's cookie domain.
-        # SESSION_COOKIE_DOMAIN (e.g., ".example.com") defines the trust boundary —
-        # any service sharing the session cookie is a safe redirect target.
+        # Validate redirect_url to prevent open redirect attacks. Relative URLs
+        # are always safe; absolute URLs must be within SESSION_COOKIE_DOMAIN.
         cookie_domain = os.environ.get("SESSION_COOKIE_DOMAIN", "").strip()
         redirect_parsed = urlparse(redirect_url)
-        redirect_is_safe = False
-        if not redirect_parsed.scheme and not redirect_parsed.netloc:
-            # Relative URL — always safe
-            redirect_is_safe = True
-        elif redirect_parsed.scheme in ("http", "https"):
-            redirect_hostname = redirect_parsed.hostname or ""
-            if cookie_domain and redirect_hostname.endswith(cookie_domain):
-                # Redirect is within the deployment's cookie domain
-                redirect_is_safe = True
+        redirect_is_safe = (
+            not redirect_parsed.scheme and not redirect_parsed.netloc
+        ) or _is_redirect_within_cookie_domain(redirect_url, cookie_domain)
         if not redirect_is_safe:
             logger.warning(f"Blocked unsafe redirect URL: {redirect_url}, falling back to /")
             redirect_url = "/"
@@ -3092,8 +3108,9 @@ async def oauth2_callback(
 
         response.set_cookie(**cookie_params)
 
-        # Clear temporary OAuth2 session
-        response.delete_cookie("oauth2_temp_session")
+        # Clear temporary OAuth2 session. The cookie was set without a
+        # domain attribute, so delete must also omit domain to match.
+        response.delete_cookie("oauth2_temp_session", path="/")
 
         logger.info(
             f"Successfully authenticated user {hash_username(mapped_user['username'])} via {provider}"
@@ -3201,6 +3218,21 @@ async def oauth2_logout(
     try:
         if provider not in OAUTH2_CONFIG.get("providers", {}):
             raise HTTPException(status_code=404, detail=f"Provider {provider} not found")
+
+        # Reject absolute redirect_uri that escapes the
+        # deployment's cookie domain before forwarding it to the IdP. The IdP's
+        # post_logout_redirect_uri allow-list is the authoritative check, but
+        # this guards against misconfigured IdP clients and makes the intent
+        # explicit at our boundary.
+        if redirect_uri:
+            parsed = urlparse(redirect_uri)
+            if parsed.scheme or parsed.netloc:
+                cookie_domain = os.environ.get("SESSION_COOKIE_DOMAIN", "").strip()
+                if not _is_redirect_within_cookie_domain(redirect_uri, cookie_domain):
+                    logger.warning(
+                        f"Blocked unsafe logout redirect_uri for {provider}: {redirect_uri}"
+                    )
+                    redirect_uri = None
 
         provider_config = OAUTH2_CONFIG["providers"][provider]
         logout_url = provider_config.get("logout_url")

--- a/charts/keycloak-configure/templates/configmap.yaml
+++ b/charts/keycloak-configure/templates/configmap.yaml
@@ -121,6 +121,46 @@ data:
         fi
     }
 
+    # Upsert a Keycloak client: create if missing, otherwise PUT the full
+    # representation to apply any attribute changes (e.g. post.logout.redirect.uris)
+    # to existing deployments.
+    upsert_client() {
+        local token=$1
+        local client_id=$2
+        local client_json=$3
+
+        local existing_id=$(curl -s \
+            -H "Authorization: Bearer ${token}" \
+            "${KEYCLOAK_URL}/admin/realms/${REALM}/clients?clientId=${client_id}" \
+            | grep -o '"id":"[^"]*' | head -1 | cut -d'"' -f4)
+
+        if [ -z "$existing_id" ]; then
+            local status=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/clients" \
+                -H "Authorization: Bearer ${token}" \
+                -H "Content-Type: application/json" \
+                -d "$client_json")
+            if [ "$status" = "201" ] || [ "$status" = "409" ]; then
+                echo -e "${GREEN}Client ${client_id} created${NC}"
+            else
+                echo -e "${RED}Failed to create client ${client_id} (HTTP ${status})${NC}"
+                return 1
+            fi
+        else
+            local status=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/clients/${existing_id}" \
+                -H "Authorization: Bearer ${token}" \
+                -H "Content-Type: application/json" \
+                -d "$client_json")
+            if [ "$status" = "204" ]; then
+                echo -e "${GREEN}Client ${client_id} updated${NC}"
+            else
+                echo -e "${RED}Failed to update client ${client_id} (HTTP ${status})${NC}"
+                return 1
+            fi
+        fi
+    }
+
     # Function to create clients
     create_clients() {
         local token=$1
@@ -144,6 +184,9 @@ data:
                 "http://localhost:7860",
                 "+"
             ],
+            "attributes": {
+                "post.logout.redirect.uris": "'${REGISTRY_URL:-http://localhost:7860}'/*##http://localhost:7860/*##http://localhost:8888/*"
+            },
             "protocol": "openid-connect",
             "standardFlowEnabled": true,
             "implicitFlowEnabled": false,
@@ -152,10 +195,7 @@ data:
             "publicClient": false
         }'
 
-        curl -s -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/clients" \
-            -H "Authorization: Bearer ${token}" \
-            -H "Content-Type: application/json" \
-            -d "$web_client_json" > /dev/null
+        upsert_client "$token" "mcp-gateway-web" "$web_client_json"
 
         # Create M2M client
         local m2m_client_json='{
@@ -171,10 +211,7 @@ data:
             "publicClient": false
         }'
 
-        curl -s -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/clients" \
-            -H "Authorization: Bearer ${token}" \
-            -H "Content-Type: application/json" \
-            -d "$m2m_client_json" > /dev/null
+        upsert_client "$token" "mcp-gateway-m2m" "$m2m_client_json"
 
         echo -e "${GREEN}Clients created successfully!${NC}"
     }

--- a/charts/keycloak-configure/templates/secret.yaml
+++ b/charts/keycloak-configure/templates/secret.yaml
@@ -3,15 +3,19 @@
 {{- $domain := .Values.global.domain | default "localhost" }}
 {{- $protocol := ternary "https" "http" .Values.global.ingress.tls }}
 {{- $authServerPath := .Values.global.ingress.paths.authServer | default "/auth-server" }}
+{{- $registryPath := .Values.global.ingress.paths.registry | default "/registry" }}
 {{- $keycloakPath := .Values.global.ingress.paths.keycloak | default "/keycloak" }}
 {{- $keycloakBaseUrl := printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace }}
 {{- $keycloakUrl := $keycloakBaseUrl }}
 {{- $authServerExternalUrl := "" }}
+{{- $registryUrl := "" }}
 {{- if eq $routingMode "path" }}
   {{- $keycloakUrl = printf "%s%s" $keycloakBaseUrl $keycloakPath }}
   {{- $authServerExternalUrl = printf "%s://%s%s" $protocol $domain $authServerPath }}
+  {{- $registryUrl = printf "%s://%s%s" $protocol $domain $registryPath }}
 {{- else }}
   {{- $authServerExternalUrl = printf "%s://auth-server.%s" $protocol $domain }}
+  {{- $registryUrl = printf "%s://mcpregistry.%s" $protocol $domain }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -24,4 +28,5 @@ data:
   KEYCLOAK_URL: {{ $keycloakUrl | b64enc | quote }}
   REALM: {{ .Values.keycloak.realm | b64enc | quote }}
   AUTH_SERVER_EXTERNAL_URL: {{ $authServerExternalUrl | b64enc | quote }}
+  REGISTRY_URL: {{ $registryUrl | b64enc | quote }}
 {{- end }}

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -147,6 +147,8 @@ data:
   {{- end }}
 {{- end }}
   ROOT_PATH: {{ $rootPath | b64enc | quote }}
+  SESSION_COOKIE_DOMAIN: {{ printf ".%s" $domain | b64enc | quote }}
+  SESSION_COOKIE_SECURE: {{ (.Values.global.ingress.tls | toString) | b64enc | quote }}
   {{- if .Values.idpGroupFilterPrefix }}
   IDP_GROUP_FILTER_PREFIX: {{ .Values.idpGroupFilterPrefix | b64enc | quote }}
   {{- end }}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,16 +11,7 @@ import Logout from './pages/Logout';
 import OAuthCallback from './pages/OAuthCallback';
 import ProtectedRoute from './components/ProtectedRoute';
 import SettingsPage from './pages/SettingsPage';
-
-// Get basename from <base> tag for path-based routing (e.g., /registry)
-const getBasename = () => {
-  const baseTag = document.querySelector('base');
-  if (baseTag && baseTag.href) {
-    const url = new URL(baseTag.href);
-    return url.pathname.replace(/\/$/, '') || '/';
-  }
-  return '/';
-};
+import { getBasename } from './utils/basePath';
 
 function App() {
   return (

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import Sidebar from './Sidebar';
 import UptimeDisplay from './UptimeDisplay';
 import { useServerStats } from '../hooks/useServerStats';
 import { useAuth } from '../contexts/AuthContext';
+import { apiUrl } from '../utils/basePath';
 import logo from '../assets/logo.png';
 
 interface LayoutProps {
@@ -33,7 +34,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   }, []);
 
   const fetchTags = useCallback(() => {
-    fetch('/api/search/tags')
+    fetch(apiUrl('/api/search/tags'))
       .then(res => res.json())
       .then(data => setAvailableTags(data.tags || []))
       .catch(err => console.error('Failed to fetch tags:', err));
@@ -41,7 +42,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   useEffect(() => {
     // Fetch version from API
-    fetch('/api/version')
+    fetch(apiUrl('/api/version'))
       .then(res => res.json())
       .then(data => setVersion(data.version))
       .catch(err => console.error('Failed to fetch version:', err));

--- a/frontend/src/components/UptimeDisplay.tsx
+++ b/frontend/src/components/UptimeDisplay.tsx
@@ -5,6 +5,7 @@ import React, {
 import {
   SystemStats,
 } from '../types/stats';
+import { apiUrl } from '../utils/basePath';
 
 
 /**
@@ -25,7 +26,7 @@ const UptimeDisplay: React.FC = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const response = await fetch('/api/stats');
+        const response = await fetch(apiUrl('/api/stats'));
         if (!response.ok) {
           throw new Error('Failed to fetch stats');
         }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,15 +1,6 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import axios from 'axios';
-
-// Get base URL from <base> tag for path-based routing (e.g., /registry)
-const getBaseURL = () => {
-  const baseTag = document.querySelector('base');
-  if (baseTag && baseTag.href) {
-    const url = new URL(baseTag.href);
-    return url.pathname.replace(/\/$/, '');
-  }
-  return '';
-};
+import { getBaseURL } from '../utils/basePath';
 
 // Configure axios to include credentials (cookies) with all requests
 axios.defaults.withCredentials = true;

--- a/frontend/src/utils/basePath.ts
+++ b/frontend/src/utils/basePath.ts
@@ -1,0 +1,21 @@
+// Shared helpers for path-based deployments (e.g. ROOT_PATH=/registry).
+// The server injects <base href="{ROOT_PATH}/"> into index.html; both
+// the router basename and the API base URL are derived from it.
+
+export const getBaseURL = (): string => {
+  const baseTag = document.querySelector('base');
+  if (baseTag && baseTag.href) {
+    const url = new URL(baseTag.href);
+    return url.pathname.replace(/\/$/, '');
+  }
+  return '';
+};
+
+export const getBasename = (): string => {
+  return getBaseURL() || '/';
+};
+
+export const apiUrl = (path: string): string => {
+  const normalized = path.startsWith('/') ? path : `/${path}`;
+  return `${getBaseURL()}${normalized}`;
+};

--- a/registry/auth/routes.py
+++ b/registry/auth/routes.py
@@ -198,9 +198,17 @@ async def logout_handler(
             except (SignatureExpired, BadSignature, Exception) as e:
                 logger.debug(f"Could not decode session for logout: {e}")
 
-        # Clear local session cookie
+        # Clear local session cookie. Must match (name, domain, path) of the
+        # Set-Cookie used by auth_server to create the cookie, or the browser
+        # will ignore the deletion. secure=False is intentional: an expired
+        # empty cookie has no secrets, and secure=True on an HTTP request
+        # would cause the browser to reject the Set-Cookie header entirely.
         response = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
-        response.delete_cookie(settings.session_cookie_name)
+        response.delete_cookie(
+            settings.session_cookie_name,
+            path="/",
+            domain=settings.session_cookie_domain,
+        )
 
         # If user was logged in via OAuth2, redirect to provider logout
         if provider:
@@ -272,7 +280,11 @@ async def logout_handler(
 
             logger.debug(f"Redirecting to {provider} logout")
             response = RedirectResponse(url=logout_url, status_code=status.HTTP_303_SEE_OTHER)
-            response.delete_cookie(settings.session_cookie_name)
+            response.delete_cookie(
+                settings.session_cookie_name,
+                path="/",
+                domain=settings.session_cookie_domain,
+            )
 
         logger.info("User logged out.")
         return response
@@ -281,7 +293,11 @@ async def logout_handler(
         logger.error(f"Error during logout: {e}")
         # Fallback to simple logout
         response = RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
-        response.delete_cookie(settings.session_cookie_name)
+        response.delete_cookie(
+            settings.session_cookie_name,
+            path="/",
+            domain=settings.session_cookie_domain,
+        )
         return response
 
 

--- a/registry/main.py
+++ b/registry/main.py
@@ -983,7 +983,14 @@ _ROOT_PATH: str = os.environ.get("ROOT_PATH", "")
 
 
 def _build_cached_index_html() -> str | None:
-    """Read index.html and inject <base> tag if ROOT_PATH is set.
+    """Read index.html and inject <base> tag and rewrite absolute asset paths.
+
+    Create React App (with homepage="/") emits absolute asset URLs like
+    /static/js/main.*.js and /favicon.ico. A <base> tag alone does not affect
+    absolute paths, so when ROOT_PATH is set (path-based routing) we must also
+    rewrite those URLs to include the prefix. Without this, the browser
+    requests e.g. https://host/static/js/... which bypasses the ingress rule
+    that only routes /<ROOT_PATH>/* to the app, and 404s.
 
     Returns:
         Modified HTML string if ROOT_PATH is set, None otherwise.
@@ -998,9 +1005,15 @@ def _build_cached_index_html() -> str | None:
     with open(index_path) as f:
         html_content = f.read()
 
-    # Inject <base> tag if not already present
+    prefix = _ROOT_PATH.rstrip("/")
+
+    # Rewrite absolute asset references to include ROOT_PATH
+    html_content = html_content.replace('="/static/', f'="{prefix}/static/')
+    html_content = html_content.replace('="/favicon.ico"', f'="{prefix}/favicon.ico"')
+
+    # Inject <base> tag if not already present (for React Router relative links)
     if "<base" not in html_content:
-        base_href = _ROOT_PATH if _ROOT_PATH.endswith("/") else f"{_ROOT_PATH}/"
+        base_href = f"{prefix}/"
         base_tag = f'<base href="{base_href}">'
         html_content = html_content.replace("<head>", f"<head>\n    {base_tag}")
 


### PR DESCRIPTION
## Summary

While verifying #500 locally on a Helm path-routing deployment (routingMode=path, apex-domain host), several pre-existing bugs surfaced that together broke login, logout, and SPA asset loading. This PR fixes them as one coherent set.

## Bugs fixed

### Login / OAuth

- auth_server/server.py:2676 — oauth2_login was concatenating ROOT_PATH onto AUTH_SERVER_EXTERNAL_URL even though the Helm chart already bakes the path prefix into the external URL. Result under path routing:
callback_uri=https://host/auth-server/auth-server/oauth2/callback/.... Removed the double-append.
- auth_server/server.py:~3045 — oauth2_callback's open-redirect check used `hostname.endswith(cookie_domain)`. When `SESSION_COOKIE_DOMAIN=".example.com"`, the apex host `example.com` doesn't satisfy `.endswith(".example.com")`, so legitimate redirects to the apex were rejected and silently replaced with `/`. This manifested in path mode where the apex is the only host. Now accepts exact apex match OR subdomain match, with lowercase normalization. Extracted to a reusable helper `_is_redirect_within_cookie_domain()`.

### Logout

- registry/auth/routes.py — `delete_cookie()` was called without path, domain, or matching attributes. The auth-server sets the session cookie with `Domain=.{domain}; Path=/; Secure`, and browsers silently ignore delete headers that don't match the original `(name, domain, path)`. Result: clicking "Sign Out" returned to `/login` but left the session cookie intact — users could navigate back to `/registry/` and remain logged in. Now passes matching `path="/"` and `domain=settings.session_cookie_domain`. `secure` is intentionally omitted so the delete isn't rejected on any request transported over HTTP (an empty expired cookie has no secrets to protect).
- charts/registry/templates/secret.yaml — added `SESSION_COOKIE_DOMAIN` and `SESSION_COOKIE_SECURE` env vars mirroring what the auth-server chart sets, so the registry pod has the values it needs to delete the cookie it doesn't create.
- charts/keycloak-configure/templates/configmap.yaml — the mcp-gateway-web Keycloak client was missing the `post.logout.redirect.uris` attribute. Keycloak ≥25 requires this; earlier versions fell back to redirectUris. Without it, Keycloak silently rejects or ignores `post_logout_redirect_uri` and the SSO session survives. Added `${REGISTRY_URL}/*` to the allow-list.
- charts/keycloak-configure/templates/configmap.yaml — client creation was not idempotent: POST /clients returns 409 on existing deployments and the script swallowed it, so attribute additions would never apply on upgrades. Added an `upsert_client()` helper that GETs by clientId, POSTs if missing, and PUTs the full representation otherwise.
- auth_server/server.py oauth2_logout : reject absolute `redirect_uri` values outside `SESSION_COOKIE_DOMAIN` before forwarding to the IdP, using the shared helper. This complements the Keycloak-side allow-list and doesn't rely on IdP-client configuration being correct.
- auth_server/server.py:3100 — `delete_cookie("oauth2_temp_session")` now passes `path="/"` to match the `set_cookie` that created it.

### Helm chart

- charts/keycloak-configure/templates/secret.yaml:31 — fixed missing `REGISTRY_URL` variable for the Keycloak setup script.

### SPA under path routing

- registry/main.py:_build_cached_index_html — when `ROOT_PATH` is set, now rewrites ="/static/ and ="/favicon.ico" references in the served index.html to include the prefix, in addition to the existing `<base href>` injection. `<base href>` only affects relative URLs; the CRA build (with homepage:"/") emits absolute asset URLs that bypass the ingress's `/registry/*` rule and 404 at the apex. Verified no false-positive replacements because the =/ anchor is specific to attribute syntax.
- frontend/src/utils/basePath.ts (new) — consolidates `getBaseURL`, `getBasename`, `apiUrl` into a single source of truth. App.tsx and AuthContext.tsx now import from it, dropping their local duplicates.
- frontend/src/components/Layout.tsx, frontend/src/components/UptimeDisplay.tsx — three bare `fetch('/api/...')` calls were bypassing `axios.defaults.baseURL` and hitting the apex root. Now use `apiUrl(...)` to include `ROOT_PATH`. Fixes 404s on /api/stats, /api/version, /api/search/tags.

## Scope

All changes are no-ops in subdomain mode and local development (ROOT_PATH="", no <base> tag, SESSION_COOKIE_DOMAIN as before). Impact is limited to routingMode=path deployments plus the cookie-deletion fix which applies to any deployment where the session cookie has a Domain= attribute.