### PR TITLE
chore: follow-up cleanup and tests for #932 null-description fix

### DIFF
--- a/registry/repositories/documentdb/virtual_server_repository.py
+++ b/registry/repositories/documentdb/virtual_server_repository.py
@@ -120,9 +120,7 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
                 configs.append(_document_to_config(doc))
             except Exception as e:
                 doc_id = doc.get("_id", "unknown")
-                logger.error(
-                    f"Failed to parse virtual server document '{doc_id}': {e}"
-                )
+                logger.error(f"Failed to parse virtual server document '{doc_id}': {e}")
         return configs
 
     async def list_enabled(self) -> list[VirtualServerConfig]:
@@ -135,9 +133,7 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
                 configs.append(_document_to_config(doc))
             except Exception as e:
                 doc_id = doc.get("_id", "unknown")
-                logger.error(
-                    f"Failed to parse virtual server document '{doc_id}': {e}"
-                )
+                logger.error(f"Failed to parse virtual server document '{doc_id}': {e}")
         return configs
 
     async def create(

--- a/registry/schemas/virtual_server_models.py
+++ b/registry/schemas/virtual_server_models.py
@@ -16,7 +16,6 @@ from pydantic import (
     ConfigDict,
     Field,
     field_validator,
-    model_validator,
 )
 
 # Configure logging

--- a/tests/unit/test_virtual_server_models.py
+++ b/tests/unit/test_virtual_server_models.py
@@ -338,6 +338,28 @@ class TestVirtualServerConfig:
         assert restored.tags == ["dev"]
         assert restored.is_enabled is True
 
+    def test_null_description_coerced_to_empty_string(self):
+        """MongoDB docs with description=null must deserialize (PR #932 fix).
+
+        Older records persisted a literal null for description. The Pydantic
+        validator added in PR #932 coerces that to the empty string on read
+        so the repository does not silently drop the document.
+        """
+        config = VirtualServerConfig(
+            path="/virtual/legacy-null",
+            server_name="Legacy",
+            description=None,
+        )
+        assert config.description == ""
+
+    def test_missing_description_defaults_to_empty_string(self):
+        """Description field is optional with a default of empty string."""
+        config = VirtualServerConfig(
+            path="/virtual/no-description",
+            server_name="No Description",
+        )
+        assert config.description == ""
+
 
 class TestVirtualServerInfo:
     """Tests for VirtualServerInfo model."""
@@ -369,6 +391,15 @@ class TestVirtualServerInfo:
         assert info.tags == []
         assert info.created_by is None
         assert info.created_at is None
+
+    def test_null_description_coerced_to_empty_string(self):
+        """Symmetric defensive coercion on VirtualServerInfo (PR #932 fix)."""
+        info = VirtualServerInfo(
+            path="/virtual/legacy-null",
+            server_name="Legacy",
+            description=None,
+        )
+        assert info.description == ""
 
 
 class TestCreateVirtualServerRequest:

--- a/tests/unit/test_virtual_server_service.py
+++ b/tests/unit/test_virtual_server_service.py
@@ -441,6 +441,33 @@ class TestVirtualServerServiceCRUD:
             await service.update_virtual_server("/virtual/nonexistent", request)
 
     @pytest.mark.asyncio
+    async def test_update_virtual_server_coerces_null_description(self, service, mock_vs_repo):
+        """Description=None from the request must be persisted as "" (PR #932 fix).
+
+        The frontend previously sent description=null when the field was
+        cleared. Without this coercion, MongoDB stored a literal null and
+        subsequent reads failed Pydantic validation, silently dropping the
+        document from listings.
+        """
+        existing = VirtualServerConfig(
+            path="/virtual/dev",
+            server_name="Dev",
+            description="Old description",
+        )
+        mock_vs_repo.get.return_value = existing
+        mock_vs_repo.update.return_value = existing
+
+        request = UpdateVirtualServerRequest(description=None)
+
+        with patch.object(service, "_trigger_nginx_reload", new_callable=AsyncMock):
+            await service.update_virtual_server("/virtual/dev", request)
+
+        # Verify the update dict passed to the repo has "" not None
+        mock_vs_repo.update.assert_called_once()
+        _call_path, call_updates = mock_vs_repo.update.call_args.args
+        assert call_updates["description"] == ""
+
+    @pytest.mark.asyncio
     async def test_update_virtual_server_with_new_tool_mappings(
         self, service, mock_vs_repo, mock_server_repo
     ):


### PR DESCRIPTION
Follow-up to #932 (null-description fix for virtual servers). Addresses the three non-blocking items from the PR review while leaving the core fix untouched.

## Summary

1. **Remove unused import** `pydantic.model_validator` in [registry/schemas/virtual_server_models.py:19](../blob/main/registry/schemas/virtual_server_models.py#L19). Ruff flagged this as F401 but CI did not fail because the workflow runs ruff with \`continue-on-error: true\`.
2. **Format** [virtual_server_repository.py](../blob/main/registry/repositories/documentdb/virtual_server_repository.py) so the new error-log lines fit on one line (zero behavior change).
3. **Add targeted tests** pinning the null-description coercion:
   - `TestVirtualServerConfig.test_null_description_coerced_to_empty_string`
   - `TestVirtualServerConfig.test_missing_description_defaults_to_empty_string`
   - `TestVirtualServerInfo.test_null_description_coerced_to_empty_string`
   - `TestVirtualServerServiceCRUD.test_update_virtual_server_coerces_null_description`

Without these tests the fix from #932 is unprotected against accidental regressions (e.g., someone removing \`mode=\"before\"\` from the validator, or changing the service-layer coercion).

## Test plan

- [x] \`uv run pytest tests/unit/test_virtual_server_models.py tests/unit/test_virtual_server_service.py --no-cov\` -> 122 passed
- [x] \`uv run pytest tests/ -n 8 --no-cov\` -> 2674 passed, 67 skipped
- [x] \`uv run ruff check\` and \`uv run ruff format --check\` on all touched files -> clean

## Note on CI hygiene (separate follow-up)

This PR surfaced that [.github/workflows/registry-test.yml](../blob/main/.github/workflows/registry-test.yml) runs ruff with \`continue-on-error: true\`, which is why the F401 in #932 slipped through. Worth opening a tracking issue to remove that flag so lint failures actually block PRs. Out of scope for this PR.