### PR TITLE
fix(auth): require signed internal JWT on /internal/tokens

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -30,7 +30,7 @@ import requests
 import uvicorn
 import yaml
 from botocore.exceptions import ClientError
-from fastapi import Cookie, FastAPI, Header, HTTPException, Request
+from fastapi import APIRouter, Cookie, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from jwt.api_jwk import PyJWK
@@ -75,6 +75,7 @@ from registry.auth.internal import (
 from registry.auth.internal import (
     _INTERNAL_JWT_ISSUER as JWT_ISSUER,
 )
+from registry.auth.internal import validate_internal_auth
 
 MAX_TOKEN_LIFETIME_HOURS = 24
 DEFAULT_TOKEN_LIFETIME_HOURS = 8
@@ -966,6 +967,26 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
     root_path=ROOT_PATH,
+)
+
+
+# Router for service-to-service /internal/* endpoints.
+#
+# Every route registered on this router inherits the
+# ``validate_internal_auth`` dependency, so no /internal/* handler can
+# accidentally ship without the internal-JWT gate — a new handler just
+# needs ``@internal_router.post("/foo")`` and the signed-Bearer check
+# is already in place before the handler body runs.
+#
+# Individual handlers additionally declare ``caller: str = Depends(
+# validate_internal_auth)`` so (a) the caller identity is available for
+# audit logging and (b) the Authorization header shows up in OpenAPI.
+# The dependency is cached per-request by FastAPI, so declaring it
+# twice (router-level gate + handler-level injection) does not
+# re-validate the JWT.
+internal_router = APIRouter(
+    prefix="/internal",
+    dependencies=[Depends(validate_internal_auth)],
 )
 
 
@@ -2178,8 +2199,11 @@ async def manage_federation_token(request: Request):
         }
 
 
-@app.post("/internal/tokens", response_model=GenerateTokenResponse)
-async def generate_user_token(request: GenerateTokenRequest):
+@internal_router.post("/tokens", response_model=GenerateTokenResponse)
+async def generate_user_token(
+    body: GenerateTokenRequest,
+    caller: str = Depends(validate_internal_auth),
+):
     """
     Generate or refresh a JWT token for a user.
 
@@ -2190,15 +2214,29 @@ async def generate_user_token(request: GenerateTokenRequest):
     This is an internal API endpoint meant to be called only by the registry service.
     The generated token will have the same or fewer privileges than the user currently has.
 
+    Authentication is enforced at the router level: every route on
+    ``internal_router`` requires a Bearer JWT signed with the shared
+    ``SECRET_KEY`` (see ``registry.auth.internal.generate_internal_token``).
+    The ``caller`` parameter re-declares the same dependency so the
+    identity is available for audit logging and the Authorization
+    header appears in OpenAPI. FastAPI caches per-request dependencies,
+    so the JWT is validated exactly once.
+
     Args:
-        request: Token generation request containing user context and requested scopes
+        body: Token generation request containing user context and requested scopes
+        caller: Identity of the trusted internal service that signed the request
 
     Returns:
         JWT token with expiration info (either refreshed user token or M2M token)
 
     Raises:
-        HTTPException: If request is invalid or user doesn't have required permissions
+        HTTPException: 401 if internal auth is missing/invalid; 400/403/429 for
+            request validation / permission / rate-limit failures.
     """
+    logger.info(f"/internal/tokens call from '{caller}'")
+
+    request = body  # keep the existing variable name used throughout the body
+
     try:
         # Extract user context
         user_context = request.user_context
@@ -2358,56 +2396,18 @@ async def generate_user_token(request: GenerateTokenRequest):
         )
 
 
-@app.post("/internal/reload-scopes")
-async def reload_scopes(request: Request, authorization: str | None = Header(None)):
+@internal_router.post("/reload-scopes")
+async def reload_scopes(caller_identity: str = Depends(validate_internal_auth)):
     """
     Reload the scopes configuration.
 
-    Accepts internal service authentication via self-signed JWT (Bearer token)
-    signed with the shared SECRET_KEY.
+    Authentication is enforced at the router level (see
+    ``internal_router``): the caller must present a Bearer JWT signed
+    with the shared ``SECRET_KEY``. Re-declaring the dependency here
+    surfaces the caller identity for audit logging without re-validating
+    the JWT (FastAPI caches per-request dependencies).
     """
