### PR TITLE
Feat/extended mongo connection string support

### DIFF
--- a/charts/mcp-gateway-registry-stack/README.md
+++ b/charts/mcp-gateway-registry-stack/README.md
@@ -590,7 +590,7 @@ can reference pre-existing secrets instead.
 |-------|---------------------|-------------|
 | `global.existingSharedSecret` | `shared-secret` | SECRET_KEY and federation tokens shared by auth-server and registry |
 | `global.existingOauthProviderSecret` | `oauth-provider-secret` | Auth provider credentials (Keycloak/Entra/Okta/Auth0/Cognito) |
-| `global.existingMongoCredentialsSecret` | `mongo-credentials` | MongoDB connection credentials used by auth-server and registry |
+| `global.existingMongoCredentialsSecret` | `mongo-credentials` | MongoDB connection credentials used by auth-server and registry. When set, `mongodb.connectionString` has no effect — deployment pods read their connection values directly from this existing secret. |
 | `mongodb.existingPasswordSecret` | `my-user-password` | MongoDB operator user password |
 
 ### Per-Service Existing Secrets

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -82,6 +82,11 @@ mongodb:
   password: &mongoPassword CHANGEME # Set the password for the MongoDB user
   database: &mongoDatabase mcp_registry
   existingPasswordSecret: "" # If set, skip creating my-user-password secret and use this name instead
+  # connectionString: Full MongoDB URI override (MongoDB Atlas, externally-
+  # managed replica sets, etc.). When set, takes precedence over user/
+  # password/host-based assembly throughout the stack. For production,
+  # prefer providing the URI via global.existingMongoCredentialsSecret.
+  connectionString: &mongoConnectionString ""
 
 # Keycloak configuration
 # Set create: true to deploy Keycloak as part of this stack
@@ -182,6 +187,7 @@ mongodb-configure:
     username: *mongoUser
     password: *mongoPassword
     database: *mongoDatabase
+    connectionString: *mongoConnectionString
 
 # Registry service configuration
 registry:

--- a/charts/mongodb-configure/templates/configmap.yaml
+++ b/charts/mongodb-configure/templates/configmap.yaml
@@ -47,26 +47,45 @@ data:
   wait.py: |
     import pymongo
     import os
+    import re
     import time
-    import sys
+    from urllib.parse import urlsplit
 
+    OVERRIDE = os.getenv("MONGODB_CONNECTION_STRING", "")
     MONGO_HOST = os.getenv("DOCUMENTDB_HOST", "mongodb")
     MONGO_PORT = os.getenv("DOCUMENTDB_PORT", "27017")
     REPLICA_SET = os.getenv("DOCUMENTDB_REPLICA_SET", "rs0")
     USERNAME = os.getenv("DOCUMENTDB_USERNAME", "")
     PASSWORD = os.getenv("DOCUMENTDB_PASSWORD", "")
 
+    def _redact(msg):
+        return re.sub(r"mongodb(?:\+srv)?://[^\s]*", "<redacted-uri>", str(msg))
+
     def wait_for_mongodb():
+        if OVERRIDE:
+            uri = OVERRIDE
+            display_host = urlsplit(uri).hostname or "(override)"
+            skip_replset_check = True
+        else:
+            uri = f"mongodb://{USERNAME}:{PASSWORD}@{MONGO_HOST}:{MONGO_PORT}/?authMechanism=SCRAM-SHA-256&authSource=admin"
+            display_host = f"{MONGO_HOST}:{MONGO_PORT}"
+            skip_replset_check = False
+
+        client = None
         while True:
             try:
-                # First check basic connectivity
-                client = pymongo.MongoClient(f"mongodb://{USERNAME}:{PASSWORD}@{MONGO_HOST}:{MONGO_PORT}/?authMechanism=SCRAM-SHA-256&authSource=admin",
-                                             serverSelectionTimeoutMS=5000,
-                                             connectTimeoutMS=5000)
+                client = pymongo.MongoClient(
+                    uri,
+                    serverSelectionTimeoutMS=5000,
+                    connectTimeoutMS=5000,
+                )
                 client.admin.command('ping')
-                print("MongoDB is accepting connections. Checking replica set status...")
 
-                # Check replica set status
+                if skip_replset_check:
+                    print(f"MongoDB is ready ({display_host})")
+                    break
+
+                print("MongoDB is accepting connections. Checking replica set status...")
                 status = client.admin.command('replSetGetStatus')
 
                 if status['ok'] != 1:
@@ -74,7 +93,7 @@ data:
                     time.sleep(10)
                     continue
 
-                ready_members = [m for m in status['members'] if m['state'] in [1, 2]]  # PRIMARY or SECONDARY
+                ready_members = [m for m in status['members'] if m['state'] in [1, 2]]
                 total_members = len(status['members'])
 
                 if len(ready_members) == total_members:
@@ -85,16 +104,17 @@ data:
                     time.sleep(10)
 
             except Exception as e:
-                print(f"MongoDB not ready yet: {e}")
+                print(f"MongoDB not ready yet: {_redact(e)}")
                 time.sleep(5)
             finally:
                 try:
-                    client.close()
-                except:
+                    if client is not None:
+                        client.close()
+                except Exception:
                     pass
 
     wait_for_mongodb()
