### PR TITLE
fix(iam): skip IdP admin calls for local-only groups (#946)

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1260,6 +1260,14 @@ class GroupSummary(BaseModel):
     name: str = Field(..., description="Group name")
     path: str = Field(..., description="Group path")
     attributes: dict[str, Any] | None = Field(None, description="Group attributes")
+    is_idp_managed: bool | None = Field(
+        None,
+        description=(
+            "Whether the group is managed in the upstream identity provider. "
+            "None for legacy records that predate the flag; True means "
+            "PATCH/DELETE call the IdP, False means local-only. See issue #946."
+        ),
+    )
 
 
 class IdPM2MClient(BaseModel):
@@ -3054,13 +3062,23 @@ class RegistryClient:
         logger.info(f"Retrieved {result.total} Keycloak groups")
         return result
 
-    def create_keycloak_group(self, name: str, description: str | None = None) -> GroupSummary:
+    def create_keycloak_group(
+        self,
+        name: str,
+        description: str | None = None,
+        create_in_idp: bool = False,
+    ) -> GroupSummary:
         """
         Create a new Keycloak group (admin only).
 
         Args:
             name: Group name
             description: Optional group description
+            create_in_idp: When True, also creates the group in the configured
+                identity provider (Keycloak/Entra/Okta/Auth0) and persists
+                `is_idp_managed=True`. When False (default), the group is
+                local-only and PATCH/DELETE will not call the IdP. See
+                issue #946.
 
         Returns:
             GroupSummary with created group details
@@ -3068,9 +3086,14 @@ class RegistryClient:
         Raises:
             requests.HTTPError: If not authorized (403), already exists (400), or request fails
         """
-        logger.info(f"Creating Keycloak group: {name}")
+        logger.info(
+            f"Creating Keycloak group: {name} (create_in_idp={create_in_idp})"
+        )
 
-        data = {"name": name}
+        data: dict[str, Any] = {
+            "name": name,
+            "scope_config": {"create_in_idp": create_in_idp},
+        }
         if description:
             data["description"] = description
 

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -475,7 +475,9 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
         setUiPermissions({});
       }
 
