### PR TITLE
fix overriding the image tag from helm variables

### DIFF
--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: auth-server  # Image name within the registry
-  tag: 1.0.22
+  tag: ""           # Overrides global.image.tag when set
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration

--- a/charts/mcpgw/values.yaml
+++ b/charts/mcpgw/values.yaml
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: mcpgw  # Image name within the registry
-  tag: 1.0.22
+  tag: ""           # Overrides global.image.tag when set
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -11,7 +11,7 @@ global:
 image:
   registry: ""      # Overrides global.image.registry when set
   repository: registry  # Image name within the registry
-  tag: 1.0.22
+  tag: ""           # Overrides global.image.tag when set
   pullPolicy: ""    # Overrides global.image.pullPolicy when set
 
 # Application configuration


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Image tags were set in chart specific variables, making them not overridable. This is now fixed. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