-    print("MongoDB replica set is fully ready!")
+    print("MongoDB is fully ready!")
 
   mcp-registry-admin.json: |
     {
@@ -207,8 +227,14 @@ data:
 
 
     def _get_config_from_env() -> dict:
-        """Get MongoDB CE configuration from environment variables."""
+        """Get MongoDB CE configuration from environment variables.
+
+        When MONGODB_CONNECTION_STRING is set, the caller owns the full URI
+        (Atlas, externally-managed replica set, etc.) and the discrete
+        host/port/user/password values are ignored.
+        """
         return {
+            "connection_string": os.getenv("MONGODB_CONNECTION_STRING", ""),
             "host": os.getenv("DOCUMENTDB_HOST", "mongodb"),
             "port": int(os.getenv("DOCUMENTDB_PORT", "27017")),
             "database": os.getenv("DOCUMENTDB_DATABASE", "mcp_registry"),
@@ -405,11 +431,16 @@ data:
     async def _initialize_mongodb_ce() -> None:
         """Main initialization function."""
         config = _get_config_from_env()
+        override = config["connection_string"]
 
         logger.info("=" * 60)
         logger.info("MongoDB CE Initialization for MCP Gateway")
         logger.info("=" * 60)
-        logger.info(f"Host: {config['host']}:{config['port']}")
+        if override:
+            from urllib.parse import urlsplit
+            logger.info(f"Host: {urlsplit(override).hostname or '(override)'} (connection string override)")
+        else:
+            logger.info(f"Host: {config['host']}:{config['port']}")
         logger.info(f"Database: {config['database']}")
         logger.info(f"Namespace: {config['namespace']}")
         logger.info("")
@@ -418,11 +449,18 @@ data:
         logger.info("Waiting for MongoDB to be ready...")
         time.sleep(10)
 
-        # Initialize replica set (synchronous)
-        _initialize_replica_set(config["host"], config["port"], config["username"], config["password"])
+        if override:
+            # Caller owns the topology (Atlas, externally-managed replica set, etc.).
+            # Skip replSetInitiate — we lack admin rights and the replica set is
+            # already configured by the provider.
+            logger.info("Skipping replica-set initialization (connection string override in use)")
+            connection_string = override
+        else:
+            # Initialize replica set (synchronous)
+            _initialize_replica_set(config["host"], config["port"], config["username"], config["password"])
 
-        # Connect with motor for async operations
-        connection_string = f"mongodb://{config['username']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}&authMechanism=SCRAM-SHA-256&authSource=admin"
+            # Connect with motor for async operations
+            connection_string = f"mongodb://{config['username']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}&authMechanism=SCRAM-SHA-256&authSource=admin"
         try:
             client = AsyncIOMotorClient(
                 connection_string,

--- a/charts/mongodb-configure/templates/secret.yaml
+++ b/charts/mongodb-configure/templates/secret.yaml
@@ -7,13 +7,20 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 data:
   DOCUMENTDB_DATABASE: {{.Values.mongodb.database | b64enc | quote}}
-  DOCUMENTDB_HOST: {{ if contains "." .Values.mongodb.host }}{{ .Values.mongodb.host | b64enc | quote }}{{ else }}{{ printf "%s.%s.svc.cluster.local" .Values.mongodb.host .Release.Namespace | b64enc | quote }}{{ end }}
   DOCUMENTDB_NAMESPACE: {{.Values.mongodb.namespace | b64enc | quote}}
+  DOCUMENTDB_USE_TLS: {{.Values.mongodb.use_tls | toString | b64enc | quote}}
+  STORAGE_BACKEND: {{.Values.mongodb.storage_backend | b64enc | quote}}
+  {{- if .Values.mongodb.connectionString }}
+  # Connection string override: caller owns the full URI. Discrete
+  # HOST/PORT/USERNAME/PASSWORD keys are omitted to avoid a second
+  # source of truth.
+  MONGODB_CONNECTION_STRING: {{.Values.mongodb.connectionString | b64enc | quote}}
+  {{- else }}
+  DOCUMENTDB_HOST: {{ if contains "." .Values.mongodb.host }}{{ .Values.mongodb.host | b64enc | quote }}{{ else }}{{ printf "%s.%s.svc.cluster.local" .Values.mongodb.host .Release.Namespace | b64enc | quote }}{{ end }}
   DOCUMENTDB_PASSWORD: {{.Values.mongodb.password | b64enc | quote}}
   DOCUMENTDB_PORT: {{.Values.mongodb.port | toString | b64enc | quote}}
   DOCUMENTDB_REPLICA_SET: {{.Values.mongodb.replica_set | b64enc | quote}}
   DOCUMENTDB_USERNAME: {{.Values.mongodb.username | b64enc | quote}}
-  DOCUMENTDB_USE_TLS: {{.Values.mongodb.use_tls | toString | b64enc | quote}}
-  STORAGE_BACKEND: {{.Values.mongodb.storage_backend | b64enc | quote}}
+  {{- end }}
 type: Opaque
 {{- end }}

--- a/charts/mongodb-configure/values.yaml
+++ b/charts/mongodb-configure/values.yaml
@@ -19,3 +19,14 @@ mongodb:
   username: my-user
   use_tls: false
   storage_backend: mongodb-ce
+  # connectionString: Full MongoDB URI override. When set, takes precedence
+  # over host/port/username/password above and is passed verbatim to the
+  # MongoDB client. Required for MongoDB Atlas (mongodb+srv://...) and any
+  # externally-managed MongoDB. When set, the replica-set init job will
+  # skip replSetInitiate (the caller's cluster is assumed to already be
+  # configured).
+  #
+  # For production, prefer providing the URI via an existing Kubernetes
+  # Secret: put MONGODB_CONNECTION_STRING into your own Secret and set
+  # global.existingMongoCredentialsSecret to its name.
+  connectionString: ""

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -85,6 +85,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}
@@ -274,6 +278,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb or mongodb-ce)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -91,6 +91,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}
@@ -275,6 +279,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb or mongodb-ce)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}
@@ -389,6 +393,10 @@ services:
       # Storage Backend Configuration
       - STORAGE_BACKEND=${STORAGE_BACKEND:-file}
       # DocumentDB/MongoDB Configuration (when STORAGE_BACKEND=documentdb or mongodb-ce)
+      # MONGODB_CONNECTION_STRING: Optional full URI override (e.g. for MongoDB
+      # Atlas, mongodb+srv://...). When set, takes precedence over the discrete
+      # DOCUMENTDB_* values below.
+      - MONGODB_CONNECTION_STRING=${MONGODB_CONNECTION_STRING:-}
       - DOCUMENTDB_HOST=${DOCUMENTDB_HOST:-mongodb}
       - DOCUMENTDB_PORT=${DOCUMENTDB_PORT:-27017}
       - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME}

--- a/docker/auth-entrypoint.sh
+++ b/docker/auth-entrypoint.sh
@@ -26,33 +26,55 @@ else
     echo "No DocumentDB host detected or DOCUMENTDB_HOST is empty - skipping CA bundle download"
 fi
 
-# --- Wait for MongoDB Replica Set ---
-if [ -n "$DOCUMENTDB_HOST" ]; then
-    echo "Waiting for MongoDB replica set at ${DOCUMENTDB_HOST}:${DOCUMENTDB_PORT:-27017}..."
+# --- Wait for MongoDB ---
+if [ -n "$MONGODB_CONNECTION_STRING" ] || [ -n "$DOCUMENTDB_HOST" ]; then
+    if [ -n "$MONGODB_CONNECTION_STRING" ]; then
+        echo "Waiting for MongoDB via connection string override..."
+    else
+        echo "Waiting for MongoDB replica set at ${DOCUMENTDB_HOST}:${DOCUMENTDB_PORT:-27017}..."
+    fi
     source /app/.venv/bin/activate
     python3 -c "
-import pymongo, os, time, sys
-host = os.getenv('DOCUMENTDB_HOST', 'mongodb')
-port = int(os.getenv('DOCUMENTDB_PORT', '27017'))
-user = os.getenv('DOCUMENTDB_USERNAME', '')
-pwd = os.getenv('DOCUMENTDB_PASSWORD', '')
-backend = os.getenv('STORAGE_BACKEND', 'mongodb-ce')
-use_tls = os.getenv('DOCUMENTDB_USE_TLS', 'true').lower() == 'true'
-ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
-auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
-if user and pwd:
-    uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+import pymongo, os, re, time
+from urllib.parse import urlsplit
+
+override = os.getenv('MONGODB_CONNECTION_STRING', '')
+if override:
+    uri = override
+    tls_options = {}
+    skip_replset_check = True
+    display_host = urlsplit(uri).hostname or '(override)'
 else:
