### PR TITLE
fix(helm): respect mongodb.host, mongodb.replicas, mongodb.version values in MongoDBCommunity template

### DIFF
--- a/charts/mcp-gateway-registry-stack/templates/mongodb-cluster.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/mongodb-cluster.yaml
@@ -2,12 +2,12 @@
 apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity
 metadata:
-  name: {{ default .Values.mongodb.host "mcp-registry-mongodb" }}
+  name: {{ .Values.mongodb.host | default "mcp-registry-mongodb" }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
-  members: {{ default .Values.mongodb.replicas "3"}}
+  members: {{ .Values.mongodb.replicas | default 3 }}
   type: ReplicaSet
-  version: {{ default .Values.mongodb.version "8.0.16" | quote }}
+  version: {{ .Values.mongodb.version | default "8.0.16" | quote }}
   security:
     authentication:
       modes: ["SCRAM"]


### PR DESCRIPTION
## Summary

The `MongoDBCommunity` template in `charts/mcp-gateway-registry-stack/templates/mongodb-cluster.yaml` uses Helm's `default` function with the arguments inverted on three lines, so values supplied for `mongodb.host`, `mongodb.replicas`, and `mongodb.version` are silently ignored — the literal fallbacks always win.

`default A B` returns `B` if non-empty, else `A`. The chart writes `default .Values.mongodb.replicas "3"` which passes the values value as fallback A and the literal `"3"` as B; `"3"` is always truthy, so the result is always `"3"` regardless of overrides. Same for the other two.

## Approach

Flip to the canonical `.Values.X | default "Y"` pipeline form. Default values preserved exactly — `helm template` output is byte-for-byte identical when no overrides are set.

## Files changed (1)

| File | Change |
|------|--------|
| `charts/mcp-gateway-registry-stack/templates/mongodb-cluster.yaml` | Fix three inverted `default` calls (`mongodb.host`, `mongodb.replicas`, `mongodb.version`) |

## Backward compatibility — verified

```
$ helm template demo charts/mcp-gateway-registry-stack \
    | awk '/^kind: MongoDBCommunity$/,/^---$/' | head -7
kind: MongoDBCommunity
metadata:
  name: mcp-registry-mongodb
  namespace: "default"
spec:
  members: 3
  type: ReplicaSet
  version: "8.0.16"

$ helm template demo charts/mcp-gateway-registry-stack \
    --set mongodb.host=custom-mongo \
    --set mongodb.replicas=1 \
    --set mongodb.version=7.0.5 \
    | awk '/^kind: MongoDBCommunity$/,/^---$/' | head -7
kind: MongoDBCommunity
metadata:
  name: custom-mongo
  namespace: "default"
spec:
  members: 1
  type: ReplicaSet
  version: "7.0.5"
```

## How I noticed

Setting `mongodb.replicas: 1` in a PoC values file had no effect; the chart still rendered a 3-member replica set. Tracing it back to the template revealed the inverted `default` calls.
