### PR TITLE
fix(ui): propagate lifecycle_status to agent cards (#962)

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -409,6 +409,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
       sync_metadata: a.sync_metadata,
       ans_metadata: a.ans_metadata,
       registered_by: a.registered_by,
+      lifecycle_status: a.lifecycle_status,
     }));
   }, [agentsFromStats]);
 


### PR DESCRIPTION
Fixes #962.

## Summary

- The agent lifecycle badge (Draft / Beta / Deprecated) was never rendering on agent cards, even after a user saved a non-active lifecycle status.
- The Edit Agent modal always opened with Lifecycle Status pre-selected to Active, regardless of the agent's saved status.

Root cause was in [frontend/src/pages/Dashboard.tsx](frontend/src/pages/Dashboard.tsx): the Server to Agent transform copied most fields but dropped `lifecycle_status`, leaving every derived agent object with `lifecycle_status === undefined`. `AgentCard` only renders the badge when `agent.lifecycle_status && agent.lifecycle_status !== 'active'`, so the badge was never shown. `handleEditAgent` also uses `agent.lifecycle_status` as a fallback when populating the edit form, which is why the modal defaulted to Active.

Backend behavior is unchanged: the PUT endpoint persists `status` correctly in DocumentDB and the list / single-agent GET endpoints return it. This is a client-side field plumbing fix only.

## Change

One line added to the Server to Agent transform in Dashboard.tsx to copy `lifecycle_status` through.

## Test plan

- [x] Edit an agent, set Lifecycle Status to Draft, save. Confirm the gray Draft badge appears next to the agent name on the card.
- [x] Re-open the edit modal for the same agent and confirm the Lifecycle Status dropdown is pre-selected to Draft.
- [x] Repeat for Beta (blue badge) and Deprecated (orange badge).
- [x] Confirm the backend state in `mcp_agents_default` shows the updated `status` value (no regression in save path).
- [x] Hard refresh after the new bundle is deployed to pick up the updated content-hashed JS.