### PR TITLE
feat(helm): support extraEnv and extraEnvFrom in subcharts and stack

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,12 +26,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
-          version: '3.14.0'
+          version: '3.20.2'
 
       - name: Add Helm repositories
         run: |
@@ -69,12 +69,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
-          version: '3.14.0'
+          version: '3.20.2'
 
       - name: Template validation
         run: |
@@ -97,12 +97,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
-          version: '3.14.0'
+          version: '3.20.2'
 
       - name: Install kubeconform
         run: |
@@ -125,12 +125,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
-          version: '3.14.0'
+          version: '3.20.2'
 
       - name: Add Helm repositories
         run: |
@@ -144,11 +144,55 @@ jobs:
             helm dependency build charts/mcp-gateway-registry-stack || true
           fi
 
+  unittest:
+    name: "Helm Unit Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
+        with:
+          version: '3.20.2'
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami || true
+          helm repo update
+
+      - name: Build dependencies for umbrella chart
+        run: |
+          if [ -f "charts/mcp-gateway-registry-stack/Chart.yaml" ]; then
+            helm dependency build charts/mcp-gateway-registry-stack
+          fi
+
+      - name: Run helm unit tests
+        run: |
+          echo "## Helm Unit Test Results" >> $GITHUB_STEP_SUMMARY
+          failed=0
+          for chart in charts/*/; do
+            if [ -d "${chart}tests" ] && [ -n "$(ls -A ${chart}tests/*_test.yaml 2>/dev/null)" ]; then
+              echo "Running unit tests for ${chart}..."
+              if helm unittest "$chart"; then
+                echo "- ${chart}: PASSED" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "- ${chart}: FAILED" >> $GITHUB_STEP_SUMMARY
+                failed=1
+              fi
+            fi
+          done
+          exit $failed
+
   summary:
     name: "Helm Test Summary"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint, template, kubeconform, dependency-check]
+    needs: [lint, template, kubeconform, dependency-check, unittest]
     if: always()
 
     steps:
@@ -162,3 +206,4 @@ jobs:
           echo "| Template | ${{ needs.template.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Kubeconform | ${{ needs.kubeconform.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Dependencies | ${{ needs.dependency-check.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Unit Tests | ${{ needs.unittest.result }} |" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1527,6 +1527,40 @@ project_root/
 - [ ] Create utility methods
 ```
 
+## Helm Chart Development
+
+The Helm charts under `charts/` have `helm-unittest` suites in each chart's `tests/` directory. The plugin is installed locally (`helm plugin list` shows `unittest`).
+
+### Running the suites
+
+```bash
+# All four charts (subcharts + parent stack)
+helm unittest charts/mcpgw charts/auth-server charts/registry charts/mcp-gateway-registry-stack
+```
+
+For stack-level tests that render via subchart dependencies, run `helm dep update charts/mcp-gateway-registry-stack` after editing any subchart so the packaged `.tgz` files in `charts/mcp-gateway-registry-stack/charts/` pick up your changes.
+
+### Tests are part of the contract
+
+Any change to a Helm chart must keep the unittest suites passing, and new chart functionality must come with new unittest coverage. Things worth testing:
+- New values.yaml fields that affect rendered output (happy path + edge cases).
+- New `fail` guards or validation helpers (assert the failure mode with `failedTemplate: errorPattern: ...`).
+- Changes to `env:` / `envFrom:` ordering, resource refs, or conditional blocks.
+
+Prefer `equal:` over `contains:` when asserting something must appear in a specific position — `contains:` only checks membership and will not catch ordering regressions.
+
+### Keeping index-based and reserved-name assertions in sync
+
+Two places encode assumptions about the current set of chart-managed env vars, and both need updating whenever `env:` entries, `envFrom:` sources, or secret/configmap keys are added, removed, or reordered in a deployment template:
+
+1. **Reserved-name lists in `charts/<subchart>/templates/_helpers.tpl`** (`{{ define "<chart>.reservedEnvNames" }}`). These are the union of every name the chart's deployment can render into `env:` (across all conditional branches) plus every key consumed via `envFrom`. Over-rejection is preferred to under-rejection. If you add a new env var, a new secret key, or wire up a new configmap/secret via `envFrom`, extend the corresponding chart's reserved list. Each helper has a block comment listing the sources it's cross-referenced against — update that comment if the set of sources changes.
+
+2. **Index-based order assertions in the `tests/extra_env_test.yaml` suites** (e.g. `spec.template.spec.containers[0].env[6].name: KEYCLOAK_ADMIN_PASSWORD`). These hardcode the position where chart-managed entries end and user-supplied `extraEnv` entries begin. They come with `NOTE:` comments describing the conditional values they assume (e.g. `global.authProvider.type=keycloak`, `awsRegistry.federationEnabled=false`). If you insert a new conditional block before the `extraEnv` append, update the expected indices — and update the `NOTE:` comment to describe the new assumption.
+
+If you only update one of the two, the unittest suite catches it: a drifting reserved list lets a rejection test fail (the catastrophic key isn't rejected anymore), and drifting order assertions fail the positional tests. Both run in the `unittest` job of `.github/workflows/helm-test.yml` on any PR that touches `charts/**`.
+
+Note: only the unittest suite enforces these invariants — `helm lint`, `helm template`, and `kubeconform` do not. If you add a new env var to a deployment but forget to update the reserved list AND nobody writes an extraEnv test for that name, nothing will detect the gap. Treat the reserved list and the deployment template as a matched pair.
+
 ## Docker Build and Deployment
 
 When building and pushing Docker containers, create a shell script following this pattern:

--- a/charts/auth-server/templates/_helpers.tpl
+++ b/charts/auth-server/templates/_helpers.tpl
@@ -1,0 +1,120 @@
+{{/*
+Reserved env var names for the auth-server chart.
+
+Users must not supply these via .Values.extraEnv. The list is the union of:
+  - the superset of names the chart may render into `env:` (including
+    every conditional branch), and
+  - every key the chart sources via `envFrom` from stack-level or
+    per-chart secrets/configmaps.
+
+Sections (in order below):
+  1. env: block — IdP secrets via valueFrom (conditional)
+  2. auth-server-app-log-config configmap
+  3. auth-server per-chart secret
+  4. keycloak-client-secret (runtime-created by keycloak-configure Job)
+  5. mongo-credentials secret
+  6. shared-secret (stack-level)
+
+Over-rejection is preferred to under-rejection: a user attempting to
+inject one of these via extraEnv gets a clear template-render error.
+*/}}
+{{- define "auth-server.reservedEnvNames" -}}
+- ENTRA_CLIENT_SECRET
+- OKTA_CLIENT_SECRET
+- OKTA_M2M_CLIENT_SECRET
+- OKTA_API_TOKEN
+- AUTH0_CLIENT_SECRET
+- AUTH0_M2M_CLIENT_SECRET
+- AUTH0_MANAGEMENT_API_TOKEN
+- APP_LOG_BACKUP_COUNT
+- APP_LOG_CENTRALIZED_ENABLED
+- APP_LOG_CENTRALIZED_TTL_DAYS
+- APP_LOG_EXCLUDED_LOGGERS
+- APP_LOG_LEVEL
+- APP_LOG_MAX_BYTES
+- APP_LOG_MONGODB_BUFFER_SIZE
+- APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS
+- AUTH_PROVIDER
+- AUTH_SERVER_EXTERNAL_URL
+- AWS_REGION
+- COGNITO_CLIENT_ID
+- COGNITO_CLIENT_SECRET
+- COGNITO_DOMAIN
+- COGNITO_ENABLED
+- COGNITO_USER_POOL_ID
+- ENTRA_CLIENT_ID
+- ENTRA_ENABLED
+- ENTRA_LOGIN_BASE_URL
+- ENTRA_TENANT_ID
+- FEDERATION_ENCRYPTION_KEY
+- FEDERATION_STATIC_TOKEN
+- FEDERATION_STATIC_TOKEN_AUTH_ENABLED
+- JWT_AUDIENCE
+- JWT_ISSUER
+- KEYCLOAK_ENABLED
+- KEYCLOAK_EXTERNAL_URL
+- KEYCLOAK_REALM
+- KEYCLOAK_URL
+- MAX_TOKENS_PER_USER_PER_HOUR
+- OAUTH_STORE_TOKENS_IN_SESSION
+- OKTA_AUTH_SERVER_ID
+- OKTA_CLIENT_ID
+- OKTA_DOMAIN
+- OKTA_ENABLED
+- REGISTRY_API_TOKEN
+- REGISTRY_ID
+- REGISTRY_ROOT_PATH
+- REGISTRY_STATIC_TOKEN_AUTH_ENABLED
+- REGISTRY_URL
+- ROOT_PATH
+- SECRET_KEY
+- SESSION_COOKIE_DOMAIN
+- SESSION_COOKIE_SECURE
+- KEYCLOAK_CLIENT_ID
+- KEYCLOAK_CLIENT_SECRET
+- KEYCLOAK_M2M_CLIENT_ID
+- KEYCLOAK_M2M_CLIENT_SECRET
+- DOCUMENTDB_DATABASE
+- DOCUMENTDB_HOST
+- DOCUMENTDB_NAMESPACE
+- DOCUMENTDB_PASSWORD
+- DOCUMENTDB_PORT
+- DOCUMENTDB_REPLICA_SET
+- DOCUMENTDB_USERNAME
+- DOCUMENTDB_USE_TLS
+- MONGODB_CONNECTION_STRING
+- STORAGE_BACKEND
+- ASOR_ACCESS_TOKEN
+- FEDERATION_CLIENT_ID
+- FEDERATION_CLIENT_SECRET
+- FEDERATION_TOKEN_ENDPOINT
+- WORKDAY_TOKEN_URL
+{{- end -}}
+
+{{/*
+Validate .Values.extraEnv for the auth-server chart.
+
+Fails helm template render if any entry:
+  - is missing the required `name` field,
+  - shares a name with another entry in extraEnv (would silently shadow
+    under Kubernetes merge rules), or
+  - collides with a chart-reserved name.
+
+Call as: {{- include "auth-server.validateExtraEnv" . -}}
+*/}}
+{{- define "auth-server.validateExtraEnv" -}}
+{{- $reserved := fromYamlArray (include "auth-server.reservedEnvNames" .) -}}
+{{- $seen := dict -}}
+{{- range $i, $e := .Values.extraEnv -}}
+  {{- if not $e.name -}}
+    {{- fail (printf "auth-server.extraEnv[%d]: missing required 'name' field" $i) -}}
+  {{- end -}}
+  {{- if has $e.name $reserved -}}
+    {{- fail (printf "auth-server.extraEnv[%d]: %q is a reserved variable managed by the chart (via env: or envFrom from the chart's secrets/configmaps). Remove it from extraEnv. If a values.yaml field controls it (e.g. app.jwtIssuer for JWT_ISSUER), set that instead; otherwise the value is managed by the chart's internal secrets and must not be overridden via extraEnv." $i $e.name) -}}
+  {{- end -}}
+  {{- if hasKey $seen $e.name -}}
+    {{- fail (printf "auth-server.extraEnv[%d]: duplicate name %q (first seen at index %v)" $i $e.name (index $seen $e.name)) -}}
+  {{- end -}}
+  {{- $_ := set $seen $e.name $i -}}
+{{- end -}}
+{{- end -}}