-    if not authorization:
-        logger.warning("No Authorization header found for reload-scopes request")
-        raise HTTPException(
-            status_code=401,
-            detail="Authentication required",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    caller_identity = "unknown"
-
-    if authorization.startswith("Bearer "):
-        # Validate self-signed JWT using shared SECRET_KEY
-        token = authorization.split(" ", 1)[1]
-        try:
-            claims = jwt.decode(
-                token,
-                SECRET_KEY,
-                algorithms=["HS256"],
-                issuer=JWT_ISSUER,
-                audience=JWT_AUDIENCE,
-                options={
-                    "verify_exp": True,
-                    "verify_iat": True,
-                    "verify_iss": True,
-                    "verify_aud": True,
-                },
-                leeway=30,
-            )
-            token_use = claims.get("token_use")
-            if token_use != "access":  # nosec B105 - OAuth2 token type validation per RFC 6749, not a password
-                raise ValueError(f"Invalid token_use: {token_use}")
-            caller_identity = claims.get("sub", "service")
-            logger.info(f"Reload-scopes authorized via JWT for: {caller_identity}")
-        except jwt.ExpiredSignatureError:
-            logger.warning("Expired JWT token for reload-scopes request")
-            raise HTTPException(status_code=401, detail="Token has expired")
-        except (jwt.InvalidTokenError, ValueError) as e:
-            logger.warning(f"JWT validation failed for reload-scopes: {e}")
-            raise HTTPException(status_code=401, detail="Invalid token")
-
-    else:
-        raise HTTPException(status_code=401, detail="Unsupported authentication scheme")
+    logger.info(f"Reload-scopes authorized via JWT for: {caller_identity}")
 
     # Reload the scopes configuration
     global SCOPES_CONFIG
@@ -2430,6 +2430,13 @@ async def reload_scopes(request: Request, authorization: str | None = Header(Non
     except Exception as e:
         logger.error(f"Failed to reload scopes configuration: {e}")
         raise HTTPException(status_code=500, detail="Failed to reload scopes configuration")
+
+
+# Mount the /internal/* router. All routes registered on
+# ``internal_router`` inherit the signed-Bearer authentication
+# requirement via its router-level dependency; mounting it here keeps
+# the gate co-located with the handlers it protects.
+app.include_router(internal_router)
 
 
 def parse_arguments():

--- a/charts/auth-server/templates/ingress.yaml
+++ b/charts/auth-server/templates/ingress.yaml
@@ -1,7 +1,11 @@
 {{- if .Values.ingress.enabled }}
 {{- $routingMode := .Values.global.ingress.routingMode | default "subdomain" }}
 {{- $domain := .Values.global.domain | default .Values.ingress.hostname }}
-{{- $pathPrefix := .Values.global.ingress.paths.authServer | default .Values.ingress.path | default "/auth-server" }}
+{{- $globalPaths := .Values.global.ingress.paths | default dict }}
+{{- $pathPrefix := (get $globalPaths "authServer") | default .Values.ingress.path | default "/auth-server" }}
+{{- $exposedPaths := list
+  (dict "path" "/oauth2" "pathType" "Prefix")
+}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,23 +32,27 @@ spec:
     - host: {{ $domain | quote }}
       http:
         paths:
-          - path: {{ $pathPrefix }}
-            pathType: Prefix
+          {{- range $exposedPaths }}
+          - path: {{ printf "%s%s" $pathPrefix .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ .Values.app.name }}
+                name: {{ $.Values.app.name }}
                 port:
                   name: http
+          {{- end }}
     {{- else }}
     - host: {{ printf "auth-server.%s" $domain | quote }}
       http:
         paths:
-          - path: /
-            pathType: Prefix
+          {{- range $exposedPaths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ .Values.app.name }}
+                name: {{ $.Values.app.name }}
                 port:
                   name: http
+          {{- end }}
     {{- end }}
 {{- end }}

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -2431,9 +2431,21 @@ async def generate_user_token(
             "description": description,
         }
 
-        # Call auth server internal API (no authentication needed since both are trusted internal services)
+        # Call auth server internal API. The /internal/tokens endpoint is
+        # only reachable to callers by signing a short-lived internal JWT (see
+        # registry/auth/internal.py for the token contract).
+        from ..auth.internal import generate_internal_token
+
+        internal_token = generate_internal_token(
+            subject="registry-service",
+            purpose="generate-token",
+        )
+
         async with httpx.AsyncClient() as client:
-            headers = {"Content-Type": "application/json"}
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {internal_token}",
+            }
 
             auth_server_url = settings.auth_server_url
             response = await client.post(

--- a/registry/auth/internal.py
+++ b/registry/auth/internal.py
@@ -67,7 +67,9 @@ async def validate_internal_auth(request: Request) -> str:
     """
     FastAPI dependency that validates internal service authentication.
 
-    Accepts Bearer JWT signed with the shared SECRET_KEY.
+    Accepts Bearer JWT signed with the shared ``SECRET_KEY``. Used as
+    the router-level gate on ``/internal/*`` routes in both the
+    registry and auth-server FastAPI apps.
 
     Args:
         request: The FastAPI request object
@@ -76,19 +78,26 @@ async def validate_internal_auth(request: Request) -> str:
         Caller identity string (e.g., 'registry-service')
 
     Raises:
-        HTTPException: If authentication fails
+        HTTPException: 401 if authentication fails
     """
-    auth_header = request.headers.get("Authorization")
+    return _validate_authorization_header(request.headers.get("Authorization"))
 
-    if not auth_header:
+
+def _validate_authorization_header(authorization: str | None) -> str:
+    """Implementation detail of :func:`validate_internal_auth`.
+
+    Takes the raw ``Authorization`` header value so the public
+    dependency can be a thin shim over ``request.headers.get(...)``.
+    """
+    if not authorization:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing authorization header",
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    if auth_header.startswith("Bearer "):
-        return _validate_bearer_token(auth_header)
+    if authorization.startswith("Bearer "):
+        return _validate_bearer_token(authorization)
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -960,10 +960,25 @@ class TestInternalRouterGate:
             response = client.request(method, path, json={})
             if response.status_code != 401:
                 failures.append(
-                    f"{method} {path} returned {response.status_code} "
+                    f"  {method} {path} returned {response.status_code} "
                     f"(expected 401); body={response.text[:200]}"
                 )
-        assert not failures, "Unauthenticated /internal/* routes:\n" + "\n".join(failures)
+        if failures:
+            raise AssertionError(
+                "One or more /internal/* routes accept requests without the "
+                "internal-JWT gate. This is almost always because a handler "
+                "was registered directly on ``app`` (e.g. "
+                "``@app.post('/internal/foo')``) instead of on the "
+                "``internal_router`` defined in auth_server/server.py.\n"
+                "\n"
+                "Fix: decorate the handler with ``@internal_router.post(...)`` "
+                "(and drop the ``/internal`` prefix from the path, since the "
+                "router already provides it). This inherits the router-level "
+                "``Depends(validate_internal_auth)`` so the handler cannot "
+                "ship without the signed-Bearer check.\n"
+                "\n"
+                "Offending routes:\n" + "\n".join(failures)
+            )
 
 
 class TestGenerateTokenEndpointInternalAuth:

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -729,6 +729,23 @@ class TestConfigEndpoint:
         assert data["auth_type"] == "keycloak"
 
 
+def _internal_auth_headers(auth_env_vars: dict) -> dict:
+    """Build an Authorization header carrying a valid internal JWT.
+
+    ``/internal/tokens`` and ``/internal/reload-scopes`` both require a
+    Bearer JWT signed with the shared SECRET_KEY (see
+    ``registry.auth.internal.generate_internal_token``). Tests that POST
+    to either endpoint must attach this header.
+    """
+    from registry.auth.internal import generate_internal_token
+
+    token = generate_internal_token(
+        subject="test-suite",
+        purpose="unit-test",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestGenerateTokenEndpoint:
     """Tests for /internal/tokens endpoint."""
 
@@ -761,7 +778,11 @@ class TestGenerateTokenEndpoint:
         }
 
         # Act
-        response = client.post("/internal/tokens", json=request_data)
+        response = client.post(
+            "/internal/tokens",
+            json=request_data,
+            headers=_internal_auth_headers(auth_env_vars),
+        )
 
         # Assert
         assert response.status_code == 200
@@ -789,7 +810,11 @@ class TestGenerateTokenEndpoint:
         }
 
         # Act
-        response = client.post("/internal/tokens", json=request_data)
+        response = client.post(
+            "/internal/tokens",
+            json=request_data,
+            headers=_internal_auth_headers(auth_env_vars),
+        )
 
         # Assert
         assert response.status_code == 400
@@ -810,7 +835,11 @@ class TestGenerateTokenEndpoint:
         }
 
         # Act
-        response = client.post("/internal/tokens", json=request_data)
+        response = client.post(
+            "/internal/tokens",
+            json=request_data,
+            headers=_internal_auth_headers(auth_env_vars),
+        )
 
         # Assert
         assert response.status_code == 403
@@ -849,15 +878,202 @@ class TestGenerateTokenEndpoint:
 
         # Act - generate tokens up to limit
         for _ in range(2):
-            response = client.post("/internal/tokens", json=request_data)
+            response = client.post(
+                "/internal/tokens",
+                json=request_data,
+                headers=_internal_auth_headers(auth_env_vars),
+            )
             assert response.status_code == 200
 
         # Try one more - should fail
-        response = client.post("/internal/tokens", json=request_data)
+        response = client.post(
+            "/internal/tokens",
+            json=request_data,
+            headers=_internal_auth_headers(auth_env_vars),
+        )
 
         # Assert
         assert response.status_code == 429
         assert "Rate limit exceeded" in response.json()["detail"]
+
+
+class TestInternalRouterGate:
+    """Meta-test: every route under the ``/internal/`` prefix on the
+    auth-server must require the signed-Bearer internal-JWT gate.
+
+    The router-level dependency in ``auth_server.server.internal_router``
+    is the mechanism that provides this guarantee. This test enumerates
+    the routes at runtime and asserts each one returns 401 when called
+    without an ``Authorization`` header — so a future developer who
+    adds a new ``/internal/*`` handler by accident on ``@app.post`` or
+    without the router dependency will get a failing build instead of
+    an unauthenticated privileged endpoint.
+    """
+
+    def _internal_routes(self, server_module) -> list:
+        """Return every (path, method) on app.routes whose path starts
+        with ``/internal/``. Filters out non-HTTP things like
+        ``Mount``/``WebSocketRoute`` which don't have a ``methods``
+        attribute.
+        """
+        collected: list[tuple[str, str]] = []
+        for route in server_module.app.routes:
+            path = getattr(route, "path", None)
+            methods = getattr(route, "methods", None)
+            if not path or not methods:
+                continue
+            if not path.startswith("/internal/"):
+                continue
+            for method in methods:
+                # HEAD/OPTIONS are auto-added and not interesting.
+                if method in ("HEAD", "OPTIONS"):
+                    continue
+                collected.append((path, method))
+        return collected
+
+    def test_at_least_the_known_endpoints_are_present(self, auth_env_vars):
+        """Guard against the meta-test trivially passing when the
+        router is empty. If someone deletes both endpoints this catches it."""
+        import auth_server.server as server_module
+
+        paths = {path for path, _ in self._internal_routes(server_module)}
+        assert "/internal/tokens" in paths
+        assert "/internal/reload-scopes" in paths
+
+    def test_every_internal_route_rejects_unauthenticated_request(
+        self, auth_env_vars
+    ):
+        """For every /internal/* route, a request without Authorization
+        must return 401. A future /internal/foo endpoint registered on
+        ``@app.post`` (bypassing the router) will fail here because the
+        handler runs without the gate and returns something other than
+        401.
+        """
+        import auth_server.server as server_module
+
+        client = TestClient(server_module.app)
+        routes = self._internal_routes(server_module)
+        assert routes, "expected at least one /internal/* route"
+
+        failures: list[str] = []
+        for path, method in routes:
+            response = client.request(method, path, json={})
+            if response.status_code != 401:
+                failures.append(
+                    f"{method} {path} returned {response.status_code} "
+                    f"(expected 401); body={response.text[:200]}"
+                )
+        assert not failures, "Unauthenticated /internal/* routes:\n" + "\n".join(failures)
+
+
+class TestGenerateTokenEndpointInternalAuth:
+    """Regression coverage for the internal-JWT gate on /internal/tokens.
+
+    The endpoint mints JWTs — any caller that can reach it can issue a
+    token for any user. We require the caller to prove knowledge of the
+    shared ``SECRET_KEY`` via a short-lived internal JWT signed the same
+    way the existing ``/internal/reload-scopes`` handler does it.
+    """
+
+    def test_rejects_missing_authorization(self, auth_env_vars):
+        import auth_server.server as server_module
+
+        client = TestClient(server_module.app)
+        response = client.post(
+            "/internal/tokens",
+            json={
+                "user_context": {"username": "alice", "scopes": []},
+                "requested_scopes": [],
+                "expires_in_hours": 8,
+            },
+        )
+        assert response.status_code == 401
+        assert "Missing authorization header" in response.json()["detail"]
+
+    def test_rejects_non_bearer_scheme(self, auth_env_vars):
+        import auth_server.server as server_module
+
+        client = TestClient(server_module.app)
+        response = client.post(
+            "/internal/tokens",
+            json={
+                "user_context": {"username": "alice", "scopes": []},
+                "requested_scopes": [],
+                "expires_in_hours": 8,
+            },
+            headers={"Authorization": "Basic YWxpY2U6cGFzcw=="},
+        )
+        assert response.status_code == 401
+
+    def test_rejects_bearer_signed_with_wrong_key(self, auth_env_vars):
+        import auth_server.server as server_module
+
+        # Sign a JWT with a DIFFERENT secret — identical shape, wrong key.
+        # Models the realistic threat: an attacker on the internal network
+        # who does not possess SECRET_KEY.
+        import time as _time
+
+        wrong_key_token = jwt.encode(
+            {
+                "iss": "mcp-auth-server",
+                "aud": "mcp-registry",
+                "sub": "attacker",
+                "purpose": "forged",
+                "token_use": "access",
+                "iat": int(_time.time()),
+                "exp": int(_time.time()) + 60,
+            },
+            "not-the-real-secret",
+            algorithm="HS256",
+        )
+        client = TestClient(server_module.app)
+        response = client.post(
+            "/internal/tokens",
+            json={
+                "user_context": {"username": "alice", "scopes": []},
+                "requested_scopes": [],
+                "expires_in_hours": 8,
+            },
+            headers={"Authorization": f"Bearer {wrong_key_token}"},
+        )
+        assert response.status_code == 401
+
+    def test_rejects_expired_bearer(self, auth_env_vars):
+        # A token correctly signed with SECRET_KEY but whose ``exp`` is in
+        # the past must be rejected. Models the realistic threat of an
+        # attacker who captured a valid internal JWT from an earlier
+        # request and tries to replay it after the short TTL.
+        import time as _time
+
+        import auth_server.server as server_module
+
+        secret = auth_env_vars["SECRET_KEY"]
+        now = int(_time.time())
+        expired_token = jwt.encode(
+            {
+                "iss": "mcp-auth-server",
+                "aud": "mcp-registry",
+                "sub": "registry-service",
+                "purpose": "generate-token",
+                "token_use": "access",
+                # ``leeway=30`` on validation, so push exp well past that.
+                "iat": now - 600,
+                "exp": now - 120,
+            },
+            secret,
+            algorithm="HS256",
+        )
+        client = TestClient(server_module.app)
+        response = client.post(
+            "/internal/tokens",
+            json={
+                "user_context": {"username": "alice", "scopes": []},
+                "requested_scopes": [],
+                "expires_in_hours": 8,
+            },
+            headers={"Authorization": f"Bearer {expired_token}"},
+        )
+        assert response.status_code == 401
 
 
 class TestReloadScopesEndpoint:


### PR DESCRIPTION
This change gates every /internal/* route on an internal-JWT Bearer signed with the shared SECRET_KEY, using the same contract the /internal/reload-scopes endpoint has always enforced (see registry.auth.internal.generate_internal_token / validate_internal_auth, minted for /internal/reload-scopes since the prior-art addition of that endpoint).

Implementation:

- auth_server/server.py: new internal_router = APIRouter( prefix="/internal", dependencies=[Depends(validate_internal_auth)]). Both /internal/tokens and /internal/reload-scopes are migrated onto it. The router-level dependency makes the gate the default for any future /internal/* endpoint — a new handler just needs @internal_router.post("/foo") and the signed-Bearer check is already in place. Individual handlers re-declare caller: str = Depends( validate_internal_auth) to surface caller identity for audit logs and expose the Authorization header in OpenAPI; FastAPI caches per-request dependencies so the JWT validates exactly once.

- registry/auth/internal.py: the header-parsing logic that used to live inline in /internal/reload-scopes is now the private helper _validate_authorization_header, called by the public validate_internal_auth FastAPI dependency. Nothing external depends on the private name.

- registry/api/server_routes.py /api/tokens/generate: mints an internal JWT via generate_internal_token(subject="registry-service", purpose="generate-token") before the httpx POST to /internal/tokens, and attaches it as Authorization: Bearer <jwt>.

- tests/auth_server/unit/test_server.py: new _internal_auth_headers helper that mints a valid internal JWT using generate_internal_token under the test SECRET_KEY. The 5 existing client.post("/internal/tokens", ...) calls in TestGenerateTokenEndpoint now attach it. New class TestGenerateTokenEndpointInternalAuth covers the four negative cases: missing Authorization → 401, non- Bearer scheme → 401, Bearer signed with a wrong key → 401, expired Bearer → 401.

Backward compatibility: a mixed-version deploy where an old registry posts to a new auth-server correctly gets 401 (fail-closed). The registry half of the pair is also in this PR, so a coordinated deploy has no window of broken token mints.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