-    uri = f'mongodb://{host}:{port}/'
-# Prepare TLS options
-tls_options = {}
-if use_tls:
-    tls_options['tls'] = True
-    tls_options['tlsCAFile'] = ca_file
+    host = os.getenv('DOCUMENTDB_HOST', 'mongodb')
+    port = int(os.getenv('DOCUMENTDB_PORT', '27017'))
+    user = os.getenv('DOCUMENTDB_USERNAME', '')
+    pwd = os.getenv('DOCUMENTDB_PASSWORD', '')
+    backend = os.getenv('STORAGE_BACKEND', 'mongodb-ce')
+    use_tls = os.getenv('DOCUMENTDB_USE_TLS', 'true').lower() == 'true'
+    ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
+    auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
+    if user and pwd:
+        uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+    else:
+        uri = f'mongodb://{host}:{port}/'
+    tls_options = {}
+    if use_tls:
+        tls_options['tls'] = True
+        tls_options['tlsCAFile'] = ca_file
+    skip_replset_check = False
+    display_host = f'{host}:{port}'
+
+def _redact(msg):
+    return re.sub(r'mongodb(?:\+srv)?://[^\s]*', '<redacted-uri>', str(msg))
+
 while True:
     try:
         c = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000, connectTimeoutMS=5000, **tls_options)
         c.admin.command('ping')
+        if skip_replset_check:
+            print(f'MongoDB is ready ({display_host})')
+            c.close()
+            break
         try:
             st = c.admin.command('replSetGetStatus')
             ready = [m for m in st['members'] if m['state'] in [1, 2]]
@@ -68,7 +90,7 @@ while True:
             c.close()
             break
     except Exception as e:
-        print(f'MongoDB not ready yet: {e}')
+        print(f'MongoDB not ready yet: {_redact(e)}')
     time.sleep(5)
 "
     deactivate

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -30,33 +30,57 @@ if [ "$RUN_INIT_SCRIPTS" = "true" ]; then
     exec "$@"
 fi
 
-# --- Wait for MongoDB Replica Set ---
-if [ -n "$DOCUMENTDB_HOST" ]; then
-    echo "Waiting for MongoDB replica set at ${DOCUMENTDB_HOST}:${DOCUMENTDB_PORT:-27017}..."
+# --- Wait for MongoDB ---
+if [ -n "$MONGODB_CONNECTION_STRING" ] || [ -n "$DOCUMENTDB_HOST" ]; then
+    if [ -n "$MONGODB_CONNECTION_STRING" ]; then
+        echo "Waiting for MongoDB via connection string override..."
+    else
+        echo "Waiting for MongoDB replica set at ${DOCUMENTDB_HOST}:${DOCUMENTDB_PORT:-27017}..."
+    fi
     source /app/.venv/bin/activate
     python3 -c "
-import pymongo, os, time, sys
-host = os.getenv('DOCUMENTDB_HOST', 'mongodb')
-port = int(os.getenv('DOCUMENTDB_PORT', '27017'))
-user = os.getenv('DOCUMENTDB_USERNAME', '')
-pwd = os.getenv('DOCUMENTDB_PASSWORD', '')
-backend = os.getenv('STORAGE_BACKEND', 'mongodb-ce')
-use_tls = os.getenv('DOCUMENTDB_USE_TLS', 'true').lower() == 'true'
-ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
-auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
-if user and pwd:
-    uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+import pymongo, os, re, time
+from urllib.parse import urlsplit
+
+override = os.getenv('MONGODB_CONNECTION_STRING', '')
+if override:
+    uri = override
+    tls_options = {}
+    # URI owns TLS; skip replica-set check (caller owns the topology)
+    skip_replset_check = True
+    display_host = urlsplit(uri).hostname or '(override)'
 else:
-    uri = f'mongodb://{host}:{port}/'
-# Prepare TLS options
-tls_options = {}
-if use_tls:
-    tls_options['tls'] = True
-    tls_options['tlsCAFile'] = ca_file
+    host = os.getenv('DOCUMENTDB_HOST', 'mongodb')
+    port = int(os.getenv('DOCUMENTDB_PORT', '27017'))
+    user = os.getenv('DOCUMENTDB_USERNAME', '')
+    pwd = os.getenv('DOCUMENTDB_PASSWORD', '')
+    backend = os.getenv('STORAGE_BACKEND', 'mongodb-ce')
+    use_tls = os.getenv('DOCUMENTDB_USE_TLS', 'true').lower() == 'true'
+    ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
+    auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
+    if user and pwd:
+        uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+    else:
+        uri = f'mongodb://{host}:{port}/'
+    tls_options = {}
+    if use_tls:
+        tls_options['tls'] = True
+        tls_options['tlsCAFile'] = ca_file
+    skip_replset_check = False
+    display_host = f'{host}:{port}'
+
+def _redact(msg):
+    # Strip any mongodb://user:pass@... substrings that pymongo may echo in errors
+    return re.sub(r'mongodb(?:\+srv)?://[^\s]*', '<redacted-uri>', str(msg))
+
 while True:
     try:
         c = pymongo.MongoClient(uri, serverSelectionTimeoutMS=5000, connectTimeoutMS=5000, **tls_options)
         c.admin.command('ping')
+        if skip_replset_check:
+            print(f'MongoDB is ready ({display_host})')
+            c.close()
+            break
         try:
             st = c.admin.command('replSetGetStatus')
             ready = [m for m in st['members'] if m['state'] in [1, 2]]
@@ -72,7 +96,7 @@ while True:
             c.close()
             break
     except Exception as e:
