### PR TITLE
fix: handle null description in virtual server documents

### DIFF
--- a/frontend/src/components/VirtualServerForm.tsx
+++ b/frontend/src/components/VirtualServerForm.tsx
@@ -204,7 +204,7 @@ const VirtualServerForm: React.FC<VirtualServerFormProps> = ({
       if (isEditMode) {
         const updateData: UpdateVirtualServerRequest = {
           server_name: name.trim(),
-          description: description.trim() || null,
+          description: description.trim() || '',
           tool_mappings: allMappings,
           required_scopes: parsedScopes,
           tags: parsedTags,

--- a/registry/repositories/documentdb/virtual_server_repository.py
+++ b/registry/repositories/documentdb/virtual_server_repository.py
@@ -119,7 +119,10 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
             try:
                 configs.append(_document_to_config(doc))
             except Exception as e:
-                logger.error(f"Failed to parse virtual server document: {e}")
+                doc_id = doc.get("_id", "unknown")
+                logger.error(
+                    f"Failed to parse virtual server document '{doc_id}': {e}"
+                )
         return configs
 
     async def list_enabled(self) -> list[VirtualServerConfig]:
@@ -131,7 +134,10 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
             try:
                 configs.append(_document_to_config(doc))
             except Exception as e:
-                logger.error(f"Failed to parse virtual server document: {e}")
+                doc_id = doc.get("_id", "unknown")
+                logger.error(
+                    f"Failed to parse virtual server document '{doc_id}': {e}"
+                )
         return configs
 
     async def create(

--- a/registry/schemas/virtual_server_models.py
+++ b/registry/schemas/virtual_server_models.py
@@ -16,6 +16,7 @@ from pydantic import (
     ConfigDict,
     Field,
     field_validator,
+    model_validator,
 )
 
 # Configure logging
@@ -123,6 +124,14 @@ class VirtualServerConfig(BaseModel):
         max_length=2048,
         description="Description of the virtual server's purpose",
     )
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def coerce_null_description(cls, v: Any) -> str:
+        """Coerce None to empty string for MongoDB documents with null description."""
+        if v is None:
+            return ""
+        return v
 
     # Tool configuration
     tool_mappings: list[ToolMapping] = Field(
@@ -237,6 +246,15 @@ class VirtualServerInfo(BaseModel):
     path: str = Field(..., description="Virtual server path")
     server_name: str = Field(..., description="Human-readable name")
     description: str = Field(default="", description="Server description")
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def coerce_null_description(cls, v: Any) -> str:
+        """Coerce None to empty string for MongoDB documents with null description."""
+        if v is None:
+            return ""
+        return v
+
     tool_count: int = Field(default=0, description="Number of mapped tools")
     backend_count: int = Field(default=0, description="Number of unique backend servers")
     backend_paths: list[str] = Field(

--- a/registry/services/virtual_server_service.py
+++ b/registry/services/virtual_server_service.py
@@ -206,6 +206,11 @@ class VirtualServerService:
 
         updates = request.model_dump(exclude_unset=True)
 
+        # Coerce None string fields to empty string to prevent MongoDB
+        # from storing null which breaks Pydantic validation on read
+        if "description" in updates and updates["description"] is None:
+            updates["description"] = ""
+
         # Validate tool mappings if being updated
         if "tool_mappings" in updates and updates["tool_mappings"]:
             tool_mappings = [ToolMapping(**tm) for tm in updates["tool_mappings"]]


### PR DESCRIPTION
## Problem

Virtual MCP servers disappear from the UI after editing. The root cause is a Pydantic validation error when reading documents from MongoDB:

```
Failed to parse virtual server document: 1 validation error for VirtualServerConfig
description
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

### Root Cause

1. The frontend edit form sends `description: null` when the description field is empty (line 207 of VirtualServerForm.tsx)
2. The update service stores this `null` in MongoDB via `$set`
3. On subsequent reads, `VirtualServerConfig` rejects `None` for the `str`-typed `description` field
4. The repository silently skips unparseable documents → virtual servers vanish from listings
5. The update endpoint also fails with 500 because it reads the document first

### Fixes

- **Backend model** (`virtual_server_models.py`): Add `field_validator` on `VirtualServerConfig` and `VirtualServerInfo` that coerces `None` → `""` (defensive read path)
- **Backend service** (`virtual_server_service.py`): Coerce `None` description to empty string before writing to MongoDB (defensive write path)
- **Frontend** (`VirtualServerForm.tsx`): Send `''` instead of `null` for empty description in edit mode
- **Repository** (`virtual_server_repository.py`): Include document `_id` in parse error logs for diagnosability

### Testing

- Verified via `mongosh` that existing documents with `description: null` are now parseable
- Pydantic validator handles all cases: `None` → `""`, missing → `""`, valid string → kept as-is
