### PR TITLE
fix(iam): surface /api/iam/m2m-clients records in IAM > M2M Accounts UI (#945)

### DIFF
--- a/docs/faq/registering-m2m-client-without-idp-admin-token.md
+++ b/docs/faq/registering-m2m-client-without-idp-admin-token.md
@@ -62,6 +62,36 @@ Updated at:   ...
 
 `Provider: manual` means the record was created via this API (rather than synced from an IdP). Manual records are the only ones this API can modify or delete later.
 
+## Step 2b (optional): Register via the Registry UI
+
+In v1.0.22 and later, the same registration is available in the UI:
+
+1. Open **Settings > IAM > M2M Accounts**.
+2. Click **Register existing client** (the gray button next to the purple "Create M2M Account" button).
+3. Fill in `Client ID`, a human-readable `Client Name`, pick one or more groups, and (optionally) a description.
+4. Click **Register**. The new record appears in the list with a `manual` provider badge, and the **Registered by** column shows the admin username who submitted the form.
+
+Use the UI path when you want a point-and-click flow; use the CLI path from Step 2 for scripted automation or CI.
+
+The same list page also shows records synced from your IdP (`okta`, `auth0`, `keycloak`, `entra`). Edit and Delete are disabled on those rows because they are owned by the IdP sync layer; manage them in the IdP instead.
+
+## Least-privilege reminder
+
+Registered clients inherit the authorization of their assigned groups as soon as the next token is issued. Grant only the minimum groups necessary. In practice:
+
+- Start with a read-only group (for example `registry-readonly`) and add more only when the workload actually needs them.
+- Prefer narrow groups (for example `pipeline-operators`) over broad ones (for example `registry-admins`).
+- Removing a group via the UI Edit view or via `PATCH /api/iam/m2m-clients/{client_id}` takes effect on the next token issued for that client; existing tokens retain their groups until they expire.
+
+## Rotating or recovering the client secret
+
+The registry does not manage secrets for manually-registered clients. The client secret lives in your IdP (Keycloak / Entra / Okta / Auth0), where it was created. If you lose it:
+
+- Rotate the secret in your IdP's admin UI (Keycloak: **Clients > your client > Credentials > Regenerate secret**; Entra: **App registrations > your app > Certificates & secrets**).
+- Update your application with the new secret. No change is required in the registry: `client_id` did not change, so groups and authorization continue to work.
+
+If you want the registry to manage secrets end-to-end, use the legacy "Create M2M Account" path instead; that flow requires an IdP Admin API token.
+
 ## Step 3: Verify from your application
 
 1. Request an M2M access token from Keycloak using client credentials:

--- a/frontend/src/components/IAMM2M.tsx
+++ b/frontend/src/components/IAMM2M.tsx
@@ -9,73 +9,141 @@ import {
   EyeIcon,
   EyeSlashIcon,
   PencilIcon,
+  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
-import { useIAMUsers, useIAMGroups, createM2MAccount, deleteUser, updateUserGroups, CreateM2MPayload, M2MCredentials, IAMUser } from '../hooks/useIAM';
+import {
+  useM2MClients,
+  useIAMGroups,
+  createM2MAccount,
+  registerM2MClient,
+  patchM2MClient,
+  deleteM2MClient,
+  CreateM2MPayload,
+  RegisterM2MClientPayload,
+  PatchM2MClientPayload,
+  M2MCredentials,
+  M2MClient,
+} from '../hooks/useIAM';
 import DeleteConfirmation from './DeleteConfirmation';
 
 interface IAMM2MProps {
   onShowToast: (message: string, type: 'success' | 'error' | 'info') => void;
 }
 
-type View = 'list' | 'create' | 'credentials' | 'edit';
+type View = 'list' | 'create' | 'credentials' | 'edit' | 'register';
 
 interface FormErrors {
   name?: string;
   groups?: string;
 }
 
+interface RegisterFormErrors {
+  clientId?: string;
+  clientName?: string;
+  groups?: string;
+}
+
+// Mirrors the backend regex at registry/schemas/idp_m2m_client.py:18.
+const CLIENT_ID_REGEX = /^[A-Za-z0-9_\-.:]{1,256}$/;
+
+const PROVIDER_STYLES: Record<string, string> = {
+  manual: 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300',
+  okta: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
+  auth0: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
+  keycloak: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
+  entra: 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300',
+};
+
+const ProviderBadge: React.FC<{ provider: string }> = ({ provider }) => {
+  const style =
+    PROVIDER_STYLES[provider] ??
+    'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300';
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs rounded-full font-mono ${style}`}
+    >
+      {provider}
+    </span>
+  );
+};
+
+const extractDetail = (err: any, fallback: string): string => {
+  const detail = err?.response?.data?.detail;
+  if (Array.isArray(detail)) {
+    return detail.map((d: any) => d?.msg).filter(Boolean).join(', ') || fallback;
+  }
+  return detail || fallback;
+};
+
 const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
-  // Filter to only M2M accounts
-  const { users, isLoading, error, refetch } = useIAMUsers();
+  const { clients, isLoading, error, refetch } = useM2MClients();
   const { groups } = useIAMGroups();
   const [searchQuery, setSearchQuery] = useState('');
   const [view, setView] = useState<View>('list');
+  const [showCreateHelp, setShowCreateHelp] = useState(false);
 
-  // Create form state
+  // Create form state (legacy "Create M2M Account" flow).
   const [formName, setFormName] = useState('');
   const [formDescription, setFormDescription] = useState('');
   const [formGroups, setFormGroups] = useState<Set<string>>(new Set());
   const [isCreating, setIsCreating] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
 
-  // Credentials display
+  // Register form state (new "Register existing client" flow).
+  const [registerClientId, setRegisterClientId] = useState('');
+  const [registerClientName, setRegisterClientName] = useState('');
+  const [registerDescription, setRegisterDescription] = useState('');
+  const [registerGroups, setRegisterGroups] = useState<Set<string>>(new Set());
+  const [isRegistering, setIsRegistering] = useState(false);
+  const [registerErrors, setRegisterErrors] = useState<RegisterFormErrors>({});
+
+  // Credentials display (legacy flow only).
   const [credentials, setCredentials] = useState<M2MCredentials | null>(null);
   const [showSecret, setShowSecret] = useState(false);
 
-  // Delete state
+  // Delete state.
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
-  // Edit state
-  const [editTarget, setEditTarget] = useState<IAMUser | null>(null);
+  // Edit state.
+  const [editTarget, setEditTarget] = useState<M2MClient | null>(null);
   const [isUpdating, setIsUpdating] = useState(false);
 
-  const m2mAccounts = useMemo(() => {
-    // M2M service accounts are identified by their email domain.
-    // The backend sets email to "{clientId}@service-account.local" for all M2M accounts.
-    return users.filter(
-      (u) => (u.email || '').endsWith('@service-account.local')
-    );
-  }, [users]);
-
-  const filteredAccounts = useMemo(() => {
-    if (!searchQuery) return m2mAccounts;
+  const filteredClients = useMemo(() => {
+    if (!searchQuery) return clients;
     const q = searchQuery.toLowerCase();
-    return m2mAccounts.filter(
-      (u) =>
-        u.username.toLowerCase().includes(q) ||
-        (u.email || '').toLowerCase().includes(q)
+    return clients.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.client_id.toLowerCase().includes(q)
     );
-  }, [m2mAccounts, searchQuery]);
+  }, [clients, searchQuery]);
 
-  const resetForm = useCallback(() => {
+  const resetCreateForm = useCallback(() => {
     setFormName('');
     setFormDescription('');
     setFormGroups(new Set());
     setErrors({});
   }, []);
 
-  const toggleGroup = (groupName: string) => {
+  const resetRegisterForm = useCallback(() => {
+    setRegisterClientId('');
+    setRegisterClientName('');
+    setRegisterDescription('');
+    setRegisterGroups(new Set());
+    setRegisterErrors({});
+  }, []);
+
+  const toggleCreateGroup = (groupName: string) => {
     setFormGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupName)) next.delete(groupName);
+      else next.add(groupName);
+      return next;
+    });
+  };
+
+  const toggleRegisterGroup = (groupName: string) => {
+    setRegisterGroups((prev) => {
       const next = new Set(prev);
       if (next.has(groupName)) next.delete(groupName);
       else next.add(groupName);
@@ -93,7 +161,6 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
   };
 
   const handleCreate = async () => {
-    // Validate
     const newErrors: FormErrors = {};
     if (!formName.trim()) newErrors.name = 'Name is required';
     if (formGroups.size === 0) newErrors.groups = 'At least one group is required';
@@ -111,35 +178,79 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
       setCredentials(creds);
       setView('credentials');
       onShowToast(`M2M account "${formName}" created`, 'success');
-      resetForm();
+      resetCreateForm();
     } catch (err: any) {
-      const detail = err.response?.data?.detail;
-      const message = Array.isArray(detail)
-        ? detail.map((d: any) => d.msg).join(', ')
-        : detail || 'Failed to create M2M account';
-      onShowToast(message, 'error');
+      onShowToast(extractDetail(err, 'Failed to create M2M account'), 'error');
     } finally {
       setIsCreating(false);
     }
   };
 
-  const handleDelete = async (username: string) => {
-    await deleteUser(username);
-    onShowToast(`Account "${username}" deleted`, 'success');
+  const handleRegister = async () => {
+    const newErrors: RegisterFormErrors = {};
+    const trimmedId = registerClientId.trim();
+    if (!trimmedId) {
+      newErrors.clientId = 'Client ID is required';
+    } else if (!CLIENT_ID_REGEX.test(trimmedId)) {
+      newErrors.clientId =
+        'Allowed characters: letters, digits, _ - . : (1-256 chars)';
+    }
+    if (!registerClientName.trim()) {
+      newErrors.clientName = 'Client name is required';
+    }
+    if (registerGroups.size === 0) {
+      newErrors.groups = 'At least one group is required';
+    }
+    setRegisterErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) return;
+
+    setIsRegistering(true);
+    try {
+      const payload: RegisterM2MClientPayload = {
+        client_id: trimmedId,
+        client_name: registerClientName.trim(),
+        description: registerDescription.trim() || undefined,
+        groups: Array.from(registerGroups),
+      };
+      await registerM2MClient(payload);
+      onShowToast(
+        `Registered M2M client "${payload.client_name}"`,
+        'success'
+      );
+      resetRegisterForm();
+      setView('list');
+      await refetch();
+    } catch (err: any) {
+      onShowToast(
+        extractDetail(err, 'Failed to register M2M client'),
+        'error'
+      );
+    } finally {
+      setIsRegistering(false);
+    }
+  };
+
+  const handleDelete = async (clientId: string) => {
+    try {
+      await deleteM2MClient(clientId);
+      onShowToast('M2M client deleted', 'success');
+    } catch (err: any) {
+      onShowToast(extractDetail(err, 'Failed to delete M2M client'), 'error');
+      throw err;
+    }
     setDeleteTarget(null);
     await refetch();
   };
 
-  const handleEdit = (user: IAMUser) => {
-    setEditTarget(user);
-    setFormGroups(new Set(user.groups || []));
+  const handleEdit = (client: M2MClient) => {
+    setEditTarget(client);
+    setFormGroups(new Set(client.groups || []));
     setView('edit');
   };
 
   const handleUpdate = async () => {
     if (!editTarget) return;
 
-    // Validate
     const newErrors: FormErrors = {};
     if (formGroups.size === 0) newErrors.groups = 'At least one group is required';
     setErrors(newErrors);
@@ -147,24 +258,23 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
 
     setIsUpdating(true);
     try {
-      await updateUserGroups(editTarget.username, Array.from(formGroups));
-      onShowToast(`Groups updated for "${editTarget.username}"`, 'success');
+      const payload: PatchM2MClientPayload = {
+        groups: Array.from(formGroups),
+      };
+      await patchM2MClient(editTarget.client_id, payload);
+      onShowToast(`Groups updated for "${editTarget.name}"`, 'success');
       setEditTarget(null);
       setFormGroups(new Set());
       setView('list');
       await refetch();
     } catch (err: any) {
-      const detail = err.response?.data?.detail;
-      const message = Array.isArray(detail)
-        ? detail.map((d: any) => d.msg).join(', ')
-        : detail || 'Failed to update groups';
-      onShowToast(message, 'error');
+      onShowToast(extractDetail(err, 'Failed to update groups'), 'error');
     } finally {
       setIsUpdating(false);
     }
   };
 
-  // ─── Credentials View (after creation) ────────────────────────
+  // ─── Credentials View (after legacy-flow creation) ────────────
   if (view === 'credentials' && credentials) {
     return (
       <div className="space-y-6">
@@ -233,7 +343,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-            IAM &gt; M2M Accounts &gt; Edit "{editTarget.username}"
+            IAM &gt; M2M Accounts &gt; Edit "{editTarget.name}"
           </h2>
           <button onClick={() => { setFormGroups(new Set()); setEditTarget(null); setErrors({}); setView('list'); }}
             className="flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
@@ -253,7 +363,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
                 groups.map((g) => (
                   <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
                     <input type="checkbox" checked={formGroups.has(g.name)}
-                      onChange={() => { toggleGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
+                      onChange={() => { toggleCreateGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
                       className="rounded border-gray-300 dark:border-gray-600 text-purple-600 focus:ring-purple-500" />
                     <span className="text-sm text-gray-700 dark:text-gray-300">{g.name}</span>
                   </label>
@@ -278,7 +388,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
     );
   }
 
-  // ─── Create View ──────────────────────────────────────────────
+  // ─── Create View (legacy flow) ────────────────────────────────
   if (view === 'create') {
     return (
       <div className="space-y-6">
@@ -286,7 +396,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             IAM &gt; M2M Accounts &gt; Create
           </h2>
-          <button onClick={() => { resetForm(); setView('list'); }}
+          <button onClick={() => { resetCreateForm(); setView('list'); }}
             className="flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
             <ArrowLeftIcon className="h-4 w-4 mr-1" /> Back to List
           </button>
@@ -320,7 +430,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
                 groups.map((g) => (
                   <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
                     <input type="checkbox" checked={formGroups.has(g.name)}
-                      onChange={() => { toggleGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
+                      onChange={() => { toggleCreateGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
                       className="rounded border-gray-300 dark:border-gray-600 text-purple-600 focus:ring-purple-500" />
                     <span className="text-sm text-gray-700 dark:text-gray-300">{g.name}</span>
                   </label>
@@ -332,13 +442,96 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
         </div>
 
         <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-          <button onClick={() => { resetForm(); setView('list'); }}
+          <button onClick={() => { resetCreateForm(); setView('list'); }}
             className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600">
             Cancel
           </button>
           <button onClick={handleCreate} disabled={isCreating}
             className="px-4 py-2 text-sm text-white bg-purple-600 rounded-lg hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed">
             {isCreating ? 'Creating...' : 'Create Account'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── Register View (new flow for existing IdP clients) ────────
+  if (view === 'register') {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            IAM &gt; M2M Accounts &gt; Register Existing Client
+          </h2>
+          <button onClick={() => { resetRegisterForm(); setView('list'); }}
+            className="flex items-center text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+            <ArrowLeftIcon className="h-4 w-4 mr-1" /> Back to List
+          </button>
+        </div>
+
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-sm text-gray-700 dark:text-gray-300">
+          Register a <code className="font-mono">client_id</code> that already exists in your
+          IdP so the registry can attach groups to it. No IdP Admin API call is made; supply
+          the client secret to your application out-of-band.
+        </div>
+
+        <div className="space-y-4 max-w-lg">
+          <div>
+            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">Client ID *</label>
+            <input type="text" value={registerClientId}
+              onChange={(e) => { setRegisterClientId(e.target.value); if (registerErrors.clientId) setRegisterErrors((p) => ({ ...p, clientId: undefined })); }}
+              placeholder="e.g. my-pipeline-client"
+              className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white font-mono focus:ring-2 focus:ring-purple-500 focus:border-transparent ${
+                registerErrors.clientId ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+              }`} />
+            {registerErrors.clientId && <p className="mt-1 text-sm text-red-500">{registerErrors.clientId}</p>}
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">Client Name *</label>
+            <input type="text" value={registerClientName}
+              onChange={(e) => { setRegisterClientName(e.target.value); if (registerErrors.clientName) setRegisterErrors((p) => ({ ...p, clientName: undefined })); }}
+              placeholder="Human-readable name"
+              className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent ${
+                registerErrors.clientName ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
+              }`} />
+            {registerErrors.clientName && <p className="mt-1 text-sm text-red-500">{registerErrors.clientName}</p>}
+          </div>
+          <div>
+            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-1">Description (optional)</label>
+            <input type="text" value={registerDescription} onChange={(e) => setRegisterDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent" />
+          </div>
+
+          <div>
+            <label className="block text-sm text-gray-600 dark:text-gray-400 mb-2">Groups *</label>
+            <div className={`space-y-2 max-h-48 overflow-y-auto rounded-lg p-3 ${
+              registerErrors.groups ? 'border-2 border-red-500' : 'border border-gray-200 dark:border-gray-700'
+            }`}>
+              {groups.length === 0 ? (
+                <p className="text-xs text-gray-400">No groups available</p>
+              ) : (
+                groups.map((g) => (
+                  <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
+                    <input type="checkbox" checked={registerGroups.has(g.name)}
+                      onChange={() => { toggleRegisterGroup(g.name); if (registerErrors.groups) setRegisterErrors((p) => ({ ...p, groups: undefined })); }}
+                      className="rounded border-gray-300 dark:border-gray-600 text-purple-600 focus:ring-purple-500" />
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{g.name}</span>
+                  </label>
+                ))
+              )}
+            </div>
+            {registerErrors.groups && <p className="mt-1 text-sm text-red-500">{registerErrors.groups}</p>}
+          </div>
+        </div>
+
+        <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <button onClick={() => { resetRegisterForm(); setView('list'); }}
+            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600">
+            Cancel
+          </button>
+          <button onClick={handleRegister} disabled={isRegistering}
+            className="px-4 py-2 text-sm text-white bg-purple-600 rounded-lg hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed">
+            {isRegistering ? 'Registering...' : 'Register'}
           </button>
         </div>
       </div>
@@ -354,12 +547,44 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
           <button onClick={refetch} className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200" title="Refresh">
             <ArrowPathIcon className="h-5 w-5" />
           </button>
+          <button onClick={() => setShowCreateHelp((v) => !v)}
+            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+            title="Help: which button should I use?"
+            aria-label="Help">
+            <InformationCircleIcon className="h-5 w-5" />
+          </button>
+          <button onClick={() => { resetRegisterForm(); setView('register'); }}
+            className="flex items-center px-3 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600"
+            title="Register a client_id that already exists in your IdP (no IdP Admin API token required)">
+            <PlusIcon className="h-4 w-4 mr-1" /> Register existing client
+          </button>
           <button onClick={() => setView('create')}
-            className="flex items-center px-3 py-2 text-sm text-white bg-purple-600 rounded-lg hover:bg-purple-700">
+            className="flex items-center px-3 py-2 text-sm text-white bg-purple-600 rounded-lg hover:bg-purple-700"
+            title="Create a new M2M account via the IdP (requires IdP Admin API token)">
             <PlusIcon className="h-4 w-4 mr-1" /> Create M2M Account
           </button>
         </div>
       </div>
+
+      {showCreateHelp && (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-blue-50 dark:bg-blue-900/20 p-4 text-sm text-gray-700 dark:text-gray-300 space-y-2">
+          <p>
+            <strong>Create M2M Account</strong> creates a new client application inside
+            your IdP (Keycloak, Entra, Okta, Auth0) via its Admin API and returns the
+            client secret. Use this if your registry has an IdP Admin API token
+            configured.
+          </p>
+          <p>
+            <strong>Register existing client</strong> records a <code className="font-mono">client_id</code>
+            you have already created in your IdP so the registry can attach groups to
+            it. No IdP Admin API call is made; supply the secret to your application
+            out-of-band. Use this for Entra tenants without
+            <code className="font-mono"> Application.ReadWrite.*</code>, Okta tenants
+            without Admin API access, or any environment where you don't want the
+            registry to manage IdP app lifecycle.
+          </p>
+        </div>
+      )}
 
       <div className="relative">
         <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
@@ -374,63 +599,92 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
       {error && !isLoading && (
         <div className="text-center py-8 text-red-500 dark:text-red-400 text-sm">{error}</div>
       )}
-      {!isLoading && !error && filteredAccounts.length === 0 && (
+      {!isLoading && !error && filteredClients.length === 0 && (
         <div className="text-center py-12 text-gray-500 dark:text-gray-400">
           {searchQuery ? 'No accounts match your search.' : 'No M2M accounts yet. Create your first service account.'}
         </div>
       )}
 
-      {!isLoading && !error && filteredAccounts.length > 0 && (
+      {!isLoading && !error && filteredClients.length > 0 && (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-gray-200 dark:border-gray-700">
                 <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-400">Name</th>
+                <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-400">Provider</th>
                 <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-400">Groups</th>
+                <th className="text-left py-3 px-4 font-medium text-gray-500 dark:text-gray-400">Registered by</th>
                 <th className="text-right py-3 px-4 font-medium text-gray-500 dark:text-gray-400">Action</th>
               </tr>
             </thead>
             <tbody>
-              {filteredAccounts.map((u) => (
-                <React.Fragment key={u.username}>
-                  <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                    <td className="py-3 px-4 text-gray-900 dark:text-white font-medium">{u.username}</td>
-                    <td className="py-3 px-4">
-                      <div className="flex flex-wrap gap-1">
-                        {(u.groups || []).map((g) => (
-                          <span key={g} className="inline-block px-2 py-0.5 text-xs rounded-full bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">
-                            {g}
-                          </span>
-                        ))}
-                        {(!u.groups || u.groups.length === 0) && <span className="text-gray-400 text-xs">{'\u2014'}</span>}
-                      </div>
-                    </td>
-                    <td className="py-3 px-4 text-right">
-                      <div className="flex items-center justify-end space-x-2">
-                        <button onClick={() => handleEdit(u)} className="p-1 text-gray-400 hover:text-purple-500 dark:hover:text-purple-400" title="Edit groups">
-                          <PencilIcon className="h-4 w-4" />
-                        </button>
-                        <button onClick={() => setDeleteTarget(u.username)} className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400" title="Delete account">
-                          <TrashIcon className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                  {deleteTarget === u.username && (
-                    <tr>
-                      <td colSpan={3} className="p-2">
-                        <DeleteConfirmation
-                          entityType="m2m"
-                          entityName={u.username}
-                          entityPath={u.username}
-                          onConfirm={handleDelete}
-                          onCancel={() => setDeleteTarget(null)}
-                        />
+              {filteredClients.map((c) => {
+                const isManual = c.provider === 'manual';
+                return (
+                  <React.Fragment key={c.client_id}>
+                    <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                      <td className="py-3 px-4 text-gray-900 dark:text-white font-medium">
+                        <div>{c.name}</div>
+                        <div className="text-xs text-gray-400 font-mono">{c.client_id}</div>
+                      </td>
+                      <td className="py-3 px-4">
+                        <ProviderBadge provider={c.provider} />
+                      </td>
+                      <td className="py-3 px-4">
+                        <div className="flex flex-wrap gap-1">
+                          {(c.groups || []).map((g) => (
+                            <span key={g} className="inline-block px-2 py-0.5 text-xs rounded-full bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300">
+                              {g}
+                            </span>
+                          ))}
+                          {(!c.groups || c.groups.length === 0) && <span className="text-gray-400 text-xs">{'—'}</span>}
+                        </div>
+                      </td>
+                      <td
+                        className="py-3 px-4 text-sm text-gray-600 dark:text-gray-400"
+                        title={c.created_at ? `Created at ${c.created_at}` : undefined}
+                      >
+                        {c.created_by || <span className="text-gray-400">{'—'}</span>}
+                      </td>
+                      <td className="py-3 px-4 text-right">
+                        <div className="flex items-center justify-end space-x-2">
+                          <button
+                            onClick={() => handleEdit(c)}
+                            disabled={!isManual}
+                            aria-disabled={!isManual}
+                            className="p-1 text-gray-400 hover:text-purple-500 dark:hover:text-purple-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                            title={isManual ? 'Edit groups' : 'Managed by IdP sync; cannot edit here'}
+                          >
+                            <PencilIcon className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => setDeleteTarget(c.client_id)}
+                            disabled={!isManual}
+                            aria-disabled={!isManual}
+                            className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-40 disabled:cursor-not-allowed"
+                            title={isManual ? 'Delete account' : 'Managed by IdP sync; cannot delete here'}
+                          >
+                            <TrashIcon className="h-4 w-4" />
+                          </button>
+                        </div>
                       </td>
                     </tr>
-                  )}
-                </React.Fragment>
-              ))}
+                    {deleteTarget === c.client_id && (
+                      <tr>
+                        <td colSpan={5} className="p-2">
+                          <DeleteConfirmation
+                            entityType="m2m"
+                            entityName={c.name}
+                            entityPath={c.client_id}
+                            onConfirm={handleDelete}
+                            onCancel={() => setDeleteTarget(null)}
+                          />
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/components/__tests__/IAMM2M.test.tsx
+++ b/frontend/src/components/__tests__/IAMM2M.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import axios from 'axios';
+import IAMM2M from '../IAMM2M';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+Object.assign(navigator, {
+  clipboard: { writeText: jest.fn().mockResolvedValue(undefined) },
+});
+
+const mockGroups = [
+  { name: 'pipeline-operators' },
+  { name: 'registry-readonly' },
+];
+
+const manualClient = {
+  client_id: 'my-pipeline',
+  name: 'My Pipeline',
+  description: 'CI service account',
+  groups: ['pipeline-operators'],
+  enabled: true,
+  provider: 'manual',
+  created_at: '2026-05-06T18:15:00Z',
+  updated_at: '2026-05-06T18:15:00Z',
+  idp_app_id: null,
+  created_by: 'admin',
+};
+
+const oktaClient = {
+  client_id: 'okta-synced',
+  name: 'Okta Synced',
+  description: null,
+  groups: ['registry-readonly'],
+  enabled: true,
+  provider: 'okta',
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+  idp_app_id: 'okta-app-123',
+  created_by: null,
+};
+
+const keycloakClient = {
+  client_id: 'kc-legacy',
+  name: 'Keycloak Legacy',
+  description: null,
+  groups: [],
+  enabled: true,
+  provider: 'keycloak',
+  created_at: '2026-04-01T10:00:00Z',
+  updated_at: '2026-04-01T10:00:00Z',
+  idp_app_id: null,
+  created_by: null,
+};
+
+const mockListResponse = {
+  data: {
+    total: 3,
+    limit: 1000,
+    skip: 0,
+    items: [manualClient, oktaClient, keycloakClient],
+  },
+};
+
+const mockGroupsResponse = { data: { groups: mockGroups } };
+
+function setupDefaultMocks() {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url === '/api/iam/m2m-clients') {
+      return Promise.resolve(mockListResponse);
+    }
+    if (url === '/api/management/iam/groups') {
+      return Promise.resolve(mockGroupsResponse);
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+}
+
+const toastSpy = jest.fn();
+
+describe('IAMM2M list view', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('renders a row per client with provider badge', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Pipeline')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Okta Synced')).toBeInTheDocument();
+    expect(screen.getByText('Keycloak Legacy')).toBeInTheDocument();
+    expect(screen.getByText('manual')).toBeInTheDocument();
+    expect(screen.getByText('okta')).toBeInTheDocument();
+    expect(screen.getByText('keycloak')).toBeInTheDocument();
+  });
+
+  test('shows created_by for manual records and em-dash otherwise', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    const manualRow = screen.getByText('My Pipeline').closest('tr')!;
+    expect(within(manualRow).getByText('admin')).toBeInTheDocument();
+
+    const oktaRow = screen.getByText('Okta Synced').closest('tr')!;
+    expect(within(oktaRow).getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('disables edit and delete buttons on non-manual rows', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => expect(screen.getByText('Okta Synced')).toBeInTheDocument());
+
+    const oktaRow = screen.getByText('Okta Synced').closest('tr')!;
+    const editBtn = within(oktaRow).getByTitle(/Managed by IdP sync; cannot edit here/);
+    const deleteBtn = within(oktaRow).getByTitle(/Managed by IdP sync; cannot delete here/);
+    expect(editBtn).toBeDisabled();
+    expect(deleteBtn).toBeDisabled();
+  });
+
+  test('enables edit and delete buttons on manual rows', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    const manualRow = screen.getByText('My Pipeline').closest('tr')!;
+    const editBtn = within(manualRow).getByTitle('Edit groups');
+    const deleteBtn = within(manualRow).getByTitle('Delete account');
+    expect(editBtn).not.toBeDisabled();
+    expect(deleteBtn).not.toBeDisabled();
+  });
+
+  test('search filters by name or client_id', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    const input = screen.getByPlaceholderText('Search M2M accounts...');
+    await userEvent.type(input, 'okta');
+
+    expect(screen.queryByText('My Pipeline')).not.toBeInTheDocument();
+    expect(screen.getByText('Okta Synced')).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'kc-legacy');
+    expect(screen.getByText('Keycloak Legacy')).toBeInTheDocument();
+    expect(screen.queryByText('Okta Synced')).not.toBeInTheDocument();
+  });
+
+  test('help popover toggles on icon click', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    expect(screen.queryByText(/records a/)).not.toBeInTheDocument();
+
+    const helpBtn = screen.getByRole('button', { name: 'Help' });
+    await userEvent.click(helpBtn);
+    expect(screen.getByText(/records a/)).toBeInTheDocument();
+
+    await userEvent.click(helpBtn);
+    expect(screen.queryByText(/records a/)).not.toBeInTheDocument();
+  });
+});
+
+describe('IAMM2M register flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupDefaultMocks();
+  });
+
+  test('validates invalid client_id before submitting', async () => {
+    render(<IAMM2M onShowToast={toastSpy} />);
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Register existing client/i }));
+    expect(
+      screen.getByText(/Register Existing Client/i)
+    ).toBeInTheDocument();
+
+    await userEvent.type(screen.getByPlaceholderText('e.g. my-pipeline-client'), 'bad id!');
+    await userEvent.type(screen.getByPlaceholderText('Human-readable name'), 'Some Name');
+    await userEvent.click(screen.getByRole('button', { name: /^Register$/ }));
+
+    expect(screen.getByText(/Allowed characters/)).toBeInTheDocument();
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+
+  test('submits valid registration via POST /api/iam/m2m-clients', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: manualClient });
+
+    render(<IAMM2M onShowToast={toastSpy} />);
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Register existing client/i }));
+    await userEvent.type(screen.getByPlaceholderText('e.g. my-pipeline-client'), 'new-svc');
+    await userEvent.type(screen.getByPlaceholderText('Human-readable name'), 'New Service');
+
+    const groupCheckbox = screen.getByLabelText('pipeline-operators');
+    await userEvent.click(groupCheckbox);
+
+    await userEvent.click(screen.getByRole('button', { name: /^Register$/ }));
+
+    await waitFor(() => {
+      expect(mockedAxios.post).toHaveBeenCalledWith('/api/iam/m2m-clients', {
+        client_id: 'new-svc',
+        client_name: 'New Service',
+        description: undefined,
+        groups: ['pipeline-operators'],
+      });
+    });
+    expect(toastSpy).toHaveBeenCalledWith(
+      'Registered M2M client "New Service"',
+      'success'
+    );
+  });
+
+  test('surfaces 409 conflict detail as error toast', async () => {
+    mockedAxios.post.mockRejectedValueOnce({
+      response: { data: { detail: 'M2M client new-svc already exists' } },
+    });
+
+    render(<IAMM2M onShowToast={toastSpy} />);
+    await waitFor(() => expect(screen.getByText('My Pipeline')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: /Register existing client/i }));
+    await userEvent.type(screen.getByPlaceholderText('e.g. my-pipeline-client'), 'new-svc');
+    await userEvent.type(screen.getByPlaceholderText('Human-readable name'), 'New Service');
+    await userEvent.click(screen.getByLabelText('pipeline-operators'));
+    await userEvent.click(screen.getByRole('button', { name: /^Register$/ }));
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        'M2M client new-svc already exists',
+        'error'
+      );
+    });
+  });
+});

--- a/frontend/src/hooks/__tests__/useM2MClients.test.ts
+++ b/frontend/src/hooks/__tests__/useM2MClients.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import axios from 'axios';
+import {
+  useM2MClients,
+  registerM2MClient,
+  patchM2MClient,
+  deleteM2MClient,
+} from '../useIAM';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const mockListResponse = {
+  data: {
+    total: 1,
+    limit: 1000,
+    skip: 0,
+    items: [
+      {
+        client_id: 'my-pipeline',
+        name: 'My Pipeline',
+        description: 'CI service account',
+        groups: ['pipeline-operators'],
+        enabled: true,
+        provider: 'manual',
+        created_at: '2026-05-06T18:15:00Z',
+        updated_at: '2026-05-06T18:15:00Z',
+        idp_app_id: null,
+        created_by: 'admin',
+      },
+    ],
+  },
+};
+
+describe('useM2MClients', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetches clients on mount with limit=1000', async () => {
+    mockedAxios.get.mockResolvedValueOnce(mockListResponse);
+
+    const { result } = renderHook(() => useM2MClients());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/iam/m2m-clients',
+      { params: { limit: 1000 } }
+    );
+    expect(result.current.clients).toHaveLength(1);
+    expect(result.current.clients[0].client_id).toBe('my-pipeline');
+    expect(result.current.error).toBeNull();
+  });
+
+  test('populates error state when fetch fails', async () => {
+    mockedAxios.get.mockRejectedValueOnce({
+      response: { data: { detail: 'Failed to load' } },
+    });
+
+    const { result } = renderHook(() => useM2MClients());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.clients).toEqual([]);
+    expect(result.current.error).toBe('Failed to load');
+  });
+
+  test('uses default error message when detail is absent', async () => {
+    mockedAxios.get.mockRejectedValueOnce({});
+
+    const { result } = renderHook(() => useM2MClients());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to load M2M clients');
+  });
+
+  test('refetch re-requests the list', async () => {
+    mockedAxios.get.mockResolvedValue(mockListResponse);
+
+    const { result } = renderHook(() => useM2MClients());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('registerM2MClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('POSTs the expected payload shape', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: mockListResponse.data.items[0] });
+
+    const payload = {
+      client_id: 'my-pipeline',
+      client_name: 'My Pipeline',
+      groups: ['pipeline-operators'],
+      description: 'CI service account',
+    };
+    const result = await registerM2MClient(payload);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/iam/m2m-clients', payload);
+    expect(result.client_id).toBe('my-pipeline');
+  });
+});
+
+describe('patchM2MClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('PATCHes with url-encoded client_id for special chars', async () => {
+    mockedAxios.patch.mockResolvedValueOnce({ data: mockListResponse.data.items[0] });
+
+    await patchM2MClient('svc:pipeline.v2', { groups: ['g1'] });
+
+    expect(mockedAxios.patch).toHaveBeenCalledWith(
+      '/api/iam/m2m-clients/svc%3Apipeline.v2',
+      { groups: ['g1'] }
+    );
+  });
+});
+
+describe('deleteM2MClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('issues DELETE with url-encoded client_id', async () => {
+    mockedAxios.delete.mockResolvedValueOnce({});
+
+    await deleteM2MClient('svc:pipeline');
+
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      '/api/iam/m2m-clients/svc%3Apipeline'
+    );
+  });
+});

--- a/frontend/src/hooks/useIAM.ts
+++ b/frontend/src/hooks/useIAM.ts
@@ -181,3 +181,92 @@ export async function updateUserGroups(
   );
   return res.data;
 }
+
+// ─── M2M Client (idp_m2m_clients) Types ────────────────────────
+// Mirrors registry/schemas/idp_m2m_client.py IdPM2MClient / Create / Patch / ListResponse.
+
+export interface M2MClient {
+  client_id: string;
+  name: string;
+  description?: string | null;
+  groups: string[];
+  enabled: boolean;
+  provider: 'manual' | 'okta' | 'auth0' | 'keycloak' | 'entra' | string;
+  created_at: string;
+  updated_at: string;
+  idp_app_id?: string | null;
+  created_by?: string | null;
+}
+
+export interface RegisterM2MClientPayload {
+  client_id: string;
+  client_name: string;
+  groups: string[];
+  description?: string;
+}
+
+export interface PatchM2MClientPayload {
+  client_name?: string;
+  groups?: string[];
+  description?: string;
+  enabled?: boolean;
+}
+
+export interface M2MClientListResponse {
+  total: number;
+  limit: number;
+  skip: number;
+  items: M2MClient[];
+}
+
+// ─── Hook: useM2MClients ────────────────────────────────────────
+
+export function useM2MClients() {
+  const [clients, setClients] = useState<M2MClient[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchClients = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await axios.get<M2MClientListResponse>(
+        '/api/iam/m2m-clients',
+        { params: { limit: 1000 } }
+      );
+      setClients(res.data.items || []);
+    } catch (err: any) {
+      setError(err.response?.data?.detail || 'Failed to load M2M clients');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetchClients(); }, [fetchClients]);
+
+  return { clients, isLoading, error, refetch: fetchClients };
+}
+
+export async function registerM2MClient(
+  payload: RegisterM2MClientPayload
+): Promise<M2MClient> {
+  const res = await axios.post<M2MClient>('/api/iam/m2m-clients', payload);
+  return res.data;
+}
+
+export async function patchM2MClient(
+  clientId: string,
+  payload: PatchM2MClientPayload
+): Promise<M2MClient> {
+  const res = await axios.patch<M2MClient>(
+    `/api/iam/m2m-clients/${encodeURIComponent(clientId)}`,
+    payload
+  );
+  return res.data;
+}
+
+export async function deleteM2MClient(clientId: string): Promise<void> {
+  await axios.delete(
+    `/api/iam/m2m-clients/${encodeURIComponent(clientId)}`
+  );
+}

--- a/release-notes/v1.0.22.md
+++ b/release-notes/v1.0.22.md
@@ -1,0 +1,67 @@
+# Release v1.0.22 - IAM M2M UI Improvements
+
+**May 2026**
+
+---
+
+## Upgrading from v1.0.21
+
+This section covers everything you need to know to upgrade from v1.0.21 to v1.0.22.
+
+### Breaking Changes
+
+No breaking changes.
+
+### New Environment Variables
+
+None.
+
+### Upgrade Instructions
+
+#### Docker Compose
+
+```bash
+cd mcp-gateway-registry
+git pull
+docker compose pull
+docker compose up -d
+```
+
+No configuration changes are required.
+
+## Fixed
+
+- **IAM > M2M Accounts UI now lists direct-registration clients.** M2M clients
+  registered via `POST /api/iam/m2m-clients` (added in v1.0.20 for environments
+  without an IdP Admin API token) are now visible in the Registry UI's
+  **Settings > IAM > M2M Accounts** page alongside records created via the
+  legacy "Create M2M Account" flow. The page adds a `Provider` column
+  (`manual`, `okta`, `auth0`, `keycloak`, `entra`) and a `Registered by`
+  column. Edit and Delete actions on `provider: manual` records route through
+  `/api/iam/m2m-clients/{client_id}`; rows written by IdP sync show these
+  actions as disabled with an explanatory tooltip, consistent with the
+  backend's 403 ownership guard. Fixes
+  [#945](https://github.com/agentic-community/mcp-gateway-registry/issues/945).
+
+## New Features
+
+- **"Register existing client" button in IAM > M2M Accounts.** A new button
+  next to "Create M2M Account" lets operators register a `client_id` that
+  already exists in their IdP without requiring an IdP Admin API token. This
+  is the UI equivalent of the `registry_management.py m2m-client-create`
+  command documented in the FAQ. Use this flow for Entra tenants without
+  `Application.ReadWrite.*` grants, Okta tenants without Admin API tokens,
+  or any environment where you don't want the registry to manage IdP app
+  lifecycle.
+
+## Documentation
+
+- FAQ [`docs/faq/registering-m2m-client-without-idp-admin-token.md`](../docs/faq/registering-m2m-client-without-idp-admin-token.md)
+  now covers:
+  - **Step 2b: Register via the Registry UI**, showing the new button and
+    the resulting `manual` provider badge.
+  - A **Least-privilege reminder** on group assignment and token refresh
+    semantics.
+  - A **Rotating or recovering the client secret** section explaining
+    that secrets live in the IdP, not the registry, for manually-registered
+    clients.


### PR DESCRIPTION
## Summary

- Rewires **IAM > M2M Accounts** to read from `/api/iam/m2m-clients` so records registered via the direct-registration endpoint (added in v1.0.20) now appear in the UI alongside legacy records.
- Surfaces the `provider` field (`manual` / `okta` / `auth0` / `keycloak` / `entra`) as a new column plus a `Registered by` column backed by `created_by`.
- Adds a **Register existing client** button for environments without an IdP Admin API token (Entra without `Application.ReadWrite.*`, Okta without Admin API, etc.), alongside the existing purple **Create M2M Account** button; an info-icon popover explains which one to use.
- Edit and Delete on `provider: manual` rows route through `PATCH` / `DELETE /api/iam/m2m-clients/{client_id}`; rows owned by IdP sync have both actions disabled with an explanatory tooltip, matching the backend's 403 ownership guard.
- No backend changes. Endpoints and schemas were already shipped in v1.0.20 (PR #866).

Closes #945.

## Changes

- ``frontend/src/hooks/useIAM.ts`` — `M2MClient` / `RegisterM2MClientPayload` / `PatchM2MClientPayload` / `M2MClientListResponse` types, plus the `useM2MClients` hook and `registerM2MClient` / `patchM2MClient` / `deleteM2MClient` helpers.
- ``frontend/src/components/IAMM2M.tsx`` — swap `useIAMUsers` -> `useM2MClients`, new `ProviderBadge`, new `register` view, help popover, disabled-action contract for non-manual rows, rewired Edit/Delete handlers.
- ``docs/faq/registering-m2m-client-without-idp-admin-token.md`` — Step 2b (UI path), least-privilege reminder, secret-rotation guidance.
- ``release-notes/v1.0.22.md`` — new release entry.
- Tests (Jest + React Testing Library): `frontend/src/hooks/__tests__/useM2MClients.test.ts` and `frontend/src/components/__tests__/IAMM2M.test.tsx`.

## Test plan

- [x] `CI=true npx react-scripts test --testPathPattern='useM2MClients|IAMM2M' --watchAll=false` — 16 tests pass across 2 suites.
- [ ] Manual smoke in local docker-compose (Keycloak): create via legacy button, register via new button, confirm provider badges, confirm edit/delete disabled on synced rows.
- [ ] Manual smoke in Entra stack without `Application.ReadWrite.*`: register existing client, confirm authorization works end-to-end.
- [ ] `cd frontend && npm run build` — no TS errors.
- [ ] `uv run pytest tests/ -n 8` — no backend regressions (no backend changes, but verifying).

## Notes

- The v1 Edit view only exposes groups (matching prior UI behavior); name/description/enabled are accepted by the backend PATCH but intentionally deferred to a follow-up. `patchM2MClient` is already typed for all four fields so the follow-up is a pure component change.
- No new environment variables, no changes to Docker Compose / Terraform / Helm, no config keys.
- Legacy `POST /api/management/iam/users/m2m` flow and `GET /api/management/iam/users` users-merge are preserved unchanged; the Users page still uses them.