### PR TITLE
chore: update Helm chart image tags to 1.0.22

### DIFF
--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -3,7 +3,7 @@ global:
   image:
     # Container registry (host + optional namespace). Shared default across subcharts.
     registry: public.ecr.aws/p3v1o3c6
-    tag: 1.0.21
+    tag: 1.0.22
     pullPolicy: IfNotPresent
 
 # Per-service image configuration
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: auth-server  # Image name within the registry
-  tag: ""           # Overrides global.image.tag when set
+  tag: 1.0.22
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -8,7 +8,7 @@ global:
   image:
     # Container registry (host + optional namespace), e.g. "public.ecr.aws/p3v1o3c6"
     registry: public.ecr.aws/p3v1o3c6
-    tag: 1.0.21
+    tag: 1.0.22
     pullPolicy: IfNotPresent
 
   # When installing chart from repository, add --set global.chartVersion=$(git rev-parse HEAD) to add the git hash to a configmap for debugging

--- a/charts/mcpgw/values.yaml
+++ b/charts/mcpgw/values.yaml
@@ -3,7 +3,7 @@ global:
   image:
     # Container registry (host + optional namespace). Shared default across subcharts.
     registry: public.ecr.aws/p3v1o3c6
-    tag: 1.0.21
+    tag: 1.0.22
     pullPolicy: IfNotPresent
 
 # Per-service image configuration
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: mcpgw  # Image name within the registry
-  tag: ""           # Overrides global.image.tag when set
+  tag: 1.0.22
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -3,7 +3,7 @@ global:
   image:
     # Container registry (host + optional namespace). Shared default across subcharts.
     registry: public.ecr.aws/p3v1o3c6
-    tag: 1.0.21
+    tag: 1.0.22
     pullPolicy: IfNotPresent
 
 # Per-service image configuration
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: registry  # Image name within the registry
-  tag: ""           # Overrides global.image.tag when set
+  tag: 1.0.22
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration


### PR DESCRIPTION
Automated update of Helm chart image tags to `1.0.22` following release `v1.0.22`.

The bot branch `helm-update-1.0.22` was pushed by the [helm-chart-update workflow](https://github.com/agentic-community/mcp-gateway-registry/actions/workflows/helm-chart-update.yml) but the PR creation step failed with _"GitHub Actions is not permitted to create or approve pull requests."_ (a repo/org setting blocks that). Opening the PR manually from the branch the workflow already pushed.

Updated files:
- `charts/mcp-gateway-registry-stack/values.yaml`
- `charts/auth-server/values.yaml`
- `charts/registry/values.yaml`
- `charts/mcpgw/values.yaml`

Follows the v1.0.22 release (release notes in [`release-notes/v1.0.22.md`](release-notes/v1.0.22.md)).