--- a/charts/auth-server/templates/deployment.yaml
+++ b/charts/auth-server/templates/deployment.yaml
@@ -8,6 +8,8 @@
 {{- $imgRepository := required "image.repository must be set" .Values.image.repository }}
 {{- $imgTag := default .Values.global.image.tag .Values.image.tag }}
 {{- $imgPullPolicy := default .Values.global.image.pullPolicy .Values.image.pullPolicy }}
+{{- /* Fail-fast validation of user-supplied extraEnv */ -}}
+{{- include "auth-server.validateExtraEnv" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,6 +72,9 @@ spec:
             - secretRef:
                 name: {{ .Values.global.existingOauthProviderSecret | default .Values.global.oauthProviderSecretName }}
             {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             {{- if .Values.entra.clientSecretExistingSecret }}
             - name: ENTRA_CLIENT_SECRET
@@ -119,6 +124,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.auth0.managementApiTokenExistingSecret }}
                   key: {{ .Values.auth0.managementApiTokenExistingSecretKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/auth-server/tests/extra_env_test.yaml
+++ b/charts/auth-server/tests/extra_env_test.yaml
@@ -1,0 +1,133 @@
+suite: extraEnv and extraEnvFrom
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: renders without extraEnv by default
+    asserts:
+      - isKind:
+          of: Deployment
+
+  - it: appends extraEnv entries after chart-managed env vars
+    set:
+      entra:
+        clientSecretExistingSecret: my-entra
+        clientSecretExistingSecretKey: ENTRA_CLIENT_SECRET
+      extraEnv:
+        - name: MY_FLAG
+          value: "on"
+        - name: MY_SECRET_VAR
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: my-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_FLAG
+            value: "on"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: my-key
+      # Order: chart-managed ENTRA_CLIENT_SECRET comes first (conditional
+      # valueFrom block), then user extraEnv entries.
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: ENTRA_CLIENT_SECRET
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: MY_FLAG
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: MY_SECRET_VAR
+
+  - it: appends extraEnvFrom entries after chart-managed envFrom sources
+    set:
+      extraEnvFrom:
+        - secretRef:
+            name: my-external-secrets
+        - configMapRef:
+            name: my-external-config
+            optional: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-external-secrets
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-external-config
+              optional: true
+      # Order: chart-managed configmap/secrets come first; user entries last.
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: auth-server-app-log-config
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: auth-server-secret
+
+  - it: fails when extraEnv contains an env-block reserved name (ENTRA_CLIENT_SECRET)
+    set:
+      extraEnv:
+        - name: ENTRA_CLIENT_SECRET
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"ENTRA_CLIENT_SECRET\" is a reserved variable"
+
+  - it: fails when extraEnv contains a reserved envFrom-sourced name (SECRET_KEY)
+    set:
+      extraEnv:
+        - name: SECRET_KEY
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"SECRET_KEY\" is a reserved variable"
+
+  - it: fails when extraEnv contains a reserved envFrom-sourced name (AUTH_PROVIDER)
+    set:
+      extraEnv:
+        - name: AUTH_PROVIDER
+          value: "entra"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"AUTH_PROVIDER\" is a reserved variable"
+
+  - it: fails when extraEnv contains an envFrom-sourced name (DOCUMENTDB_PASSWORD)
+    set:
+      extraEnv:
+        - name: DOCUMENTDB_PASSWORD
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"DOCUMENTDB_PASSWORD\" is a reserved variable"
+
+  - it: fails on duplicate names within extraEnv
+    set:
+      extraEnv:
+        - name: MY_VAR
+          value: "a"
+        - name: MY_VAR
+          value: "b"
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicate name \"MY_VAR\""
+
+  - it: fails when an extraEnv entry is missing the name field
+    set:
+      extraEnv:
+        - value: "just-a-value"
+    asserts:
+      - failedTemplate:
+          errorPattern: "missing required 'name' field"

--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -153,4 +153,57 @@ ingress:
   # Path prefix when using path-based routing (default: /auth-server)
   path: /auth-server
 
+# Extra environment variables appended to the container's `env:` list.
+# Uses the native Kubernetes EnvVar schema, so `valueFrom` is supported.
+#
+# Validation (template render fails if violated):
+#   - Names must be unique within this list.
+#   - Names must not collide with chart-managed variables; use the
+#     corresponding values.yaml field instead (e.g. set app.jwtIssuer
+#     rather than JWT_ISSUER here). See the reserved list in
+#     templates/_helpers.tpl.
+#
+# User entries are appended last, so they win over chart `envFrom:`
+# sources on name collision — which is why the reserved list guards
+# catastrophic envFrom-sourced keys like SECRET_KEY, AUTH_PROVIDER,
+# and DOCUMENTDB_PASSWORD.
+#
+# Example:
+# extraEnv:
+#   - name: MY_FEATURE_FLAG
+#     value: "true"
+#   - name: MY_SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+extraEnv: []
+
+# Extra `envFrom:` sources appended to the container. Use this to inject
+# all keys from an external ConfigMap or Secret you manage (e.g. via
+# External Secrets Operator, SealedSecrets, or Vault CSI).
+#
+# NOT validated at template time — Helm cannot introspect external
+# ConfigMap/Secret contents. Consequences:
+#   - Keys in your source will SILENTLY OVERRIDE chart-managed envFrom
+#     entries (within envFrom, last source wins). Do NOT include keys
+#     like SECRET_KEY, AUTH_PROVIDER, DOCUMENTDB_PASSWORD,
+#     MONGODB_CONNECTION_STRING, KEYCLOAK_URL — shadowing these breaks
+#     cross-service auth or data access with no error.
+#   - Chart-managed `env:` entries (e.g. ENTRA_CLIENT_SECRET via
+#     valueFrom) always win over anything in extraEnvFrom — K8s rules:
+#     explicit env: beats envFrom regardless of order.
+#   - Referenced resources must exist when the pod starts (the default
+#     is optional: false). Set `optional: true` if the resource may be
+#     absent.
+#
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: my-external-secrets
+#   - configMapRef:
+#       name: my-external-config
+#       optional: true
+extraEnvFrom: []
+
 nodeSelector: {}

--- a/charts/mcp-gateway-registry-stack/tests/extra_env_forwarding_test.yaml
+++ b/charts/mcp-gateway-registry-stack/tests/extra_env_forwarding_test.yaml
@@ -1,0 +1,223 @@
+suite: stack forwards extraEnv and extraEnvFrom to each subchart
+release:
+  name: test
+  namespace: default
+tests:
+  # registry forwarding
+  - it: forwards registry.extraEnv to the registry deployment
+    templates:
+      - charts/registry/templates/deployment.yaml
+    set:
+      registry:
+        extraEnv:
+          - name: FROM_STACK_REGISTRY
+            value: "1"
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_STACK_REGISTRY
+            value: "1"
+
+  - it: forwards registry.extraEnvFrom to the registry deployment
+    templates:
+      - charts/registry/templates/deployment.yaml
+    set:
+      registry:
+        extraEnvFrom:
+          - secretRef:
+              name: stack-registry-externals
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: stack-registry-externals
+
+  - it: stack-forwarded registry.extraEnv with reserved name fails
+    templates:
+      - charts/registry/templates/deployment.yaml
+    set:
+      registry:
+        extraEnv:
+          - name: SECRET_KEY
+            value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"SECRET_KEY\" is a reserved variable"
+
+  # auth-server forwarding
+  - it: forwards auth-server.extraEnv to the auth-server deployment
+    templates:
+      - charts/auth-server/templates/deployment.yaml
+    set:
+      auth-server:
+        extraEnv:
+          - name: FROM_STACK_AUTH
+            value: "1"
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_STACK_AUTH
+            value: "1"
+
+  - it: forwards auth-server.extraEnvFrom to the auth-server deployment
+    templates:
+      - charts/auth-server/templates/deployment.yaml
+    set:
+      auth-server:
+        extraEnvFrom:
+          - configMapRef:
+              name: stack-auth-config
+              optional: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: stack-auth-config
+              optional: true
+
+  - it: stack-forwarded auth-server.extraEnv with reserved name fails
+    templates:
+      - charts/auth-server/templates/deployment.yaml
+    set:
+      auth-server:
+        extraEnv:
+          - name: AUTH_PROVIDER
+            value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"AUTH_PROVIDER\" is a reserved variable"
+
+  # mcpgw forwarding
+  - it: forwards mcpgw.extraEnv to the mcpgw deployment
+    templates:
+      - charts/mcpgw/templates/deployment.yaml
+    set:
+      mcpgw:
+        extraEnv:
+          - name: FROM_STACK_MCPGW
+            value: "1"
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FROM_STACK_MCPGW
+            value: "1"
+
+  - it: forwards mcpgw.extraEnvFrom to the mcpgw deployment
+    templates:
+      - charts/mcpgw/templates/deployment.yaml
+    set:
+      mcpgw:
+        extraEnvFrom:
+          - secretRef:
+              name: stack-mcpgw-externals
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: stack-mcpgw-externals
+
+  - it: stack-forwarded mcpgw.extraEnv with reserved name fails
+    templates:
+      - charts/mcpgw/templates/deployment.yaml
+    set:
+      mcpgw:
+        extraEnv:
+          - name: PORT
+            value: "9999"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"PORT\" is a reserved variable"
+
+  # extraEnv and extraEnvFrom for different services are independent.
+  # Setting registry.extraEnv must NOT leak into auth-server. We assert
+  # this by giving auth-server its own extraEnv (so env: is a non-empty
+  # array and the notContains check runs) and confirming the
+  # registry-scoped entry isn't present.
+  - it: registry extraEnv is not forwarded to auth-server
+    templates:
+      - charts/auth-server/templates/deployment.yaml
+    set:
+      registry:
+        extraEnv:
+          - name: ONLY_ON_REGISTRY
+            value: "1"
+      auth-server:
+        extraEnv:
+          - name: AUTH_ANCHOR
+            value: "1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AUTH_ANCHOR
+            value: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONLY_ON_REGISTRY
+            value: "1"
+
+  - it: mcpgw extraEnvFrom is not forwarded to registry
+    templates:
+      - charts/registry/templates/deployment.yaml
+    set:
+      mcpgw:
+        extraEnvFrom:
+          - secretRef:
+              name: mcpgw-only-source
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: mcpgw-only-source
+
+  - it: auth-server extraEnv is not forwarded to mcpgw
+    templates:
+      - charts/mcpgw/templates/deployment.yaml
+    set:
+      auth-server:
+        extraEnv:
+          - name: ONLY_ON_AUTH_SERVER
+            value: "1"
+      mcpgw:
+        extraEnv:
+          - name: MCPGW_ANCHOR
+            value: "1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCPGW_ANCHOR
+            value: "1"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ONLY_ON_AUTH_SERVER
+            value: "1"
+
+  - it: stack-forwarded extraEnv with duplicate names fails validation in the subchart
+    templates:
+      - charts/registry/templates/deployment.yaml
+    set:
+      registry:
+        extraEnv:
+          - name: MY_VAR
+            value: "a"
+          - name: MY_VAR
+            value: "b"
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicate name \"MY_VAR\""

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -123,6 +123,11 @@ keycloak:
   # IMPORTANT: This must have a trailing "/"
   httpRelativePath: /
 
+  # NOTE: Keycloak uses Bitnami's `extraEnvVars` convention. Our own
+  # subcharts (auth-server, registry, mcpgw) use `extraEnv` instead —
+  # see the `<subchart>.extraEnv` sections later in this file. Both
+  # accept the Kubernetes EnvVar schema (name + value/valueFrom); only
+  # the key name differs.
   extraEnvVars:
     - name: KC_PROXY
       value: edge
@@ -317,6 +322,13 @@ registry:
 
   nodeSelector: {}
 
+  # Extra env vars / envFrom sources appended to the registry container.
+  # See charts/registry/values.yaml for validation rules, reserved names,
+  # and footgun warnings. These values are forwarded to the registry
+  # subchart unchanged.
+  extraEnv: []
+  extraEnvFrom: []
+
 # MCPGW MCP server configuration
 mcpgw:
   enabled: true # Set to true to deploy the MCPGW MCP server
@@ -333,6 +345,13 @@ mcpgw:
     ingressClassName: alb
 
   nodeSelector: {}
+
+  # Extra env vars / envFrom sources appended to the mcpgw container.
+  # See charts/mcpgw/values.yaml for validation rules, reserved names,
+  # and footgun warnings. These values are forwarded to the mcpgw
+  # subchart unchanged.
+  extraEnv: []
+  extraEnvFrom: []
 
 # Auth server configuration
 auth-server:
@@ -399,3 +418,10 @@ auth-server:
     ingressClassName: alb
 
   nodeSelector: {}
+
+  # Extra env vars / envFrom sources appended to the auth-server container.
+  # See charts/auth-server/values.yaml for validation rules, reserved names,
+  # and footgun warnings. These values are forwarded to the auth-server
+  # subchart unchanged.
+  extraEnv: []
+  extraEnvFrom: []

--- a/charts/mcpgw/templates/_helpers.tpl
+++ b/charts/mcpgw/templates/_helpers.tpl
@@ -1,0 +1,72 @@
+{{/*
+Reserved env var names for the mcpgw chart.
+
+Users must not supply these via .Values.extraEnv. The list is the union of:
+  - the superset of names the chart may render into `env:` (including
+    every conditional branch), and
+  - every key the chart sources via `envFrom` from stack-level or
+    per-chart secrets/configmaps.
+
+Sections (in order below):
+  1. env: block (HOST, EMBEDDINGS_*, GITHUB_*)
+  2. mcpgw per-chart secret
+  3. shared-secret (stack-level)
+
+Over-rejection is preferred to under-rejection: a user attempting to
+inject one of these via extraEnv gets a clear template-render error.
+*/}}
+{{- define "mcpgw.reservedEnvNames" -}}
+- HOST
+- EMBEDDINGS_API_KEY
+- GITHUB_APP_ID
+- GITHUB_APP_INSTALLATION_ID
+- GITHUB_EXTRA_HOSTS
+- GITHUB_API_BASE_URL
+- GITHUB_PAT
+- GITHUB_APP_PRIVATE_KEY
+- EMBEDDINGS_API_BASE
+- EMBEDDINGS_AWS_REGION
+- EMBEDDINGS_MODEL_DIMENSIONS
+- EMBEDDINGS_MODEL_NAME
+- EMBEDDINGS_PROVIDER
+- PORT
+- REGISTRY_BASE_URL
+- SECRET_KEY
+- ASOR_ACCESS_TOKEN
+- FEDERATION_CLIENT_ID
+- FEDERATION_CLIENT_SECRET
+- FEDERATION_ENCRYPTION_KEY
+- FEDERATION_STATIC_TOKEN
+- FEDERATION_STATIC_TOKEN_AUTH_ENABLED
+- FEDERATION_TOKEN_ENDPOINT
+- REGISTRY_ID
+- WORKDAY_TOKEN_URL
+{{- end -}}
+
+{{/*
+Validate .Values.extraEnv for the mcpgw chart.
+
+Fails helm template render if any entry:
+  - is missing the required `name` field,
+  - shares a name with another entry in extraEnv (would silently shadow
+    under Kubernetes merge rules), or
+  - collides with a chart-reserved name.
+
+Call as: {{- include "mcpgw.validateExtraEnv" . -}}
+*/}}
+{{- define "mcpgw.validateExtraEnv" -}}
+{{- $reserved := fromYamlArray (include "mcpgw.reservedEnvNames" .) -}}
+{{- $seen := dict -}}
+{{- range $i, $e := .Values.extraEnv -}}
+  {{- if not $e.name -}}
+    {{- fail (printf "mcpgw.extraEnv[%d]: missing required 'name' field" $i) -}}
+  {{- end -}}
+  {{- if has $e.name $reserved -}}
+    {{- fail (printf "mcpgw.extraEnv[%d]: %q is a reserved variable managed by the chart (via env: or envFrom from the chart's secrets/configmaps). Remove it from extraEnv. If a values.yaml field controls it (e.g. app.githubAppId for GITHUB_APP_ID), set that instead; otherwise the value is managed by the chart's internal secrets and must not be overridden via extraEnv." $i $e.name) -}}
+  {{- end -}}
+  {{- if hasKey $seen $e.name -}}
+    {{- fail (printf "mcpgw.extraEnv[%d]: duplicate name %q (first seen at index %v)" $i $e.name (index $seen $e.name)) -}}
+  {{- end -}}
+  {{- $_ := set $seen $e.name $i -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mcpgw/templates/deployment.yaml
+++ b/charts/mcpgw/templates/deployment.yaml
@@ -3,6 +3,8 @@
 {{- $imgRepository := required "image.repository must be set" .Values.image.repository }}
 {{- $imgTag := default .Values.global.image.tag .Values.image.tag }}
 {{- $imgPullPolicy := default .Values.global.image.pullPolicy .Values.image.pullPolicy }}
+{{- /* Fail-fast validation of user-supplied extraEnv */ -}}
+{{- include "mcpgw.validateExtraEnv" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,6 +55,9 @@ spec:
             - secretRef:
                 name: {{ .Values.global.existingSharedSecret | default .Values.global.sharedSecretName }}
             {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: HOST
               value: 0.0.0.0
@@ -99,6 +104,9 @@ spec:
             {{- else if .Values.app.githubAppPrivateKey }}
             - name: GITHUB_APP_PRIVATE_KEY
               value: {{ .Values.app.githubAppPrivateKey | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:
             tcpSocket:

--- a/charts/mcpgw/tests/extra_env_test.yaml
+++ b/charts/mcpgw/tests/extra_env_test.yaml
@@ -1,0 +1,127 @@
+suite: extraEnv and extraEnvFrom
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  - it: renders without extraEnv by default
+    set:
+      app.secretKey: test-key
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HOST
+            value: 0.0.0.0
+
+  - it: appends extraEnv entries after chart-managed env vars
+    set:
+      app.secretKey: test-key
+      extraEnv:
+        - name: MY_FLAG
+          value: "on"
+        - name: MY_SECRET_VAR
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: my-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_FLAG
+            value: "on"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: my-key
+      # Order: chart-managed HOST comes first, user extraEnv entries last.
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: HOST
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: MY_FLAG
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: MY_SECRET_VAR
+
+  - it: appends extraEnvFrom entries after chart-managed envFrom sources
+    set:
+      app.secretKey: test-key
+      extraEnvFrom:
+        - secretRef:
+            name: my-external-secrets
+        - configMapRef:
+            name: my-external-config
+            optional: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-external-secrets
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-external-config
+              optional: true
+      # Order: chart-managed mcpgw-secret is envFrom[0]; user entries are last.
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: mcpgw-secret
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: my-external-secrets
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[2].configMapRef.name
+          value: my-external-config
+
+  - it: fails when extraEnv contains a reserved name (HOST)
+    set:
+      app.secretKey: test-key
+      extraEnv:
+        - name: HOST
+          value: "1.2.3.4"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"HOST\" is a reserved variable"
+
+  - it: fails when extraEnv contains a reserved envFrom-sourced name (SECRET_KEY)
+    set:
+      app.secretKey: test-key
+      extraEnv:
+        - name: SECRET_KEY
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"SECRET_KEY\" is a reserved variable"
+
+  - it: fails on duplicate names within extraEnv
+    set:
+      app.secretKey: test-key
+      extraEnv:
+        - name: MY_VAR
+          value: "a"
+        - name: MY_VAR
+          value: "b"
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicate name \"MY_VAR\""
+
+  - it: fails when an extraEnv entry is missing the name field
+    set:
+      app.secretKey: test-key
+      extraEnv:
+        - value: "just-a-value"
+    asserts:
+      - failedTemplate:
+          errorPattern: "missing required 'name' field"

--- a/charts/mcpgw/values.yaml
+++ b/charts/mcpgw/values.yaml
@@ -82,4 +82,56 @@ ingress:
   # Path prefix when using path-based routing (default: /mcpgw)
   path: /mcpgw
 
+# Extra environment variables appended to the container's `env:` list.
+# Uses the native Kubernetes EnvVar schema, so `valueFrom` is supported.
+#
+# Validation (template render fails if violated):
+#   - Names must be unique within this list.
+#   - Names must not collide with chart-managed variables; use the
+#     corresponding values.yaml field instead (e.g. set app.githubAppId
+#     rather than GITHUB_APP_ID here). See the reserved list in
+#     templates/_helpers.tpl.
+#
+# User entries are appended last, so they win over chart `envFrom:`
+# sources on name collision — which is why the reserved list guards
+# catastrophic envFrom-sourced keys like SECRET_KEY.
+#
+# Example:
+# extraEnv:
+#   - name: MY_FEATURE_FLAG
+#     value: "true"
+#   - name: MY_SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+extraEnv: []
+
+# Extra `envFrom:` sources appended to the container. Use this to inject
+# all keys from an external ConfigMap or Secret you manage (e.g. via
+# External Secrets Operator, SealedSecrets, or Vault CSI).
+#
+# NOT validated at template time — Helm cannot introspect external
+# ConfigMap/Secret contents. Consequences:
+#   - Keys in your source will SILENTLY OVERRIDE chart-managed envFrom
+#     entries (within envFrom, last source wins). Do NOT include keys
+#     like SECRET_KEY, PORT, REGISTRY_BASE_URL, EMBEDDINGS_API_KEY, or
+#     any EMBEDDINGS_* / FEDERATION_* key — shadowing them breaks
+#     service wiring with no error.
+#   - Chart-managed `env:` entries (e.g. HOST) always win over anything
+#     in extraEnvFrom — K8s rules: explicit env: beats envFrom regardless
+#     of order.
+#   - Referenced resources must exist when the pod starts (the default
+#     is optional: false). Set `optional: true` if the resource may be
+#     absent.
+#
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: my-external-secrets
+#   - configMapRef:
+#       name: my-external-config
+#       optional: true
+extraEnvFrom: []
+
 nodeSelector: {}

--- a/charts/registry/templates/_helpers.tpl
+++ b/charts/registry/templates/_helpers.tpl
@@ -1,0 +1,165 @@
+{{/*
+Reserved env var names for the registry chart.
+
+Users must not supply these via .Values.extraEnv. The list is the union of:
+  - the superset of names the chart may render into `env:` (including
+    every conditional branch), and
+  - every key the chart sources via `envFrom` from stack-level or
+    per-chart secrets/configmaps.
+
+Sections (in order below):
+  1. env: block — feature flags and IdP secrets via valueFrom
+  2. registry-app-log-config configmap
+  3. registry-otel-config configmap
+  4. registry per-chart secret
+  5. keycloak-client-secret (runtime-created by keycloak-configure Job)
+  6. mongo-credentials secret
+  7. shared-secret (stack-level)
+
+Over-rejection is preferred to under-rejection: a user attempting to
+inject one of these via extraEnv gets a clear template-render error.
+*/}}
+{{- define "registry.reservedEnvNames" -}}
+- DEPLOYMENT_MODE
+- REGISTRY_MODE
+- SHOW_SERVERS_TAB
+- SHOW_VIRTUAL_SERVERS_TAB
+- SHOW_SKILLS_TAB
+- SHOW_AGENTS_TAB
+- AWS_REGISTRY_FEDERATION_ENABLED
+- KEYCLOAK_ADMIN_PASSWORD
+- ENTRA_CLIENT_SECRET
+- OKTA_CLIENT_SECRET
+- OKTA_M2M_CLIENT_SECRET
+- OKTA_API_TOKEN
+- AUTH0_CLIENT_SECRET
+- AUTH0_M2M_CLIENT_SECRET
+- AUTH0_MANAGEMENT_API_TOKEN
+- REGISTRY_API_KEYS
+- ANS_API_KEY
+- ANS_API_SECRET
+- APP_LOG_BACKUP_COUNT
+- APP_LOG_CENTRALIZED_ENABLED
+- APP_LOG_CENTRALIZED_TTL_DAYS
+- APP_LOG_EXCLUDED_LOGGERS
+- APP_LOG_LEVEL
+- APP_LOG_MAX_BYTES
+- APP_LOG_MONGODB_BUFFER_SIZE
+- APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS
+- DISABLE_AI_REGISTRY_TOOLS_SERVER
+- MCP_TELEMETRY_DEBUG
+- MCP_TELEMETRY_DISABLED
+- MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES
+- MCP_TELEMETRY_OPT_OUT
+- OTEL_EXPORTER_OTLP_HEADERS
+- OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+- OTEL_OTLP_ENDPOINT
+- OTEL_OTLP_EXPORT_INTERVAL_MS
+- ANS_API_ENDPOINT
+- ANS_API_TIMEOUT_SECONDS
+- ANS_INTEGRATION_ENABLED
+- ANS_SYNC_INTERVAL_HOURS
+- ANS_VERIFICATION_CACHE_TTL_SECONDS
+- AUTH_PROVIDER
+- AUTH_SERVER_EXTERNAL_URL
+- AUTH_SERVER_URL
+- AWS_REGION
+- COGNITO_CLIENT_ID
+- COGNITO_CLIENT_SECRET
+- COGNITO_DOMAIN
+- COGNITO_ENABLED
+- COGNITO_USER_POOL_ID
+- ENTRA_CLIENT_ID
+- ENTRA_ENABLED
+- ENTRA_TENANT_ID
+- GATEWAY_ADDITIONAL_SERVER_NAMES
+- IDP_GROUP_FILTER_PREFIX
+- KEYCLOAK_ADMIN
+- KEYCLOAK_ENABLED
+- KEYCLOAK_REALM
+- KEYCLOAK_URL
+- OKTA_AUTH_SERVER_ID
+- OKTA_CLIENT_ID
+- OKTA_DOMAIN
+- OKTA_ENABLED
+- REGISTRATION_GATE_AUTH_CREDENTIAL
+- REGISTRATION_GATE_AUTH_HEADER_NAME
+- REGISTRATION_GATE_AUTH_TYPE
+- REGISTRATION_GATE_ENABLED
+- REGISTRATION_GATE_MAX_RETRIES
+- REGISTRATION_GATE_TIMEOUT_SECONDS
+- REGISTRATION_GATE_URL
+- REGISTRATION_GATE_OAUTH2_TOKEN_URL
+- REGISTRATION_GATE_OAUTH2_CLIENT_ID
+- REGISTRATION_GATE_OAUTH2_CLIENT_SECRET
+- REGISTRATION_GATE_OAUTH2_SCOPE
+- M2M_DIRECT_REGISTRATION_ENABLED
+- REGISTRATION_WEBHOOK_AUTH_HEADER
+- REGISTRATION_WEBHOOK_AUTH_TOKEN
+- REGISTRATION_WEBHOOK_TIMEOUT_SECONDS
+- REGISTRATION_WEBHOOK_URL
+- REGISTRY_API_TOKEN
+- REGISTRY_CONTACT_EMAIL
+- REGISTRY_CONTACT_URL
+- REGISTRY_DESCRIPTION
+- REGISTRY_ID
+- REGISTRY_NAME
+- REGISTRY_ORGANIZATION_NAME
+- REGISTRY_URL
+- ROOT_PATH
+- SECRET_KEY
+- SESSION_COOKIE_DOMAIN
+- SESSION_COOKIE_SECURE
+- SKILL_SECURITY_ANALYZERS
+- SKILL_SECURITY_SCAN_ENABLED
+- KEYCLOAK_CLIENT_ID
+- KEYCLOAK_CLIENT_SECRET
+- KEYCLOAK_M2M_CLIENT_ID
+- KEYCLOAK_M2M_CLIENT_SECRET
+- DOCUMENTDB_DATABASE
+- DOCUMENTDB_HOST
+- DOCUMENTDB_NAMESPACE
+- DOCUMENTDB_PASSWORD
+- DOCUMENTDB_PORT
+- DOCUMENTDB_REPLICA_SET
+- DOCUMENTDB_USERNAME
+- DOCUMENTDB_USE_TLS
+- MONGODB_CONNECTION_STRING
+- STORAGE_BACKEND
+- ASOR_ACCESS_TOKEN
+- FEDERATION_CLIENT_ID
+- FEDERATION_CLIENT_SECRET
+- FEDERATION_ENCRYPTION_KEY
+- FEDERATION_STATIC_TOKEN
+- FEDERATION_STATIC_TOKEN_AUTH_ENABLED
+- FEDERATION_TOKEN_ENDPOINT
+- WORKDAY_TOKEN_URL
+{{- end -}}
+
+{{/*
+Validate .Values.extraEnv for the registry chart.
+
+Fails helm template render if any entry:
+  - is missing the required `name` field,
+  - shares a name with another entry in extraEnv (would silently shadow
+    under Kubernetes merge rules), or
+  - collides with a chart-reserved name.
+
+Call as: {{- include "registry.validateExtraEnv" . -}}
+*/}}
+{{- define "registry.validateExtraEnv" -}}
+{{- $reserved := fromYamlArray (include "registry.reservedEnvNames" .) -}}
+{{- $seen := dict -}}
+{{- range $i, $e := .Values.extraEnv -}}
+  {{- if not $e.name -}}
+    {{- fail (printf "registry.extraEnv[%d]: missing required 'name' field" $i) -}}
+  {{- end -}}
+  {{- if has $e.name $reserved -}}
+    {{- fail (printf "registry.extraEnv[%d]: %q is a reserved variable managed by the chart (via env: or envFrom from the chart's secrets/configmaps). Remove it from extraEnv. If a values.yaml field controls it (e.g. app.showSkillsTab for SHOW_SKILLS_TAB), set that instead; otherwise the value is managed by the chart's internal secrets and must not be overridden via extraEnv." $i $e.name) -}}
+  {{- end -}}
+  {{- if hasKey $seen $e.name -}}
+    {{- fail (printf "registry.extraEnv[%d]: duplicate name %q (first seen at index %v)" $i $e.name (index $seen $e.name)) -}}
+  {{- end -}}
+  {{- $_ := set $seen $e.name $i -}}
+{{- end -}}
+{{- end -}}

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -3,6 +3,8 @@
 {{- $imgRepository := required "image.repository must be set" .Values.image.repository }}
 {{- $imgTag := default .Values.global.image.tag .Values.image.tag }}
 {{- $imgPullPolicy := default .Values.global.image.pullPolicy .Values.image.pullPolicy }}
+{{- /* Fail-fast validation of user-supplied extraEnv */ -}}
+{{- include "registry.validateExtraEnv" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,6 +72,9 @@ spec:
             {{- if .Values.global.oauthProviderSecretName }}
             - secretRef:
                 name: {{ .Values.global.existingOauthProviderSecret | default .Values.global.oauthProviderSecretName }}
+            {{- end }}
+            {{- with .Values.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
             - name: DEPLOYMENT_MODE
@@ -164,6 +169,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.ans.apiSecretExistingSecret }}
                   key: {{ .Values.ans.apiSecretExistingSecretKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/registry/tests/extra_env_test.yaml
+++ b/charts/registry/tests/extra_env_test.yaml
@@ -1,0 +1,187 @@
+suite: extraEnv and extraEnvFrom
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+set:
+  global:
+    authProvider:
+      type: keycloak
+tests:
+  - it: renders without extraEnv by default
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEPLOYMENT_MODE
+            value: "with-gateway"
+
+  - it: appends extraEnv entries after chart-managed env vars
+    set:
+      extraEnv:
+        - name: MY_FLAG
+          value: "on"
+        - name: MY_SECRET_VAR
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: my-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_FLAG
+            value: "on"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MY_SECRET_VAR
+            valueFrom:
+              secretKeyRef:
+                name: my-secret
+                key: my-key
+      # Order: chart-managed feature flags come first (DEPLOYMENT_MODE is
+      # env[0]); KEYCLOAK_ADMIN_PASSWORD (conditional on keycloak provider)
+      # is env[6]; user extraEnv entries are appended at the end.
+      #
+      # NOTE: The indices below assume global.authProvider.type=keycloak
+      # (set at the suite level) and awsRegistry.federationEnabled=false.
+      # Enabling federation or changing the auth provider shifts these
+      # indices. If you add a new conditional env block between the
+      # SHOW_*_TAB entries and KEYCLOAK_ADMIN_PASSWORD, update the
+      # expected index below.
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: DEPLOYMENT_MODE
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: REGISTRY_MODE
+      - equal:
+          path: spec.template.spec.containers[0].env[6].name
+          value: KEYCLOAK_ADMIN_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[7].name
+          value: MY_FLAG
+      - equal:
+          path: spec.template.spec.containers[0].env[8].name
+          value: MY_SECRET_VAR
+
+  - it: appends extraEnvFrom entries after chart-managed envFrom sources
+    set:
+      extraEnvFrom:
+        - secretRef:
+            name: my-external-secrets
+        - configMapRef:
+            name: my-external-config
+            optional: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-external-secrets
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-external-config
+              optional: true
+      # Order: chart-managed configmaps/secrets come first; user entries last.
+      # NOTE: These indices assume the stack-level secrets (shared-secret,
+      # oauth-provider-secret) are NOT set — those would append before the
+      # extraEnvFrom entries. When running standalone (no parent stack),
+      # envFrom[0..2] are otel-config, app-log-config, registry-secret.
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: registry-otel-config
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].configMapRef.name
+          value: registry-app-log-config
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[2].secretRef.name
+          value: registry-secret
+
+  - it: fails when extraEnv contains an env-block reserved name (DEPLOYMENT_MODE)
+    set:
+      extraEnv:
+        - name: DEPLOYMENT_MODE
+          value: "registry-only"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"DEPLOYMENT_MODE\" is a reserved variable"
+
+  - it: fails when extraEnv contains an env-block reserved name (SHOW_SKILLS_TAB)
+    set:
+      extraEnv:
+        - name: SHOW_SKILLS_TAB
+          value: "false"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"SHOW_SKILLS_TAB\" is a reserved variable"
+
+  - it: fails when extraEnv contains a reserved envFrom-sourced name (SECRET_KEY)
+    set:
+      extraEnv:
+        - name: SECRET_KEY
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"SECRET_KEY\" is a reserved variable"
+
+  - it: fails when extraEnv contains DOCUMENTDB_PASSWORD
+    set:
+      extraEnv:
+        - name: DOCUMENTDB_PASSWORD
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"DOCUMENTDB_PASSWORD\" is a reserved variable"
+
+  - it: fails when extraEnv contains REGISTRY_API_KEYS
+    set:
+      extraEnv:
+        - name: REGISTRY_API_KEYS
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"REGISTRY_API_KEYS\" is a reserved variable"
+
+  - it: fails when extraEnv contains M2M_DIRECT_REGISTRATION_ENABLED
+    set:
+      extraEnv:
+        - name: M2M_DIRECT_REGISTRATION_ENABLED
+          value: "false"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"M2M_DIRECT_REGISTRATION_ENABLED\" is a reserved variable"
+
+  - it: fails when extraEnv contains REGISTRATION_GATE_OAUTH2_CLIENT_SECRET
+    set:
+      extraEnv:
+        - name: REGISTRATION_GATE_OAUTH2_CLIENT_SECRET
+          value: "oops"
+    asserts:
+      - failedTemplate:
+          errorPattern: "\"REGISTRATION_GATE_OAUTH2_CLIENT_SECRET\" is a reserved variable"
+
+  - it: fails on duplicate names within extraEnv
+    set:
+      extraEnv:
+        - name: MY_VAR
+          value: "a"
+        - name: MY_VAR
+          value: "b"
+    asserts:
+      - failedTemplate:
+          errorPattern: "duplicate name \"MY_VAR\""
+
+  - it: fails when an extraEnv entry is missing the name field
+    set:
+      extraEnv:
+        - value: "just-a-value"
+    asserts:
+      - failedTemplate:
+          errorPattern: "missing required 'name' field"

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -229,4 +229,57 @@ ingress:
   # Path prefix when using path-based routing (default: /registry)
   path: /registry
 
+# Extra environment variables appended to the container's `env:` list.
+# Uses the native Kubernetes EnvVar schema, so `valueFrom` is supported.
+#
+# Validation (template render fails if violated):
+#   - Names must be unique within this list.
+#   - Names must not collide with chart-managed variables; use the
+#     corresponding values.yaml field instead (e.g. set app.showSkillsTab
+#     rather than SHOW_SKILLS_TAB here). See the reserved list in
+#     templates/_helpers.tpl.
+#
+# User entries are appended last, so they win over chart `envFrom:`
+# sources on name collision — which is why the reserved list guards
+# catastrophic envFrom-sourced keys like SECRET_KEY, AUTH_PROVIDER,
+# and DOCUMENTDB_PASSWORD.
+#
+# Example:
+# extraEnv:
+#   - name: MY_FEATURE_FLAG
+#     value: "true"
+#   - name: MY_SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+extraEnv: []
+
+# Extra `envFrom:` sources appended to the container. Use this to inject
+# all keys from an external ConfigMap or Secret you manage (e.g. via
+# External Secrets Operator, SealedSecrets, or Vault CSI).
+#
+# NOT validated at template time — Helm cannot introspect external
+# ConfigMap/Secret contents. Consequences:
+#   - Keys in your source will SILENTLY OVERRIDE chart-managed envFrom
+#     entries (within envFrom, last source wins). Do NOT include keys
+#     like SECRET_KEY, AUTH_PROVIDER, DOCUMENTDB_PASSWORD,
+#     MONGODB_CONNECTION_STRING, KEYCLOAK_URL — shadowing these breaks
+#     cross-service auth or data access with no error.
+#   - Chart-managed `env:` entries (e.g. DEPLOYMENT_MODE, SHOW_*_TAB)
+#     always win over anything in extraEnvFrom — K8s rules: explicit
+#     env: beats envFrom regardless of order.
+#   - Referenced resources must exist when the pod starts (the default
+#     is optional: false). Set `optional: true` if the resource may be
+#     absent.
+#
+# Example:
+# extraEnvFrom:
+#   - secretRef:
+#       name: my-external-secrets
+#   - configMapRef:
+#       name: my-external-config
+#       optional: true
+extraEnvFrom: []
+
 nodeSelector: {}


### PR DESCRIPTION
Add `extraEnv` and `extraEnvFrom` values to auth-server, registry, and mcpgw subcharts (and the parent stack), letting operators inject arbitrary env vars or envFrom sources into each service without forking the charts.

User entries are appended to the end of the container's `env:` and `envFrom:` lists, so they win over chart-managed envFrom sources on name collision. A template-render-time validator rejects `extraEnv` entries that are missing a `name`, duplicate another user entry, or collide with a chart-reserved name. Reserved names are the union of every env: name the chart may render and every key sourced via envFrom from stack-level and per-chart secrets/configmaps, giving over-rejection as the safe default.

`extraEnvFrom` is intentionally not validated (Helm cannot introspect external ConfigMap/Secret contents); the values.yaml documentation names the catastrophic keys to avoid.

Adds helm-unittest suites for each chart (41 tests total) covering baseline render, append ordering, reserved-name rejection, duplicate rejection, missing-name rejection, and cross-subchart isolation at the stack level. Wires `helm unittest` into the existing .github/workflows/helm-test.yml so these tests gate PRs.

Updates CLAUDE.md with a Helm Chart Development section explaining the unittest workflow and the invariant that the reserved-name list and deployment template must be kept in sync.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
