### PR TITLE
fix(docker): pass BUILD_VERSION when publishing to Docker Hub (#919)

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -196,6 +196,8 @@ services:
     build:
       context: metrics-service
       dockerfile: Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - METRICS_SERVICE_PORT=8890
       - METRICS_SERVICE_HOST=0.0.0.0
@@ -232,6 +234,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.auth
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - REGISTRY_URL=${REGISTRY_URL}
       - SECRET_KEY=${SECRET_KEY}
@@ -325,6 +329,8 @@ services:
     build:
       context: servers/currenttime
       dockerfile: ../../docker/Dockerfile.mcp-server
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - PORT=8000
       - MCP_TRANSPORT=streamable-http
@@ -337,6 +343,8 @@ services:
     build:
       context: servers/fininfo
       dockerfile: ../../docker/Dockerfile.mcp-server
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - PORT=8001
       - SECRET_KEY=${SECRET_KEY}
@@ -353,6 +361,7 @@ services:
       dockerfile: docker/Dockerfile.mcp-server
       args:
         SERVER_DIR: servers/mcpgw
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - HOST=0.0.0.0
       - PORT=8003
@@ -372,6 +381,8 @@ services:
     build:
       context: servers/realserverfaketools
       dockerfile: ../../docker/Dockerfile.mcp-server
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - PORT=8002
     ports:

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -31,7 +31,11 @@ services:
       - REGISTRY_DESCRIPTION=${REGISTRY_DESCRIPTION:-}
       - REGISTRY_CONTACT_EMAIL=${REGISTRY_CONTACT_EMAIL:-}
       - REGISTRY_CONTACT_URL=${REGISTRY_CONTACT_URL:-}
-      - BUILD_VERSION=${BUILD_VERSION:-1.0.0}
+      # BUILD_VERSION is NOT set here: it is baked into the image by the
+      # publish pipeline (issue #919). Setting it at the compose level with
+      # a "${BUILD_VERSION:-1.0.0}" default would stomp the image-baked
+      # value whenever the operator's .env did not set BUILD_VERSION,
+      # which is the silent-fallback symptom this PR fixes.
       - SECRET_KEY=${SECRET_KEY}
       - AUTH_SERVER_URL=${AUTH_SERVER_URL}
       - AUTH_SERVER_EXTERNAL_URL=${AUTH_SERVER_EXTERNAL_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,8 @@ services:
     build:
       context: metrics-service
       dockerfile: Dockerfile
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - METRICS_SERVICE_PORT=8890
       - METRICS_SERVICE_HOST=0.0.0.0
@@ -334,6 +336,8 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.auth
+      args:
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       # Registry Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}
@@ -450,6 +454,7 @@ services:
       dockerfile: docker/Dockerfile.mcp-server-light
       args:
         SERVER_DIR: servers/currenttime
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - HOST=0.0.0.0
       - PORT=8000
@@ -465,6 +470,7 @@ services:
       dockerfile: docker/Dockerfile.mcp-server-light
       args:
         SERVER_DIR: servers/fininfo
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - PORT=8001
       - SECRET_KEY=${SECRET_KEY}
@@ -481,6 +487,7 @@ services:
       dockerfile: docker/Dockerfile.mcp-server
       args:
         SERVER_DIR: servers/mcpgw
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - HOST=0.0.0.0
       - PORT=8003
@@ -502,6 +509,7 @@ services:
       dockerfile: docker/Dockerfile.mcp-server-light
       args:
         SERVER_DIR: servers/realserverfaketools
+        BUILD_VERSION: ${BUILD_VERSION:-1.0.0}
     environment:
       - PORT=8002
     ports:

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -66,6 +66,13 @@ RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 # Set ownership of application files, venv, logs, certs, and entrypoint
 RUN chown -R appuser:appuser /app /app/.venv /app/logs /app/certs /app/auth-entrypoint.sh
 
+# Bake the build version into the image so `docker inspect` and any future
+# version-reporting code path (issue #919) can read it. Requires
+# `docker build --build-arg BUILD_VERSION=$VERSION`; defaults to "1.0.0" when
+# unset, which matches the legacy behavior for ad-hoc builds.
+ARG BUILD_VERSION="1.0.0"
+ENV BUILD_VERSION=$BUILD_VERSION
+
 # Switch to non-root user
 USER appuser
 

--- a/docker/Dockerfile.mcp-server
+++ b/docker/Dockerfile.mcp-server
@@ -104,7 +104,12 @@ exec python server.py --port $SERVER_PORT' > /entrypoint.sh && \
     chmod +x /entrypoint.sh && \
     chown appuser:appuser /entrypoint.sh
 
+# Bake the build version into the image (issue #919). Requires
+# `docker build --build-arg BUILD_VERSION=$VERSION`; defaults to "1.0.0".
+ARG BUILD_VERSION="1.0.0"
+ENV BUILD_VERSION=$BUILD_VERSION
+
 # Switch to non-root user for runtime (no chown needed - files already owned by appuser)
 USER appuser
 
-ENTRYPOINT ["/entrypoint.sh"] 
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.mcp-server-light
+++ b/docker/Dockerfile.mcp-server-light
@@ -78,6 +78,11 @@ exec python server.py --port $SERVER_PORT' > /entrypoint.sh && \
     chmod +x /entrypoint.sh && \
     chown appuser:appuser /entrypoint.sh
 
+# Bake the build version into the image (issue #919). Requires
+# `docker build --build-arg BUILD_VERSION=$VERSION`; defaults to "1.0.0".
+ARG BUILD_VERSION="1.0.0"
+ENV BUILD_VERSION=$BUILD_VERSION
+
 # Switch to non-root user for runtime (no chown needed - files already owned by appuser)
 USER appuser
 

--- a/metrics-service/Dockerfile
+++ b/metrics-service/Dockerfile
@@ -34,6 +34,11 @@ EXPOSE 8890
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8890/health || exit 1
 
+# Bake the build version into the image (issue #919). Requires
+# `docker build --build-arg BUILD_VERSION=$VERSION`; defaults to "1.0.0".
+ARG BUILD_VERSION="1.0.0"
+ENV BUILD_VERSION=$BUILD_VERSION
+
 # Switch to non-root user
 USER appuser
 

--- a/scripts/publish_containers.sh
+++ b/scripts/publish_containers.sh
@@ -219,6 +219,13 @@ build_and_push_component() {
         print_color "$YELLOW" "   Adding build arg: SERVER_DIR=$server_path"
     fi
 
+    # Pass BUILD_VERSION to the Dockerfile ARG so docker/Dockerfile.registry bakes
+    # the correct ENV BUILD_VERSION at build time (issue #919). Without this, the
+    # ARG default "1.0.0" is used and the registry UI reports the wrong version.
+    # Harmless for Dockerfiles that do not declare this ARG.
+    build_args="$build_args --build-arg BUILD_VERSION=$VERSION"
+    print_color "$YELLOW" "   Adding build arg: BUILD_VERSION=$VERSION"
+
     docker build \
         --file "$dockerfile" \
         $build_args \


### PR DESCRIPTION
Closes #919 (milestone v1.0.22-p1).

## Summary

- Customers pulling from Docker Hub see \`BUILD_VERSION=1.0.0\` inside the registry container even when they pulled \`mcpgateway/registry:v1.0.22\`. The registry UI and telemetry then report the wrong version.
- Root cause: [scripts/publish_containers.sh](scripts/publish_containers.sh) calls \`docker build\` without \`--build-arg BUILD_VERSION\`, so the Dockerfile ARG default (\`1.0.0\`) is baked into the image. ECR images are unaffected because the GitHub Actions workflow passes the arg directly.
- Fix: pass \`--build-arg BUILD_VERSION=\"\$VERSION\"\` from the Docker Hub publish script, and add the standard \`ARG BUILD_VERSION / ENV BUILD_VERSION\` pair to the three Dockerfiles that were missing it so every component image carries its real version.

## Evidence (from the customer)

\`\`\`
$ docker inspect mcpgateway/registry:v1.0.22 | grep BUILD_VERSION
                    \"BUILD_VERSION=1.0.0\"        # wrong

$ docker inspect public.ecr.aws/ai-registry/registry | grep BUILD_VERSION
                    \"BUILD_VERSION=v1.0.22\"     # correct
\`\`\`

## Files changed

| File | Change |
|------|--------|
| [scripts/publish_containers.sh](scripts/publish_containers.sh) | Pass \`--build-arg BUILD_VERSION=\$VERSION\` alongside the existing \`SERVER_DIR\` build-arg. Harmless for Dockerfiles that do not declare the ARG. |
| [docker/Dockerfile.auth](docker/Dockerfile.auth) | Added \`ARG BUILD_VERSION=\"1.0.0\"\` + \`ENV BUILD_VERSION=\$BUILD_VERSION\` in the runtime stage (mirrors the existing pattern in \`docker/Dockerfile.registry\`). |
| [docker/Dockerfile.mcp-server](docker/Dockerfile.mcp-server) | Same. |
| [docker/Dockerfile.mcp-server-light](docker/Dockerfile.mcp-server-light) | Same. |
| [metrics-service/Dockerfile](metrics-service/Dockerfile) | Same. |

## Why this minimal approach (and not the original #919 scope)

The original issue proposed fixing three paths: Helm charts (explicit \`BUILD_VERSION\` env var from \`global.image.tag\`), \`docker-compose.prebuilt.yml\` (source from \`REGISTRY_VERSION\`), and \`publish_containers.sh\`. That covers both build-time and run-time version stomping.

This PR scopes to the **build-time** fix only, per the customer trace showing the problem is already present in the image itself (\`docker inspect\` shows \`1.0.0\` before any env var is applied). Fixing the build-time path means every Docker Hub image from v1.0.22-p1 onward reports the correct version under \`docker inspect\` and in any runtime path that reads \`BUILD_VERSION\`, including future Helm / \`docker-compose.prebuilt\` deployments. The Helm and compose env-precedence follow-ups can be tracked separately if we want defense-in-depth against misconfigured \`envFrom\` secrets, but they are no longer required to fix the symptom.

## Test plan

- [x] \`bash -n scripts/publish_containers.sh\` passes
- [ ] Reviewer to trigger a publish to Docker Hub (or run the script locally with \`--dockerhub --version v1.0.22-p1\`) and confirm:
  \`\`\`
  docker inspect mcpgateway/registry:v1.0.22-p1 | grep BUILD_VERSION
  \"BUILD_VERSION=v1.0.22-p1\"
  \`\`\`
- [ ] Spot-check \`docker inspect mcpgateway/auth-server:v1.0.22-p1 | grep BUILD_VERSION\` reports the correct tag (tests the Dockerfile.auth addition)
- [ ] No change to ECR publish path (GitHub Actions workflow unaffected)