-        print(f'MongoDB not ready yet: {e}')
+        print(f'MongoDB not ready yet: {_redact(e)}')
     time.sleep(5)
 "
     deactivate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,6 +381,26 @@ mongosh --host <cluster-endpoint> \
         --eval "use mcp_registry; show collections"
 ```
 
+#### Full Connection String Override (MongoDB Atlas and any externally-managed MongoDB)
+
+For MongoDB Atlas or any MongoDB cluster you manage yourself, set `MONGODB_CONNECTION_STRING` to the full URI. When set, it takes precedence over all of the discrete `DOCUMENTDB_HOST`, `DOCUMENTDB_PORT`, `DOCUMENTDB_USERNAME`, `DOCUMENTDB_PASSWORD`, and TLS settings — the URI owns connection behavior end to end, including TLS, `retryWrites`, replica-set selection, and read preference.
+
+```bash
+# MongoDB Atlas example
+export STORAGE_BACKEND=mongodb-ce
+export MONGODB_CONNECTION_STRING='mongodb+srv://user:password@cluster0.abc123.mongodb.net/mcp_registry?retryWrites=true&w=majority'
+export DOCUMENTDB_DATABASE=mcp_registry
+export DOCUMENTDB_NAMESPACE=default
+```
+
+**Notes:**
+- `STORAGE_BACKEND=mongodb-ce` is the correct value for Atlas — it is wire-compatible MongoDB.
+- The registry **never logs the full URI** and the health endpoint extracts only the hostname (via `urllib.parse.urlsplit`, no DNS, no userinfo).
+- Do **not** set `STORAGE_BACKEND=documentdb` when pointing at Atlas; that backend selects SCRAM-SHA-1 for the discrete-vars path (used only when `MONGODB_CONNECTION_STRING` is unset) and hardcodes `retryWrites=False`.
+- For Helm, set `mongodb.connectionString` (see `charts/mongodb-configure/values.yaml`). For externally-managed MongoDB, also set `mongodb.enabled: false` at the stack level to skip the in-cluster MongoDB operator.
+- For production, prefer injecting the URI via a pre-existing Kubernetes Secret (`global.existingMongoCredentialsSecret`) or AWS Secrets Manager rather than as a plain Helm value.
+- The replica-set initialization job (`mongodb-configure`) automatically skips `replSetInitiate` when the override is set — Atlas clusters are already configured and will reject the command.
+
 **Important Notes:**
 - MongoDB CE uses application-level vector search (Python cosine similarity)
 - DocumentDB uses native HNSW vector indexes for production performance

--- a/registry/api/system_routes.py
+++ b/registry/api/system_routes.py
@@ -177,6 +177,7 @@ async def _get_database_status() -> dict:
         }
 
     # DocumentDB/MongoDB backend - check connection
+    host_str = _describe_mongo_host()
     try:
         from registry.repositories.documentdb.client import get_documentdb_client
 
@@ -185,9 +186,6 @@ async def _get_database_status() -> dict:
         # Try to ping the database (db is AsyncIOMotorDatabase, not client)
         await db.command("ping")
 
-        # Get host information
-        host_str = f"{settings.documentdb_host}:{settings.documentdb_port}"
-
         return {
             "backend": backend,
             "status": "Healthy",
@@ -195,12 +193,32 @@ async def _get_database_status() -> dict:
         }
     except Exception as e:
         logger.error(f"Database health check failed: {e}")
-        host_str = f"{settings.documentdb_host}:{settings.documentdb_port}"
         return {
             "backend": backend,
             "status": "Unhealthy",
             "host": host_str,
         }
+
+
+def _describe_mongo_host() -> str:
+    """Describe the MongoDB host for the health endpoint without leaking creds.
+
+    When a full connection-string override is in use, parse the URI with
+    ``urllib.parse.urlsplit`` to extract the hostname only — stdlib parsing
+    strips the userinfo and triggers no DNS (unlike pymongo.uri_parser.parse_uri,
+    which resolves mongodb+srv:// records live).
+    """
+    if settings.mongodb_connection_string:
+        from urllib.parse import urlsplit
+
+        try:
+            host = urlsplit(settings.mongodb_connection_string).hostname
+            if host:
+                return host
+        except ValueError:
+            pass
+        return "(connection string override)"
+    return f"{settings.documentdb_host}:{settings.documentdb_port}"
 
 
 async def _get_registry_card_status() -> dict:

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -494,7 +494,7 @@ class Settings(BaseSettings):
     # Storage Backend Configuration
     storage_backend: str = "file"  # Options: "file", "documentdb"
 
-    # DocumentDB Configuration (only used when storage_backend="documentdb")
+    # DocumentDB Configuration (only used when storage_backend="documentdb" or "mongodb-ce")
     documentdb_host: str = "localhost"
     documentdb_port: int = 27017
     documentdb_database: str = "mcp_registry"
@@ -506,6 +506,12 @@ class Settings(BaseSettings):
     documentdb_replica_set: str | None = None
     documentdb_read_preference: str = "secondaryPreferred"
     documentdb_direct_connection: bool = False  # Set to True only for single-node MongoDB (tests)
+
+    # Full MongoDB connection URI override. When set, bypasses host/port/user/password
+    # assembly and is passed verbatim to the MongoDB client. Required for MongoDB Atlas
+    # (mongodb+srv://...) and any externally-managed MongoDB where the caller wants to
+    # own the full URI (replica sets, TLS params, retryWrites, etc.).
+    mongodb_connection_string: str | None = None
 
     # DocumentDB Namespace (for multi-tenancy support)
     documentdb_namespace: str = "default"

--- a/registry/repositories/documentdb/client.py
+++ b/registry/repositories/documentdb/client.py
@@ -21,10 +21,13 @@ async def get_documentdb_client() -> AsyncIOMotorDatabase:
         return _database
 
     connection_string = build_connection_string()
-    logger.info(
-        f"Connecting to {settings.storage_backend} "
-        f"(host: {settings.documentdb_host})"
-    )
+    if settings.mongodb_connection_string:
+        logger.info(f"Connecting to {settings.storage_backend} via connection string override")
+    else:
+        logger.info(
+            f"Connecting to {settings.storage_backend} "
+            f"(host: {settings.documentdb_host})"
+        )
 
     _client = AsyncIOMotorClient(
         connection_string,

--- a/registry/utils/mongodb_connection.py
+++ b/registry/utils/mongodb_connection.py
@@ -11,12 +11,16 @@ from typing import Any
 def build_connection_string() -> str:
     """Build a MongoDB/DocumentDB connection string from registry settings.
 
-    Handles three authentication modes:
+    If ``mongodb_connection_string`` is set, it is returned verbatim and all
+    other auth/host branches are skipped. Otherwise, handles three modes:
     - IAM (MONGODB-AWS) for DocumentDB with AWS credentials
     - Username/password (SCRAM-SHA-256 for MongoDB CE, SCRAM-SHA-1 for DocumentDB)
     - No authentication (local development)
     """
     from ..core.config import settings
+
+    if settings.mongodb_connection_string:
+        return settings.mongodb_connection_string
 
     if settings.documentdb_use_iam:
         import boto3
@@ -50,8 +54,16 @@ def build_connection_string() -> str:
 
 
 def build_tls_kwargs() -> dict[str, Any]:
-    """Build TLS keyword arguments for MongoDB client."""
+    """Build TLS keyword arguments for MongoDB client.
+
+    When ``mongodb_connection_string`` is set, the URI owns TLS configuration
+    (e.g. ``mongodb+srv://`` implies TLS automatically), so we return an
+    empty dict.
+    """
     from ..core.config import settings
+
+    if settings.mongodb_connection_string:
+        return {}
 
     kwargs: dict[str, Any] = {}
     if settings.documentdb_use_tls:
@@ -62,8 +74,16 @@ def build_tls_kwargs() -> dict[str, Any]:
 
 
 def build_client_options() -> dict[str, Any]:
-    """Build common client options for MongoDB connections."""
+    """Build common client options for MongoDB connections.
+
+    When ``mongodb_connection_string`` is set, the URI owns all options
+    (retryWrites, directConnection, replicaSet, etc.), so we return an
+    empty dict and let the caller-supplied URI decide.
+    """
     from ..core.config import settings
+
+    if settings.mongodb_connection_string:
+        return {}
 
     options: dict[str, Any] = {"retryWrites": False}
     if settings.documentdb_direct_connection:

--- a/scripts/backfill_agent_fields.py
+++ b/scripts/backfill_agent_fields.py
@@ -1,6 +1,7 @@
 """One-time backfill: normalize supported_protocol, trust_level, and visibility on existing agents and servers."""
 
 import logging
+import os
 
 from pymongo import MongoClient
 
@@ -10,8 +11,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-MONGODB_URI = "mongodb://localhost:27017"
-DB_NAME = "mcp_registry"
+# Allow override via MONGODB_CONNECTION_STRING (Atlas, externally-managed, etc.)
+MONGODB_URI = os.getenv("MONGODB_CONNECTION_STRING") or "mongodb://localhost:27017"
+DB_NAME = os.getenv("DOCUMENTDB_DATABASE", "mcp_registry")
 AGENTS_COLLECTION = "mcp_agents_default"
 SERVERS_COLLECTION = "mcp_servers_default"
 
@@ -58,7 +60,12 @@ def _backfill_visibility(
 
 def backfill_agent_fields() -> None:
     """Run all backfill operations on agents and servers."""
-    client = MongoClient(MONGODB_URI, directConnection=True)
+    # Only force directConnection=True for the local default; if the caller
+    # provided their own URI, it owns topology (replica sets, SRV, etc.).
+    if os.getenv("MONGODB_CONNECTION_STRING"):
+        client = MongoClient(MONGODB_URI)
+    else:
+        client = MongoClient(MONGODB_URI, directConnection=True)
     db = client[DB_NAME]
 
     # Backfill agents collection

--- a/scripts/debug-scopes.py
+++ b/scripts/debug-scopes.py
@@ -11,6 +11,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 async def debug_scopes():
     """Inspect DocumentDB scopes collection."""
     # Get connection details from environment
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
     host = os.getenv("DOCUMENTDB_HOST", "localhost")
     port = int(os.getenv("DOCUMENTDB_PORT", "27017"))
     username = os.getenv("DOCUMENTDB_USERNAME")
@@ -23,40 +24,52 @@ async def debug_scopes():
     print("=" * 80)
     print("DocumentDB Scopes Debug")
     print("=" * 80)
-    print(f"Host: {host}:{port}")
+    if override:
+        from urllib.parse import urlsplit
+
+        print(f"Host: {urlsplit(override).hostname or '(override)'} (connection string override)")
+    else:
+        print(f"Host: {host}:{port}")
     print(f"Database: {database}")
     print(f"Namespace: {namespace}")
     print(f"TLS: {use_tls}")
     print("=" * 80)
     print()
 
-    # Build connection string with appropriate auth mechanism
-    # Choose auth mechanism based on storage backend from environment
-    storage_backend = os.getenv("STORAGE_BACKEND", "documentdb")
-    if storage_backend == "mongodb-ce":
-        auth_mechanism = "SCRAM-SHA-256"
+    if override:
+        # URI owns all options: auth, TLS, retryWrites, replica set.
+        connection_string = override
+        client_kwargs: dict = {}
     else:
-        auth_mechanism = "SCRAM-SHA-1"
-
-    if username and password:
-        connection_string = f"mongodb://{username}:{password}@{host}:{port}/{database}?authMechanism={auth_mechanism}&authSource=admin"
-    else:
-        connection_string = f"mongodb://{host}:{port}/{database}"
-
-    # TLS options
-    tls_options = {}
-    if use_tls:
-        tls_options["tls"] = True
-        if ca_file and os.path.exists(ca_file):
-            tls_options["tlsCAFile"] = ca_file
-            print(f"Using CA file: {ca_file}")
+        # Build connection string with appropriate auth mechanism
+        # Choose auth mechanism based on storage backend from environment
+        storage_backend = os.getenv("STORAGE_BACKEND", "documentdb")
+        if storage_backend == "mongodb-ce":
+            auth_mechanism = "SCRAM-SHA-256"
         else:
-            print(f"WARNING: CA file not found: {ca_file}")
+            auth_mechanism = "SCRAM-SHA-1"
+
+        if username and password:
+            connection_string = f"mongodb://{username}:{password}@{host}:{port}/{database}?authMechanism={auth_mechanism}&authSource=admin"
+        else:
+            connection_string = f"mongodb://{host}:{port}/{database}"
+
+        # TLS options
+        tls_options: dict = {}
+        if use_tls:
+            tls_options["tls"] = True
+            if ca_file and os.path.exists(ca_file):
+                tls_options["tlsCAFile"] = ca_file
+                print(f"Using CA file: {ca_file}")
+            else:
+                print(f"WARNING: CA file not found: {ca_file}")
+
+        # DocumentDB does not support retryable writes
+        client_kwargs = {"retryWrites": False, **tls_options}
 
     # Connect to DocumentDB
     print("Connecting to DocumentDB...")
-    # IMPORTANT: DocumentDB does not support retryable writes
-    client = AsyncIOMotorClient(connection_string, retryWrites=False, **tls_options)
+    client = AsyncIOMotorClient(connection_string, **client_kwargs)
     db = client[database]
 
     try:

--- a/scripts/init-documentdb-indexes.py
+++ b/scripts/init-documentdb-indexes.py
@@ -70,7 +70,15 @@ async def _get_documentdb_connection_string(
 
     Args:
         storage_backend: Either 'documentdb' (uses SCRAM-SHA-1) or 'mongodb-ce' (uses SCRAM-SHA-256)
+
+    If MONGODB_CONNECTION_STRING is set in the environment, it is returned
+    verbatim and all host/port/auth construction is skipped.
     """
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
+    if override:
+        logger.info("Using MONGODB_CONNECTION_STRING override")
+        return override
+
     if use_iam:
         import boto3
 

--- a/scripts/init-documentdb.sh
+++ b/scripts/init-documentdb.sh
@@ -24,14 +24,17 @@ echo "DocumentDB Initialization Script"
 echo "================================="
 echo ""
 
-# Check if DocumentDB host is set
-if [ -z "$DOCUMENTDB_HOST" ]; then
+# Check if DocumentDB host is set (not required when MONGODB_CONNECTION_STRING is provided)
+if [ -z "$DOCUMENTDB_HOST" ] && [ -z "${MONGODB_CONNECTION_STRING:-}" ]; then
     echo "${RED}Error: DOCUMENTDB_HOST environment variable is not set${NC}"
     echo ""
     echo "Please set the required environment variables:"
     echo "  export DOCUMENTDB_HOST=your-cluster.docdb.amazonaws.com"
     echo "  export DOCUMENTDB_USERNAME=admin"
     echo "  export DOCUMENTDB_PASSWORD=yourpassword"
+    echo ""
+    echo "Or provide a full connection URI:"
+    echo "  export MONGODB_CONNECTION_STRING='mongodb+srv://user:pass@cluster.mongodb.net/db'"
     echo ""
     echo "Or use command-line arguments:"
     echo "  $0 --host your-cluster.docdb.amazonaws.com --username admin --password yourpassword"
@@ -79,16 +82,19 @@ fi
 export DOCUMENTDB_TLS_CA_FILE="$CA_BUNDLE_PATH"
 
 echo "Environment Configuration:"
-echo "  DOCUMENTDB_HOST: ${DOCUMENTDB_HOST}"
-echo "  DOCUMENTDB_PORT: ${DOCUMENTDB_PORT:-27017}"
+if [ -n "${MONGODB_CONNECTION_STRING:-}" ]; then
+    echo "  MONGODB_CONNECTION_STRING: (override set, host/port/auth derived from URI)"
+else
+    echo "  DOCUMENTDB_HOST: ${DOCUMENTDB_HOST}"
+    echo "  DOCUMENTDB_PORT: ${DOCUMENTDB_PORT:-27017}"
+    echo "  DOCUMENTDB_USE_IAM: ${DOCUMENTDB_USE_IAM:-false}"
+    if [ -n "$DOCUMENTDB_USERNAME" ]; then
+        echo "  DOCUMENTDB_USERNAME: ${DOCUMENTDB_USERNAME}"
+    fi
+fi
 echo "  DOCUMENTDB_DATABASE: ${DOCUMENTDB_DATABASE:-mcp_registry}"
 echo "  DOCUMENTDB_NAMESPACE: ${DOCUMENTDB_NAMESPACE:-default}"
 echo "  DOCUMENTDB_USE_TLS: ${USE_TLS}"
-echo "  DOCUMENTDB_USE_IAM: ${DOCUMENTDB_USE_IAM:-false}"
-
-if [ -n "$DOCUMENTDB_USERNAME" ]; then
-    echo "  DOCUMENTDB_USERNAME: ${DOCUMENTDB_USERNAME}"
-fi
 
 echo ""
 echo "Step 1: Creating collections and indexes..."

--- a/scripts/init-mongodb-ce.py
+++ b/scripts/init-mongodb-ce.py
@@ -43,8 +43,14 @@ COLLECTION_SKILLS = "agent_skills"
 
 
 def _get_config_from_env() -> dict:
-    """Get MongoDB CE configuration from environment variables."""
+    """Get MongoDB CE configuration from environment variables.
+
+    When MONGODB_CONNECTION_STRING is set, the caller owns the full URI
+    (Atlas, externally-managed replica set, etc.) and discrete
+    host/port/user/password values are ignored.
+    """
     return {
+        "connection_string": os.getenv("MONGODB_CONNECTION_STRING", ""),
         "host": os.getenv("DOCUMENTDB_HOST", "mongodb"),
         "port": int(os.getenv("DOCUMENTDB_PORT", "27017")),
         "database": os.getenv("DOCUMENTDB_DATABASE", "mcp_registry"),
@@ -290,11 +296,19 @@ async def _load_default_scopes(
 async def _initialize_mongodb_ce() -> None:
     """Main initialization function."""
     config = _get_config_from_env()
+    override = config["connection_string"]
 
     logger.info("=" * 60)
     logger.info("MongoDB CE Initialization for MCP Gateway")
     logger.info("=" * 60)
-    logger.info(f"Host: {config['host']}:{config['port']}")
+    if override:
+        from urllib.parse import urlsplit
+
+        logger.info(
+            f"Host: {urlsplit(override).hostname or '(override)'} (connection string override)"
+        )
+    else:
+        logger.info(f"Host: {config['host']}:{config['port']}")
     logger.info(f"Database: {config['database']}")
     logger.info(f"Namespace: {config['namespace']}")
     logger.info("")
@@ -303,16 +317,25 @@ async def _initialize_mongodb_ce() -> None:
     logger.info("Waiting for MongoDB to be ready...")
     time.sleep(10)
 
-    # Initialize replica set (synchronous)
-    _initialize_replica_set(config["host"], config["port"], config["username"], config["password"])
-
-    # Connect with motor for async operations
-    # Use auth only if username is provided (MongoDB CE runs without auth by default)
-    if config["username"] and config["password"]:
-        connection_string = f"mongodb://{config['username']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}&authMechanism=SCRAM-SHA-256&authSource=admin"
+    if override:
+        # Caller owns the topology (Atlas, externally-managed replica set, etc.).
+        # Skip replSetInitiate — we lack admin rights and the replica set is
+        # already configured by the provider.
+        logger.info("Skipping replica-set initialization (connection string override in use)")
+        connection_string = override
     else:
-        connection_string = f"mongodb://{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}"
-        logger.info("Using no-auth connection for async client")
+        # Initialize replica set (synchronous)
+        _initialize_replica_set(
+            config["host"], config["port"], config["username"], config["password"]
+        )
+
+        # Connect with motor for async operations
+        # Use auth only if username is provided (MongoDB CE runs without auth by default)
+        if config["username"] and config["password"]:
+            connection_string = f"mongodb://{config['username']}:{config['password']}@{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}&authMechanism=SCRAM-SHA-256&authSource=admin"
+        else:
+            connection_string = f"mongodb://{config['host']}:{config['port']}/{config['database']}?replicaSet={config['replicaset']}"
+            logger.info("Using no-auth connection for async client")
 
     try:
         client = AsyncIOMotorClient(

--- a/scripts/init-mongodb.sh
+++ b/scripts/init-mongodb.sh
@@ -11,10 +11,25 @@ DOCUMENTDB_PASSWORD="${DOCUMENTDB_PASSWORD:-admin}"
 DOCUMENTDB_DATABASE="${DOCUMENTDB_DATABASE:-mcp_registry}"
 DOCUMENTDB_NAMESPACE="${DOCUMENTDB_NAMESPACE:-default}"
 
+# MONGODB_CONNECTION_STRING override: when set, use the URI verbatim and skip
+# replSetInitiate (caller's cluster is assumed to already be configured, e.g.
+# MongoDB Atlas or any externally-managed replica set).
+if [ -n "${MONGODB_CONNECTION_STRING:-}" ]; then
+  MONGO_URL="$MONGODB_CONNECTION_STRING"
+  SKIP_REPLSET_INIT=1
+else
+  MONGO_URL=""
+  SKIP_REPLSET_INIT=0
+fi
+
 echo "=========================================="
 echo "MongoDB Initialization for MCP Gateway"
 echo "=========================================="
-echo "Host: $DOCUMENTDB_HOST:$DOCUMENTDB_PORT"
+if [ "$SKIP_REPLSET_INIT" = "1" ]; then
+  echo "Host: (connection string override)"
+else
+  echo "Host: $DOCUMENTDB_HOST:$DOCUMENTDB_PORT"
+fi
 echo "Database: $DOCUMENTDB_DATABASE"
 echo "Namespace: $DOCUMENTDB_NAMESPACE"
 echo ""
@@ -22,14 +37,17 @@ echo ""
 echo "Waiting for MongoDB to be ready..."
 sleep 10
 
-echo "Initializing MongoDB replica set..."
-# Check if authentication is configured
-if [ -n "$DOCUMENTDB_USERNAME" ] && [ -n "$DOCUMENTDB_PASSWORD" ] && [ "$DOCUMENTDB_USERNAME" != "admin" ] || [ "$DOCUMENTDB_PASSWORD" != "admin" ]; then
-  MONGO_URL="mongodb://$DOCUMENTDB_USERNAME:$DOCUMENTDB_PASSWORD@$DOCUMENTDB_HOST:$DOCUMENTDB_PORT/admin"
+if [ "$SKIP_REPLSET_INIT" = "1" ]; then
+  echo "Skipping replica-set initialization (connection string override in use)"
 else
-  MONGO_URL="mongodb://$DOCUMENTDB_HOST:$DOCUMENTDB_PORT"
-fi
-mongosh "$MONGO_URL" <<EOF
+  echo "Initializing MongoDB replica set..."
+  # Check if authentication is configured
+  if [ -n "$DOCUMENTDB_USERNAME" ] && [ -n "$DOCUMENTDB_PASSWORD" ] && [ "$DOCUMENTDB_USERNAME" != "admin" ] || [ "$DOCUMENTDB_PASSWORD" != "admin" ]; then
+    MONGO_URL="mongodb://$DOCUMENTDB_USERNAME:$DOCUMENTDB_PASSWORD@$DOCUMENTDB_HOST:$DOCUMENTDB_PORT/admin"
+  else
+    MONGO_URL="mongodb://$DOCUMENTDB_HOST:$DOCUMENTDB_PORT"
+  fi
+  mongosh "$MONGO_URL" <<EOF
 // Initialize replica set (required for transactions and vector search)
 try {
   rs.initiate({
@@ -38,18 +56,19 @@ try {
       { _id: 0, host: "$DOCUMENTDB_HOST:$DOCUMENTDB_PORT" }
     ]
   });
-  print("✓ Replica set initialized");
+  print("Replica set initialized");
 } catch (e) {
   if (e.codeName === 'AlreadyInitialized') {
-    print("✓ Replica set already initialized");
+    print("Replica set already initialized");
   } else {
     throw e;
   }
 }
 EOF
 
-echo "Waiting for replica set to elect primary..."
-sleep 10
+  echo "Waiting for replica set to elect primary..."
+  sleep 10
+fi
 
 echo "Creating database and collections with indexes..."
 mongosh "$MONGO_URL" <<EOF

--- a/scripts/load-scopes.py
+++ b/scripts/load-scopes.py
@@ -40,7 +40,15 @@ async def _get_documentdb_connection_string(
 
     Args:
         storage_backend: Either 'documentdb' (uses SCRAM-SHA-1) or 'mongodb-ce' (uses SCRAM-SHA-256)
+
+    If MONGODB_CONNECTION_STRING is set in the environment, it is returned
+    verbatim and all host/port/auth construction is skipped.
     """
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
+    if override:
+        logger.info("Using MONGODB_CONNECTION_STRING override")
+        return override
+
     if use_iam:
         import boto3
 

--- a/scripts/manage-documentdb.py
+++ b/scripts/manage-documentdb.py
@@ -59,7 +59,15 @@ async def _get_documentdb_connection_string(
 
     Args:
         storage_backend: Either 'documentdb' (uses SCRAM-SHA-1) or 'mongodb-ce' (uses SCRAM-SHA-256)
+
+    If MONGODB_CONNECTION_STRING is set in the environment, it is returned
+    verbatim and all host/port/auth construction is skipped.
     """
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
+    if override:
+        logger.info("Using MONGODB_CONNECTION_STRING override")
+        return override
+
     if use_iam:
         import boto3
 

--- a/scripts/migrate-file-to-mongodb.py
+++ b/scripts/migrate-file-to-mongodb.py
@@ -66,7 +66,20 @@ async def _get_mongodb_client(
     Args:
         config: MongoDB connection configuration
         direct_connection: Use directConnection=true for single-node replica sets
+
+    If MONGODB_CONNECTION_STRING is set in the environment, it is used
+    verbatim and direct_connection is ignored (URI owns topology).
     """
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
+    if override:
+        logger.info("Using MONGODB_CONNECTION_STRING override")
+        client = AsyncIOMotorClient(override, serverSelectionTimeoutMS=10000)
+        await client.admin.command("ping")
+        from urllib.parse import urlsplit
+
+        logger.info(f"Connected to MongoDB at {urlsplit(override).hostname or '(override)'}")
+        return client
+
     if config["username"] and config["password"]:
         connection_string = (
             f"mongodb://{config['username']}:{config['password']}@"

--- a/scripts/migrate-servers-add-is-active.py
+++ b/scripts/migrate-servers-add-is-active.py
@@ -141,11 +141,17 @@ async def _migrate_documentdb(args: argparse.Namespace, dry_run: bool) -> dict[s
     port = args.port
     database = args.database
 
-    if not host:
-        logger.error("DocumentDB host required. Set via --host or DOCUMENTDB_HOST env var")
+    override = os.getenv("MONGODB_CONNECTION_STRING", "")
+    if override:
+        logger.info("Using MONGODB_CONNECTION_STRING override")
+        connection_string = override
+    elif not host:
+        logger.error(
+            "DocumentDB host required. Set via --host, DOCUMENTDB_HOST, "
+            "or MONGODB_CONNECTION_STRING env var"
+        )
         return {"error": "host required"}
-
-    if args.use_iam:
+    elif args.use_iam:
         try:
             import boto3
 
@@ -166,11 +172,20 @@ async def _migrate_documentdb(args: argparse.Namespace, dry_run: bool) -> dict[s
         else:
             connection_string = f"mongodb://{host}:{port}/"
 
-    # Handle MongoDB CE with directConnection
-    if args.storage == "mongodb-ce":
+    # Handle MongoDB CE with directConnection (only for discrete-var path —
+    # override URI owns topology)
+    if args.storage == "mongodb-ce" and not override:
         connection_string += "?directConnection=true"
 
-    logger.info(f"Connecting to {args.storage} at {host}:{port}")
+    if override:
+        from urllib.parse import urlsplit
+
+        logger.info(
+            f"Connecting to {args.storage} at "
+            f"{urlsplit(connection_string).hostname or '(override)'}"
+        )
+    else:
+        logger.info(f"Connecting to {args.storage} at {host}:{port}")
 
     client = AsyncIOMotorClient(connection_string)
     db = client[database]

--- a/tests/unit/test_stats_endpoint.py
+++ b/tests/unit/test_stats_endpoint.py
@@ -254,6 +254,7 @@ class TestGetDatabaseStatus:
             mock_settings.storage_backend = "documentdb"
             mock_settings.documentdb_host = "localhost"
             mock_settings.documentdb_port = 27017
+            mock_settings.mongodb_connection_string = None
 
             with patch(
                 "registry.repositories.documentdb.client.get_documentdb_client",
@@ -277,6 +278,7 @@ class TestGetDatabaseStatus:
             mock_settings.storage_backend = "documentdb"
             mock_settings.documentdb_host = "localhost"
             mock_settings.documentdb_port = 27017
+            mock_settings.mongodb_connection_string = None
 
             with patch(
                 "registry.repositories.documentdb.client.get_documentdb_client",

--- a/tests/unit/test_stats_endpoint.py
+++ b/tests/unit/test_stats_endpoint.py
@@ -270,6 +270,34 @@ class TestGetDatabaseStatus:
                 assert status["host"] == "localhost:27017"
 
     @pytest.mark.asyncio
+    async def test_database_status_documentdb_with_connection_string_override(
+        self, mock_documentdb_client
+    ):
+        """Test database status masks credentials when a connection string override is set."""
+        from registry.api.system_routes import _get_database_status
+
+        connection_string = "mongodb+srv://user:pass@cluster.example.net/db"
+
+        with patch("registry.api.system_routes.settings") as mock_settings:
+            mock_settings.storage_backend = "documentdb"
+            mock_settings.documentdb_host = "should-not-be-used"
+            mock_settings.documentdb_port = 12345
+            mock_settings.mongodb_connection_string = connection_string
+
+            with patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new_callable=AsyncMock,
+                return_value=mock_documentdb_client,
+            ):
+                status = await _get_database_status()
+
+                assert status["backend"] == "documentdb"
+                assert status["status"] == "Healthy"
+                assert status["host"] == "cluster.example.net"
+                assert "user:pass" not in status["host"]
+                assert "mongodb+srv://" not in status["host"]
+
+    @pytest.mark.asyncio
     async def test_database_status_documentdb_unhealthy(self):
         """Test database status with unhealthy DocumentDB."""
         from registry.api.system_routes import _get_database_status

--- a/tests/unit/utils/test_mongodb_connection.py
+++ b/tests/unit/utils/test_mongodb_connection.py
@@ -1,0 +1,146 @@
+"""Unit tests for registry/utils/mongodb_connection.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from registry.utils.mongodb_connection import (
+    build_client_options,
+    build_connection_string,
+    build_tls_kwargs,
+)
+
+
+def _mock_settings(**overrides):
+    defaults = {
+        "mongodb_connection_string": None,
+        "documentdb_use_iam": False,
+        "documentdb_host": "mongo.example.com",
+        "documentdb_port": 27017,
+        "documentdb_database": "mcp_registry",
+        "documentdb_username": None,
+        "documentdb_password": None,
+        "documentdb_use_tls": False,
+        "documentdb_tls_ca_file": "",
+        "documentdb_direct_connection": False,
+        "storage_backend": "mongodb-ce",
+    }
+    defaults.update(overrides)
+    s = MagicMock()
+    for key, value in defaults.items():
+        setattr(s, key, value)
+    return s
+
+
+class TestConnectionStringOverride:
+    """When mongodb_connection_string is set, it short-circuits all other logic."""
+
+    def test_override_returned_verbatim(self):
+        uri = "mongodb+srv://user:pass@cluster.mongodb.net/mcp_registry?retryWrites=true"
+        settings = _mock_settings(mongodb_connection_string=uri)
+        with patch("registry.core.config.settings", settings):
+            assert build_connection_string() == uri
+
+    def test_override_ignores_iam(self):
+        """Override wins over IAM auth path — no boto3 import attempted."""
+        uri = "mongodb+srv://user:pass@cluster.mongodb.net/mcp_registry"
+        settings = _mock_settings(mongodb_connection_string=uri, documentdb_use_iam=True)
+        with patch("registry.core.config.settings", settings):
+            assert build_connection_string() == uri
+
+    def test_override_ignores_username_password(self):
+        uri = "mongodb://override:creds@host/db"
+        settings = _mock_settings(
+            mongodb_connection_string=uri,
+            documentdb_username="other",
+            documentdb_password="other",
+        )
+        with patch("registry.core.config.settings", settings):
+            assert build_connection_string() == uri
+
+    def test_client_options_empty_when_override_set(self):
+        """Override owns retryWrites, directConnection, etc. — no defaults injected."""
+        settings = _mock_settings(
+            mongodb_connection_string="mongodb+srv://x/y",
+            documentdb_direct_connection=True,  # would normally set directConnection
+        )
+        with patch("registry.core.config.settings", settings):
+            assert build_client_options() == {}
+
+    def test_tls_kwargs_empty_when_override_set(self):
+        """Override URI owns TLS (mongodb+srv:// implies TLS automatically)."""
+        settings = _mock_settings(
+            mongodb_connection_string="mongodb+srv://x/y",
+            documentdb_use_tls=True,
+            documentdb_tls_ca_file="/tmp/ca.pem",
+        )
+        with patch("registry.core.config.settings", settings):
+            assert build_tls_kwargs() == {}
+
+
+class TestDiscreteVarPathUnchanged:
+    """Without the override, legacy behavior is preserved."""
+
+    def test_username_password_builds_uri(self):
+        settings = _mock_settings(
+            documentdb_username="user",
+            documentdb_password="pass",
+            documentdb_host="myhost",
+            documentdb_port=27018,
+            documentdb_database="mydb",
+            storage_backend="mongodb-ce",
+        )
+        with patch("registry.core.config.settings", settings):
+            uri = build_connection_string()
+        assert uri == (
+            "mongodb://user:pass@myhost:27018/mydb"
+            "?authMechanism=SCRAM-SHA-256&authSource=admin"
+        )
+
+    def test_documentdb_backend_uses_scram_sha_1(self):
+        settings = _mock_settings(
+            documentdb_username="user",
+            documentdb_password="pass",
+            storage_backend="documentdb",
+        )
+        with patch("registry.core.config.settings", settings):
+            assert "SCRAM-SHA-1" in build_connection_string()
+
+    def test_no_auth_local_dev(self):
+        settings = _mock_settings(documentdb_host="localhost", documentdb_port=27017)
+        with patch("registry.core.config.settings", settings):
+            assert build_connection_string() == "mongodb://localhost:27017/mcp_registry"
+
+    def test_client_options_forces_retry_writes_false(self):
+        """DocumentDB requires retryWrites=false; preserved when no override."""
+        settings = _mock_settings()
+        with patch("registry.core.config.settings", settings):
+            opts = build_client_options()
+        assert opts == {"retryWrites": False}
+
+    def test_client_options_direct_connection(self):
+        settings = _mock_settings(documentdb_direct_connection=True)
+        with patch("registry.core.config.settings", settings):
+            opts = build_client_options()
+        assert opts == {"retryWrites": False, "directConnection": True}
+
+    def test_tls_kwargs_when_enabled(self):
+        settings = _mock_settings(
+            documentdb_use_tls=True,
+            documentdb_tls_ca_file="/certs/ca.pem",
+        )
+        with patch("registry.core.config.settings", settings):
+            assert build_tls_kwargs() == {"tls": True, "tlsCAFile": "/certs/ca.pem"}
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", None],
+)
+def test_empty_override_falls_through_to_discrete_vars(value):
+    """Empty string and None both mean 'override not set'."""
+    settings = _mock_settings(mongodb_connection_string=value)
+    with patch("registry.core.config.settings", settings):
+        uri = build_connection_string()
+    # Falls through to no-auth path
+    assert uri == "mongodb://mongo.example.com:27017/mcp_registry"


### PR DESCRIPTION
## Summary

Adds a `MONGODB_CONNECTION_STRING` override that, when set, is passed
verbatim to the MongoDB client and bypasses the discrete
`DOCUMENTDB_HOST/PORT/USERNAME/PASSWORD` assembly. Unlocks MongoDB Atlas
(`mongodb+srv://...`) and any externally-managed MongoDB where the
caller wants to own the full URI — TLS, `retryWrites`, replica-set
selection, read preference, all from the URI.

