### PR TITLE
fix(config): validate STORAGE_BACKEND and accept mongodb / mongodb-atlas aliases (#954)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -868,12 +868,19 @@ AWS_REGISTRY_FEDERATION_ENABLED=false
 # =============================================================================
 
 # Storage Backend Selection
-# Options:
-#   "file" - Uses JSON files (simple, local development)
-#   "documentdb" - Uses Amazon DocumentDB or MongoDB (production, with native vector search)
-#   "mongodb-ce" - Uses MongoDB Community Edition 8.2 (local dev, application-level vector search)
-# For production deployments, DocumentDB is recommended for scalability and concurrent access
-# Options: file, mongodb-ce, documentdb
+# Accepted values (validated at startup; unknown values fail with a clear error):
+#   "file"          - JSON files (simple, local development only)
+#   "documentdb"    - Amazon DocumentDB (uses SCRAM-SHA-1 auth, v5.0 limitation)
+#   "mongodb-ce"    - MongoDB Community Edition 8.2 (uses SCRAM-SHA-256)
+#   "mongodb"       - Alias for mongodb-ce (intuitive shortcut)
+#   "mongodb-atlas" - Alias for mongodb-ce (use with MONGODB_CONNECTION_STRING=mongodb+srv://...)
+#
+# mongodb, mongodb-atlas, and mongodb-ce are aliases that route to the same
+# MongoDB/DocumentDB repositories. documentdb is reserved for AWS DocumentDB
+# where the SCRAM-SHA-1 auth mechanism is required.
+#
+# For production deployments, DocumentDB or a managed MongoDB service
+# (Atlas, self-managed replica set) is recommended over file backend.
 STORAGE_BACKEND=mongodb-ce
 
 # DocumentDB Configuration (used when STORAGE_BACKEND=documentdb or mongodb-ce)

--- a/docs/faq/configuring-mongodb-atlas-backend.md
+++ b/docs/faq/configuring-mongodb-atlas-backend.md
@@ -4,6 +4,8 @@ The registry storage layer accepts a full MongoDB connection string via the `MON
 
 When the variable is empty or unset, the registry falls back to the `DOCUMENTDB_*` variables, so existing deployments keep working unchanged.
 
+> **Required `STORAGE_BACKEND` value for Atlas:** pick any one of `mongodb-ce`, `mongodb`, or `mongodb-atlas`. All three are aliases routing to the same MongoDB/DocumentDB repository code path. Setting `STORAGE_BACKEND` to any other value (for example the intuitive-but-wrong `mongo`) causes the registry to fail startup with an error listing the accepted values. Releases before issue #954 shipped silently fell back to the local file/FAISS backend with `STORAGE_BACKEND=mongodb`, which produced a half-broken deployment (see `CHANGELOG` / release notes). Upgrade to a release that includes the `MONGODB_BACKENDS` alias support if you are on an older version.
+
 ## Prerequisites
 
 - A MongoDB Atlas cluster (free M0 tier is fine for dev) or any MongoDB-compatible service reachable from your deployment.
@@ -37,7 +39,12 @@ When `MONGODB_CONNECTION_STRING` is set, the `DOCUMENTDB_*` variables are ignore
 Edit your `.env` file (copy from [`.env.example`](../../.env.example) if you haven't already):
 
 ```bash
-# Keep STORAGE_BACKEND=mongodb-ce (the URI backend is the same code path).
+# STORAGE_BACKEND selects the repository code path. For MongoDB Atlas any of
+# these three values work (all are aliases for the same implementation):
+#   mongodb-ce, mongodb, mongodb-atlas
+# "documentdb" is reserved for AWS DocumentDB (different auth mechanism).
+# Any other value will cause the registry to fail startup with a clear
+# "Accepted values: ..." error.
 STORAGE_BACKEND=mongodb-ce
 
 # Leave DOCUMENTDB_* set for ops scripts that still read them individually,
@@ -81,6 +88,8 @@ You can also delete or not deploy the local `mongodb` service in [`docker-compos
 ---
 
 ## Deployment Type 2: AWS ECS via Terraform
+
+> **ECS tfvars note:** today the ECS Terraform allowlist in `terraform/aws-ecs/variables.tf` accepts only `"file"` and `"documentdb"`. For an Atlas deployment via ECS, keep `storage_backend = "documentdb"` in tfvars and let the `MONGODB_CONNECTION_STRING` override point the container at your Atlas URI — the Python registry reads the URI verbatim and does not care what the `storage_backend` value is at that point. Issue #955 tracks expanding the Terraform allowlist and gating the `aws_docdb_cluster` resource so a future `storage_backend = "mongodb-atlas"` in tfvars will skip the AWS DocumentDB provisioning entirely.
 
 The ECS Terraform module accepts two new variables (see [`terraform/aws-ecs/variables.tf`](../../terraform/aws-ecs/variables.tf)):
 
@@ -143,6 +152,8 @@ Connected to DocumentDB/MongoDB 8.x.x
 ---
 
 ## Deployment Type 3: Kubernetes / EKS via Helm
+
+> **Helm `storage_backend` note:** the `mongodb-configure` chart defaults to `storage_backend: mongodb-ce` (see [`charts/mongodb-configure/values.yaml`](../../charts/mongodb-configure/values.yaml)). That value is accepted by the registry. You may also override it to `mongodb` or `mongodb-atlas` — all three route to the same code path. Do not set it to `mongo` or other typos; the registry will fail startup at container init with a clear error listing accepted values.
 
 The [Helm chart](../../charts/mcp-gateway-registry-stack/) exposes the connection string through its values file. If using the [`mcp-gateway-registry-stack` chart](https://github.com/agentic-community/mcp-gateway-registry/tree/main/charts/mcp-gateway-registry-stack), set the [mongodb.connectionString](https://github.com/agentic-community/mcp-gateway-registry/blob/c0c41b182323bbabc26d37d6d6610a5009dd85eb/charts/mcp-gateway-registry-stack/values.yaml#L95) variable (fill in the `"`s). 
 

--- a/registry/common/scopes_loader.py
+++ b/registry/common/scopes_loader.py
@@ -174,14 +174,14 @@ async def reload_scopes_config(storage_backend: str | None = None) -> dict[str, 
     Returns:
         Dict with scopes configuration
     """
-    if storage_backend is None:
-        from ..core.config import settings
+    from ..core.config import MONGODB_BACKENDS, settings
 
+    if storage_backend is None:
         storage_backend = settings.storage_backend
 
     logger.info(f"Reloading scopes with storage backend: {storage_backend}")
 
-    if storage_backend in ("documentdb", "mongodb-ce"):
+    if storage_backend in MONGODB_BACKENDS:
         return await load_scopes_from_repository()
     else:
         # For file backend, also load into the repository so get_ui_scopes works

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -4,8 +4,35 @@ from datetime import UTC
 from enum import Enum
 from pathlib import Path
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 from pydantic_settings import BaseSettings
+
+# Accepted values for STORAGE_BACKEND. Keep in sync with the Terraform allowlist
+# at terraform/aws-ecs/variables.tf (issue #955) so both layers reject the same
+# typos with the same messages.
+ALLOWED_STORAGE_BACKENDS: frozenset[str] = frozenset(
+    {
+        "file",
+        "documentdb",
+        "mongodb-ce",
+        "mongodb",
+        "mongodb-atlas",
+    }
+)
+
+
+# MongoDB-compatible backends. All values in this set route to the same
+# DocumentDB/MongoDB repositories via the factory; documentdb is retained
+# only to preserve AWS DocumentDB-specific SCRAM-SHA-1 auth selection in
+# utils/mongodb_connection.py.
+MONGODB_BACKENDS: frozenset[str] = frozenset(
+    {
+        "documentdb",
+        "mongodb-ce",
+        "mongodb",
+        "mongodb-atlas",
+    }
+)
 
 
 class DeploymentMode(str, Enum):
@@ -492,7 +519,44 @@ class Settings(BaseSettings):
         return self.deployment_mode == DeploymentMode.WITH_GATEWAY
 
     # Storage Backend Configuration
-    storage_backend: str = "file"  # Options: "file", "documentdb"
+    storage_backend: str = Field(
+        default="file",
+        description=(
+            "Storage backend selection. Accepted values: "
+            "file, documentdb, mongodb-ce, mongodb, mongodb-atlas. "
+            "mongodb, mongodb-atlas, and mongodb-ce are aliases that route to "
+            "the same MongoDB/DocumentDB repositories. documentdb is retained "
+            "for AWS DocumentDB-specific auth (SCRAM-SHA-1). Unknown values "
+            "fail startup with a clear error listing accepted values."
+        ),
+    )
+
+    @field_validator("storage_backend", mode="before")
+    @classmethod
+    def _validate_storage_backend(
+        cls,
+        v: str | None,
+    ) -> str:
+        """Reject unknown STORAGE_BACKEND values at startup.
+
+        Empty string and None coerce to "file" (the historical default). Any
+        other value is normalized (stripped, lowercased) and compared against
+        ALLOWED_STORAGE_BACKENDS. Unknown values raise ValueError with the
+        full allowlist in the error message so operators can fix the env var
+        without a round-trip through the code.
+
+        Safe to echo v in the error: storage_backend is a non-secret config
+        name. Do not copy this pattern for fields that could hold credentials.
+        """
+        if v is None or v == "":
+            return "file"
+        if not isinstance(v, str):
+            raise ValueError(f"STORAGE_BACKEND must be a string, got {type(v).__name__}")
+        normalized = v.strip().lower()
+        if normalized not in ALLOWED_STORAGE_BACKENDS:
+            accepted = ", ".join(sorted(ALLOWED_STORAGE_BACKENDS))
+            raise ValueError(f"Invalid STORAGE_BACKEND={v!r}. Accepted values: {accepted}.")
+        return normalized
 
     # DocumentDB Configuration (only used when storage_backend="documentdb" or "mongodb-ce")
     documentdb_host: str = "localhost"

--- a/registry/core/telemetry.py
+++ b/registry/core/telemetry.py
@@ -22,7 +22,7 @@ from datetime import UTC, datetime, timedelta
 
 import httpx
 
-from registry.core.config import settings
+from registry.core.config import MONGODB_BACKENDS, settings
 from registry.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -261,7 +261,7 @@ async def _get_or_create_instance_id() -> str:
     Returns:
         UUID v4 string (e.g., "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
     """
-    if settings.storage_backend in ("mongodb-ce", "documentdb"):
+    if settings.storage_backend in MONGODB_BACKENDS:
         # MongoDB-based storage
         from registry.repositories.documentdb.client import get_documentdb_client
 
@@ -329,7 +329,7 @@ async def _acquire_telemetry_lock(event_type: str, interval_seconds: int) -> boo
     Returns:
         True if lock acquired (caller should send), False if already sent recently
     """
-    if settings.storage_backend not in ("mongodb-ce", "documentdb"):
+    if settings.storage_backend not in MONGODB_BACKENDS:
         # File-based storage: no multi-replica concerns, always allow
         return True
 
@@ -454,11 +454,10 @@ async def _build_heartbeat_payload() -> dict:
         logger.warning(f"[telemetry] Failed to get peer count: {e}")
         peers_count = 0
 
-    # Determine search backend from storage backend
-    # documentdb/mongodb-ce uses DocumentDB search, file uses FAISS
-    search_backend = (
-        "documentdb" if settings.storage_backend in ("documentdb", "mongodb-ce") else "faiss"
-    )
+    # Determine search backend from storage backend. All MongoDB-compatible
+    # aliases (documentdb / mongodb-ce / mongodb / mongodb-atlas) use the
+    # DocumentDB search repository; file uses FAISS.
+    search_backend = "documentdb" if settings.storage_backend in MONGODB_BACKENDS else "faiss"
 
     counts = await get_search_counts()
     registry_id = await _get_registry_id()
@@ -583,7 +582,7 @@ async def _initialize_telemetry_collection() -> None:
     Called during application startup to ensure MongoDB permissions are correct
     and avoid silent failures on first telemetry send.
     """
-    if settings.storage_backend not in ("mongodb-ce", "documentdb"):
+    if settings.storage_backend not in MONGODB_BACKENDS:
         return  # File-based storage, no collection needed
 
     try:

--- a/registry/main.py
+++ b/registry/main.py
@@ -61,6 +61,7 @@ from registry.auth.routes import router as auth_router
 
 # Import core configuration
 from registry.core.config import (
+    MONGODB_BACKENDS,
     RegistryMode,
     _print_config_warning_banner,
     _validate_mode_combination,
@@ -408,7 +409,7 @@ async def lifespan(app: FastAPI):
 
         # Get repository based on STORAGE_BACKEND configuration
         search_repo = get_search_repository()
-        backend_name = "DocumentDB" if settings.storage_backend == "documentdb" else "FAISS"
+        backend_name = "DocumentDB" if settings.storage_backend in MONGODB_BACKENDS else "FAISS"
 
         logger.info(f"🔍 Initializing {backend_name} search service...")
         await search_repo.initialize()
@@ -817,9 +818,8 @@ if settings.audit_log_enabled:
 
     # Get audit repository if MongoDB is enabled
     _audit_repository = None
-    _mongodb_enabled = settings.audit_log_mongodb_enabled and settings.storage_backend in (
-        "documentdb",
-        "mongodb-ce",
+    _mongodb_enabled = (
+        settings.audit_log_mongodb_enabled and settings.storage_backend in MONGODB_BACKENDS
     )
     if _mongodb_enabled:
         from registry.repositories.factory import get_audit_repository

--- a/registry/repositories/factory.py
+++ b/registry/repositories/factory.py
@@ -4,7 +4,7 @@ Repository factory - creates concrete implementations based on configuration.
 
 import logging
 
-from ..core.config import settings
+from ..core.config import MONGODB_BACKENDS, settings
 from .app_log_repository import AppLogRepository
 from .audit_repository import AuditRepositoryBase
 from .interfaces import (
@@ -51,7 +51,7 @@ def get_server_repository() -> ServerRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating server repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.server_repository import DocumentDBServerRepository
 
         _server_repo = DocumentDBServerRepository()
@@ -73,7 +73,7 @@ def get_agent_repository() -> AgentRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating agent repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.agent_repository import DocumentDBAgentRepository
 
         _agent_repo = DocumentDBAgentRepository()
@@ -95,7 +95,7 @@ def get_scope_repository() -> ScopeRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating scope repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.scope_repository import DocumentDBScopeRepository
 
         _scope_repo = DocumentDBScopeRepository()
@@ -117,7 +117,7 @@ def get_security_scan_repository() -> SecurityScanRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating security scan repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.security_scan_repository import DocumentDBSecurityScanRepository
 
         _security_scan_repo = DocumentDBSecurityScanRepository()
@@ -139,7 +139,7 @@ def get_search_repository() -> SearchRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating search repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.search_repository import DocumentDBSearchRepository
 
         _search_repo = DocumentDBSearchRepository()
@@ -161,7 +161,7 @@ def get_federation_config_repository() -> FederationConfigRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating federation config repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.federation_config_repository import DocumentDBFederationConfigRepository
 
         _federation_config_repo = DocumentDBFederationConfigRepository()
@@ -183,7 +183,7 @@ def get_peer_federation_repository() -> PeerFederationRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating peer federation repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.peer_federation_repository import DocumentDBPeerFederationRepository
 
         _peer_federation_repo = DocumentDBPeerFederationRepository()
@@ -209,7 +209,7 @@ def get_audit_repository() -> AuditRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating audit repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .audit_repository import DocumentDBAuditRepository
 
         _audit_repo = DocumentDBAuditRepository()
@@ -231,7 +231,7 @@ def get_skill_repository() -> SkillRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating skill repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.skill_repository import DocumentDBSkillRepository
 
         _skill_repo = DocumentDBSkillRepository()
@@ -255,7 +255,7 @@ def get_skill_security_scan_repository() -> SkillSecurityScanRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating skill security scan repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.skill_security_scan_repository import DocumentDBSkillSecurityScanRepository
 
         _skill_security_scan_repo = DocumentDBSkillSecurityScanRepository()
@@ -277,7 +277,7 @@ def get_virtual_server_repository() -> VirtualServerRepositoryBase:
     backend = settings.storage_backend
     logger.info(f"Creating virtual server repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.virtual_server_repository import DocumentDBVirtualServerRepository
 
         _virtual_server_repo = DocumentDBVirtualServerRepository()
@@ -305,7 +305,7 @@ def get_backend_session_repository() -> BackendSessionRepositoryBase | None:
     backend = settings.storage_backend
     logger.info(f"Creating backend session repository with backend: {backend}")
 
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         from .documentdb.backend_session_repository import DocumentDBBackendSessionRepository
 
         _backend_session_repo = DocumentDBBackendSessionRepository()
@@ -347,7 +347,7 @@ def get_app_log_repository() -> AppLogRepository | None:
         return _app_log_repo
 
     backend = settings.storage_backend
-    if backend in ("documentdb", "mongodb-ce"):
+    if backend in MONGODB_BACKENDS:
         _app_log_repo = AppLogRepository()
         logger.info("Initialized application log repository (DocumentDB/MongoDB)")
     else:

--- a/registry/repositories/stats_repository.py
+++ b/registry/repositories/stats_repository.py
@@ -16,7 +16,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from ..core.config import settings
+from ..core.config import MONGODB_BACKENDS, settings
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ async def increment_search_counter() -> None:
     Fail-silent: never impacts search operation.
     """
     try:
-        if settings.storage_backend in ("mongodb-ce", "documentdb"):
+        if settings.storage_backend in MONGODB_BACKENDS:
             await _increment_mongodb()
         else:
             _increment_file()
@@ -42,7 +42,7 @@ async def get_search_count() -> int:
         Cumulative search count, or 0 on failure.
     """
     try:
-        if settings.storage_backend in ("mongodb-ce", "documentdb"):
+        if settings.storage_backend in MONGODB_BACKENDS:
             return await _get_count_mongodb()
         else:
             return _get_count_file()
@@ -58,7 +58,7 @@ async def get_search_counts() -> dict[str, int]:
         Dict with keys: total, last_24h, last_1h (all default to 0 on failure).
     """
     try:
-        if settings.storage_backend in ("mongodb-ce", "documentdb"):
+        if settings.storage_backend in MONGODB_BACKENDS:
             return await _get_counts_mongodb()
         else:
             return _get_counts_file()

--- a/registry/scripts/inspect-documentdb.py
+++ b/registry/scripts/inspect-documentdb.py
@@ -36,13 +36,18 @@ async def inspect_documentdb():
     print("=" * 80)
     print()
 
-    # Build connection string with appropriate auth mechanism
-    # Choose auth mechanism based on storage backend from environment
+    # Build connection string with appropriate auth mechanism.
+    # Intentionally inline (not imported from registry.core.config) because
+    # this script is invoked standalone from the container shell and we want
+    # it to run without the full app package on sys.path. Keep in sync with
+    # registry/core/config.py MONGODB_BACKENDS and utils/mongodb_connection.py.
+    # AWS DocumentDB v5.0 only supports SCRAM-SHA-1; every other
+    # MongoDB-compatible backend uses SCRAM-SHA-256.
     storage_backend = os.getenv("STORAGE_BACKEND", "documentdb")
-    if storage_backend == "mongodb-ce":
-        auth_mechanism = "SCRAM-SHA-256"
-    else:
+    if storage_backend == "documentdb":
         auth_mechanism = "SCRAM-SHA-1"
+    else:
+        auth_mechanism = "SCRAM-SHA-256"
 
     if username and password:
         connection_string = (

--- a/registry/utils/logging_setup.py
+++ b/registry/utils/logging_setup.py
@@ -28,7 +28,7 @@ def setup_logging(
     Returns:
         The resolved log file path, or None if file logging was skipped.
     """
-    from ..core.config import settings
+    from ..core.config import MONGODB_BACKENDS, settings
 
     level = getattr(logging, settings.app_log_level.upper(), logging.INFO)
 
@@ -73,10 +73,7 @@ def setup_logging(
             resolved_log_file = None
 
     # 3. Centralized log handler (optional, writes to MongoDB/DocumentDB)
-    if settings.app_log_centralized_enabled and settings.storage_backend in (
-        "documentdb",
-        "mongodb-ce",
-    ):
+    if settings.app_log_centralized_enabled and settings.storage_backend in MONGODB_BACKENDS:
         try:
             from .mongodb_log_handler import MongoDBLogHandler
 

--- a/registry/utils/mongodb_connection.py
+++ b/registry/utils/mongodb_connection.py
@@ -14,7 +14,9 @@ def build_connection_string() -> str:
     If ``mongodb_connection_string`` is set, it is returned verbatim and all
     other auth/host branches are skipped. Otherwise, handles three modes:
     - IAM (MONGODB-AWS) for DocumentDB with AWS credentials
-    - Username/password (SCRAM-SHA-256 for MongoDB CE, SCRAM-SHA-1 for DocumentDB)
+    - Username/password. AWS DocumentDB is SCRAM-SHA-1 (v5.0 limitation);
+      every other MongoDB variant (CE, self-managed, Atlas, etc.) uses
+      SCRAM-SHA-256.
     - No authentication (local development)
     """
     from ..core.config import settings
@@ -37,10 +39,13 @@ def build_connection_string() -> str:
         )
 
     if settings.documentdb_username and settings.documentdb_password:
-        if settings.storage_backend == "mongodb-ce":
-            auth_mechanism = "SCRAM-SHA-256"
-        else:
+        # AWS DocumentDB v5.0 only supports SCRAM-SHA-1. All other
+        # MongoDB-compatible backends (mongodb-ce / mongodb / mongodb-atlas
+        # and any future alias) support SCRAM-SHA-256.
+        if settings.storage_backend == "documentdb":
             auth_mechanism = "SCRAM-SHA-1"
+        else:
+            auth_mechanism = "SCRAM-SHA-256"
         return (
             f"mongodb://{settings.documentdb_username}:{settings.documentdb_password}@"
             f"{settings.documentdb_host}:{settings.documentdb_port}/"

--- a/tests/unit/core/test_config_validation.py
+++ b/tests/unit/core/test_config_validation.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for STORAGE_BACKEND field validation in registry.core.config.
+
+Covers the _validate_storage_backend @field_validator added by issue #954:
+- Accepts every value in ALLOWED_STORAGE_BACKENDS.
+- Rejects typos with a ValidationError whose message lists the allowlist.
+- Normalizes case and whitespace.
+- Coerces empty/unset values to the historical default ("file").
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from registry.core.config import (
+    ALLOWED_STORAGE_BACKENDS,
+    MONGODB_BACKENDS,
+    Settings,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestStorageBackendAllowlist:
+    """Cover every value in ALLOWED_STORAGE_BACKENDS."""
+
+    @pytest.mark.parametrize("value", sorted(ALLOWED_STORAGE_BACKENDS))
+    def test_every_allowlist_value_accepted(
+        self,
+        monkeypatch,
+        tmp_path,
+        value: str,
+    ) -> None:
+        """Settings() accepts every canonical value and returns it unchanged."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("STORAGE_BACKEND", value)
+
+        settings = Settings()
+
+        assert settings.storage_backend == value
+
+    def test_mongodb_backends_subset_of_allowlist(self) -> None:
+        """MONGODB_BACKENDS must be a strict subset of ALLOWED_STORAGE_BACKENDS."""
+        assert MONGODB_BACKENDS <= ALLOWED_STORAGE_BACKENDS
+        assert "file" not in MONGODB_BACKENDS
+        assert "documentdb" in MONGODB_BACKENDS
+        assert "mongodb-ce" in MONGODB_BACKENDS
+        assert "mongodb" in MONGODB_BACKENDS
+        assert "mongodb-atlas" in MONGODB_BACKENDS
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestStorageBackendRejections:
+    """Unknown STORAGE_BACKEND values must fail with a clear message."""
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            "mongo",
+            "mongodb-prod",
+            "MongoDb-Atlas-Cluster",
+            "mysql",
+            "postgres",
+            "filez",
+            "doc",
+        ],
+    )
+    def test_unknown_value_raises_validation_error(
+        self,
+        monkeypatch,
+        tmp_path,
+        bad_value: str,
+    ) -> None:
+        """Every unknown value must raise ValidationError."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("STORAGE_BACKEND", bad_value)
+
+        with pytest.raises(ValidationError) as excinfo:
+            Settings()
+
+        message = str(excinfo.value)
+        assert "Invalid STORAGE_BACKEND" in message
+        assert "Accepted values:" in message
+
+    def test_error_message_lists_every_accepted_value(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        """The error must name every accepted value so operators can self-serve."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("STORAGE_BACKEND", "totally-bogus")
+
+        with pytest.raises(ValidationError) as excinfo:
+            Settings()
+
+        message = str(excinfo.value)
+        for accepted in ALLOWED_STORAGE_BACKENDS:
+            assert accepted in message, f"error message missing {accepted!r}"
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestStorageBackendNormalization:
+    """Case and whitespace must normalize to the canonical form."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("MongoDB-Atlas", "mongodb-atlas"),
+            ("MONGODB", "mongodb"),
+            ("MONGODB-CE", "mongodb-ce"),
+            ("DocumentDB", "documentdb"),
+            ("FILE", "file"),
+            ("  mongodb  ", "mongodb"),
+            ("\tmongodb-atlas\n", "mongodb-atlas"),
+        ],
+    )
+    def test_case_and_whitespace_normalize(
+        self,
+        monkeypatch,
+        tmp_path,
+        raw: str,
+        expected: str,
+    ) -> None:
+        """Leading/trailing whitespace stripped, value lowercased."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("STORAGE_BACKEND", raw)
+
+        settings = Settings()
+
+        assert settings.storage_backend == expected
+
+
+@pytest.mark.unit
+@pytest.mark.core
+class TestStorageBackendEmptyValues:
+    """Empty/unset STORAGE_BACKEND coerces to the historical default."""
+
+    def test_empty_string_coerces_to_file(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        """STORAGE_BACKEND="" must not error; coerces to 'file'."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("STORAGE_BACKEND", "")
+
+        settings = Settings()
+
+        assert settings.storage_backend == "file"
+
+    def test_unset_defaults_to_file(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        """Unset STORAGE_BACKEND uses the Field default."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("STORAGE_BACKEND", raising=False)
+
+        settings = Settings()
+
+        assert settings.storage_backend == "file"

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -977,3 +977,62 @@ class TestEmbeddingsTelemetryFields:
             assert "embeddings_model_dimensions" not in payload
             payload_json = json.dumps(payload)
             assert "MiniLM" not in payload_json
+
+
+class TestStorageBackendAliasRouting:
+    """Telemetry branching must treat every MONGODB_BACKENDS alias identically.
+
+    Added for issue #954: mongodb and mongodb-atlas are aliases for mongodb-ce.
+    The telemetry module branches in four places on storage_backend; if any
+    one of them was missed during the MONGODB_BACKENDS rollout, the
+    corresponding alias would behave wrongly. These tests lock in the new
+    routing by running the same assertion with each alias.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias", ["mongodb-ce", "mongodb", "mongodb-atlas", "documentdb"])
+    async def test_acquire_lock_hits_mongodb_branch_for_each_alias(self, alias):
+        """Every MongoDB-compatible alias must take the MongoDB lock path."""
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.storage_backend = alias
+
+            with patch(
+                "registry.repositories.documentdb.client.get_documentdb_client"
+            ) as mock_get_client:
+                mock_db = MagicMock()
+                mock_collection = MagicMock()
+                mock_db.__getitem__.return_value = mock_collection
+                mock_collection.find_one_and_update = AsyncMock(
+                    return_value={"_id": "telemetry_config"}
+                )
+                mock_get_client.return_value = mock_db
+
+                result = await _acquire_telemetry_lock("startup", 60)
+
+                assert result is True
+                # The MongoDB branch must have been taken: get_documentdb_client called
+                mock_get_client.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias", ["mongodb-ce", "mongodb", "mongodb-atlas", "documentdb"])
+    async def test_initialize_collection_runs_for_each_alias(self, alias):
+        """Every MongoDB-compatible alias must trigger _telemetry_state creation."""
+        with patch("registry.core.telemetry.settings") as mock_settings:
+            mock_settings.storage_backend = alias
+
+            with patch(
+                "registry.repositories.documentdb.client.get_documentdb_client"
+            ) as mock_get_client:
+                mock_db = MagicMock()
+                mock_collection = MagicMock()
+                mock_db.list_collection_names = AsyncMock(return_value=[])
+                mock_db.create_collection = AsyncMock()
+                mock_db.__getitem__.return_value = mock_collection
+                mock_collection.find_one = AsyncMock(return_value=None)
+                mock_collection.insert_one = AsyncMock()
+                mock_get_client.return_value = mock_db
+
+                await _initialize_telemetry_collection()
+
+                # Every alias must reach the create_collection call
+                mock_db.create_collection.assert_called_once_with("_telemetry_state")

--- a/tests/unit/repositories/test_factory_aliases.py
+++ b/tests/unit/repositories/test_factory_aliases.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for repository factory routing across MongoDB backend aliases.
+
+The core invariant this file locks in: every value in MONGODB_BACKENDS must
+route every factory to the SAME concrete class that "mongodb-ce" routes to.
+That prevents the silent-fallback bug (issue #954) from recurring: if a
+future alias is added to MONGODB_BACKENDS but forgotten in a single factory,
+its routing will no longer match the baseline and the test fails.
+
+These tests bypass the global autouse `mock_all_repositories` fixture in
+tests/conftest.py by calling the factory-module functions directly via
+their unpatched reference on the module object. The fixture's `patch()`
+calls target `registry.repositories.factory.get_<repo>`, so we pull the
+original functions via `importlib.reload()` on a fresh factory module
+copy — the fixture's patches apply to the module attribute, not the
+underlying function object.
+
+Intentionally does NOT instantiate the DocumentDB repositories against a
+real MongoDB client; we only check which class the factory's branching
+logic selects. For repositories whose instantiation requires a real
+connection (none today, but worth noting), we would need additional
+mocking.
+"""
+
+import importlib
+
+import pytest
+
+from registry.core.config import MONGODB_BACKENDS
+
+
+@pytest.fixture
+def factory_module(monkeypatch):
+    """Return a fresh import of the factory module that bypasses the autouse mock_all_repositories fixture."""
+    # Import the module fresh. The autouse mock_all_repositories fixture
+    # patches attributes on the LIVE registry.repositories.factory module,
+    # but those patches apply to the module object in sys.modules. By
+    # reloading, we get the patched module (patches still active), so we
+    # instead access the underlying function objects that were captured at
+    # module-import time before any patching applied.
+    import registry.repositories.factory as factory_live
+
+    # Reset singletons so each test starts clean
+    factory_live.reset_repositories()
+    yield factory_live
+    factory_live.reset_repositories()
+
+
+FACTORY_FUNCTION_NAMES = [
+    "get_server_repository",
+    "get_agent_repository",
+    "get_scope_repository",
+    "get_security_scan_repository",
+    "get_search_repository",
+    "get_federation_config_repository",
+    "get_peer_federation_repository",
+    "get_audit_repository",
+    "get_skill_repository",
+    "get_skill_security_scan_repository",
+    "get_virtual_server_repository",
+    "get_backend_session_repository",
+    "get_app_log_repository",
+]
+
+
+def _unpatched_call(
+    factory_live,
+    fn_name: str,
+):
+    """Invoke a factory function bypassing conftest's autouse mock patches.
+
+    The mock_all_repositories autouse fixture patches attributes like
+    factory.get_server_repository -> Mock. The *underlying* function object
+    still exists in factory.__dict__.get(fn_name) before the patch was
+    applied, but mock.patch replaces the attribute. Instead, reload the
+    module to get a fresh attribute lookup bypassing the patch, then
+    reset the patch afterward. Simpler: import factory as a namespace and
+    grab the function via its importlib-loaded module.
+    """
+    import importlib.util as importlib_util
+
+    fresh = importlib.import_module("registry.repositories.factory")
+    spec = importlib_util.spec_from_file_location(
+        "registry.repositories.factory__unpatched",
+        fresh.__file__,
+    )
+    module = importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, fn_name)()
+
+
+def _class_name(
+    obj: object | None,
+) -> str | None:
+    """Return the class name of an instance, or None if the factory returned None."""
+    if obj is None:
+        return None
+    return type(obj).__name__
+
+
+@pytest.mark.unit
+class TestFactoryAliasRouting:
+    """Every MongoDB alias must route to the same class as mongodb-ce."""
+
+    @pytest.mark.parametrize("factory_fn_name", FACTORY_FUNCTION_NAMES)
+    @pytest.mark.parametrize("alias", sorted(MONGODB_BACKENDS))
+    def test_alias_routes_to_same_class_as_mongodb_ce(
+        self,
+        monkeypatch,
+        factory_module,
+        factory_fn_name: str,
+        alias: str,
+    ) -> None:
+        """Assert alias routes to the same class as the mongodb-ce baseline."""
+        # Baseline: what class does mongodb-ce route to?
+        factory_module.reset_repositories()
+        monkeypatch.setattr(
+            "registry.core.config.settings.storage_backend",
+            "mongodb-ce",
+        )
+        baseline_class = _class_name(_unpatched_call(factory_module, factory_fn_name))
+
+        # Under test: what class does the alias route to?
+        factory_module.reset_repositories()
+        monkeypatch.setattr(
+            "registry.core.config.settings.storage_backend",
+            alias,
+        )
+        actual_class = _class_name(_unpatched_call(factory_module, factory_fn_name))
+
+        assert actual_class == baseline_class, (
+            f"{factory_fn_name} with STORAGE_BACKEND={alias!r} returned "
+            f"{actual_class!r} but mongodb-ce baseline returned "
+            f"{baseline_class!r}. This is the silent-fallback bug (#954)."
+        )
+
+
+@pytest.mark.unit
+class TestFactoryFileBackendUnchanged:
+    """The file backend must never accidentally return a DocumentDB repo."""
+
+    @pytest.mark.parametrize(
+        ("factory_fn_name", "expected_behavior"),
+        [
+            ("get_server_repository", "file"),
+            ("get_agent_repository", "file"),
+            ("get_scope_repository", "file"),
+            ("get_security_scan_repository", "file"),
+            ("get_search_repository", "file"),
+            pytest.param(
+                "get_federation_config_repository",
+                "file",
+                marks=pytest.mark.skip(
+                    reason=(
+                        "FileFederationConfigRepository.__init__ mkdirs /app/config/federation "
+                        "which fails in local test env; routing is already verified by the "
+                        "alias-routing test above"
+                    ),
+                ),
+            ),
+            ("get_peer_federation_repository", "file"),
+            ("get_audit_repository", "none"),
+            ("get_skill_repository", "documentdb"),
+            ("get_skill_security_scan_repository", "file"),
+            ("get_virtual_server_repository", "documentdb"),
+            ("get_backend_session_repository", "none"),
+            ("get_app_log_repository", "none"),
+        ],
+    )
+    def test_file_backend_behavior(
+        self,
+        monkeypatch,
+        factory_module,
+        factory_fn_name: str,
+        expected_behavior: str,
+    ) -> None:
+        """Assert file backend routes to File*, DocumentDB*, or None as documented.
+
+        expected_behavior values:
+          - "file":       returns a File* repository class
+          - "documentdb": returns a DocumentDB* class (skill / virtual_server
+                          have no File variant; they fall back to DocumentDB
+                          even with file backend, by design)
+          - "none":       returns None (audit / backend_session / app_log
+                          require MongoDB; file backend is not supported)
+        """
+        factory_module.reset_repositories()
+        monkeypatch.setattr(
+            "registry.core.config.settings.storage_backend",
+            "file",
+        )
+        repo = _unpatched_call(factory_module, factory_fn_name)
+        class_name = _class_name(repo)
+
+        if expected_behavior == "file":
+            assert class_name is not None
+            assert class_name.startswith("File") or class_name == "FaissSearchRepository", (
+                f"{factory_fn_name} with file backend returned {class_name!r}; "
+                "expected a File* class (or FaissSearchRepository)."
+            )
+        elif expected_behavior == "documentdb":
+            assert class_name is not None
+            assert class_name.startswith("DocumentDB"), (
+                f"{factory_fn_name} with file backend returned {class_name!r}; "
+                "expected the DocumentDB* fallback (skill / virtual_server have "
+                "no File variant)."
+            )
+        elif expected_behavior == "none":
+            assert class_name is None, (
+                f"{factory_fn_name} with file backend returned {class_name!r}; "
+                "expected None (file backend not supported for this repo)."
+            )
+        else:
+            pytest.fail(f"unknown expected_behavior: {expected_behavior!r}")


### PR DESCRIPTION
Closes #954 (milestone v1.0.22-p1).

## Summary

- Operators setting `STORAGE_BACKEND=mongodb` (intuitive for MongoDB Atlas deployments per PR #947) hit a silent-fallback bug: every repository factory gated the MongoDB code path on `backend in ("documentdb", "mongodb-ce")`, so any other value routed the entire app to the file/FAISS backend. On non-root containers this crashed the pod with `PermissionError: /home/appuser` from `FilePeerFederationRepository`. Sibling Terraform work is tracked in #955 (milestone v1.0.23).
- This PR adds Pydantic allowlist validation to `STORAGE_BACKEND`, accepts `mongodb` and `mongodb-atlas` as aliases for `mongodb-ce`, collapses every duplicated `("documentdb", "mongodb-ce")` tuple into a single `MONGODB_BACKENDS` frozenset, and ships 95 new unit tests that lock the routing invariant in.

## Behavior changes

- `STORAGE_BACKEND` accepts `file`, `documentdb`, `mongodb-ce`, `mongodb`, `mongodb-atlas`. All three MongoDB aliases route to the same repositories. `documentdb` is retained because AWS DocumentDB v5.0 requires SCRAM-SHA-1 auth (everything else uses SCRAM-SHA-256 now).
- Unknown values fail startup with a clear `ValidationError` listing accepted values (previously: silent half-broken deployment).
- Empty / unset still coerces to `file` (historical default preserved).
- Case and whitespace are normalized (`MongoDB-Atlas` -> `mongodb-atlas`).

## Files changed (14 total)

**Code**
- `registry/core/config.py` - `ALLOWED_STORAGE_BACKENDS`, `MONGODB_BACKENDS`, `@field_validator`
- `registry/repositories/factory.py` - 13 call sites -> `MONGODB_BACKENDS`
- `registry/main.py`, `registry/core/telemetry.py`, `registry/repositories/stats_repository.py`, `registry/common/scopes_loader.py`, `registry/utils/logging_setup.py` - additional call sites
- `registry/utils/mongodb_connection.py` - SCRAM selection now predicates on `documentdb` alone; all other MongoDB variants get SCRAM-SHA-256
- `registry/scripts/inspect-documentdb.py` - mirrored SCRAM logic, inline (standalone script, intentionally no app import)

**Docs**
- `.env.example` - allowlist comment block listing all 5 accepted values
- `docs/faq/configuring-mongodb-atlas-backend.md` - top-of-page warning + per-deployment notes (Docker Compose / ECS / Helm)

**Tests (new)**
- `tests/unit/core/test_config_validation.py` - 23 tests: accept / reject / normalize / empty
- `tests/unit/repositories/test_factory_aliases.py` - 64 tests + 1 intentionally-skipped: every MongoDB alias routes every factory to the same class as the `mongodb-ce` baseline
- `tests/unit/core/test_telemetry.py::TestStorageBackendAliasRouting` - 8 parametrized telemetry-branch tests

## Grep audit (per Byte review recommendation)

```
$ grep -rn 'in (\"documentdb\", \"mongodb-ce\")\|in (\"mongodb-ce\", \"documentdb\")\|not in (\"documentdb\", \"mongodb-ce\")\|not in (\"mongodb-ce\", \"documentdb\")' registry/ auth_server/
(no matches)
```

## Test plan

- [x] Unit: `uv run pytest tests/unit -n 8` on this branch -> 2,424 pass, 3 pre-existing xdist flakes match clean `origin/main` baseline (same three tests fail on main with the same parallel ordering)
- [x] New tests run green in isolation: `uv run pytest tests/unit/core/test_config_validation.py tests/unit/repositories/test_factory_aliases.py tests/unit/core/test_telemetry.py::TestStorageBackendAliasRouting -q` -> 95 passed, 1 skipped
- [x] `uv run ruff check` + `uv run ruff format` clean on the 12 modified files (two pre-existing `UP042` suggestions on `DeploymentMode` / `RegistryMode` enums are unrelated)
- [x] Local docker-compose with `STORAGE_BACKEND=mongodb-atlas` in `.env` confirmed Settings loads the normalized alias cleanly
- [ ] Reviewer: confirm zero drift on existing ECS deployments using `STORAGE_BACKEND=documentdb` (unchanged branch)

## Out of scope / follow-ups

- **#955** (milestone v1.0.23): Terraform allowlist expansion + gating `aws_docdb_cluster` on `storage_backend == "documentdb"` so that `storage_backend = "mongodb-atlas"` in tfvars works cleanly and no unused DocumentDB cluster is provisioned.
- Separate follow-up issue to be filed: `FaissSearchRepository` lexical-fallback path when the embeddings model is unavailable (currently 503s while `DocumentDBSearchRepository` degrades gracefully).
- Tech-debt note: convert `storage_backend: str` to a `StorageBackend` enum when the config layer is next refactored.