### PR TITLE
feat(terraform): gate AWS DocumentDB on storage_backend == documentdb; accept MongoDB aliases (#955)

### DIFF
--- a/terraform/aws-ecs/cloudwatch-alarms.tf
+++ b/terraform/aws-ecs/cloudwatch-alarms.tf
@@ -149,7 +149,11 @@ resource "aws_cloudwatch_metric_alarm" "waf_rate_limit_triggered_keycloak" {
 #
 
 # CloudWatch Alarm: KMS Throttling (DocumentDB Key)
+# Gated on is_aws_documentdb: no KMS key exists for external MongoDB
+# backends, so there's nothing to alarm on. Issue #955.
 resource "aws_cloudwatch_metric_alarm" "kms_throttling_documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   alarm_name          = "${var.name}-kms-throttling-documentdb"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
@@ -162,7 +166,7 @@ resource "aws_cloudwatch_metric_alarm" "kms_throttling_documentdb" {
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    KeyId = aws_kms_key.documentdb.id
+    KeyId = aws_kms_key.documentdb[0].id
   }
 
   alarm_actions = var.alarm_sns_topic_arn != "" ? [var.alarm_sns_topic_arn] : []
@@ -211,7 +215,10 @@ resource "aws_cloudwatch_metric_alarm" "kms_throttling_rds" {
 #
 
 # CloudWatch Alarm: DocumentDB Audit Log Failures
+# Gated on is_aws_documentdb. Issue #955.
 resource "aws_cloudwatch_metric_alarm" "documentdb_audit_log_failures" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   alarm_name          = "${var.name}-documentdb-audit-log-failures"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 2
@@ -224,7 +231,7 @@ resource "aws_cloudwatch_metric_alarm" "documentdb_audit_log_failures" {
   treat_missing_data  = "notBreaching"
 
   dimensions = {
-    DBClusterIdentifier = aws_docdb_cluster.registry.id
+    DBClusterIdentifier = aws_docdb_cluster.registry[0].id
   }
 
   alarm_actions = var.alarm_sns_topic_arn != "" ? [var.alarm_sns_topic_arn] : []

--- a/terraform/aws-ecs/documentdb.tf
+++ b/terraform/aws-ecs/documentdb.tf
@@ -9,8 +9,13 @@
 
 #
 # Security Group for DocumentDB
+# Gated on local.is_aws_documentdb (issue #955): external-MongoDB deployments
+# (Atlas / self-managed) reach their MongoDB through a different network path
+# and do not need this SG.
 #
 resource "aws_security_group" "documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name        = "${var.name}-v2-documentdb-sg"
   description = "Security group for DocumentDB Elastic Cluster" # Keep original description to avoid recreation
   vpc_id      = module.vpc.vpc_id
@@ -30,7 +35,9 @@ resource "aws_security_group" "documentdb" {
 
 # Ingress from Registry service
 resource "aws_vpc_security_group_ingress_rule" "documentdb_from_registry" {
-  security_group_id = aws_security_group.documentdb.id
+  count = local.is_aws_documentdb ? 1 : 0
+
+  security_group_id = aws_security_group.documentdb[0].id
 
   referenced_security_group_id = module.mcp_gateway.ecs_security_group_ids.registry
   from_port                    = 27017
@@ -48,7 +55,9 @@ resource "aws_vpc_security_group_ingress_rule" "documentdb_from_registry" {
 
 # Ingress from Auth service
 resource "aws_vpc_security_group_ingress_rule" "documentdb_from_auth" {
-  security_group_id = aws_security_group.documentdb.id
+  count = local.is_aws_documentdb ? 1 : 0
+
+  security_group_id = aws_security_group.documentdb[0].id
 
   referenced_security_group_id = module.mcp_gateway.ecs_security_group_ids.auth
   from_port                    = 27017
@@ -66,7 +75,9 @@ resource "aws_vpc_security_group_ingress_rule" "documentdb_from_auth" {
 
 # Egress
 resource "aws_vpc_security_group_egress_rule" "documentdb_egress" {
-  security_group_id = aws_security_group.documentdb.id
+  count = local.is_aws_documentdb ? 1 : 0
+
+  security_group_id = aws_security_group.documentdb[0].id
 
   cidr_ipv4   = "0.0.0.0/0"
   ip_protocol = "-1"
@@ -82,9 +93,11 @@ resource "aws_vpc_security_group_egress_rule" "documentdb_egress" {
 
 # Registry -> DocumentDB
 resource "aws_vpc_security_group_egress_rule" "registry_to_documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   security_group_id = module.mcp_gateway.ecs_security_group_ids.registry
 
-  referenced_security_group_id = aws_security_group.documentdb.id
+  referenced_security_group_id = aws_security_group.documentdb[0].id
   from_port                    = 27017
   to_port                      = 27017
   ip_protocol                  = "tcp"
@@ -100,9 +113,11 @@ resource "aws_vpc_security_group_egress_rule" "registry_to_documentdb" {
 
 # Auth -> DocumentDB
 resource "aws_vpc_security_group_egress_rule" "auth_to_documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   security_group_id = module.mcp_gateway.ecs_security_group_ids.auth
 
-  referenced_security_group_id = aws_security_group.documentdb.id
+  referenced_security_group_id = aws_security_group.documentdb[0].id
   from_port                    = 27017
   to_port                      = 27017
   ip_protocol                  = "tcp"
@@ -118,8 +133,12 @@ resource "aws_vpc_security_group_egress_rule" "auth_to_documentdb" {
 
 #
 # KMS Key for DocumentDB Encryption
+# Gated on is_aws_documentdb. NOTE: re-planning out of the documentdb backend
+# enters this key into a 7-day pending-deletion window. See PR release notes.
 #
 resource "aws_kms_key" "documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   description             = "KMS key for DocumentDB Cluster and secrets encryption"
   deletion_window_in_days = 7
   enable_key_rotation     = true
@@ -195,19 +214,26 @@ resource "aws_kms_key" "documentdb" {
 }
 
 resource "aws_kms_alias" "documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name          = "alias/${var.name}-documentdb"
-  target_key_id = aws_kms_key.documentdb.key_id
+  target_key_id = aws_kms_key.documentdb[0].key_id
 }
 
 #
 # Secrets Manager Secret for DocumentDB Credentials
+# Gated on is_aws_documentdb. NOTE: recovery_window_in_days = 0 means an
+# apply that re-plans this out destroys the secret IMMEDIATELY with no
+# recovery window. See PR release notes for the rollout warning.
 #
 #checkov:skip=CKV2_AWS_57:Secret rotation managed externally via dedicated rotation Lambda
 resource "aws_secretsmanager_secret" "documentdb_credentials" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name                    = "${var.name}/documentdb/credentials"
   description             = "DocumentDB Cluster admin credentials"
   recovery_window_in_days = 0
-  kms_key_id              = aws_kms_key.documentdb.id
+  kms_key_id              = aws_kms_key.documentdb[0].id
 
   tags = merge(
     local.common_tags,
@@ -218,7 +244,9 @@ resource "aws_secretsmanager_secret" "documentdb_credentials" {
 }
 
 resource "aws_secretsmanager_secret_version" "documentdb_credentials" {
-  secret_id = aws_secretsmanager_secret.documentdb_credentials.id
+  count = local.is_aws_documentdb ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.documentdb_credentials[0].id
   secret_string = jsonencode({
     username = var.documentdb_admin_username
     password = var.documentdb_admin_password
@@ -230,6 +258,8 @@ resource "aws_secretsmanager_secret_version" "documentdb_credentials" {
 # DocumentDB Subnet Group
 #
 resource "aws_docdb_subnet_group" "registry" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name       = "${var.name}-registry-subnet-group"
   subnet_ids = module.vpc.private_subnets
 
@@ -246,6 +276,8 @@ resource "aws_docdb_subnet_group" "registry" {
 # DocumentDB Cluster Parameter Group
 #
 resource "aws_docdb_cluster_parameter_group" "registry" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   family      = "docdb5.0"
   name        = "${var.name}-registry-params"
   description = "DocumentDB cluster parameter group for MCP Gateway Registry"
@@ -281,6 +313,8 @@ resource "aws_docdb_cluster_parameter_group" "registry" {
 # DocumentDB Cluster
 #
 resource "aws_docdb_cluster" "registry" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   cluster_identifier = "${var.name}-registry"
 
   # Engine
@@ -292,8 +326,8 @@ resource "aws_docdb_cluster" "registry" {
   master_password = var.documentdb_admin_password
 
   # Network configuration
-  db_subnet_group_name   = aws_docdb_subnet_group.registry.name
-  vpc_security_group_ids = [aws_security_group.documentdb.id]
+  db_subnet_group_name   = aws_docdb_subnet_group.registry[0].name
+  vpc_security_group_ids = [aws_security_group.documentdb[0].id]
   port                   = 27017
 
   # Backup configuration
@@ -305,10 +339,10 @@ resource "aws_docdb_cluster" "registry" {
 
   # Encryption
   storage_encrypted = true
-  kms_key_id        = aws_kms_key.documentdb.arn
+  kms_key_id        = aws_kms_key.documentdb[0].arn
 
   # Parameter group
-  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.registry.name
+  db_cluster_parameter_group_name = aws_docdb_cluster_parameter_group.registry[0].name
 
   # Deletion protection (enable for production)
   deletion_protection = false
@@ -332,8 +366,10 @@ resource "aws_docdb_cluster" "registry" {
 #
 # Primary instance
 resource "aws_docdb_cluster_instance" "registry_primary" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   identifier         = "${var.name}-registry-primary"
-  cluster_identifier = aws_docdb_cluster.registry.id
+  cluster_identifier = aws_docdb_cluster.registry[0].id
 
   # Instance class (can be adjusted based on needs)
   # db.t3.medium = 2 vCPU, 4 GB RAM - good starting point
@@ -378,14 +414,16 @@ resource "aws_docdb_cluster_instance" "registry_primary" {
 # }
 
 #
-# Update SSM Parameters with new cluster endpoints
+# Update SSM Parameters with new cluster endpoints (gated on is_aws_documentdb)
 #
 #checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
 resource "aws_ssm_parameter" "documentdb_endpoint" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name        = "/${var.name}/documentdb/endpoint"
   description = "DocumentDB Cluster endpoint"
   type        = "String"
-  value       = aws_docdb_cluster.registry.endpoint
+  value       = aws_docdb_cluster.registry[0].endpoint
   overwrite   = true
 
   tags = merge(
@@ -398,10 +436,12 @@ resource "aws_ssm_parameter" "documentdb_endpoint" {
 
 #checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
 resource "aws_ssm_parameter" "documentdb_reader_endpoint" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name        = "/${var.name}/documentdb/reader_endpoint"
   description = "DocumentDB Cluster reader endpoint"
   type        = "String"
-  value       = aws_docdb_cluster.registry.reader_endpoint
+  value       = aws_docdb_cluster.registry[0].reader_endpoint
 
   tags = merge(
     local.common_tags,
@@ -412,17 +452,19 @@ resource "aws_ssm_parameter" "documentdb_reader_endpoint" {
 }
 
 resource "aws_ssm_parameter" "documentdb_connection_string" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name        = "/${var.name}/documentdb/connection_string"
   description = "DocumentDB Cluster connection string"
   type        = "SecureString"
-  key_id      = aws_kms_key.documentdb.id
+  key_id      = aws_kms_key.documentdb[0].id
   # AWS DocumentDB only supports SCRAM-SHA-1 (not SCRAM-SHA-256 as of v5.0)
   # TODO: Update to SCRAM-SHA-256 when AWS DocumentDB adds support
   value = format(
     "mongodb://%s:%s@%s:27017/?authMechanism=SCRAM-SHA-1&authSource=admin&tls=true&tlsCAFile=global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false",
     var.documentdb_admin_username,
     var.documentdb_admin_password,
-    aws_docdb_cluster.registry.endpoint
+    aws_docdb_cluster.registry[0].endpoint
   )
   overwrite = true
 

--- a/terraform/aws-ecs/ecs.tf
+++ b/terraform/aws-ecs/ecs.tf
@@ -56,7 +56,7 @@ module "ecs_cluster" {
 
 # IAM policy for task execution role to access DocumentDB credentials
 resource "aws_iam_role_policy" "task_execution_documentdb_secrets" {
-  count = var.storage_backend == "documentdb" ? 1 : 0
+  count = local.is_aws_documentdb ? 1 : 0
 
   name = "${var.name}-task-execution-documentdb-secrets"
   role = module.ecs_cluster.task_exec_iam_role_name
@@ -70,7 +70,7 @@ resource "aws_iam_role_policy" "task_execution_documentdb_secrets" {
           "secretsmanager:GetSecretValue"
         ]
         Resource = [
-          aws_secretsmanager_secret.documentdb_credentials.arn
+          aws_secretsmanager_secret.documentdb_credentials[0].arn
         ]
       }
     ]

--- a/terraform/aws-ecs/locals.tf
+++ b/terraform/aws-ecs/locals.tf
@@ -20,4 +20,24 @@ locals {
     ManagedBy   = "terraform"
     CreatedAt   = timestamp()
   }
+
+  # Storage backend classification (issue #955).
+  # Keep mongodb_compatible_backends in sync with registry/core/config.py
+  # ALLOWED_STORAGE_BACKENDS / MONGODB_BACKENDS (issue #954).
+  #
+  # - is_aws_documentdb:     true only when Terraform should provision AWS DocumentDB.
+  # - is_mongodb_compatible: true for any MongoDB-API-compatible backend.
+  # - uses_external_mongodb: true when the registry connects to a MongoDB the
+  #                          operator owns (Atlas, self-managed, etc.) via
+  #                          mongodb_connection_string / _secret_arn.
+  mongodb_compatible_backends = [
+    "documentdb",
+    "mongodb-ce",
+    "mongodb",
+    "mongodb-atlas",
+  ]
+
+  is_aws_documentdb     = var.storage_backend == "documentdb"
+  is_mongodb_compatible = contains(local.mongodb_compatible_backends, var.storage_backend)
+  uses_external_mongodb = local.is_mongodb_compatible && !local.is_aws_documentdb
 }

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -2,7 +2,10 @@
 # This Terraform configuration deploys the MCP Gateway to AWS ECS Fargate
 
 terraform {
-  required_version = ">= 1.0"
+  # 1.2 required for `precondition` blocks on modules (used in the
+  # mcp_gateway module to validate mongodb_connection_string* presence
+  # for non-documentdb MongoDB backends, issue #955).
+  required_version = ">= 1.2"
 
   required_providers {
     aws = {
@@ -108,13 +111,16 @@ module "mcp_gateway" {
   session_cookie_domain = var.session_cookie_domain
 
   # DocumentDB configuration
-  storage_backend                   = var.storage_backend
-  documentdb_endpoint               = aws_docdb_cluster.registry.endpoint
+  storage_backend = var.storage_backend
+  # Cluster endpoint + credentials secret are gated on is_aws_documentdb so
+  # that external-MongoDB (Atlas / self-managed) deployments do not require
+  # the AWS DocumentDB resources to exist (issue #955).
+  documentdb_endpoint               = local.is_aws_documentdb ? aws_docdb_cluster.registry[0].endpoint : ""
   documentdb_database               = var.documentdb_database
   documentdb_namespace              = var.documentdb_namespace
   documentdb_use_tls                = var.documentdb_use_tls
   documentdb_use_iam                = var.documentdb_use_iam
-  documentdb_credentials_secret_arn = var.storage_backend == "documentdb" ? aws_secretsmanager_secret.documentdb_credentials.arn : ""
+  documentdb_credentials_secret_arn = local.is_aws_documentdb ? aws_secretsmanager_secret.documentdb_credentials[0].arn : ""
 
   # Optional full MongoDB connection string override (PR #947). See variable
   # docs in variables.tf. Leave both empty to use the DOCUMENTDB_* block above.
@@ -173,13 +179,13 @@ module "mcp_gateway" {
   registration_webhook_timeout_seconds = var.registration_webhook_timeout_seconds
 
   # Registration gate / admission control (issue #809)
-  registration_gate_enabled          = var.registration_gate_enabled
-  registration_gate_url              = var.registration_gate_url
-  registration_gate_auth_type        = var.registration_gate_auth_type
-  registration_gate_auth_credential  = var.registration_gate_auth_credential
-  registration_gate_auth_header_name = var.registration_gate_auth_header_name
-  registration_gate_timeout_seconds  = var.registration_gate_timeout_seconds
-  registration_gate_max_retries      = var.registration_gate_max_retries
+  registration_gate_enabled              = var.registration_gate_enabled
+  registration_gate_url                  = var.registration_gate_url
+  registration_gate_auth_type            = var.registration_gate_auth_type
+  registration_gate_auth_credential      = var.registration_gate_auth_credential
+  registration_gate_auth_header_name     = var.registration_gate_auth_header_name
+  registration_gate_timeout_seconds      = var.registration_gate_timeout_seconds
+  registration_gate_max_retries          = var.registration_gate_max_retries
   registration_gate_oauth2_token_url     = var.registration_gate_oauth2_token_url
   registration_gate_oauth2_client_id     = var.registration_gate_oauth2_client_id
   registration_gate_oauth2_client_secret = var.registration_gate_oauth2_client_secret
@@ -220,8 +226,8 @@ module "mcp_gateway" {
   # Application log configuration
   app_log_centralized_enabled  = var.app_log_centralized_enabled
   app_log_centralized_ttl_days = var.app_log_centralized_ttl_days
-  app_log_level            = var.app_log_level
-  app_log_excluded_loggers = var.app_log_excluded_loggers
+  app_log_level                = var.app_log_level
+  app_log_excluded_loggers     = var.app_log_excluded_loggers
 
   # Deployment mode configuration
   deployment_mode = var.deployment_mode
@@ -264,6 +270,33 @@ module "mcp_gateway" {
   # Wait for S3 bucket policy to propagate (30s delay)
   # This prevents "Access Denied" errors when ALB tests write permissions
   depends_on = [time_sleep.wait_for_bucket_policy]
+}
+
+# When storage_backend is a non-documentdb MongoDB variant (mongodb-ce,
+# mongodb, mongodb-atlas), Terraform does not provision AWS DocumentDB, so
+# the registry MUST be given a MongoDB URI via mongodb_connection_string or
+# mongodb_connection_string_secret_arn. Enforce at plan time rather than at
+# apply/runtime. Implemented as a precondition on a terraform_data resource
+# because Terraform 1.11 does not yet support `lifecycle` blocks directly on
+# `module` references. Issue #955.
+resource "terraform_data" "mongodb_backend_uri_required" {
+  input = var.storage_backend
+
+  lifecycle {
+    precondition {
+      condition = !local.uses_external_mongodb || (
+        var.mongodb_connection_string != "" ||
+        var.mongodb_connection_string_secret_arn != ""
+      )
+      error_message = join(" ", [
+        "When storage_backend is one of mongodb-ce / mongodb / mongodb-atlas,",
+        "you must set either mongodb_connection_string or",
+        "mongodb_connection_string_secret_arn (prefer the _secret_arn form",
+        "for credentials). See terraform.tfvars.example and",
+        "docs/faq/configuring-mongodb-atlas-backend.md.",
+      ])
+    }
+  }
 }
 
 # =============================================================================

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -406,12 +406,20 @@ variable "security_add_pending_tag" {
 # =============================================================================
 
 variable "storage_backend" {
-  description = "Storage backend to use: 'file' or 'documentdb'"
+  description = <<-DESC
+    Storage backend. Accepted values (mirrors root variables.tf and
+    registry/core/config.py ALLOWED_STORAGE_BACKENDS): file, documentdb,
+    mongodb-ce, mongodb, mongodb-atlas. mongodb and mongodb-atlas are
+    aliases for mongodb-ce at the Python repository layer.
+  DESC
   type        = string
   default     = "file"
   validation {
-    condition     = contains(["file", "documentdb"], var.storage_backend)
-    error_message = "Storage backend must be either 'file' or 'documentdb'."
+    condition = contains(
+      ["file", "documentdb", "mongodb-ce", "mongodb", "mongodb-atlas"],
+      var.storage_backend,
+    )
+    error_message = "Storage backend must be one of: file, documentdb, mongodb-ce, mongodb, mongodb-atlas."
   }
 }
 

--- a/terraform/aws-ecs/outputs.tf
+++ b/terraform/aws-ecs/outputs.tf
@@ -199,39 +199,44 @@ output "grafana_url" {
 #
 # DocumentDB Cluster Outputs
 #
+# All DocumentDB outputs return null when storage_backend != "documentdb"
+# because the underlying resources are gated on local.is_aws_documentdb.
+# Any downstream Terraform module that consumes these via terraform_remote_state
+# must handle the null case. Issue #955.
+#
 
 output "documentdb_cluster_endpoint" {
-  description = "DocumentDB Cluster endpoint"
-  value       = aws_docdb_cluster.registry.endpoint
+  description = "DocumentDB Cluster endpoint. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_docdb_cluster.registry[0].endpoint : null
 }
 
 output "documentdb_cluster_arn" {
-  description = "DocumentDB Cluster ARN"
-  value       = aws_docdb_cluster.registry.arn
+  description = "DocumentDB Cluster ARN. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_docdb_cluster.registry[0].arn : null
 }
 
 output "documentdb_reader_endpoint" {
-  description = "DocumentDB Cluster reader endpoint"
-  value       = aws_docdb_cluster.registry.reader_endpoint
+  description = "DocumentDB Cluster reader endpoint. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_docdb_cluster.registry[0].reader_endpoint : null
 }
 
 output "documentdb_security_group_id" {
-  description = "DocumentDB security group ID"
-  value       = aws_security_group.documentdb.id
+  description = "DocumentDB security group ID. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_security_group.documentdb[0].id : null
 }
 
 output "documentdb_kms_key_id" {
-  description = "KMS key ID for DocumentDB encryption"
-  value       = aws_kms_key.documentdb.id
+  description = "KMS key ID for DocumentDB encryption. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_kms_key.documentdb[0].id : null
 }
 
 output "documentdb_kms_key_arn" {
-  description = "KMS key ARN for DocumentDB encryption"
-  value       = aws_kms_key.documentdb.arn
+  description = "KMS key ARN for DocumentDB encryption. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_kms_key.documentdb[0].arn : null
 }
 
 output "documentdb_secrets_manager_secret_arn" {
-  description = "Secrets Manager secret ARN for DocumentDB credentials"
-  value       = aws_secretsmanager_secret.documentdb_credentials.arn
+  description = "Secrets Manager secret ARN for DocumentDB credentials. Null when storage_backend != documentdb."
+  value       = local.is_aws_documentdb ? aws_secretsmanager_secret.documentdb_credentials[0].arn : null
   sensitive   = true
 }

--- a/terraform/aws-ecs/secret-rotation-config.tf
+++ b/terraform/aws-ecs/secret-rotation-config.tf
@@ -10,10 +10,14 @@
 
 #
 # Enable Rotation for DocumentDB Credentials
+# Gated on is_aws_documentdb. The rotation Lambda and its permissions are
+# also gated in secret-rotation.tf. Issue #955.
 #
 resource "aws_secretsmanager_secret_rotation" "documentdb_credentials" {
-  secret_id           = aws_secretsmanager_secret.documentdb_credentials.id
-  rotation_lambda_arn = aws_lambda_function.documentdb_rotation.arn
+  count = local.is_aws_documentdb ? 1 : 0
+
+  secret_id           = aws_secretsmanager_secret.documentdb_credentials[0].id
+  rotation_lambda_arn = aws_lambda_function.documentdb_rotation[0].arn
 
   rotation_rules {
     automatically_after_days = 30

--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -37,6 +37,11 @@ resource "aws_iam_role" "rotation_lambda" {
 
 #
 # IAM Policy for Lambda to Rotate Secrets
+# The IAM role is shared across the DocumentDB rotation Lambda (gated on
+# is_aws_documentdb) and the RDS/Keycloak rotation Lambda (always created).
+# DocumentDB-specific resources are conditionally included so the policy
+# does not reference non-existent resources when DocumentDB is gated out.
+# Issue #955.
 #
 #checkov:skip=CKV_AWS_290:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
 #checkov:skip=CKV_AWS_355:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
@@ -46,74 +51,77 @@ resource "aws_iam_role_policy" "rotation_lambda" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "SecretsManagerAccess"
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:DescribeSecret",
-          "secretsmanager:GetSecretValue",
-          "secretsmanager:PutSecretValue",
-          "secretsmanager:UpdateSecretVersionStage"
-        ]
-        Resource = [
-          aws_secretsmanager_secret.documentdb_credentials.arn,
-          aws_secretsmanager_secret.keycloak_db_secret.arn
-        ]
-      },
-      {
-        Sid    = "GenerateRandomPassword"
-        Effect = "Allow"
-        Action = [
-          "secretsmanager:GetRandomPassword"
-        ]
-        Resource = "*"
-      },
-      {
-        Sid    = "KMSAccess"
-        Effect = "Allow"
-        Action = [
-          "kms:Decrypt",
-          "kms:DescribeKey",
-          "kms:GenerateDataKey"
-        ]
-        Resource = [
-          aws_kms_key.documentdb.arn,
-          aws_kms_key.rds.arn
-        ]
-      },
-      {
-        Sid    = "RDSAccess"
-        Effect = "Allow"
-        Action = [
-          "rds:DescribeDBInstances",
-          "rds:DescribeDBClusters",
-          "rds:ModifyDBCluster"
-        ]
-        Resource = aws_rds_cluster.keycloak.arn
-      },
-      {
+    Statement = concat(
+      [
+        {
+          Sid    = "SecretsManagerAccess"
+          Effect = "Allow"
+          Action = [
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecretVersionStage"
+          ]
+          Resource = concat(
+            local.is_aws_documentdb ? [aws_secretsmanager_secret.documentdb_credentials[0].arn] : [],
+            [aws_secretsmanager_secret.keycloak_db_secret.arn],
+          )
+        },
+        {
+          Sid    = "GenerateRandomPassword"
+          Effect = "Allow"
+          Action = [
+            "secretsmanager:GetRandomPassword"
+          ]
+          Resource = "*"
+        },
+        {
+          Sid    = "KMSAccess"
+          Effect = "Allow"
+          Action = [
+            "kms:Decrypt",
+            "kms:DescribeKey",
+            "kms:GenerateDataKey"
+          ]
+          Resource = concat(
+            local.is_aws_documentdb ? [aws_kms_key.documentdb[0].arn] : [],
+            [aws_kms_key.rds.arn],
+          )
+        },
+        {
+          Sid    = "RDSAccess"
+          Effect = "Allow"
+          Action = [
+            "rds:DescribeDBInstances",
+            "rds:DescribeDBClusters",
+            "rds:ModifyDBCluster"
+          ]
+          Resource = aws_rds_cluster.keycloak.arn
+        },
+        {
+          Sid    = "VPCNetworkInterface"
+          Effect = "Allow"
+          Action = [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface",
+            "ec2:AssignPrivateIpAddresses",
+            "ec2:UnassignPrivateIpAddresses"
+          ]
+          Resource = "*"
+        },
+      ],
+      # DocumentDBAccess statement only when the DocumentDB cluster exists.
+      local.is_aws_documentdb ? [{
         Sid    = "DocumentDBAccess"
         Effect = "Allow"
         Action = [
           "docdb:DescribeDBClusters",
           "docdb:ModifyDBCluster"
         ]
-        Resource = aws_docdb_cluster.registry.arn
-      },
-      {
-        Sid    = "VPCNetworkInterface"
-        Effect = "Allow"
-        Action = [
-          "ec2:CreateNetworkInterface",
-          "ec2:DescribeNetworkInterfaces",
-          "ec2:DeleteNetworkInterface",
-          "ec2:AssignPrivateIpAddresses",
-          "ec2:UnassignPrivateIpAddresses"
-        ]
-        Resource = "*"
-      }
-    ]
+        Resource = aws_docdb_cluster.registry[0].arn
+      }] : [],
+    )
   })
 }
 
@@ -143,12 +151,14 @@ resource "aws_security_group" "rotation_lambda" {
 }
 
 #
-# Lambda -> DocumentDB
+# Lambda -> DocumentDB (gated on is_aws_documentdb - issue #955)
 #
 resource "aws_vpc_security_group_egress_rule" "lambda_to_documentdb" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   security_group_id = aws_security_group.rotation_lambda.id
 
-  referenced_security_group_id = aws_security_group.documentdb.id
+  referenced_security_group_id = aws_security_group.documentdb[0].id
   from_port                    = 27017
   to_port                      = 27017
   ip_protocol                  = "tcp"
@@ -163,10 +173,12 @@ resource "aws_vpc_security_group_egress_rule" "lambda_to_documentdb" {
 }
 
 #
-# DocumentDB <- Lambda
+# DocumentDB <- Lambda (gated on is_aws_documentdb - issue #955)
 #
 resource "aws_vpc_security_group_ingress_rule" "documentdb_from_lambda" {
-  security_group_id = aws_security_group.documentdb.id
+  count = local.is_aws_documentdb ? 1 : 0
+
+  security_group_id = aws_security_group.documentdb[0].id
 
   referenced_security_group_id = aws_security_group.rotation_lambda.id
   from_port                    = 27017
@@ -247,6 +259,8 @@ resource "aws_vpc_security_group_egress_rule" "lambda_to_https" {
 #
 #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
 resource "aws_cloudwatch_log_group" "documentdb_rotation" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   name              = "/aws/lambda/${var.name}-rotate-documentdb"
   retention_in_days = 30
 
@@ -273,8 +287,12 @@ resource "aws_cloudwatch_log_group" "rds_rotation" {
 
 #
 # Lambda Function Package - DocumentDB Rotation
+# Gated via `count` on the data source so the archive is not built when
+# DocumentDB is not provisioned. Issue #955.
 #
 data "archive_file" "documentdb_rotation" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   type        = "zip"
   source_dir  = "${path.module}/lambda/rotate-documentdb"
   output_path = "${path.module}/.terraform/lambda/rotate-documentdb.zip"
@@ -290,18 +308,20 @@ data "archive_file" "rds_rotation" {
 }
 
 #
-# Lambda Function - DocumentDB Rotation
+# Lambda Function - DocumentDB Rotation (gated on is_aws_documentdb)
 #
 #checkov:skip=CKV_AWS_115:Reserved concurrency not needed for secret rotation Lambda
 #checkov:skip=CKV_AWS_116:DLQ not needed for synchronous secret rotation Lambda
 #checkov:skip=CKV_AWS_173:Lambda environment variables use default encryption
 #checkov:skip=CKV_AWS_272:Code signing not configured for internal rotation Lambdas
 resource "aws_lambda_function" "documentdb_rotation" {
-  filename         = data.archive_file.documentdb_rotation.output_path
+  count = local.is_aws_documentdb ? 1 : 0
+
+  filename         = data.archive_file.documentdb_rotation[0].output_path
   function_name    = "${var.name}-rotate-documentdb"
   role             = aws_iam_role.rotation_lambda.arn
   handler          = "index.lambda_handler"
-  source_code_hash = data.archive_file.documentdb_rotation.output_base64sha256
+  source_code_hash = data.archive_file.documentdb_rotation[0].output_base64sha256
   runtime          = "python3.13"
   timeout          = 300
   memory_size      = 256
@@ -384,13 +404,15 @@ resource "aws_lambda_function" "rds_rotation" {
 }
 
 #
-# Lambda Permission for Secrets Manager - DocumentDB
+# Lambda Permission for Secrets Manager - DocumentDB (gated on is_aws_documentdb)
 #
 #checkov:skip=CKV_AWS_364:Lambda resource-based policy does not use IAM policy document version field
 resource "aws_lambda_permission" "documentdb_rotation" {
+  count = local.is_aws_documentdb ? 1 : 0
+
   statement_id  = "AllowExecutionFromSecretsManager"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.documentdb_rotation.function_name
+  function_name = aws_lambda_function.documentdb_rotation[0].function_name
   principal     = "secretsmanager.amazonaws.com"
 }
 

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -280,6 +280,35 @@ oauth_store_tokens_in_session = false
 # mongodb_connection_string_secret_arn = ""
 
 # ============================================================================
+# EXTERNAL MONGODB (Atlas, self-managed) - issue #955
+# ============================================================================
+# To point the registry at a MongoDB you already own (MongoDB Atlas,
+# self-managed replica set, etc.) WITHOUT provisioning AWS DocumentDB in
+# this Terraform state, set:
+#
+#   storage_backend = "mongodb-atlas"
+#   mongodb_connection_string_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:mongodb-atlas-uri-XXXXXX"
+#
+# Accepted storage_backend values (must match registry/core/config.py):
+#   "file"          - JSON files, no DocumentDB provisioned
+#   "documentdb"    - Provision AWS DocumentDB (this module manages the cluster)
+#   "mongodb-ce"    - External MongoDB CE, URI via mongodb_connection_string*
+#   "mongodb"       - Alias for mongodb-ce
+#   "mongodb-atlas" - Alias for mongodb-ce (intended for MongoDB Atlas)
+#
+# For any non-"documentdb" MongoDB backend, mongodb_connection_string or
+# mongodb_connection_string_secret_arn is REQUIRED. `terraform plan` will
+# fail with a clear precondition error if you forget.
+#
+# The Secrets Manager secret value must be the full URI, e.g.:
+#   mongodb+srv://user:pass@cluster.mongodb.net/mcp_registry?retryWrites=true&w=majority
+#
+# When switching from "documentdb" to an external-MongoDB backend, `terraform
+# apply` will destroy the existing DocumentDB cluster, its KMS key (7-day
+# pending-deletion), and the credentials secret (0-day recovery window -
+# immediate delete). Take a final snapshot first. See the PR release notes.
+
+# ============================================================================
 # REGISTRY STATIC TOKEN AUTH (IdP-independent API access)
 # ============================================================================
 

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -316,13 +316,32 @@ variable "documentdb_replica_count" {
 
 # Storage Backend Configuration
 variable "storage_backend" {
-  description = "Storage backend to use: 'file' or 'documentdb'"
+  description = <<-DESC
+    Storage backend selection. Must match the Python-side allowlist in
+    registry/core/config.py ALLOWED_STORAGE_BACKENDS (issue #954). Accepted
+    values:
+      "file"          - JSON files only. No AWS DocumentDB provisioned.
+      "documentdb"    - Provision AWS DocumentDB cluster in this Terraform
+                        state and use SCRAM-SHA-1 auth.
+      "mongodb-ce"    - Connect to an externally-provisioned MongoDB CE via
+                        mongodb_connection_string / _secret_arn. No AWS
+                        DocumentDB provisioned.
+      "mongodb"       - Alias for mongodb-ce.
+      "mongodb-atlas" - Alias for mongodb-ce (intended for MongoDB Atlas).
+
+    For non-"documentdb" MongoDB backends, mongodb_connection_string or
+    mongodb_connection_string_secret_arn must be set. Enforced at
+    `terraform plan` time via a precondition on the mcp_gateway module.
+  DESC
   type        = string
   default     = "file"
 
   validation {
-    condition     = contains(["file", "documentdb"], var.storage_backend)
-    error_message = "Storage backend must be either 'file' or 'documentdb'."
+    condition = contains(
+      ["file", "documentdb", "mongodb-ce", "mongodb", "mongodb-atlas"],
+      var.storage_backend,
+    )
+    error_message = "Storage backend must be one of: file, documentdb, mongodb-ce, mongodb, mongodb-atlas."
   }
 }
 


### PR DESCRIPTION
Closes #955 (milestone v1.0.23).

## Summary

- Mirrors the Python-side allowlist from #954 / PR #957: `storage_backend` now accepts `file`, `documentdb`, `mongodb-ce`, `mongodb`, `mongodb-atlas`. Operators deploying the registry against an external MongoDB (Atlas, self-managed) can now express that directly in tfvars.
- Every AWS DocumentDB resource (the cluster + its KMS key, credentials secret, subnet / parameter groups, primary instance, 5 security group rules, 3 SSM parameters, 6 outputs, 2 CloudWatch alarms, and the DocumentDB-specific secret-rotation Lambda + its wiring) is now gated on `local.is_aws_documentdb`. Deployments that use `storage_backend = "file"` or an external MongoDB no longer provision an unused DocumentDB cluster (~$200-400/month saved per environment).
- A new `terraform_data` resource with a `lifecycle.precondition` enforces that non-documentdb MongoDB backends have a `mongodb_connection_string` / `_secret_arn` set, failing `terraform plan` with a clear message rather than at runtime.

## Files changed (11)

| File | Change |
|------|--------|
| [`terraform/aws-ecs/locals.tf`](terraform/aws-ecs/locals.tf) | New `mongodb_compatible_backends` list + `is_aws_documentdb` / `is_mongodb_compatible` / `uses_external_mongodb` booleans. Comment cross-references the Python-side allowlist. |
| [`terraform/aws-ecs/variables.tf`](terraform/aws-ecs/variables.tf) | Expand `storage_backend` validation to `["file", "documentdb", "mongodb-ce", "mongodb", "mongodb-atlas"]` + extended heredoc description. |
| [`terraform/aws-ecs/modules/mcp-gateway/variables.tf`](terraform/aws-ecs/modules/mcp-gateway/variables.tf) | Same allowlist expansion at the module level. |
| [`terraform/aws-ecs/main.tf`](terraform/aws-ecs/main.tf) | Bump `required_version` to `>= 1.2`; gate `documentdb_endpoint` + `documentdb_credentials_secret_arn` passthroughs; new `terraform_data.mongodb_backend_uri_required` carrying the precondition. |
| [`terraform/aws-ecs/documentdb.tf`](terraform/aws-ecs/documentdb.tf) | `count = local.is_aws_documentdb ? 1 : 0` on all 14 DocumentDB-adjacent resources; internal cross-references updated to `[0]` indexing. |
| [`terraform/aws-ecs/cloudwatch-alarms.tf`](terraform/aws-ecs/cloudwatch-alarms.tf) | `count` on `kms_throttling_documentdb` and `documentdb_audit_log_failures`. |
| [`terraform/aws-ecs/secret-rotation.tf`](terraform/aws-ecs/secret-rotation.tf) | `count` on DocumentDB-specific Lambda + archive + log group + SG rules + permission; shared IAM policy uses `concat()` to conditionally include DocumentDB resources so the RDS/Keycloak rotation path is unaffected. |
| [`terraform/aws-ecs/secret-rotation-config.tf`](terraform/aws-ecs/secret-rotation-config.tf) | `count` on the DocumentDB rotation schedule. |
| [`terraform/aws-ecs/ecs.tf`](terraform/aws-ecs/ecs.tf) | Refactor existing inline check to `local.is_aws_documentdb` for consistency. |
| [`terraform/aws-ecs/outputs.tf`](terraform/aws-ecs/outputs.tf) | 7 DocumentDB outputs now return `null` when `storage_backend != "documentdb"`. |
| [`terraform/aws-ecs/terraform.tfvars.example`](terraform/aws-ecs/terraform.tfvars.example) | New "EXTERNAL MONGODB" section documenting the `storage_backend = "mongodb-atlas"` workflow + destruction warning. |

## DESTRUCTIVE behavior - read before merging (release notes)

Existing deployments that applied `storage_backend = "file"` but still have the DocumentDB resources sitting in their Terraform state (because they were ungated before this PR) will see `terraform plan` propose:

- Destroy `aws_docdb_cluster.registry` + its primary instance
- Destroy `aws_docdb_subnet_group.registry` + `aws_docdb_cluster_parameter_group.registry`
- Destroy `aws_kms_key.documentdb` - **enters a 7-day pending-deletion window**; any AWS resource still referencing this key (e.g. DocumentDB snapshots taken under it) cannot be restored after the window expires
- Destroy `aws_secretsmanager_secret.documentdb_credentials` - **`recovery_window_in_days = 0`, so the secret is destroyed IMMEDIATELY with no recovery window**. If the secret ARN was referenced from anything outside Terraform state (a Slack runbook, an external system), those references silently break
- Destroy the DocumentDB rotation Lambda + its IAM policy, the 5 security group rules, and the 2 CloudWatch alarms

This is correct - these resources were never used for `file` backend - but it is not reversible without restoring from backup. Operators with `storage_backend = "file"` deployments should:

1. Run `terraform plan -var-file=<fixture>` and inspect the destroy list
2. Take a final DocumentDB snapshot if there's any chance the cluster was ever used ad-hoc
3. Export the credentials secret value if any external system references it
4. Only then `terraform apply`

Deployments using `storage_backend = "documentdb"` (which all 5 committed IdP fixtures do) see **zero drift** - pending sandbox verification.

## Test plan

- [x] `terraform fmt -recursive` clean on the touched files (unrelated pre-existing drift in `keycloak-database.tf` left alone)
- [x] `terraform init -backend=false` succeeds
- [x] `terraform validate` passes (pre-existing `data.aws_region.current.name` deprecation warnings are unrelated)
- [x] Precondition fires as expected: `storage_backend = "mongodb-atlas"` without a URI variable fails `terraform plan` with the expected "must set either mongodb_connection_string or mongodb_connection_string_secret_arn" message
- [x] Allowlist rejects `storage_backend = "mongo"` with the full 5-value list in the error message
- [ ] **Reviewer with sandbox AWS credentials**: `terraform plan -var-file=terraform.tfvars.keycloak` (and the other 4 IdP fixtures) shows **zero drift** - no destroy, no recreate, only possibly a state-address migration for the now-count-gated resources. Attach the plan output to the PR review.
- [ ] **Reviewer with sandbox AWS credentials**: `terraform plan -var-file=<atlas_test>.tfvars` with `storage_backend = "mongodb-atlas"` + a real Secrets Manager ARN shows zero `aws_docdb_*`, zero `aws_kms_key.documentdb`, zero `aws_secretsmanager_secret.documentdb_credentials` in the plan.

## Out of scope / follow-ups

- **Terraform state-address migration helpers**: this PR adds `count` to 14 resources, which changes their Terraform state addresses from `aws_docdb_cluster.registry` to `aws_docdb_cluster.registry[0]`. Terraform 1.6+ handles this automatically for most cases, but if any reviewer sees a "must be replaced" line in the plan for an existing `documentdb` deployment, we should add `moved` blocks. Will adjust in review.
- **Helm chart parity** for the `envFrom`-precedence concern from the original #919 body: not this PR. File separately if we see the symptom on v1.0.22-p1-or-later images.