The discrete-var path is unchanged; existing deployments keep working
with no config changes.

## What changed

- **Registry core** (`registry/core/config.py`, `registry/utils/mongodb_connection.py`):
  - New `mongodb_connection_string` setting. When set, `build_connection_string()` short-circuits and `build_client_options()` / `build_tls_kwargs()` return `{}` so the URI fully owns those options.
  - 11 new unit tests covering override + legacy paths.
- **Health endpoint** (`registry/api/system_routes.py`):
  - Extracts the hostname via `urllib.parse.urlsplit` — no DNS (unlike `pymongo.uri_parser.parse_uri`, which resolves SRV records live) and no userinfo.
- **Docker entrypoints** (`docker/{registry,auth}-entrypoint.sh`):
  - Wait loops now accept the override URI and skip `replSetGetStatus` (caller owns topology).
  - Exception output runs through a regex that strips any `mongodb(+srv)?://...` substring, so creds never leak to stdout.
- **Helm** (`charts/mongodb-configure/`, `charts/mcp-gateway-registry-stack/`):
  - New `mongodb.connectionString` value plumbed through the stack chart.
  - The `mongo-credentials` Secret emits **only** `MONGODB_CONNECTION_STRING + DATABASE + STORAGE_BACKEND + USE_TLS` when the override is set — no conflicting source of truth alongside.
  - The `mongodb-configure` init job skips `replSetInitiate` when the override is in use (Atlas doesn't grant admin rights; the cluster is already configured).
- **Operational scripts** (10 files in `scripts/`):
  - Every script that built a `mongodb://` URI from env vars now short-circuits to `MONGODB_CONNECTION_STRING` when set. The replica-set-init scripts also skip that step under the override.
- **docker-compose** (3 files): `MONGODB_CONNECTION_STRING` passed through to registry + auth-server.
- **Docs** (`docs/configuration.md`): New section with Atlas example, precedence rules, security notes, and Helm plumbing guidance.