-      setCreateInIdp(true);
+      // Reflect whether the group is IdP-managed or local-only (issue #946).
+      // Null/undefined (legacy records) defaults to true to match pre-#946 behavior.
+      setCreateInIdp(detail.is_idp_managed !== false);
       setView('edit');
     } catch (err: any) {
       const detail = err.response?.data?.detail;
@@ -1062,6 +1064,26 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                              focus:ring-2 focus:ring-purple-500 focus:border-transparent"
                 />
               </div>
+              {/* Create-in-IdP toggle, locked in edit mode (issue #946). */}
+              <div className="flex flex-col space-y-1">
+                <label className="flex items-center space-x-2">
+                  <input
+                    type="checkbox"
+                    checked={createInIdp}
+                    disabled
+                    aria-describedby="create-in-idp-edit-help"
+                    className="rounded border-gray-300 dark:border-gray-600 text-purple-600
+                               focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                  <span className="text-sm text-gray-600 dark:text-gray-400">
+                    Create in Identity Provider (Keycloak / Entra ID)
+                  </span>
+                </label>
+                <p id="create-in-idp-edit-help" className="text-xs text-gray-500 dark:text-gray-400 pl-6">
+                  This setting cannot be changed after creation. To convert a group between
+                  local-only and IdP-managed, delete and recreate it.
+                </p>
+              </div>
             </div>
 
             {/* ── Server Access ──────────────────────────────────── */}
@@ -1334,7 +1356,28 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
               {filteredGroups.map((group) => (
                 <React.Fragment key={group.name}>
                   <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                    <td className="py-3 px-4 text-gray-900 dark:text-white font-medium">{group.name}</td>
+                    <td className="py-3 px-4 text-gray-900 dark:text-white font-medium">
+                      <span>{group.name}</span>
+                      {group.is_idp_managed === false ? (
+                        <span
+                          role="status"
+                          aria-label="Local-only group: PATCH and DELETE will not call the upstream identity provider. Recommended for tenants without Group.ReadWrite.All."
+                          title="Local-only: PATCH and DELETE will not call the upstream IdP. Recommended for tenants without Group.ReadWrite.All."
+                          className="ml-2 inline-flex items-center px-2 py-0.5 text-xs rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+                        >
+                          Local-only
+                        </span>
+                      ) : group.is_idp_managed === true ? (
+                        <span
+                          role="status"
+                          aria-label="IdP-managed group: PATCH and DELETE will call the upstream identity provider."
+                          title="IdP-managed: this group is managed in the upstream identity provider."
+                          className="ml-2 inline-flex items-center px-2 py-0.5 text-xs rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300"
+                        >
+                          IdP-managed
+                        </span>
+                      ) : null}
+                    </td>
                     <td className="py-3 px-4 text-gray-600 dark:text-gray-400">{group.description || '\u2014'}</td>
                     <td className="py-3 px-4 text-gray-500 dark:text-gray-500 font-mono text-xs">{group.path || '\u2014'}</td>
                     <td className="py-3 px-4 text-right">

--- a/frontend/src/components/IAMM2M.tsx
+++ b/frontend/src/components/IAMM2M.tsx
@@ -108,6 +108,18 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
   const [editTarget, setEditTarget] = useState<M2MClient | null>(null);
   const [isUpdating, setIsUpdating] = useState(false);
 
+  // Search query that filters the groups checklist in every view.
+  const [groupSearch, setGroupSearch] = useState('');
+  const filteredGroups = useMemo(() => {
+    if (!groupSearch.trim()) return groups;
+    const q = groupSearch.toLowerCase();
+    return groups.filter(
+      (g) =>
+        g.name.toLowerCase().includes(q) ||
+        (g.description || '').toLowerCase().includes(q)
+    );
+  }, [groups, groupSearch]);
+
   const filteredClients = useMemo(() => {
     if (!searchQuery) return clients;
     const q = searchQuery.toLowerCase();
@@ -123,6 +135,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
     setFormDescription('');
     setFormGroups(new Set());
     setErrors({});
+    setGroupSearch('');
   }, []);
 
   const resetRegisterForm = useCallback(() => {
@@ -131,6 +144,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
     setRegisterDescription('');
     setRegisterGroups(new Set());
     setRegisterErrors({});
+    setGroupSearch('');
   }, []);
 
   const toggleCreateGroup = (groupName: string) => {
@@ -245,6 +259,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
   const handleEdit = (client: M2MClient) => {
     setEditTarget(client);
     setFormGroups(new Set(client.groups || []));
+    setGroupSearch('');
     setView('edit');
   };
 
@@ -265,6 +280,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
       onShowToast(`Groups updated for "${editTarget.name}"`, 'success');
       setEditTarget(null);
       setFormGroups(new Set());
+      setGroupSearch('');
       setView('list');
       await refetch();
     } catch (err: any) {
@@ -354,13 +370,25 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
         <div className="space-y-4 max-w-lg">
           <div>
             <label className="block text-sm text-gray-600 dark:text-gray-400 mb-2">Groups *</label>
+            <div className="relative mb-2">
+              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                value={groupSearch}
+                onChange={(e) => setGroupSearch(e.target.value)}
+                placeholder="Search groups..."
+                className="w-full pl-10 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              />
+            </div>
             <div className={`space-y-2 max-h-48 overflow-y-auto rounded-lg p-3 ${
               errors.groups ? 'border-2 border-red-500' : 'border border-gray-200 dark:border-gray-700'
             }`}>
               {groups.length === 0 ? (
                 <p className="text-xs text-gray-400">No groups available</p>
+              ) : filteredGroups.length === 0 ? (
+                <p className="text-xs text-gray-400">No groups match "{groupSearch}"</p>
               ) : (
-                groups.map((g) => (
+                filteredGroups.map((g) => (
                   <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
                     <input type="checkbox" checked={formGroups.has(g.name)}
                       onChange={() => { toggleCreateGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
@@ -375,7 +403,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
         </div>
 
         <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-          <button onClick={() => { setFormGroups(new Set()); setEditTarget(null); setErrors({}); setView('list'); }}
+          <button onClick={() => { setFormGroups(new Set()); setEditTarget(null); setErrors({}); setGroupSearch(''); setView('list'); }}
             className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600">
             Cancel
           </button>
@@ -421,13 +449,25 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
 
           <div>
             <label className="block text-sm text-gray-600 dark:text-gray-400 mb-2">Groups *</label>
+            <div className="relative mb-2">
+              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                value={groupSearch}
+                onChange={(e) => setGroupSearch(e.target.value)}
+                placeholder="Search groups..."
+                className="w-full pl-10 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              />
+            </div>
             <div className={`space-y-2 max-h-48 overflow-y-auto rounded-lg p-3 ${
               errors.groups ? 'border-2 border-red-500' : 'border border-gray-200 dark:border-gray-700'
             }`}>
               {groups.length === 0 ? (
                 <p className="text-xs text-gray-400">No groups available</p>
+              ) : filteredGroups.length === 0 ? (
+                <p className="text-xs text-gray-400">No groups match "{groupSearch}"</p>
               ) : (
-                groups.map((g) => (
+                filteredGroups.map((g) => (
                   <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
                     <input type="checkbox" checked={formGroups.has(g.name)}
                       onChange={() => { toggleCreateGroup(g.name); if (errors.groups) setErrors((p) => ({ ...p, groups: undefined })); }}
@@ -442,7 +482,7 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
         </div>
 
         <div className="flex justify-end space-x-3 pt-4 border-t border-gray-200 dark:border-gray-700">
-          <button onClick={() => { resetCreateForm(); setView('list'); }}
+          <button onClick={() => { resetCreateForm(); setGroupSearch(''); setView('list'); }}
             className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600">
             Cancel
           </button>
@@ -504,13 +544,25 @@ const IAMM2M: React.FC<IAMM2MProps> = ({ onShowToast }) => {
 
           <div>
             <label className="block text-sm text-gray-600 dark:text-gray-400 mb-2">Groups *</label>
+            <div className="relative mb-2">
+              <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                type="text"
+                value={groupSearch}
+                onChange={(e) => setGroupSearch(e.target.value)}
+                placeholder="Search groups..."
+                className="w-full pl-10 pr-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              />
+            </div>
             <div className={`space-y-2 max-h-48 overflow-y-auto rounded-lg p-3 ${
               registerErrors.groups ? 'border-2 border-red-500' : 'border border-gray-200 dark:border-gray-700'
             }`}>
               {groups.length === 0 ? (
                 <p className="text-xs text-gray-400">No groups available</p>
+              ) : filteredGroups.length === 0 ? (
+                <p className="text-xs text-gray-400">No groups match "{groupSearch}"</p>
               ) : (
-                groups.map((g) => (
+                filteredGroups.map((g) => (
                   <label key={g.name} className="flex items-center space-x-2 cursor-pointer">
                     <input type="checkbox" checked={registerGroups.has(g.name)}
                       onChange={() => { toggleRegisterGroup(g.name); if (registerErrors.groups) setRegisterErrors((p) => ({ ...p, groups: undefined })); }}

--- a/frontend/src/hooks/useIAM.ts
+++ b/frontend/src/hooks/useIAM.ts
@@ -8,6 +8,9 @@ export interface IAMGroup {
   description?: string;
   path?: string;
   members_count?: number;
+  // True if the group is managed in the upstream IdP; false for local-only.
+  // Null/undefined for legacy records that predate the flag. See issue #946.
+  is_idp_managed?: boolean | null;
 }
 
 export interface IAMUser {
@@ -96,6 +99,8 @@ export interface GroupDetail {
   group_mappings?: string[];
   ui_permissions?: Record<string, string[]>;
   agent_access?: string[];
+  // See issue #946. True=IdP-managed, false=local-only, null=legacy/unknown.
+  is_idp_managed?: boolean | null;
 }
 
 export interface UpdateGroupPayload {

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -4,8 +4,9 @@ import logging
 import os
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from ..audit.context import set_audit_action
 from ..auth.dependencies import nginx_proxied_auth
 from ..schemas.management import (
     GroupCreateRequest,
@@ -23,6 +24,7 @@ from ..schemas.management import (
     UserSummary,
 )
 from ..services import scope_service
+from ..utils.iam_errors import IdPForbiddenError, IdPNotFoundError
 from ..utils.iam_manager import get_iam_manager
 
 logger = logging.getLogger(__name__)
@@ -354,7 +356,13 @@ async def management_update_user_groups(
         logger.warning(f"Error checking/updating M2M account in DocumentDB: {e}")
         # Continue to IdP update if DocumentDB check fails
 
-    # If not an M2M account, update through IdP
+    # If not an M2M account, update through IdP. The IdP manager computes the
+    # add/remove diff against the user's current memberships, so groups that
+    # are unchanged (including local-only scopes that happen to be in the
+    # payload) never touch the IdP. Only *new* additions hit the IdP, and if
+    # one of those doesn't exist there we surface a 400 with a helpful message
+    # pointing the operator at the correct "map an existing IdP group via
+    # group_mappings" workflow (see issue #946).
     iam = get_iam_manager()
 
     try:
@@ -363,6 +371,19 @@ async def management_update_user_groups(
             groups=payload.groups,
         )
     except Exception as exc:
+        detail = str(exc).lower()
+        if "group" in detail and "not found" in detail:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Cannot assign user '{username}' to a group that does "
+                    "not exist in the identity provider. If this is a "
+                    "local-only group (created with 'Create in identity "
+                    "provider' unchecked), add the user to the IdP group "
+                    "referenced in the scope's group_mappings instead. "
+                    f"Underlying error: {exc}"
+                ),
+            ) from exc
         raise _translate_iam_error(exc) from exc
 
     return UpdateUserGroupsResponse(
@@ -377,23 +398,20 @@ async def management_update_user_groups(
 async def management_list_groups(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
-    """List IAM groups from the configured identity provider (admin only)."""
+    """List IAM groups from the configured identity provider and local-only
+    scope documents (admin only).
+
+    Local-only groups (created with `create_in_idp=False`, see issue #946) live
+    only in the MongoDB `scopes` collection and are invisible to the IdP.
+    This handler merges the IdP list with any MongoDB scope documents that
+    don't appear in the IdP response so every UI picker sees them.
+    """
     _require_admin(user_context)
 
     iam = get_iam_manager()
 
     try:
         raw_groups = await iam.list_groups()
-        summaries = [
-            GroupSummary(
-                id=group.get("id", ""),
-                name=group.get("name", ""),
-                path=group.get("path", ""),
-                attributes=group.get("attributes"),
-            )
-            for group in raw_groups
-        ]
-        return GroupListResponse(groups=summaries, total=len(summaries))
     except Exception as exc:
         logger.error("Failed to list IAM groups: %s", exc)
         raise HTTPException(
@@ -401,10 +419,69 @@ async def management_list_groups(
             detail="Unable to list IAM groups",
         ) from exc
 
+    # Cross-reference with MongoDB scope documents.
+    # scope_service.list_groups() also eagerly backfills any legacy docs
+    # missing the is_idp_managed flag (see DocumentDBScopeRepository.list_groups).
+    scope_groups_map: dict = {}
+    try:
+        scope_groups = await scope_service.list_groups()
+        for name, meta in scope_groups.items():
+            if isinstance(meta, dict):
+                scope_groups_map[name] = meta
+    except Exception as exc:
+        logger.warning(
+            "Could not cross-reference scope docs for is_idp_managed: %s",
+            exc,
+        )
+
+    summaries: list[GroupSummary] = []
+    idp_names: set[str] = set()
+    for group in raw_groups:
+        name = group.get("name", "")
+        idp_names.add(name)
+        scope_meta = scope_groups_map.get(name, {})
+        summaries.append(
+            GroupSummary(
+                id=group.get("id", ""),
+                name=name,
+                path=group.get("path", ""),
+                attributes=group.get("attributes"),
+                is_idp_managed=scope_meta.get("is_idp_managed"),
+            )
+        )
+
+    # Append local-only groups (present in MongoDB scopes, absent from IdP).
+    # Synthesize id/path using the scope name, mirroring the create path.
+    local_only: list[GroupSummary] = []
+    for name, scope_meta in scope_groups_map.items():
+        if name in idp_names:
+            continue
+        description = scope_meta.get("description") if isinstance(scope_meta, dict) else None
+        local_only.append(
+            GroupSummary(
+                id=name,
+                name=name,
+                path=f"/{name}",
+                attributes={"description": [description]} if description else None,
+                is_idp_managed=scope_meta.get("is_idp_managed", False),
+            )
+        )
+        logger.debug(
+            "iam_groups_list_local_only_included scope=%s is_idp_managed=%s",
+            name,
+            scope_meta.get("is_idp_managed", False),
+        )
+
+    local_only.sort(key=lambda summary: summary.name)
+    summaries.extend(local_only)
+
+    return GroupListResponse(groups=summaries, total=len(summaries))
+
 
 @router.post("/iam/groups", response_model=GroupSummary)
 async def management_create_group(
     payload: GroupCreateRequest,
+    request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
@@ -412,7 +489,9 @@ async def management_create_group(
 
     When create_in_idp is True, creates in both the configured
     identity provider and MongoDB scopes collection.
-    When create_in_idp is False, creates only in MongoDB scopes collection.
+    When create_in_idp is False, creates only in MongoDB scopes collection
+    and persists `is_idp_managed=False` so subsequent PATCH/DELETE do not
+    call the IdP (see issue #946).
     """
     _require_admin(user_context)
 
@@ -426,6 +505,15 @@ async def management_create_group(
         "create_in_idp=%s for group '%s' (from scope_config)",
         create_in_idp,
         payload.name,
+    )
+
+    set_audit_action(
+        request,
+        operation="create",
+        resource_type="group",
+        resource_id=payload.name,
+        description=f"Create group '{payload.name}'",
+        idp_skip_reason=None if create_in_idp else "local_only",
     )
 
     try:
@@ -478,6 +566,7 @@ async def management_create_group(
             server_access=server_access,
             ui_permissions=ui_permissions,
             agent_access=agent_access,
+            is_idp_managed=create_in_idp,
         )
 
         if not import_success:
@@ -492,6 +581,7 @@ async def management_create_group(
             name=result.get("name", ""),
             path=result.get("path", ""),
             attributes=result.get("attributes"),
+            is_idp_managed=create_in_idp,
         )
 
     except Exception as exc:
@@ -510,33 +600,75 @@ async def management_create_group(
 @router.delete("/iam/groups/{group_name}", response_model=GroupDeleteResponse)
 async def management_delete_group(
     group_name: str,
+    request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
-    Delete a group from the identity provider and/or MongoDB (admin only).
+    Delete a group (admin only).
 
-    Attempts to delete from IdP first. If the group does not exist in the IdP
-    (e.g., it was created with create_in_idp=False), the IdP error is logged
-    and the MongoDB deletion proceeds.
+    Behavior (see issue #946):
+    - is_idp_managed=False: IdP call is skipped entirely.
+    - is_idp_managed=True and IdP 403/404: non-fatal fall-through; MongoDB
+      deletion proceeds; audit entry includes idp_skip_reason.
+    - Any other IdP error: propagates as before (502).
     """
     _require_admin(user_context)
 
+    set_audit_action(
+        request,
+        operation="delete",
+        resource_type="group",
+        resource_id=group_name,
+        description=f"Delete group '{group_name}'",
+    )
+
     iam = get_iam_manager()
+    skip_reason: str | None = None
 
     try:
-        # Step 1: Attempt to delete from identity provider
-        try:
-            await iam.delete_group(group_name=group_name)
-        except Exception as idp_exc:
-            idp_detail = str(idp_exc).lower()
-            if "not found" in idp_detail or "404" in idp_detail:
+        existing_group = await scope_service.get_group(group_name)
+        is_idp_managed = True
+        if existing_group is not None:
+            is_idp_managed = bool(existing_group.get("is_idp_managed", True))
+
+        if is_idp_managed:
+            try:
+                await iam.delete_group(group_name=group_name)
+            except IdPNotFoundError as idp_exc:
                 logger.info(
-                    "Group '%s' not found in IdP (may be local-only), "
-                    "proceeding with MongoDB deletion",
+                    "iam_idp_fallthrough operation=delete resource=%s "
+                    "status=404 reason=not_found detail=%s",
                     group_name,
+                    idp_exc,
                 )
-            else:
-                raise
+                skip_reason = "not_found"
+            except IdPForbiddenError as idp_exc:
+                logger.warning(
+                    "iam_idp_fallthrough operation=delete resource=%s "
+                    "status=403 reason=forbidden detail=%s",
+                    group_name,
+                    idp_exc,
+                )
+                skip_reason = "forbidden"
+        else:
+            logger.info(
+                "iam_idp_skipped operation=delete resource=%s reason=local_only",
+                group_name,
+            )
+            skip_reason = "local_only"
+
+        if skip_reason is not None:
+            set_audit_action(
+                request,
+                operation="delete",
+                resource_type="group",
+                resource_id=group_name,
+                description=(
+                    f"Delete group '{group_name}' - IdP call skipped "
+                    f"({skip_reason})"
+                ),
+                idp_skip_reason=skip_reason,
+            )
 
         # Step 2: Delete from MongoDB scopes collection
         delete_success = await scope_service.delete_group(
@@ -551,6 +683,8 @@ async def management_delete_group(
 
         return GroupDeleteResponse(name=group_name)
 
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Failed to delete group: %s", exc)
         detail = str(exc).lower()
@@ -595,6 +729,7 @@ async def management_get_group(
             group_mappings=group_data.get("group_mappings"),
             ui_permissions=group_data.get("ui_permissions"),
             agent_access=group_data.get("agent_access"),
+            is_idp_managed=group_data.get("is_idp_managed", True),
         )
 
     except HTTPException:
@@ -612,21 +747,34 @@ async def management_get_group(
 async def management_update_group(
     group_name: str,
     payload: GroupUpdateRequest,
+    request: Request,
     user_context: Annotated[dict, Depends(nginx_proxied_auth)] = None,
 ):
     """
     Update a group's properties and scope configuration (admin only).
 
-    This updates the group in both:
-    1. The configured identity provider (Keycloak or Entra ID)
-    2. MongoDB scopes collection for authorization
+    Behavior (see issue #946):
+    - is_idp_managed=False: IdP call is skipped entirely. MongoDB update
+      proceeds. The flag is preserved across edits.
+    - is_idp_managed=True and IdP 403/404: non-fatal fall-through; MongoDB
+      update proceeds; audit entry includes idp_skip_reason.
     """
     _require_admin(user_context)
 
+    set_audit_action(
+        request,
+        operation="update",
+        resource_type="group",
+        resource_id=group_name,
+        description=f"Update group '{group_name}'",
+    )
+
     iam = get_iam_manager()
+    skip_reason: str | None = None
 
     try:
-        # Step 1: Get existing group data to preserve group_mappings if not provided
+        # Step 1: Get existing group data.
+        # This also lazily backfills is_idp_managed for legacy documents.
         existing_group = await scope_service.get_group(group_name)
         if not existing_group:
             raise HTTPException(
@@ -634,11 +782,50 @@ async def management_update_group(
                 detail=f"Group '{group_name}' not found",
             )
 
-        # Step 2: Update group in identity provider (description only)
-        if payload.description is not None:
-            await iam.update_group(
-                group_name=group_name,
-                description=payload.description,
+        is_idp_managed = bool(existing_group.get("is_idp_managed", True))
+
+        # Step 2: Update group in identity provider (description only),
+        # gated on is_idp_managed. Catch typed IdP errors as non-fatal.
+        if payload.description is not None and is_idp_managed:
+            try:
+                await iam.update_group(
+                    group_name=group_name,
+                    description=payload.description,
+                )
+            except IdPNotFoundError as idp_exc:
+                logger.info(
+                    "iam_idp_fallthrough operation=update resource=%s "
+                    "status=404 reason=not_found detail=%s",
+                    group_name,
+                    idp_exc,
+                )
+                skip_reason = "not_found"
+            except IdPForbiddenError as idp_exc:
+                logger.warning(
+                    "iam_idp_fallthrough operation=update resource=%s "
+                    "status=403 reason=forbidden detail=%s",
+                    group_name,
+                    idp_exc,
+                )
+                skip_reason = "forbidden"
+        elif payload.description is not None:
+            logger.info(
+                "iam_idp_skipped operation=update resource=%s reason=local_only",
+                group_name,
+            )
+            skip_reason = "local_only"
+
+        if skip_reason is not None:
+            set_audit_action(
+                request,
+                operation="update",
+                resource_type="group",
+                resource_id=group_name,
+                description=(
+                    f"Update group '{group_name}' - IdP call skipped "
+                    f"({skip_reason})"
+                ),
+                idp_skip_reason=skip_reason,
             )
 
         # Step 3: Update in MongoDB scopes collection
@@ -668,14 +855,18 @@ async def management_update_group(
             agent_access, ui_permissions
         )
 
-        # Use import_group to update the scope data
+        # Use import_group to update the scope data.
+        # Preserve is_idp_managed across edits (import_group replaces the whole doc).
         import_success = await scope_service.import_group(
             scope_name=group_name,
-            description=payload.description or "",
+            description=payload.description
+            if payload.description is not None
+            else existing_group.get("description", ""),
             server_access=server_access,
             group_mappings=group_mappings,
             ui_permissions=ui_permissions,
             agent_access=agent_access,
+            is_idp_managed=is_idp_managed,
         )
 
         if not import_success:
@@ -684,7 +875,7 @@ async def management_update_group(
                 group_name,
             )
 
-        # Step 3: Fetch and return updated group details
+        # Step 4: Fetch and return updated group details
         group_data = await scope_service.get_group(group_name)
 
         if not group_data:
@@ -693,6 +884,7 @@ async def management_update_group(
                 id="",
                 name=group_name,
                 description=payload.description,
+                is_idp_managed=is_idp_managed,
             )
 
         return GroupDetailResponse(
@@ -704,8 +896,11 @@ async def management_update_group(
             group_mappings=group_data.get("group_mappings"),
             ui_permissions=group_data.get("ui_permissions"),
             agent_access=group_data.get("agent_access"),
+            is_idp_managed=group_data.get("is_idp_managed", True),
         )
 
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Failed to update group: %s", exc)
         detail = str(exc).lower()

--- a/registry/audit/context.py
+++ b/registry/audit/context.py
@@ -14,6 +14,7 @@ def set_audit_action(
     resource_type: str,
     resource_id: str | None = None,
     description: str | None = None,
+    idp_skip_reason: str | None = None,
 ) -> None:
     """
     Set audit action context on the request for the AuditMiddleware.
@@ -27,6 +28,9 @@ def set_audit_action(
         resource_type: The resource type (server, agent, auth, federation, health, search, scope, user, group)
         resource_id: Optional identifier of the resource being acted upon
         description: Optional human-readable description of the action
+        idp_skip_reason: When an IdP admin call was intentionally skipped, the
+            reason. One of: 'local_only', 'forbidden', 'not_found'.
+            See issue #946.
 
     Example:
         @router.post("/servers")
@@ -39,6 +43,7 @@ def set_audit_action(
         "resource_type": resource_type,
         "resource_id": resource_id,
         "description": description,
+        "idp_skip_reason": idp_skip_reason,
     }
 
 

--- a/registry/audit/middleware.py
+++ b/registry/audit/middleware.py
@@ -221,6 +221,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 resource_type=audit_action.get("resource_type", "unknown"),
                 resource_id=audit_action.get("resource_id"),
                 description=audit_action.get("description"),
+                idp_skip_reason=audit_action.get("idp_skip_reason"),
             )
 
         return None

--- a/registry/audit/models.py
+++ b/registry/audit/models.py
@@ -142,6 +142,14 @@ class Action(BaseModel):
     description: str | None = Field(
         default=None, description="Human-readable description of the action"
     )
+    idp_skip_reason: str | None = Field(
+        default=None,
+        description=(
+            "When an IdP admin call was intentionally skipped, the reason. "
+            "One of: 'local_only' (is_idp_managed=False), "
+            "'forbidden' (IdP 403), 'not_found' (IdP 404)."
+        ),
+    )
 
 
 class Authorization(BaseModel):

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -1,6 +1,7 @@
 """DocumentDB-based repository for authorization scopes storage."""
 
 import logging
+import re
 from datetime import datetime
 from typing import Any
 
@@ -10,6 +11,33 @@ from ..interfaces import ScopeRepositoryBase
 from .client import get_collection_name, get_documentdb_client
 
 logger = logging.getLogger(__name__)
+
+_GUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _looks_like_guid(
+    value: str,
+) -> bool:
+    """Return True if the string matches the GUID/UUID shape."""
+    return bool(_GUID_RE.match(value or ""))
+
+
+def _backfill_is_idp_managed(
+    doc: dict,
+) -> bool:
+    """Heuristic for legacy scope documents that predate issue #946.
+
+    - Any GUID-shaped entry in group_mappings is a strong signal of an
+      Entra-managed group, so treat the scope as IdP-managed.
+    - Otherwise default to True to preserve pre-#946 behavior. The 403/404
+      fall-through in PATCH/DELETE handles misclassified records safely.
+    """
+    for mapping in doc.get("group_mappings") or []:
+        if isinstance(mapping, str) and _looks_like_guid(mapping):
+            return True
+    return True
 
 
 class DocumentDBScopeRepository(ScopeRepositoryBase):
@@ -236,8 +264,16 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         self,
         group_name: str,
         description: str = "",
+        is_idp_managed: bool = True,
     ) -> bool:
-        """Create a new group in scopes."""
+        """Create a new group in scopes.
+
+        Args:
+            group_name: Name of the group.
+            description: Optional description.
+            is_idp_managed: Whether PATCH/DELETE should call the upstream IdP.
+                Defaults to True to preserve pre-#946 behavior.
+        """
         try:
             collection = await self._get_collection()
 
@@ -248,6 +284,7 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                 "server_access": [],
                 "group_mappings": [],
                 "ui_permissions": {},
+                "is_idp_managed": is_idp_managed,
                 "created_at": datetime.utcnow(),
                 "updated_at": datetime.utcnow(),
             }
@@ -257,7 +294,9 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             self._scopes_cache.setdefault("UI-Scopes", {})[group_name] = {}
             self._scopes_cache.setdefault("group_mappings", {})[group_name] = []
 
-            logger.info(f"Created group '{group_name}'")
+            logger.info(
+                f"Created group '{group_name}' (is_idp_managed={is_idp_managed})"
+            )
             return True
         except Exception as e:
             logger.error(f"Failed to create group in DocumentDB: {e}", exc_info=True)
@@ -291,13 +330,35 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         self,
         group_name: str,
     ) -> dict[str, Any]:
-        """Get full details of a specific group."""
+        """Get full details of a specific group.
+
+        Lazily backfills `is_idp_managed` for legacy documents that predate
+        issue #946 so every call site sees a populated value.
+        """
         collection = await self._get_collection()
 
         try:
             group_doc = await collection.find_one({"_id": group_name})
             if not group_doc:
                 return None
+
+            if "is_idp_managed" not in group_doc:
+                backfilled = _backfill_is_idp_managed(group_doc)
+                await collection.update_one(
+                    {"_id": group_name},
+                    {
+                        "$set": {
+                            "is_idp_managed": backfilled,
+                            "updated_at": datetime.utcnow(),
+                        }
+                    },
+                )
+                group_doc["is_idp_managed"] = backfilled
+                logger.info(
+                    "scope_backfill operation=get group=%s is_idp_managed=%s",
+                    group_name,
+                    backfilled,
+                )
 
             group_doc["scope_name"] = group_doc.pop("_id")
             return group_doc
@@ -306,10 +367,37 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             return None
 
     async def list_groups(self) -> dict[str, Any]:
-        """List all groups with server counts."""
+        """List all groups with server counts.
+
+        Eagerly backfills `is_idp_managed` on any document that predates
+        issue #946. The `$exists: False` filter returns nothing once the
+        collection has been backfilled, so this is cheap on steady state.
+        """
         collection = await self._get_collection()
 
         try:
+            legacy_cursor = collection.find({"is_idp_managed": {"$exists": False}})
+            legacy_count = 0
+            async for legacy_doc in legacy_cursor:
+                backfilled = _backfill_is_idp_managed(legacy_doc)
+                await collection.update_one(
+                    {"_id": legacy_doc["_id"]},
+                    {
+                        "$set": {
+                            "is_idp_managed": backfilled,
+                            "updated_at": datetime.utcnow(),
+                        }
+                    },
+                )
+                legacy_count += 1
+                logger.info(
+                    "scope_backfill operation=list group=%s is_idp_managed=%s",
+                    legacy_doc["_id"],
+                    backfilled,
+                )
+            if legacy_count:
+                logger.info("scope_backfill batch_count=%d", legacy_count)
+
             cursor = collection.find({})
             groups = {}
             async for doc in cursor:
@@ -319,6 +407,8 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                     "server_count": server_count,
                     "ui_scopes": doc.get("ui_permissions", {}),
                     "mappings": doc.get("group_mappings", []),
+                    "is_idp_managed": doc.get("is_idp_managed", True),
+                    "description": doc.get("description"),
                 }
             return groups
         except Exception as e:
@@ -521,6 +611,7 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         group_mappings: list = None,
         ui_permissions: dict = None,
         agent_access: list = None,
+        is_idp_managed: bool = True,
     ) -> bool:
         """
         Import a complete group definition.
@@ -532,6 +623,9 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             group_mappings: List of group names this group maps to
             ui_permissions: Dictionary of UI permissions
             agent_access: List of agent paths this group can access
+            is_idp_managed: Whether PATCH/DELETE should call the upstream IdP.
+                Defaults to True to preserve pre-#946 behavior for callers
+                that do not explicitly pass the flag.
 
         Returns:
             True if successful, False otherwise
@@ -558,6 +652,7 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                 "group_mappings": group_mappings,
                 "ui_permissions": ui_permissions,
                 "agent_access": agent_access,
+                "is_idp_managed": is_idp_managed,
                 "created_at": datetime.utcnow(),
                 "updated_at": datetime.utcnow(),
             }

--- a/registry/repositories/file/scope_repository.py
+++ b/registry/repositories/file/scope_repository.py
@@ -184,8 +184,15 @@ class FileScopeRepository(ScopeRepositoryBase):
         self,
         group_name: str,
         description: str = "",
+        is_idp_managed: bool = True,
     ) -> bool:
-        """Create a new group in scopes."""
+        """Create a new group in scopes.
+
+        The `is_idp_managed` kwarg is accepted for interface compatibility
+        with `DocumentDBScopeRepository` (see issue #946) but is not
+        persisted. The file backend is dev-only and not a production target.
+        """
+        del is_idp_managed
         try:
             if group_name in self._scopes_data:
                 logger.warning(f"Group {group_name} already exists in scopes.yml")
@@ -260,6 +267,7 @@ class FileScopeRepository(ScopeRepositoryBase):
         group_mappings: list = None,
         ui_permissions: dict = None,
         agent_access: list = None,
+        is_idp_managed: bool = True,
     ) -> bool:
         """
         Import a complete group definition.
@@ -271,7 +279,11 @@ class FileScopeRepository(ScopeRepositoryBase):
             group_mappings: List of group names this group maps to
             ui_permissions: Dictionary of UI permissions
             agent_access: List of agent paths this group can access
+            is_idp_managed: Accepted for interface compatibility with
+                `DocumentDBScopeRepository` (see issue #946) but not persisted.
+                The file backend is dev-only and not a production target.
         """
+        del is_idp_managed
         try:
             # Set defaults
             if server_access is None:

--- a/registry/schemas/management.py
+++ b/registry/schemas/management.py
@@ -77,6 +77,14 @@ class GroupSummary(BaseModel):
     name: str
     path: str
     attributes: dict | None = None
+    is_idp_managed: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the group is managed in the upstream identity provider. "
+            "None for legacy records that predate the flag; True means "
+            "PATCH/DELETE call the IdP, False means local-only. See issue #946."
+        ),
+    )
 
 
 class GroupListResponse(BaseModel):
@@ -129,3 +137,11 @@ class GroupDetailResponse(BaseModel):
     group_mappings: list | None = None
     ui_permissions: dict | None = None
     agent_access: list | None = None
+    is_idp_managed: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the group is managed in the upstream identity provider. "
+            "None for legacy records that predate the flag; True means "
+            "PATCH/DELETE call the IdP, False means local-only. See issue #946."
+        ),
+    )

--- a/registry/services/scope_service.py
+++ b/registry/services/scope_service.py
@@ -367,6 +367,7 @@ async def import_group(
     group_mappings: list = None,
     ui_permissions: dict = None,
     agent_access: list = None,
+    is_idp_managed: bool = True,
 ) -> bool:
     """
     Import a complete group definition with all document types.
@@ -382,6 +383,8 @@ async def import_group(
         group_mappings: Optional list of group names this group maps to
         ui_permissions: Optional dictionary of UI permissions
         agent_access: Optional list of agent paths this group can access
+        is_idp_managed: Whether PATCH/DELETE should call the upstream IdP.
+            See issue #946. Defaults to True to preserve pre-#946 behavior.
 
     Returns:
         True if successful, False otherwise
@@ -400,6 +403,7 @@ async def import_group(
             group_mappings=group_mappings,
             ui_permissions=ui_permissions,
             agent_access=agent_access,
+            is_idp_managed=is_idp_managed,
         )
 
         if success:

--- a/registry/utils/iam_errors.py
+++ b/registry/utils/iam_errors.py
@@ -1,0 +1,77 @@
+"""
+Typed IdP error hierarchy and raw-message detectors.
+
+Providers raise free-form exceptions (`EntraAdminError`, Keycloak/Okta/Auth0
+errors) whose message text is the only signal we have for status classification.
+The IAM manager subclasses inspect those exceptions and re-raise them as one
+of the typed errors below so route handlers can branch on exception type
+rather than substring match.
+"""
+
+from __future__ import annotations
+
+
+class IdPError(RuntimeError):
+    """Base class for IdP admin API errors."""
+
+
+class IdPForbiddenError(IdPError):
+    """Raised when the IdP returns HTTP 403 / forbidden on an admin call.
+
+    Means the registry's IdP app lacks the required write scope for this
+    operation. PATCH/DELETE callers treat this as non-fatal and fall through
+    to the MongoDB mutation.
+    """
+
+
+class IdPNotFoundError(IdPError):
+    """Raised when the IdP returns HTTP 404 on an admin call.
+
+    Means the group does not exist (or is not visible) in the upstream IdP.
+    PATCH/DELETE callers treat this as non-fatal.
+    """
+
+
+_FORBIDDEN_MARKERS: tuple[str, ...] = (
+    "403",
+    "forbidden",
+    "insufficient privileges",
+    "authorization_requestdenied",
+)
+
+_NOT_FOUND_MARKERS: tuple[str, ...] = (
+    "not found",
+    "404",
+)
+
+
+def looks_forbidden(
+    exc: Exception,
+) -> bool:
+    """Raw-message fallback: is this exception an IdP 403?"""
+    detail = str(exc).lower()
+    return any(marker in detail for marker in _FORBIDDEN_MARKERS)
+
+
+def looks_not_found(
+    exc: Exception,
+) -> bool:
+    """Raw-message fallback: is this exception an IdP 404?"""
+    detail = str(exc).lower()
+    return any(marker in detail for marker in _NOT_FOUND_MARKERS)
+
+
+def wrap_idp_admin_error(
+    exc: Exception,
+) -> Exception:
+    """Translate raw provider errors into typed IdP errors when detectable.
+
+    Returns the typed error if the message matches; otherwise returns the
+    original exception unchanged so the existing 502 translation still works
+    for unknown error types.
+    """
+    if looks_forbidden(exc):
+        return IdPForbiddenError(str(exc))
+    if looks_not_found(exc):
+        return IdPNotFoundError(str(exc))
+    return exc

--- a/registry/utils/iam_manager.py
+++ b/registry/utils/iam_manager.py
@@ -14,6 +14,8 @@ from typing import (
     runtime_checkable,
 )
 
+from .iam_errors import wrap_idp_admin_error
+
 # Configure logging with basicConfig
 logging.basicConfig(
     level=logging.INFO,
@@ -270,7 +272,13 @@ class KeycloakIAMManager:
         """Delete a group from Keycloak."""
         from .keycloak_manager import delete_keycloak_group
 
-        return await delete_keycloak_group(group_name=group_name)
+        try:
+            return await delete_keycloak_group(group_name=group_name)
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
     async def group_exists(self, group_name: str) -> bool:
         """Check if a group exists in Keycloak."""
@@ -302,7 +310,16 @@ class KeycloakIAMManager:
         """Update a group's properties in Keycloak."""
         from .keycloak_manager import update_keycloak_group
 
-        return await update_keycloak_group(group_name=group_name, description=description)
+        try:
+            return await update_keycloak_group(
+                group_name=group_name,
+                description=description,
+            )
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
 
 class EntraIAMManager:
@@ -361,7 +378,13 @@ class EntraIAMManager:
         """Delete a group from Entra ID."""
         from .entra_manager import delete_entra_group
 
-        return await delete_entra_group(group_name_or_id=group_name)
+        try:
+            return await delete_entra_group(group_name_or_id=group_name)
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
     async def group_exists(self, group_name: str) -> bool:
         """Check if a group exists in Entra ID."""
@@ -397,7 +420,16 @@ class EntraIAMManager:
         """Update a group's properties in Entra ID."""
         from .entra_manager import update_entra_group
 
-        return await update_entra_group(group_name_or_id=group_name, description=description)
+        try:
+            return await update_entra_group(
+                group_name_or_id=group_name,
+                description=description,
+            )
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
 
 class OktaIAMManager:
@@ -457,7 +489,13 @@ class OktaIAMManager:
         """Delete a group from Okta."""
         from .okta_manager import delete_okta_group
 
-        return await delete_okta_group(group_name_or_id=group_name)
+        try:
+            return await delete_okta_group(group_name_or_id=group_name)
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
     async def group_exists(self, group_name: str) -> bool:
         """Check if a group exists in Okta."""
@@ -493,7 +531,16 @@ class OktaIAMManager:
         """Update a group's properties in Okta."""
         from .okta_manager import update_okta_group
 
-        return await update_okta_group(group_name_or_id=group_name, description=description)
+        try:
+            return await update_okta_group(
+                group_name_or_id=group_name,
+                description=description,
+            )
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
 
 class Auth0IAMManager:
@@ -553,7 +600,13 @@ class Auth0IAMManager:
         """Delete a role (group) from Auth0."""
         from .auth0_manager import delete_auth0_group
 
-        return await delete_auth0_group(group_name_or_id=group_name)
+        try:
+            return await delete_auth0_group(group_name_or_id=group_name)
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
     async def group_exists(self, group_name: str) -> bool:
         """Check if a role (group) exists in Auth0."""
@@ -589,7 +642,16 @@ class Auth0IAMManager:
         """Update a role's (group's) properties in Auth0."""
         from .auth0_manager import update_auth0_group
 
-        return await update_auth0_group(group_name_or_id=group_name, description=description)
+        try:
+            return await update_auth0_group(
+                group_name_or_id=group_name,
+                description=description,
+            )
+        except Exception as exc:
+            typed = wrap_idp_admin_error(exc)
+            if typed is not exc:
+                raise typed from exc
+            raise
 
 
 def get_iam_manager() -> IAMManager:

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from registry.utils.iam_errors import IdPForbiddenError, IdPNotFoundError
+
 logger = logging.getLogger(__name__)
 
 
@@ -432,6 +434,7 @@ class TestManagementCreateGroup:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=True,
             )
 
     def test_create_group_success_entra(self, test_client_admin):
@@ -482,6 +485,7 @@ class TestManagementCreateGroup:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=True,
             )
 
     def test_create_group_requires_admin(self, test_client_regular):
@@ -610,6 +614,7 @@ class TestManagementCreateGroup:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=True,
             )
 
 
@@ -654,7 +659,9 @@ class TestManagementCreateGroupCreateInIdp:
             # IdP create_group should NOT have been called
             mock_iam.create_group.assert_not_called()
 
-            # MongoDB scope should still be created with group name as mapping
+            # MongoDB scope should still be created with group name as mapping.
+            # is_idp_managed=False is persisted so later PATCH/DELETE won't
+            # call the IdP (see issue #946).
             mock_import_group.assert_called_once_with(
                 scope_name="local-only-group",
                 description="Local only group",
@@ -662,6 +669,7 @@ class TestManagementCreateGroupCreateInIdp:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=False,
             )
 
     def test_create_group_with_create_in_idp_true(self, test_client_admin):
@@ -713,6 +721,7 @@ class TestManagementCreateGroupCreateInIdp:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=True,
             )
 
     def test_create_group_default_does_not_create_in_idp(self, test_client_admin):
@@ -742,7 +751,8 @@ class TestManagementCreateGroupCreateInIdp:
             # IdP create_group should NOT be called (default is False)
             mock_iam.create_group.assert_not_called()
 
-            # MongoDB scope should still be created with group name as mapping
+            # MongoDB scope should still be created with group name as mapping.
+            # Default create_in_idp=False => is_idp_managed=False persisted.
             mock_import_group.assert_called_once_with(
                 scope_name="default-group",
                 description="",
@@ -750,6 +760,7 @@ class TestManagementCreateGroupCreateInIdp:
                 server_access=[],
                 ui_permissions={},
                 agent_access=[],
+                is_idp_managed=False,
             )
 
 
@@ -764,16 +775,38 @@ class TestManagementDeleteGroupLocalOnly:
     """Tests for deleting groups that only exist in MongoDB (local-only)."""
 
     def test_delete_local_only_group_succeeds(self, test_client_admin):
-        """Delete succeeds when group only exists in MongoDB (IdP returns not found)."""
+        """Delete succeeds when group only exists in MongoDB (IdP returns not found).
+
+        Two paths both lead to success:
+        - is_idp_managed=False persisted (issue #946): IdP call is skipped.
+        - is_idp_managed=True but IdP raises not-found: typed exception
+          fall-through in the route handler still lets MongoDB delete proceed.
+
+        This test covers the second path (legacy record, IdP raises not found).
+        """
         # Arrange
         client, mock_iam = test_client_admin
-        mock_iam.delete_group.side_effect = Exception("Group 'local-group' not found")
+        # Provider managers translate a 404 error to IdPNotFoundError; the
+        # route catches that typed exception and falls through.
+        mock_iam.delete_group.side_effect = IdPNotFoundError(
+            "Group 'local-group' not found"
+        )
 
-        with patch(
-            "registry.api.management_routes.scope_service.delete_group",
-            new_callable=AsyncMock,
-            return_value=True,
-        ) as mock_delete_scope:
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value={
+                    "scope_name": "local-group",
+                    "is_idp_managed": True,
+                },
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.delete_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete_scope,
+        ):
             # Act
             response = client.delete("/api/management/iam/groups/local-group")
 
@@ -836,16 +869,28 @@ class TestManagementDeleteGroup:
         assert "Administrator permissions" in response.json()["detail"]
 
     def test_delete_group_not_found_in_idp_still_deletes_from_mongodb(self, test_client_admin):
-        """Test that IdP 'not found' is handled gracefully (local-only group delete)."""
+        """Test that IdP 'not found' is handled gracefully (legacy record delete)."""
         # Arrange
         client, mock_iam = test_client_admin
-        mock_iam.delete_group.side_effect = Exception("Group 'nonexistent' not found")
+        mock_iam.delete_group.side_effect = IdPNotFoundError(
+            "Group 'nonexistent' not found"
+        )
 
-        with patch(
-            "registry.api.management_routes.scope_service.delete_group",
-            new_callable=AsyncMock,
-            return_value=True,
-        ) as mock_delete_scope:
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value={
+                    "scope_name": "nonexistent",
+                    "is_idp_managed": True,
+                },
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.delete_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_delete_scope,
+        ):
             # Act
             response = client.delete("/api/management/iam/groups/nonexistent")
 


### PR DESCRIPTION
## Summary

Closes #946. Local-only groups (created via the UI with "Create in identity provider" unchecked) don't exist in the upstream IdP, so subsequent `PATCH` and `DELETE` on them were failing with 502 when the registry's IdP app lacked write scopes (e.g. Entra apps with only `Group.Read.All`). This PR persists intent on creation, gates admin calls on that intent, and adds a runtime fall-through so existing records are covered immediately.

- Persist `is_idp_managed` on scope documents at creation time; lazily backfill for legacy records on GET and eagerly on list.
- Gate `PATCH` / `DELETE` on `is_idp_managed`: `False` skips the IdP entirely; `True` + IdP 403/404 falls through to the MongoDB mutation with a structured audit reason.
- Merge local-only MongoDB scopes into `GET /iam/groups` so every UI picker can see them.
- Surface the intent in the UI: "Local-only" / "IdP-managed" badges; "Create in identity provider" checkbox locked in edit mode (self-heal is delete + recreate).

## Details

### Backend

- **New** `registry/utils/iam_errors.py` with `IdPForbiddenError` / `IdPNotFoundError` typed exceptions and a `wrap_idp_admin_error` helper.
- Provider managers (Keycloak, Entra, Okta, Auth0) wrap raw errors in `update_group` / `delete_group` into the typed exceptions.
- `DocumentDBScopeRepository` persists `is_idp_managed` in `create_group` and `import_group`; lazy backfill in `get_group`; eager per-doc backfill in `list_groups`; flag + description included in list output. MongoDB CE and DocumentDB share this implementation.
- `scope_service.import_group` threads `is_idp_managed` through.
- `Action.idp_skip_reason` new Pydantic field; `set_audit_action` accepts the kwarg.
- `GroupDetailResponse` and `GroupSummary` expose `is_idp_managed`.
- `management_routes.py`:
  - POST persists `is_idp_managed = create_in_idp`.
  - PATCH / DELETE gate on `is_idp_managed`, catch typed `IdPForbiddenError` / `IdPNotFoundError` as non-fatal, emit `iam_idp_skipped` / `iam_idp_fallthrough` structured logs and audit reasons.
  - GET single returns the flag; GET list merges IdP groups with local-only MongoDB scopes.
  - PATCH user groups delegates IdP existence checks to the provider's diff logic so unchanged local-only entries in the payload don't block saves; "group not found" on net additions maps to 400 with guidance.

### Frontend

- `IAMGroups.tsx`: "Local-only" (amber) and "IdP-managed" (blue) badges next to group names with `role=status`, `aria-label`, and tooltip. Edit drawer locks the "Create in identity provider" checkbox with help text directing operators to delete + recreate.
- `IAMM2M.tsx`: search box on the M2M Accounts group-selection checklist in Edit, Create, and Register views.
- `useIAM.ts`: `is_idp_managed?: boolean | null` on `IAMGroup` and `GroupDetail`.

### Tests

- Updated existing create/delete tests to expect the new `is_idp_managed` kwarg and raise typed `IdPNotFoundError` where the route catches it.
- All 2318 unit tests pass; the one pre-existing failure (`test_list_users_success`) is unrelated and was already failing on `main`.

## Test plan

- [ ] `uv run pytest tests/ -n 8` passes (already verified locally with 2318 passed, 11 skipped)
- [ ] Manual: create a local-only group in a tenant with `Group.Read.All` only; edit description; save; verify 200 and no Graph admin call in logs
- [ ] Manual: delete the same local-only group; verify 200 and no Graph admin call
- [ ] Manual: confirm local-only groups appear in the IAM > Groups list, the M2M Accounts > Register group picker, and the Users > Edit Groups drawer
- [ ] Manual: confirm the "Create in identity provider" checkbox is locked in the Groups edit drawer and initialized from `is_idp_managed`
- [ ] Manual: a no-op Save in the Users > Edit Groups drawer (or a save that removes an IdP-managed group) now succeeds even if the user is in groups whose names also exist as local-only scopes