### PR TITLE
feat(logging): migrate container logs to /var/log/containers/ai-registry/ with JSONL format (#987)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1055,6 +1055,34 @@ APP_LOG_CENTRALIZED_ENABLED=true
 # Comma-separated logger names to exclude from MongoDB log writes (default: uvicorn.access,httpx,pymongo,motor)
 # APP_LOG_EXCLUDED_LOGGERS=uvicorn.access,httpx,pymongo,motor
 
+# -----------------------------------------------------------------------------
+# Application log file path and format (Issue #987)
+# -----------------------------------------------------------------------------
+# APP_LOG_DIR sets the directory where service .log files are written.
+# Default: /var/log/containers/ai-registry
+#
+# Each service writes {APP_LOG_DIR}/{service-name}.log:
+#   - /var/log/containers/ai-registry/registry.log
+#   - /var/log/containers/ai-registry/auth-server.log
+#   - /var/log/containers/ai-registry/ai-registry-tools.log
+# Nginx logs also land here: nginx-access.log, nginx-error.log
+#
+# The host directory must be created with uid 1000 ownership before starting
+# the containers. build_and_run.sh handles this automatically via
+# scripts/prepare-log-dirs.sh. To prepare manually:
+#   sudo mkdir -p /var/log/containers/ai-registry
+#   sudo chown -R 1000:1000 /var/log/containers/ai-registry
+#   sudo chmod 0750 /var/log/containers/ai-registry
+#
+# Must be an absolute path; relative paths and '..' segments are rejected.
+# APP_LOG_DIR=/var/log/containers/ai-registry
+
+# APP_LOG_FILE_FORMAT controls the on-disk format of service .log files:
+#   - json (default): JSON Lines per docs/logging-standard.md (Splunk-friendly)
+#   - text: legacy comma-separated format (same as console stdout)
+# Console/stdout format is always human-readable regardless of this setting.
+# APP_LOG_FILE_FORMAT=json
+
 # =============================================================================
 # FEDERATION PEER SYNC CONFIGURATION
 # =============================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,7 @@ NEXT-STEPS-TELEMETRY.md
 .env.telemetry-test
 registry_metrics.csv
 .claude/skills/usage-report/known-internal-instances.md
+
+# Stress test generated data and results (may move to a separate repo later)
+tests/stress/data/
+tests/stress/results/

--- a/README.md
+++ b/README.md
@@ -671,6 +671,8 @@ Transform how both autonomous AI agents and development teams access enterprise 
 
 Comprehensive real-time metrics and monitoring through Grafana dashboards with dual-path storage: SQLite for detailed historical analysis and OpenTelemetry (OTEL) export for integration with Prometheus, CloudWatch, Datadog, and other monitoring platforms. Track authentication events, tool executions, discovery queries, and system performance metrics. [Learn more](docs/OBSERVABILITY.md)
 
+**Log files**: registry, auth-server, and mcpgw write JSONL-formatted log files to `/var/log/containers/ai-registry/` on the Docker host, making them easy to ingest with Splunk Universal Forwarders or similar log shippers. See the [Logging Standard](docs/logging-standard.md) for the schema and Splunk props.conf recipe.
+
 <img src="docs/img/dashboard.png" alt="Grafana Metrics Dashboard" />
 <p><em>Real-time metrics and observability dashboard tracking server health, tool usage, and authentication events</em></p>
 </td>

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -48,8 +48,6 @@ from pydantic import (
 
 sys.path.insert(0, "/app")
 # Import MCP audit logging components
-from pathlib import Path as _LogPath
-
 from registry.audit.mcp_logger import MCPLogger
 from registry.audit.models import Identity, MCPServer
 from registry.audit.service import AuditLogger
@@ -61,10 +59,10 @@ from registry.repositories.factory import get_scope_repository
 from registry.utils.logging_setup import setup_logging as _setup_logging
 from registry.utils.request_utils import get_client_ip
 
-_auth_log_file = _setup_logging(
-    service_name="auth-server",
-    log_file=_LogPath("/app/logs/auth-server.log") if _LogPath("/app").exists() else None,
-)
+# Let setup_logging resolve the file path from settings.log_dir /
+# {service_name}.log. Honors APP_LOG_DIR overrides and the new
+# /var/log/containers/ai-registry default introduced by issue #987.
+_auth_log_file = _setup_logging(service_name="auth-server")
 logger = logging.getLogger(__name__)
 logger.info(f"Auth-server logging configured. Writing to file: {_auth_log_file}")
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -484,6 +484,16 @@ else
     log "Container images built successfully with optimization"
 fi
 
+# Prepare host log directory used by registry, auth-server, and mcpgw
+# containers. See scripts/prepare-log-dirs.sh for details (Issue #987).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -x "${SCRIPT_DIR}/scripts/prepare-log-dirs.sh" ]; then
+    log "Preparing host log directory (/var/log/containers/ai-registry)..."
+    "${SCRIPT_DIR}/scripts/prepare-log-dirs.sh" || handle_error "Failed to prepare host log directory"
+else
+    log "WARNING: scripts/prepare-log-dirs.sh not found or not executable; skipping log-directory prep"
+fi
+
 # Start metrics service first to generate API keys
 log "Starting metrics service first..."
 $COMPOSE_CMD $COMPOSE_FILES up -d metrics-service || handle_error "Failed to start metrics service"

--- a/charts/auth-server/templates/configmap-app-log.yaml
+++ b/charts/auth-server/templates/configmap-app-log.yaml
@@ -15,3 +15,6 @@ data:
   APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS: {{ .Values.app.appLogMongodbFlushIntervalSeconds | default "5.0" | quote }}
   APP_LOG_LEVEL: {{ .Values.app.appLogLevel | default "INFO" | quote }}
   APP_LOG_EXCLUDED_LOGGERS: {{ .Values.app.appLogExcludedLoggers | default "uvicorn.access,httpx,pymongo,motor" | quote }}
+  # Issue #987: log file path + format. Empty APP_LOG_DIR lets the backend use its default.
+  APP_LOG_DIR: {{ .Values.app.appLogDir | default "" | quote }}
+  APP_LOG_FILE_FORMAT: {{ .Values.app.appLogFileFormat | default "json" | quote }}

--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -59,6 +59,9 @@ app:
   appLogMongodbFlushIntervalSeconds: "5.0"  # Seconds between periodic flushes
   appLogLevel: "INFO"              # Application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   appLogExcludedLoggers: "uvicorn.access,httpx,pymongo,motor"  # Comma-separated logger names to exclude from MongoDB
+  # Log file path and format (issue #987).
+  appLogDir: ""                    # Empty uses backend default: /var/log/containers/ai-registry
+  appLogFileFormat: "json"         # "json" (default, Splunk-friendly) or "text" (legacy comma-separated)
 
 # Authentication Provider Configuration
 # Choose ONE provider: keycloak, entra, okta, auth0, or cognito

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -279,6 +279,9 @@ registry:
       appLogMongodbFlushIntervalSeconds: "5.0"  # Seconds between periodic flushes
       appLogLevel: "INFO"              # Application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
       appLogExcludedLoggers: "uvicorn.access,httpx,pymongo,motor"  # Comma-separated logger names to exclude from MongoDB
+      # Log file path and format (issue #987). Propagated to auth-server via YAML anchor.
+      appLogDir: ""                    # Empty uses backend default: /var/log/containers/ai-registry
+      appLogFileFormat: "json"         # "json" (default, Splunk-friendly) or "text" (legacy comma-separated)
 
     # Demo server configuration
     disableAiRegistryToolsServer: false  # Set to true to disable auto-registration of the built-in airegistry-tools server

--- a/charts/registry/templates/configmap-app-log.yaml
+++ b/charts/registry/templates/configmap-app-log.yaml
@@ -15,3 +15,6 @@ data:
   APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS: {{ .Values.app.appLogMongodbFlushIntervalSeconds | default "5.0" | quote }}
   APP_LOG_LEVEL: {{ .Values.app.appLogLevel | default "INFO" | quote }}
   APP_LOG_EXCLUDED_LOGGERS: {{ .Values.app.appLogExcludedLoggers | default "uvicorn.access,httpx,pymongo,motor" | quote }}
+  # Issue #987: log file path + format. Empty APP_LOG_DIR lets the backend use its default.
+  APP_LOG_DIR: {{ .Values.app.appLogDir | default "" | quote }}
+  APP_LOG_FILE_FORMAT: {{ .Values.app.appLogFileFormat | default "json" | quote }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -118,6 +118,11 @@ app:
   appLogMongodbFlushIntervalSeconds: "5.0"  # Seconds between periodic flushes
   appLogLevel: "INFO"              # Application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
   appLogExcludedLoggers: "uvicorn.access,httpx,pymongo,motor"  # Comma-separated logger names to exclude from MongoDB
+  # Log file path and format (issue #987). On EKS, pod stdout is scraped by
+  # Splunk Connect for Kubernetes - these settings control the in-container
+  # file path for code-path consistency with Docker Compose deployments.
+  appLogDir: ""                    # Empty uses backend default: /var/log/containers/ai-registry
+  appLogFileFormat: "json"         # "json" (default, Splunk-friendly) or "text" (legacy comma-separated)
 
 # AWS Agent Registry Federation
 awsRegistry:

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -165,6 +165,9 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)
       - "443:8443"  # Map host 443 to container 8443 (non-root nginx)
@@ -173,11 +176,14 @@ services:
       - ${HOME}/mcp-gateway/servers:/app/registry/servers
       - ${HOME}/mcp-gateway/agents:/app/registry/agents
       - ${HOME}/mcp-gateway/models:/app/registry/models
+      # Audit logs kept under ${HOME}/mcp-gateway/logs (legacy path)
       - ${HOME}/mcp-gateway/logs:/app/logs
       - ${HOME}/mcp-gateway/security_scans:/app/security_scans
       - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
       - ${HOME}/mcp-gateway/federation.json:/app/config/federation.json
       - ${HOME}/mcp-gateway/ssl:/etc/ssl:ro
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -312,10 +318,16 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "8888:8888"
     volumes:
+      # Audit logs kept under ${HOME}/mcp-gateway/logs (legacy path)
       - ${HOME}/mcp-gateway/logs:/app/logs
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
       # - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/scopes.yml
     depends_on:
       metrics-service:
@@ -366,10 +378,18 @@ services:
       - HOST=0.0.0.0
       - PORT=8003
       - REGISTRY_BASE_URL=http://registry:8080
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
+      - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
+      - APP_LOG_MAX_BYTES=${APP_LOG_MAX_BYTES:-52428800}
+      - APP_LOG_BACKUP_COUNT=${APP_LOG_BACKUP_COUNT:-5}
     volumes:
       - ${HOME}/mcp-gateway/servers:/app/registry/servers
       - ${HOME}/mcp-gateway/models:/app/registry/models
       - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
+      # Application log file (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
       - "8003:8003"
     depends_on:

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -172,6 +172,9 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)
       - "443:8443"  # Map host 443 to container 8443 (non-root nginx)
@@ -180,11 +183,14 @@ services:
       - ${HOME}/mcp-gateway/servers:/app/registry/servers
       - ${HOME}/mcp-gateway/agents:/app/registry/agents
       - ${HOME}/mcp-gateway/models:/app/registry/models
+      # Audit logs kept under ${HOME}/mcp-gateway/logs (legacy path)
       - ${HOME}/mcp-gateway/logs:/app/logs
       - ${HOME}/mcp-gateway/security_scans:/app/security_scans
       - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
       - ${HOME}/mcp-gateway/federation.json:/app/config/federation.json
       - ${HOME}/mcp-gateway/ssl:/etc/ssl:ro
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -313,10 +319,16 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "8888:8888"
     volumes:
+      # Audit logs kept under ${HOME}/mcp-gateway/logs (legacy path)
       - ${HOME}/mcp-gateway/logs:/app/logs
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
       # - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/scopes.yml
     security_opt:
       - no-new-privileges:true
@@ -366,10 +378,18 @@ services:
       - HOST=0.0.0.0
       - PORT=8003
       - REGISTRY_BASE_URL=http://registry:8080
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
+      - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
+      - APP_LOG_MAX_BYTES=${APP_LOG_MAX_BYTES:-52428800}
+      - APP_LOG_BACKUP_COUNT=${APP_LOG_BACKUP_COUNT:-5}
     volumes:
       - ${HOME}/mcp-gateway/servers:/app/registry/servers
       - ${HOME}/mcp-gateway/models:/app/registry/models
       - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
+      # Application log file (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
       - "8003:8003"
     security_opt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,6 +259,9 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "80:8080"   # Map host 80 to container 8080 (non-root nginx)
       - "443:8443"  # Map host 443 to container 8443 (non-root nginx)
@@ -276,7 +279,9 @@ services:
       - ${HOME}/mcp-gateway/federation.json:/app/config/federation.json
       - ${HOME}/mcp-gateway/ssl:/etc/ssl:ro
       - ${HOME}/.aws:/root/.aws:ro
-      # Application-managed (named volumes with proper permissions)
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
+      # Audit logs + security scans (named volumes, unchanged)
       - registry-logs:/app/logs
       - registry-scans:/app/security_scans
     depends_on:
@@ -430,6 +435,9 @@ services:
       - APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS=${APP_LOG_MONGODB_FLUSH_INTERVAL_SECONDS:-5.0}
       - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
       - APP_LOG_EXCLUDED_LOGGERS=${APP_LOG_EXCLUDED_LOGGERS:-uvicorn.access,httpx,pymongo,motor}
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
     ports:
       - "8888:8888"
     security_opt:
@@ -437,7 +445,9 @@ services:
     cap_drop:
       - ALL
     volumes:
-      # Application-managed (named volume with proper permissions)
+      # Application log files (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
+      # Audit logs (named volume, unchanged)
       - auth-logs:/app/logs
       # - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/scopes.yml
     depends_on:
@@ -492,10 +502,18 @@ services:
       - HOST=0.0.0.0
       - PORT=8003
       - REGISTRY_BASE_URL=http://registry:8080
+      # Application file-log location (Issue #987) + format (json|text)
+      - APP_LOG_DIR=${APP_LOG_DIR:-/var/log/containers/ai-registry}
+      - APP_LOG_FILE_FORMAT=${APP_LOG_FILE_FORMAT:-json}
+      - APP_LOG_LEVEL=${APP_LOG_LEVEL:-INFO}
+      - APP_LOG_MAX_BYTES=${APP_LOG_MAX_BYTES:-52428800}
+      - APP_LOG_BACKUP_COUNT=${APP_LOG_BACKUP_COUNT:-5}
     volumes:
       - ${HOME}/mcp-gateway/servers:/app/registry/servers
       - ${HOME}/mcp-gateway/models:/app/registry/models
       - ${HOME}/mcp-gateway/auth_server/scopes.yml:/app/auth_server/scopes.yml
+      # Application log file (bind mount to host for Splunk ingestion, Issue #987)
+      - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
       - "8003:8003"
     depends_on:

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -49,9 +49,12 @@ RUN chmod +x /app/auth-entrypoint.sh
 COPY auth_server/ /app/
 COPY registry/ /app/registry/
 
-# Create logs and certs directories
+# Create logs and certs directories.
+# /app/logs is kept for audit logs; application logs now go to
+# /var/log/containers/ai-registry per issue #987.
 RUN mkdir -p /app/logs && \
-    mkdir -p /app/certs
+    mkdir -p /app/certs && \
+    mkdir -p /var/log/containers/ai-registry
 
 # Expose port
 EXPOSE 8888
@@ -64,7 +67,7 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 
 # Set ownership of application files, venv, logs, certs, and entrypoint
-RUN chown -R appuser:appuser /app /app/.venv /app/logs /app/certs /app/auth-entrypoint.sh
+RUN chown -R appuser:appuser /app /app/.venv /app/logs /app/certs /var/log/containers/ai-registry /app/auth-entrypoint.sh
 
 # Bake the build version into the image so `docker inspect` and any future
 # version-reporting code path (issue #919) can read it. Requires

--- a/docker/Dockerfile.mcp-server
+++ b/docker/Dockerfile.mcp-server
@@ -82,6 +82,12 @@ HEALTHCHECK --interval=500s --timeout=10s --start-period=30s --retries=3 \
 # Switch to root to create entrypoint script
 USER root
 
+# Create /var/log/containers/ai-registry for file logging (issue #987).
+# Only mcpgw writes to this path; other MCP servers ignore it. Creating
+# the directory unconditionally keeps the image simple and costs nothing.
+RUN mkdir -p /var/log/containers/ai-registry && \
+    chown -R appuser:appuser /var/log/containers/ai-registry
+
 # Create entrypoint script that handles environment setup and runs server.py
 RUN echo '#!/bin/bash\n\
 set -e\n\

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -70,7 +70,9 @@ ENV PYTHONUNBUFFERED=1 \
 # Build argument for version
 ARG BUILD_VERSION="1.0.0"
 
-# Install runtime dependencies including nginx with lua module
+# Install runtime dependencies including nginx with lua module.
+# logrotate is used by the entrypoint's daily rotation loop for nginx logs
+# at /var/log/containers/ai-registry/nginx-*.log (issue #987).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
@@ -79,6 +81,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     procps \
     openssl \
     ca-certificates \
+    logrotate \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -100,6 +103,10 @@ COPY --chown=appuser:appuser docker/nginx_rev_proxy_http_only.conf /app/docker/n
 COPY --chown=appuser:appuser docker/nginx_rev_proxy_http_and_https.conf /app/docker/nginx_rev_proxy_http_and_https.conf
 COPY --chown=appuser:appuser docker/lua/ /app/docker/lua/
 
+# Logrotate config for nginx logs (issue #987).
+# Invoked daily by the registry entrypoint's background loop.
+COPY docker/logrotate-nginx.conf /etc/logrotate.d/nginx-mcp
+
 # Copy entrypoint early (rarely changes)
 COPY --chown=appuser:appuser docker/registry-entrypoint.sh /app/registry-entrypoint.sh
 RUN chmod +x /app/registry-entrypoint.sh
@@ -118,6 +125,8 @@ COPY --from=frontend-builder --chown=appuser:appuser /app/frontend/build /app/fr
 # Create directories and set ownership
 # Note: /app files already have correct ownership via --chown on COPY commands above.
 # Only chown directories that are created here (not covered by COPY --chown).
+# /app/logs is still created for audit logs (see settings.audit_log_path).
+# Application logs now go to /var/log/containers/ai-registry per issue #987.
 RUN mkdir -p /app/logs && \
     mkdir -p /app/certs && \
     mkdir -p /app/security_scans /app/skill_security_scans /app/agent_security_scans && \
@@ -125,8 +134,9 @@ RUN mkdir -p /app/logs && \
     rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-available/default && \
     mkdir -p /var/lib/nginx/body /var/lib/nginx/proxy /var/lib/nginx/fastcgi /var/lib/nginx/uwsgi /var/lib/nginx/scgi && \
     mkdir -p /var/log/nginx && \
+    mkdir -p /var/log/containers/ai-registry && \
     mkdir -p /run/nginx && \
-    chown -R appuser:appuser /app/logs /app/certs /app/security_scans /app/skill_security_scans /app/agent_security_scans /etc/nginx /var/log/nginx /var/lib/nginx /run/nginx
+    chown -R appuser:appuser /app/logs /app/certs /app/security_scans /app/skill_security_scans /app/agent_security_scans /etc/nginx /var/log/nginx /var/log/containers/ai-registry /var/lib/nginx /run/nginx
 
 # Expose ports for nginx (HTTP/HTTPS on high ports for non-root) and registry
 EXPOSE 8080 8443 7860

--- a/docker/Dockerfile.registry-cpu
+++ b/docker/Dockerfile.registry-cpu
@@ -6,7 +6,8 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies including nginx with lua module and Node.js
+# Install system dependencies including nginx with lua module and Node.js.
+# logrotate rotates /var/log/containers/ai-registry/nginx-*.log daily (issue #987).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
@@ -17,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
     ca-certificates \
+    logrotate \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && apt-get clean \
@@ -78,10 +80,13 @@ RUN mkdir -p /app/registry/models && \
     . .venv/bin/activate && \
     python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2').save('/app/registry/models/all-MiniLM-L6-v2')"
 
-# Create logs and certs directories
+# Create logs and certs directories.
+# /app/logs is kept for audit logs; application logs now go to
+# /var/log/containers/ai-registry per issue #987.
 RUN mkdir -p /app/logs && \
     mkdir -p /app/certs && \
-    mkdir -p /app/security_scans
+    mkdir -p /app/security_scans && \
+    mkdir -p /var/log/containers/ai-registry
 
 # Create nginx lua directories and remove default sites (needed by entrypoint script)
 RUN mkdir -p /etc/nginx/lua/virtual_mappings && \
@@ -101,13 +106,17 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 COPY docker/registry-entrypoint.sh /app/registry-entrypoint.sh
 RUN chmod +x /app/registry-entrypoint.sh
 
+# Logrotate config for nginx logs (issue #987).
+# Invoked daily by the registry entrypoint's background loop.
+COPY docker/logrotate-nginx.conf /etc/logrotate.d/nginx-mcp
+
 # Create non-root user for security (CIS Docker Benchmark 4.1)
 RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 
 # Set ownership for runtime-writable directories and entrypoint
 # Note: Use targeted chown instead of chown -R /app to avoid slow recursive
 # ownership change on .venv (thousands of files that don't need write access)
-RUN chown -R appuser:appuser /app/logs /app/certs /app/security_scans /app/registry /etc/nginx /var/log/nginx /var/lib/nginx /run/nginx && \
+RUN chown -R appuser:appuser /app/logs /app/certs /app/security_scans /app/registry /etc/nginx /var/log/nginx /var/log/containers/ai-registry /var/lib/nginx /run/nginx && \
     chown appuser:appuser /app /app/registry-entrypoint.sh
 
 # Switch to non-root user

--- a/docker/logrotate-nginx.conf
+++ b/docker/logrotate-nginx.conf
@@ -1,0 +1,13 @@
+/var/log/containers/ai-registry/nginx-*.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 appuser appuser
+    postrotate
+        # pid file path is set by registry-entrypoint.sh via sed on nginx.conf
+        [ ! -f /run/nginx/nginx.pid ] || kill -USR1 `cat /run/nginx/nginx.pid`
+    endscript
+}

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -600,7 +600,10 @@ server {
         add_header Connection close always;
     }
 
-    error_log /var/log/nginx/error.log debug;
+    # Issue #987: nginx logs moved to /var/log/containers/ai-registry so host-side
+    # Splunk forwarders can ingest them. Rotated by /etc/logrotate.d/nginx-mcp.
+    access_log /var/log/containers/ai-registry/nginx-access.log combined;
+    error_log  /var/log/containers/ai-registry/nginx-error.log warn;
 }
 
 # Keep the HTTPS server for clients that prefer it
@@ -1165,5 +1168,8 @@ server {
         add_header Connection close always;
     }
     
-    error_log /var/log/nginx/error.log debug;
+    # Issue #987: nginx logs moved to /var/log/containers/ai-registry so host-side
+    # Splunk forwarders can ingest them. Rotated by /etc/logrotate.d/nginx-mcp.
+    access_log /var/log/containers/ai-registry/nginx-access.log combined;
+    error_log  /var/log/containers/ai-registry/nginx-error.log warn;
 }

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -650,5 +650,8 @@ server {
         add_header Connection close always;
     }
 
-    error_log /var/log/nginx/error.log debug;
+    # Issue #987: nginx logs moved to /var/log/containers/ai-registry so host-side
+    # Splunk forwarders can ingest them. Rotated by /etc/logrotate.d/nginx-mcp.
+    access_log /var/log/containers/ai-registry/nginx-access.log combined;
+    error_log  /var/log/containers/ai-registry/nginx-error.log warn;
 }

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -355,5 +355,22 @@ sed -i 's|pid /run/nginx.pid;|pid /run/nginx/nginx.pid;|' /etc/nginx/nginx.conf
 nginx
 
 echo "Registry service fully started. Keeping container alive..."
+
+# --- Nginx log rotation loop (Issue #987) ---
+# Rotate /var/log/containers/ai-registry/nginx-*.log daily. logrotate is
+# invoked once per 24h in the background so we don't need cron.
+if [ -f /etc/logrotate.d/nginx-mcp ] && command -v logrotate > /dev/null 2>&1; then
+    (
+        while true; do
+            sleep 86400
+            logrotate /etc/logrotate.d/nginx-mcp || echo "WARN: logrotate run failed"
+        done
+    ) &
+    echo "Nginx log-rotation loop started (daily)."
+else
+    echo "WARN: /etc/logrotate.d/nginx-mcp missing or logrotate not installed; nginx logs will grow unbounded."
+fi
+
 # Keep the container running indefinitely
-tail -f /dev/null 
+tail -f /dev/null
+

--- a/docs/logging-standard.md
+++ b/docs/logging-standard.md
@@ -5,6 +5,11 @@ the AI Registry deployment. It is the reference document customers and their
 log-aggregation teams (Splunk, ELK, CloudWatch, etc.) can use to configure
 ingestion.
 
+> **Related:** For the Admin API / Log Viewer UI, MongoDB-based centralized log
+> retrieval across pods, and the full `APP_LOG_*` configuration table, see
+> [logging.md](logging.md). This document focuses specifically on the on-disk
+> file format and host paths consumed by external log shippers.
+
 Scope: Docker Compose deployments. Helm/EKS and Terraform/ECS deployments use
 their platform-native log collection (pod stdout via `/var/log/containers/` on
 the node for EKS; `awslogs` driver to CloudWatch for ECS) and are not affected

--- a/docs/logging-standard.md
+++ b/docs/logging-standard.md
@@ -1,0 +1,222 @@
+# Logging Standard
+
+This document describes the log file paths, format, and rotation behavior for
+the AI Registry deployment. It is the reference document customers and their
+log-aggregation teams (Splunk, ELK, CloudWatch, etc.) can use to configure
+ingestion.
+
+Scope: Docker Compose deployments. Helm/EKS and Terraform/ECS deployments use
+their platform-native log collection (pod stdout via `/var/log/containers/` on
+the node for EKS; `awslogs` driver to CloudWatch for ECS) and are not affected
+by the host filesystem paths documented here.
+
+## Log File Paths
+
+All service log files land on the Docker host under
+`/var/log/containers/ai-registry/`:
+
+| Service | Host file path |
+| --- | --- |
+| registry | `/var/log/containers/ai-registry/registry.log` |
+| auth-server | `/var/log/containers/ai-registry/auth-server.log` |
+| mcpgw (a.k.a. ai-registry-tools) | `/var/log/containers/ai-registry/ai-registry-tools.log` |
+| nginx access | `/var/log/containers/ai-registry/nginx-access.log` |
+| nginx error | `/var/log/containers/ai-registry/nginx-error.log` |
+
+Rotated files live alongside:
+`registry.log.1`, `registry.log.2.gz`, `nginx-access.log.1.gz`, etc.
+
+### Why the `ai-registry/` subdirectory
+
+Kubernetes kubelet writes pod logs flat under `/var/log/containers/`.
+Splunk Connect for Kubernetes (and most stock inputs.conf shipped with Splunk
+Universal Forwarder) watches `/var/log/containers/*.log` non-recursively and
+expects the kubelet filename pattern
+`<pod>_<namespace>_<container>-<hash>.log`.
+
+Placing our files one directory deeper means:
+
+1. On hosts running both Docker and Kubernetes, our files do not show up under
+   the stock K8s monitor stanza and therefore do not get misclassified.
+2. Customer Splunk config for AI Registry stays isolated in its own input
+   stanza, easy to enable/disable independently of K8s scraping.
+
+## Log Format Standard
+
+Python services (registry, auth-server, mcpgw) emit JSON Lines (JSONL) to
+their `.log` files by default. One JSON object per line, UTF-8 encoded,
+newline terminated.
+
+Console / stdout output remains the existing human-readable comma-separated
+format so `docker logs <container>` stays skimmable without a JSON parser.
+
+### Mandatory fields (every record)
+
+| Field | Type | Source | Example |
+| --- | --- | --- | --- |
+| `timestamp` | string (ISO 8601 UTC, microsecond precision, with offset) | Python `datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()` | `"2026-05-09T14:23:45.123456+00:00"` |
+| `service` | string | Fixed per container: `registry`, `auth-server`, `ai-registry-tools` | `"registry"` |
+| `level` | string | Python `record.levelname` | `"INFO"` |
+| `logger` | string | Python `record.name` | `"registry.core.config"` |
+| `filename` | string | Python `record.filename` | `"config.py"` |
+| `lineno` | integer | Python `record.lineno` | `42` |
+| `process_id` | integer | Python `record.process` | `12345` |
+| `message` | string | `record.getMessage()` (format args already applied) | `"Starting registry on port 8000"` |
+
+### Additional fields (exception records)
+
+| Field | Type | Source |
+| --- | --- | --- |
+| `exc_type` | string | `record.exc_info[0].__name__` |
+| `exc_message` | string | `str(record.exc_info[1])` |
+| `stack_trace` | string | `"".join(traceback.format_exception(*record.exc_info))` |
+
+### Example records
+
+Info record:
+
+```json
+{"timestamp":"2026-05-09T14:23:45.123456+00:00","service":"registry","level":"INFO","logger":"registry.core.config","filename":"config.py","lineno":42,"process_id":12345,"message":"Starting registry on port 8000"}
+```
+
+Exception record:
+
+```json
+{"timestamp":"2026-05-09T14:23:45.987654+00:00","service":"auth-server","level":"ERROR","logger":"auth_server.oauth","filename":"oauth.py","lineno":156,"process_id":67890,"message":"Token exchange failed","exc_type":"httpx.ConnectError","exc_message":"Cannot connect to keycloak:8080","stack_trace":"Traceback (most recent call last):\n  File \"/app/auth_server/oauth.py\", line 156, in exchange\n    ...\nhttpx.ConnectError: Cannot connect to keycloak:8080\n"}
+```
+
+### Nginx log formats
+
+Nginx logs use the standard well-known formats; no custom parsing required:
+
+- `nginx-access.log`: `combined` (Apache-style). Splunk sourcetype
+  `access_combined`.
+- `nginx-error.log`: nginx default (`YYYY/MM/DD HH:MM:SS [level] pid#tid:
+  message`). Splunk sourcetype `nginx:error`.
+
+## Rotation
+
+- Python service logs rotate via `RotatingFileHandler` at
+  `APP_LOG_MAX_BYTES` bytes (default 50 MB) with `APP_LOG_BACKUP_COUNT`
+  backups (default 5).
+- Nginx logs rotate daily via `/etc/logrotate.d/nginx-mcp` inside the registry
+  container, compressed with 14-day retention. A background loop in the
+  registry entrypoint invokes `logrotate` once every 24 hours.
+
+Expected total on-disk footprint per deployment is roughly 1 GB worst case.
+
+## Configuration Knobs
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `APP_LOG_DIR` | `/var/log/containers/ai-registry` | Directory where service `.log` files are written. Must be absolute; `..` segments are rejected. |
+| `APP_LOG_FILE_FORMAT` | `json` | `json` for JSONL (default) or `text` for the legacy comma-separated format. Console format is not affected. |
+| `APP_LOG_LEVEL` | `INFO` | Root log level. `DEBUG` / `INFO` / `WARNING` / `ERROR` / `CRITICAL`. |
+| `APP_LOG_MAX_BYTES` | `52428800` (50 MB) | Python file rotation size threshold. |
+| `APP_LOG_BACKUP_COUNT` | `5` | Number of rotated backups to keep. |
+| `APP_LOG_CENTRALIZED_ENABLED` | `true` | Also write log records to MongoDB collection `application_logs_<namespace>`. Unrelated to file logging; controlled independently. |
+
+## Splunk Ingestion Recipe
+
+The following stanzas assume a Splunk Universal Forwarder or Splunk Heavy
+Forwarder running on the Docker host. Index name and host assignment should
+match your conventions.
+
+### `inputs.conf`
+
+```ini
+[monitor:///var/log/containers/ai-registry/*.log]
+disabled = false
+index = ai_registry
+sourcetype = ai-registry:json
+
+[monitor:///var/log/containers/ai-registry/nginx-access.log]
+disabled = false
+index = ai_registry
+sourcetype = access_combined
+
+[monitor:///var/log/containers/ai-registry/nginx-error.log]
+disabled = false
+index = ai_registry
+sourcetype = nginx:error
+```
+
+### `props.conf`
+
+```ini
+[ai-registry:json]
+INDEXED_EXTRACTIONS = json
+KV_MODE = none
+TIMESTAMP_FIELDS = timestamp
+TIME_FORMAT = %Y-%m-%dT%H:%M:%S.%6N%:z
+TRUNCATE = 0
+SHOULD_LINEMERGE = false
+```
+
+With this configuration analysts can query structured fields directly:
+
+```
+index=ai_registry sourcetype=ai-registry:json service=registry level=ERROR
+```
+
+## Host Preparation
+
+Before starting containers, the host log directory must exist with
+`uid 1000` ownership so the non-root container user can write to it.
+`build_and_run.sh` does this automatically via
+`scripts/prepare-log-dirs.sh`. To prepare the directory manually:
+
+```bash
+sudo mkdir -p /var/log/containers/ai-registry
+sudo chown -R 1000:1000 /var/log/containers/ai-registry
+sudo chmod 0750 /var/log/containers/ai-registry
+```
+
+## Troubleshooting
+
+### Log files are missing on the host
+
+Check the container log:
+
+```bash
+docker logs registry 2>&1 | grep -i "cannot write\|log file"
+```
+
+An error like `Cannot write to log file /var/log/containers/ai-registry/
+registry.log` indicates the host directory is either missing or not owned
+by uid 1000. Run the host preparation commands above and restart the
+container.
+
+### I want the old /app/logs behavior back
+
+Set `APP_LOG_DIR=/app/logs` in your `.env` and ensure a matching volume
+mount is available (historical docker-compose.yml named volume
+`registry-logs` is still present for audit logs and can be reused).
+This keeps file logging in the container-local overlay filesystem as it
+was before v1.23.0.
+
+### I want the legacy plain-text format in my files
+
+Set `APP_LOG_FILE_FORMAT=text` to revert to the comma-separated format.
+Useful during a phased rollout when downstream parsers still expect the
+old format.
+
+## Scope Boundaries
+
+The paths and rotation mechanisms above apply to the Docker Compose
+deployment model. Other deployment modes are unaffected:
+
+- **Helm / EKS**: logs flow via pod stdout; Splunk Connect for
+  Kubernetes picks them up from node `/var/log/containers/<pod>_<ns>_
+  <container>-<hash>.log` automatically. No changes to Helm charts.
+- **Terraform / ECS**: logs flow via the `awslogs` log driver to
+  CloudWatch. The `APP_LOG_DIR` env var is set in the task definition
+  but does not influence log shipping (files land on task-local
+  ephemeral storage).
+
+## Related
+
+- Issue: https://github.com/agentic-community/mcp-gateway-registry/issues/987
+- Audit logs (separate subsystem): `docs/OBSERVABILITY.md`
+- MongoDB centralized logging (also a separate path):
+  `registry/utils/mongodb_log_handler.py`

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,6 +2,8 @@
 
 The MCP Gateway Registry provides centralized application log collection, storage, and retrieval across all service instances. Logs from both the `registry` and `auth-server` services are written to a shared MongoDB/DocumentDB collection, enabling cross-pod log queries through the admin API and the Settings UI.
 
+> **Related:** For the on-disk JSON Lines (JSONL) log file format, host log paths (`/var/log/containers/ai-registry/<service>.log`), and Splunk Universal Forwarder ingestion recipe, see [logging-standard.md](logging-standard.md).
+
 ## Architecture
 
 ```
@@ -37,6 +39,8 @@ All parameters use the `APP_LOG_` prefix. The centralized (MongoDB) storage para
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `APP_LOG_DIR` | Directory where service `.log` files are written. Must be an absolute path; `..` segments are rejected. Empty uses the per-environment default. See [logging-standard.md](logging-standard.md). | `""` (resolves to `/var/log/containers/ai-registry` in containers, `./logs` in local dev) |
+| `APP_LOG_FILE_FORMAT` | On-disk format for service log files: `json` (JSON Lines, Splunk-friendly, see [logging-standard.md](logging-standard.md)) or `text` (legacy comma-separated). Console/stdout format is not affected. | `json` |
 | `APP_LOG_CENTRALIZED_ENABLED` | Write application logs to MongoDB/DocumentDB for centralized retrieval | `true` |
 | `APP_LOG_CENTRALIZED_TTL_DAYS` | Days to retain log entries before automatic deletion | `1` |
 | `APP_LOG_MAX_BYTES` | Maximum size per log file in bytes before rotation | `52428800` (50 MB) |
@@ -58,6 +62,10 @@ APP_LOG_CENTRALIZED_ENABLED=true
 
 # Retain logs for 1 day (default: 1)
 APP_LOG_CENTRALIZED_TTL_DAYS=1
+
+# On-disk log file path and format (see docs/logging-standard.md)
+APP_LOG_DIR=/var/log/containers/ai-registry
+APP_LOG_FILE_FORMAT=json
 
 # Optional overrides
 APP_LOG_MAX_BYTES=52428800
@@ -81,6 +89,10 @@ app_log_centralized_enabled = true
 # Retain logs for 1 day (default: 1)
 app_log_centralized_ttl_days = 1
 
+# On-disk log file path and format (see docs/logging-standard.md)
+app_log_dir          = ""        # empty = /var/log/containers/ai-registry
+app_log_file_format  = "json"    # "json" (default) or "text" (legacy)
+
 # Optional overrides
 app_log_max_bytes         = 52428800
 app_log_backup_count      = 5
@@ -101,6 +113,9 @@ registry:
   app:
     appLogCentralizedEnabled: "true"
     appLogCentralizedTtlDays: "1"
+    # On-disk log file path and format (see docs/logging-standard.md)
+    appLogDir: ""           # empty = /var/log/containers/ai-registry
+    appLogFileFormat: "json" # "json" (default) or "text" (legacy)
     appLogMaxBytes: "52428800"
     appLogBackupCount: "5"
     appLogMongodbBufferSize: "50"

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -291,9 +291,13 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
         "title": "Application Logging",
         "order": 19,
         "fields": [
+            ("app_log_dir", "Log File Directory", False),
+            ("app_log_file_format", "Log File Format (json|text)", False),
             ("app_log_centralized_enabled", "Centralized Enabled", False),
             ("app_log_centralized_ttl_days", "Centralized TTL Days", False),
             ("app_log_level", "Log Level", False),
+            ("app_log_max_bytes", "Max Log File Size (bytes)", False),
+            ("app_log_backup_count", "Rotated Backup Count", False),
             ("app_log_excluded_loggers", "Excluded Loggers", False),
         ],
     },

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -452,6 +452,24 @@ class Settings(BaseSettings):
         default="uvicorn.access,httpx,pymongo,motor",
         description="Comma-separated logger names to exclude from MongoDB log writes",
     )
+    app_log_dir: str | None = Field(
+        default=None,
+        description=(
+            "Directory where service log files are written. "
+            "When unset, defaults to /var/log/containers/ai-registry in "
+            "containers and ./logs in local dev mode. "
+            "Each service writes {app_log_dir}/{service_name}.log."
+        ),
+    )
+    app_log_file_format: str = Field(
+        default="json",
+        description=(
+            "Format for service log files. 'json' emits JSON Lines per "
+            "docs/logging-standard.md (Splunk-friendly). 'text' emits the "
+            "legacy comma-separated format. Console/stdout format is not "
+            "affected by this setting."
+        ),
+    )
 
     # Audit Logging Configuration
     audit_log_enabled: bool = True  # Enable/disable audit logging globally
@@ -530,6 +548,48 @@ class Settings(BaseSettings):
             "fail startup with a clear error listing accepted values."
         ),
     )
+
+    @field_validator("app_log_dir", mode="before")
+    @classmethod
+    def _validate_app_log_dir(
+        cls,
+        v: str | None,
+    ) -> str | None:
+        """Reject non-absolute APP_LOG_DIR and paths containing '..'.
+
+        Operator-supplied config; we validate at startup to fail fast with a
+        clear message instead of letting the container silently fall back to
+        console-only logging after a mkdir error.
+        """
+        if v is None or v == "":
+            return None
+        if not isinstance(v, str):
+            raise ValueError(f"APP_LOG_DIR must be a string, got {type(v).__name__}")
+        if not v.startswith("/"):
+            raise ValueError(f"APP_LOG_DIR must be an absolute path, got {v!r}")
+        if ".." in Path(v).parts:
+            raise ValueError(f"APP_LOG_DIR must not contain '..' segments, got {v!r}")
+        return v
+
+    @field_validator("app_log_file_format", mode="before")
+    @classmethod
+    def _validate_app_log_file_format(
+        cls,
+        v: str,
+    ) -> str:
+        """Accept only 'json' (new default) or 'text' (legacy back-compat)."""
+        if v is None:
+            return "json"
+        if not isinstance(v, str):
+            raise ValueError(
+                f"APP_LOG_FILE_FORMAT must be a string, got {type(v).__name__}"
+            )
+        normalized = v.strip().lower()
+        if normalized not in ("json", "text"):
+            raise ValueError(
+                f"APP_LOG_FILE_FORMAT must be 'json' or 'text', got {v!r}"
+            )
+        return normalized
 
     @field_validator("storage_backend", mode="before")
     @classmethod
@@ -631,16 +691,33 @@ class Settings(BaseSettings):
 
     @property
     def log_dir(self) -> Path:
-        """Get log directory based on environment."""
+        """Resolve the directory where application .log files are written.
+
+        Resolution order:
+        1. APP_LOG_DIR override (if set) - used verbatim.
+        2. ./logs in local dev (when /app does not exist).
+        3. /var/log/containers/ai-registry in containers (issue #987).
+
+        Note: this is for the Python application logs (registry.log,
+        auth-server.log, ai-registry-tools.log). Audit logs still use
+        container_log_dir via the audit_log_path property and are not
+        affected by this setting.
+        """
+        if self.app_log_dir:
+            return Path(self.app_log_dir)
         if self.is_local_dev:
             return Path.cwd() / "logs"
-        return self.container_log_dir
+        return Path("/var/log/containers/ai-registry")
 
     @property
     def log_file_path(self) -> Path:
-        if self.is_local_dev:
-            return Path.cwd() / "logs" / "registry.log"
-        return self.container_log_dir / "registry.log"
+        """Resolve the full path to this service's .log file.
+
+        Kept for backwards compatibility with callers that import log_file_path
+        directly; most code should call setup_logging(service_name=...) instead,
+        which computes the same path via log_dir.
+        """
+        return self.log_dir / "registry.log"
 
     @property
     def faiss_index_path(self) -> Path:

--- a/registry/utils/logging_setup.py
+++ b/registry/utils/logging_setup.py
@@ -1,16 +1,69 @@
 """Shared logging configuration for registry and auth-server.
 
 Configures three output destinations:
-1. Console (stdout/stderr) - always enabled
-2. RotatingFileHandler - rotated log file
+1. Console (stdout/stderr) - always enabled, human-readable format
+2. RotatingFileHandler - rotated log file (JSONL by default, text if configured)
 3. MongoDBLogHandler - optional, writes to MongoDB application_logs collection
+
+The file format is controlled by settings.app_log_file_format:
+- "json" (default): JSON Lines per docs/logging-standard.md
+- "text": legacy comma-separated format (same as console)
+
+Console format always stays human-readable so `docker logs <container>` is
+skimmable without a JSON parser.
 """
 
+import json
 import logging
+import traceback
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 LOG_FORMAT = "%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+
+
+class JsonlFormatter(logging.Formatter):
+    """Formats log records as JSON Lines (one JSON object per line).
+
+    Schema is documented in docs/logging-standard.md. Every record carries
+    eight mandatory fields; exception records add three more. Output is a
+    single line (newlines inside message text are JSON-escaped).
+    """
+
+    def __init__(
+        self,
+        service_name: str,
+    ) -> None:
+        super().__init__()
+        self._service_name = service_name
+
+    def format(
+        self,
+        record: logging.LogRecord,
+    ) -> str:
+        payload: dict = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "service": self._service_name,
+            "level": record.levelname,
+            "logger": record.name,
+            "filename": record.filename,
+            "lineno": record.lineno,
+            "process_id": record.process,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            exc_type, exc_value, _ = record.exc_info
+            payload["exc_type"] = exc_type.__name__ if exc_type else "Unknown"
+            payload["exc_message"] = str(exc_value) if exc_value else ""
+            payload["stack_trace"] = "".join(
+                traceback.format_exception(*record.exc_info)
+            )
+
+        return json.dumps(payload, default=str, ensure_ascii=False)
 
 
 def setup_logging(
@@ -20,13 +73,14 @@ def setup_logging(
     """Configure root logger with console, file, and optional MongoDB handlers.
 
     Args:
-        service_name: Identifies this process in MongoDB log documents
-            (e.g. "registry", "auth-server").
+        service_name: Identifies this process in log records and in the
+            MongoDB application_logs collection (e.g. "registry", "auth-server").
         log_file: Explicit log file path. When ``None`` the path is derived
             from settings (``settings.log_dir / f"{service_name}.log"``).
 
     Returns:
-        The resolved log file path, or None if file logging was skipped.
+        The resolved log file path, or None if file logging was skipped
+        (typically due to a PermissionError on the target directory).
     """
     from ..core.config import MONGODB_BACKENDS, settings
 
@@ -38,12 +92,21 @@ def setup_logging(
     for handler in root.handlers[:]:
         root.removeHandler(handler)
 
-    formatter = logging.Formatter(LOG_FORMAT)
+    # Console always uses the human-readable text format so `docker logs`
+    # stays skimmable without a JSON parser.
+    console_formatter = logging.Formatter(LOG_FORMAT)
+
+    # File format is selected by settings (default JSONL, per issue #987).
+    file_formatter: logging.Formatter
+    if settings.app_log_file_format == "json":
+        file_formatter = JsonlFormatter(service_name=service_name)
+    else:
+        file_formatter = console_formatter
 
     # 1. Console handler
     console = logging.StreamHandler()
     console.setLevel(level)
-    console.setFormatter(formatter)
+    console.setFormatter(console_formatter)
     root.addHandler(console)
 
     # 2. RotatingFileHandler
@@ -63,12 +126,17 @@ def setup_logging(
                 encoding="utf-8",
             )
             file_handler.setLevel(level)
-            file_handler.setFormatter(formatter)
+            file_handler.setFormatter(file_formatter)
             root.addHandler(file_handler)
-        except PermissionError:
-            root.warning(
-                f"Cannot write to log file {resolved_log_file}, "
-                "continuing with console logging only"
+        except (PermissionError, OSError) as exc:
+            root.error(
+                "Cannot write to log file %s: %s. "
+                "Fix on host: sudo mkdir -p %s && sudo chown -R 1000:1000 %s. "
+                "Continuing with console-only logging.",
+                resolved_log_file,
+                exc,
+                resolved_log_file.parent,
+                resolved_log_file.parent,
             )
             resolved_log_file = None
 
@@ -90,7 +158,10 @@ def setup_logging(
                 excluded_loggers=excluded,
             )
             mongo_handler.setLevel(level)
-            mongo_handler.setFormatter(formatter)
+            # MongoDB handler writes structured documents via its own emit();
+            # the formatter set here is only used if emit() fails and falls
+            # back to default formatting. Plain text is fine for that case.
+            mongo_handler.setFormatter(console_formatter)
             root.addHandler(mongo_handler)
         except Exception as exc:
             root.warning(f"Failed to initialize MongoDB log handler: {exc}")

--- a/scripts/prepare-log-dirs.sh
+++ b/scripts/prepare-log-dirs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# prepare-log-dirs.sh (Issue #987)
+#
+# Creates and chowns the host log directory used by AI Registry containers.
+# The registry, auth-server, and mcpgw containers bind-mount
+# /var/log/containers/ai-registry/ from the host so customer Splunk
+# forwarders can ingest the .log files directly.
+#
+# Containers run as uid 1000 (appuser), so the host directory must be owned
+# by 1000:1000 for the non-root container user to write into it.
+#
+# Safe to run multiple times. Idempotent.
+
+set -euo pipefail
+
+LOG_BASE="${APP_LOG_DIR:-/var/log/containers/ai-registry}"
+OWNER_UID="${LOG_DIR_OWNER_UID:-1000}"
+OWNER_GID="${LOG_DIR_OWNER_GID:-1000}"
+DIR_MODE="${LOG_DIR_MODE:-0750}"
+
+if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
+echo "Preparing host log directory for AI Registry..."
+echo "  Path:  ${LOG_BASE}"
+echo "  Owner: ${OWNER_UID}:${OWNER_GID}"
+echo "  Mode:  ${DIR_MODE}"
+
+if [ ! -d "${LOG_BASE}" ]; then
+    echo "Creating ${LOG_BASE}"
+    ${SUDO} mkdir -p "${LOG_BASE}"
+fi
+
+${SUDO} chown -R "${OWNER_UID}:${OWNER_GID}" "${LOG_BASE}"
+${SUDO} chmod "${DIR_MODE}" "${LOG_BASE}"
+
+echo "OK: ${LOG_BASE} prepared"
+ls -ld "${LOG_BASE}"

--- a/servers/mcpgw/logging_setup.py
+++ b/servers/mcpgw/logging_setup.py
@@ -1,0 +1,167 @@
+"""Logging setup for the mcpgw container (issue #987).
+
+Provides console + file handlers with the same JSONL format as registry and
+auth-server. Does not depend on registry/* modules or MongoDB; configuration
+comes from environment variables (APP_LOG_DIR, APP_LOG_FILE_FORMAT, etc.).
+
+Why duplicate instead of importing registry.utils.logging_setup?
+The mcpgw image is built from docker/Dockerfile.mcp-server and does not copy
+the registry/ source tree. It also does not carry a MongoDB client. A small
+standalone module with the same schema keeps the container image minimal and
+avoids cross-service import paths.
+"""
+
+import json
+import logging
+import os
+import traceback
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+CONSOLE_FORMAT = (
+    "%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s"
+)
+DEFAULT_LOG_DIR = "/var/log/containers/ai-registry"
+SERVICE_NAME = "ai-registry-tools"
+
+
+class JsonlFormatter(logging.Formatter):
+    """JSONL formatter matching docs/logging-standard.md.
+
+    Kept in sync with registry.utils.logging_setup.JsonlFormatter. Both emit
+    the same 8 mandatory fields plus 3 exception fields.
+    """
+
+    def __init__(
+        self,
+        service_name: str,
+    ) -> None:
+        super().__init__()
+        self._service_name = service_name
+
+    def format(
+        self,
+        record: logging.LogRecord,
+    ) -> str:
+        payload: dict = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).isoformat(),
+            "service": self._service_name,
+            "level": record.levelname,
+            "logger": record.name,
+            "filename": record.filename,
+            "lineno": record.lineno,
+            "process_id": record.process,
+            "message": record.getMessage(),
+        }
+
+        if record.exc_info:
+            exc_type, exc_value, _ = record.exc_info
+            payload["exc_type"] = exc_type.__name__ if exc_type else "Unknown"
+            payload["exc_message"] = str(exc_value) if exc_value else ""
+            payload["stack_trace"] = "".join(
+                traceback.format_exception(*record.exc_info)
+            )
+
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+def _resolve_log_dir() -> Path:
+    """Read APP_LOG_DIR from env, validate, fall back to default."""
+    raw = os.getenv("APP_LOG_DIR", "").strip()
+    if not raw:
+        return Path(DEFAULT_LOG_DIR)
+    if not raw.startswith("/"):
+        # Invalid config: log a warning and use the default instead of crashing.
+        logging.getLogger(__name__).warning(
+            "APP_LOG_DIR=%r is not absolute; falling back to %s",
+            raw,
+            DEFAULT_LOG_DIR,
+        )
+        return Path(DEFAULT_LOG_DIR)
+    if ".." in Path(raw).parts:
+        logging.getLogger(__name__).warning(
+            "APP_LOG_DIR=%r contains '..'; falling back to %s",
+            raw,
+            DEFAULT_LOG_DIR,
+        )
+        return Path(DEFAULT_LOG_DIR)
+    return Path(raw)
+
+
+def _resolve_file_format() -> str:
+    """Read APP_LOG_FILE_FORMAT from env; accept only 'json' or 'text'."""
+    raw = os.getenv("APP_LOG_FILE_FORMAT", "json").strip().lower()
+    if raw not in ("json", "text"):
+        logging.getLogger(__name__).warning(
+            "APP_LOG_FILE_FORMAT=%r is invalid; falling back to 'json'",
+            raw,
+        )
+        return "json"
+    return raw
+
+
+def setup_mcpgw_logging() -> Path | None:
+    """Configure root logger for mcpgw.
+
+    Returns:
+        The resolved log file path, or None if file logging could not be
+        initialized (PermissionError, missing host directory, etc.). In the
+        None case the process continues with console-only logging.
+    """
+    log_dir = _resolve_log_dir()
+    log_file = log_dir / f"{SERVICE_NAME}.log"
+    log_level = getattr(
+        logging,
+        os.getenv("APP_LOG_LEVEL", "INFO").upper(),
+        logging.INFO,
+    )
+    max_bytes = int(os.getenv("APP_LOG_MAX_BYTES", str(50 * 1024 * 1024)))
+    backup_count = int(os.getenv("APP_LOG_BACKUP_COUNT", "5"))
+    file_format = _resolve_file_format()
+
+    root = logging.getLogger()
+    root.setLevel(log_level)
+
+    for handler in root.handlers[:]:
+        root.removeHandler(handler)
+
+    console_formatter = logging.Formatter(CONSOLE_FORMAT)
+    file_formatter: logging.Formatter
+    if file_format == "json":
+        file_formatter = JsonlFormatter(service_name=SERVICE_NAME)
+    else:
+        file_formatter = console_formatter
+
+    # Console handler (always on, human-readable)
+    console = logging.StreamHandler()
+    console.setLevel(log_level)
+    console.setFormatter(console_formatter)
+    root.addHandler(console)
+
+    # Rotating file handler (JSONL by default)
+    try:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = RotatingFileHandler(
+            filename=str(log_file),
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(log_level)
+        file_handler.setFormatter(file_formatter)
+        root.addHandler(file_handler)
+        return log_file
+    except (PermissionError, OSError) as exc:
+        root.error(
+            "Cannot write to log file %s: %s. "
+            "Fix on host: sudo mkdir -p %s && sudo chown -R 1000:1000 %s. "
+            "Continuing with console-only logging.",
+            log_file,
+            exc,
+            log_dir,
+            log_dir,
+        )
+        return None

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -16,13 +16,17 @@ from typing import Any
 
 import httpx
 from fastmcp import Context, FastMCP
+from logging_setup import setup_mcpgw_logging
 from models import AgentInfo, RegistryStats, ServerInfo, SkillInfo, ToolSearchResult
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
-)
+_log_file = setup_mcpgw_logging()
 logger = logging.getLogger(__name__)
+logger.info(
+    "mcpgw logging configured: file=%s format=%s level=%s",
+    _log_file,
+    os.getenv("APP_LOG_FILE_FORMAT", "json"),
+    os.getenv("APP_LOG_LEVEL", "INFO"),
+)
 
 REGISTRY_URL = os.getenv("REGISTRY_BASE_URL", "http://localhost")
 

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -228,6 +228,8 @@ module "mcp_gateway" {
   app_log_centralized_ttl_days = var.app_log_centralized_ttl_days
   app_log_level                = var.app_log_level
   app_log_excluded_loggers     = var.app_log_excluded_loggers
+  app_log_dir                  = var.app_log_dir
+  app_log_file_format          = var.app_log_file_format
 
   # Deployment mode configuration
   deployment_mode = var.deployment_mode

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -329,6 +329,14 @@ module "ecs_service_auth" {
           name  = "APP_LOG_EXCLUDED_LOGGERS"
           value = var.app_log_excluded_loggers
         },
+        {
+          name  = "APP_LOG_DIR"
+          value = var.app_log_dir
+        },
+        {
+          name  = "APP_LOG_FILE_FORMAT"
+          value = var.app_log_file_format
+        },
         # Metrics pipeline (only wired when observability is enabled)
         {
           name  = "METRICS_SERVICE_URL"
@@ -882,6 +890,14 @@ module "ecs_service_registry" {
         {
           name  = "APP_LOG_EXCLUDED_LOGGERS"
           value = var.app_log_excluded_loggers
+        },
+        {
+          name  = "APP_LOG_DIR"
+          value = var.app_log_dir
+        },
+        {
+          name  = "APP_LOG_FILE_FORMAT"
+          value = var.app_log_file_format
         },
         {
           name  = "DEPLOYMENT_MODE"

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -1474,7 +1474,23 @@ module "ecs_service_mcpgw" {
         {
           name  = "REGISTRY_USERNAME"
           value = "admin"
-        }
+        },
+        # Application log configuration (issue #987). Matches the Docker
+        # Compose wiring for the mcpgw container; keeps behavior consistent
+        # across deployment surfaces. Values are consumed by
+        # servers/mcpgw/logging_setup.py.
+        {
+          name  = "APP_LOG_DIR"
+          value = var.app_log_dir
+        },
+        {
+          name  = "APP_LOG_FILE_FORMAT"
+          value = var.app_log_file_format
+        },
+        {
+          name  = "APP_LOG_LEVEL"
+          value = var.app_log_level
+        },
       ]
 
       secrets = []

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -951,6 +951,18 @@ variable "app_log_excluded_loggers" {
   default     = "uvicorn.access,httpx,pymongo,motor"
 }
 
+variable "app_log_dir" {
+  description = "Directory where service log files are written (issue #987). Empty string means use the backend default (/var/log/containers/ai-registry)."
+  type        = string
+  default     = ""
+}
+
+variable "app_log_file_format" {
+  description = "On-disk format for service .log files: 'json' (default) or 'text' (legacy). Console format is unaffected (issue #987)."
+  type        = string
+  default     = "json"
+}
+
 # =============================================================================
 # DEPLOYMENT MODE CONFIGURATION
 # =============================================================================

--- a/terraform/aws-ecs/scripts/ecs-ssh.sh
+++ b/terraform/aws-ecs/scripts/ecs-ssh.sh
@@ -6,11 +6,13 @@
 # Supported service types:
 #   registry      - MCP Gateway Registry
 #   auth-server   - Auth Server
+#   mcpgw         - MCP Gateway Server (ai-registry-tools)
 #   keycloak      - Keycloak (if available)
 #
 # Examples:
 #   ./ecs-ssh.sh registry
 #   ./ecs-ssh.sh auth-server
+#   ./ecs-ssh.sh mcpgw
 #   ./ecs-ssh.sh auth-server mcp-gateway-ecs-cluster us-west-2
 
 set -e
@@ -19,8 +21,34 @@ set -e
 declare -A SERVICE_MAP=(
   [registry]="mcp-gateway-v2-registry:registry"
   [auth-server]="mcp-gateway-v2-auth:auth-server"
+  [mcpgw]="mcp-gateway-v2-mcpgw:mcpgw-server"
   [keycloak]="keycloak:keycloak"
 )
+
+_print_usage() {
+  cat <<EOF
+Usage: $(basename "$0") [service-type] [cluster-name] [region]
+
+Supported service types: ${!SERVICE_MAP[@]}
+
+Defaults:
+  cluster-name  mcp-gateway-ecs-cluster
+  region        us-east-1
+
+Examples:
+  $(basename "$0") registry
+  $(basename "$0") mcpgw
+  $(basename "$0") auth-server mcp-gateway-ecs-cluster us-west-2
+EOF
+}
+
+# Handle help flags before treating the first arg as a service type.
+case "${1:-}" in
+  -h|--help|help)
+    _print_usage
+    exit 0
+    ;;
+esac
 
 # Parameters
 SERVICE_TYPE="${1:-registry}"
@@ -31,6 +59,8 @@ REGION="${3:-us-east-1}"
 if [[ -z "${SERVICE_MAP[$SERVICE_TYPE]}" ]]; then
   echo "Error: Unknown service type '$SERVICE_TYPE'"
   echo "Supported types: ${!SERVICE_MAP[@]}"
+  echo ""
+  _print_usage
   exit 1
 fi
 

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -527,6 +527,21 @@ registry_api_token = "m3zT65wREARMVDToKosg_DgNkKqS_434hNxy3sslGPY"
 # Default: "uvicorn.access,httpx,pymongo,motor"
 # app_log_excluded_loggers = "uvicorn.access,httpx,pymongo,motor"
 
+# Directory where service log files are written (issue #987).
+# Empty string uses the backend default: /var/log/containers/ai-registry.
+# Must be an absolute path when set; '..' segments are rejected.
+# On ECS, files land on task-ephemeral storage - the awslogs driver still
+# handles log shipping via CloudWatch. This variable primarily controls the
+# in-container path for code-path consistency with Docker Compose deployments.
+# Default: ""
+# app_log_dir = ""
+
+# On-disk format for service .log files: 'json' (JSON Lines per
+# docs/logging-standard.md) or 'text' (legacy comma-separated).
+# Console/stdout format is unaffected.
+# Default: "json"
+# app_log_file_format = "json"
+
 # ============================================================================
 # AUTHENTICATION PROVIDER CONFIGURATION
 # ============================================================================

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -893,6 +893,28 @@ variable "app_log_excluded_loggers" {
   default     = "uvicorn.access,httpx,pymongo,motor"
 }
 
+variable "app_log_dir" {
+  description = "Directory where service log files are written. Defaults to /var/log/containers/ai-registry when empty. Must be an absolute path; '..' segments are rejected by the backend (issue #987). ECS tasks write to task-ephemeral storage, so this is mainly a code-path toggle on ECS."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.app_log_dir == "" || (startswith(var.app_log_dir, "/") && !strcontains(var.app_log_dir, ".."))
+    error_message = "app_log_dir must be empty (use default) or an absolute path without '..' segments"
+  }
+}
+
+variable "app_log_file_format" {
+  description = "On-disk format for service .log files: 'json' (default, JSON Lines per docs/logging-standard.md) or 'text' (legacy comma-separated). Console/stdout format is unaffected (issue #987)."
+  type        = string
+  default     = "json"
+
+  validation {
+    condition     = contains(["json", "text"], var.app_log_file_format)
+    error_message = "app_log_file_format must be one of: 'json', 'text'"
+  }
+}
+
 # =============================================================================
 # REGISTRY CARD CONFIGURATION (Federation Metadata)
 # =============================================================================

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -452,7 +452,7 @@ class TestSettingsPathsContainer:
 
     @patch.object(Settings, "is_local_dev", new_callable=lambda: property(lambda self: False))
     def test_log_dir_container(self, mock_is_local_dev) -> None:
-        """Test log_dir property in container mode."""
+        """Test log_dir property in container mode (issue #987 default)."""
         # Arrange
         settings = Settings()
 
@@ -460,12 +460,12 @@ class TestSettingsPathsContainer:
         result = settings.log_dir
 
         # Assert
-        expected = Path("/app/logs")
+        expected = Path("/var/log/containers/ai-registry")
         assert result == expected
 
     @patch.object(Settings, "is_local_dev", new_callable=lambda: property(lambda self: False))
     def test_log_file_path_container(self, mock_is_local_dev) -> None:
-        """Test log_file_path property in container mode."""
+        """Test log_file_path property in container mode (issue #987 default)."""
         # Arrange
         settings = Settings()
 
@@ -473,7 +473,7 @@ class TestSettingsPathsContainer:
         result = settings.log_file_path
 
         # Assert
-        expected = Path("/app/logs") / "registry.log"
+        expected = Path("/var/log/containers/ai-registry") / "registry.log"
         assert result == expected
 
     @patch.object(Settings, "is_local_dev", new_callable=lambda: property(lambda self: False))
@@ -993,3 +993,74 @@ class TestSettingsTabVisibilityStartupWarnings:
             log_tab_visibility_warnings(s)
 
         assert not any("SHOW_" in msg for msg in caplog.messages)
+
+
+# =============================================================================
+# TEST CLASS: APP_LOG_DIR and APP_LOG_FILE_FORMAT (Issue #987)
+# =============================================================================
+
+
+class TestAppLogDirValidator:
+    """Tests for the APP_LOG_DIR path validator added in issue #987."""
+
+    def test_none_value_accepted(self) -> None:
+        """APP_LOG_DIR unset should leave app_log_dir=None."""
+        settings = Settings(app_log_dir=None)
+        assert settings.app_log_dir is None
+
+    def test_empty_string_treated_as_unset(self) -> None:
+        """Empty string should be normalized to None (uses default)."""
+        settings = Settings(app_log_dir="")
+        assert settings.app_log_dir is None
+
+    def test_absolute_path_accepted(self) -> None:
+        """Absolute paths are the only supported form."""
+        settings = Settings(app_log_dir="/var/log/custom")
+        assert settings.app_log_dir == "/var/log/custom"
+
+    def test_relative_path_rejected(self) -> None:
+        """Relative paths should be rejected at startup."""
+        with pytest.raises(ValueError, match="absolute"):
+            Settings(app_log_dir="relative/path")
+
+    def test_path_with_dotdot_rejected(self) -> None:
+        """Paths containing '..' segments should be rejected (defense in depth)."""
+        with pytest.raises(ValueError, match="'\\.\\.'"):
+            Settings(app_log_dir="/var/log/../etc")
+
+    @patch.object(Settings, "is_local_dev", new_callable=lambda: property(lambda self: False))
+    def test_override_honored_by_log_dir_property(
+        self,
+        mock_is_local_dev,
+    ) -> None:
+        """Setting app_log_dir overrides the mode-based default."""
+        settings = Settings(app_log_dir="/custom/path")
+        assert settings.log_dir == Path("/custom/path")
+
+
+class TestAppLogFileFormatValidator:
+    """Tests for the APP_LOG_FILE_FORMAT validator added in issue #987."""
+
+    def test_json_accepted(self) -> None:
+        settings = Settings(app_log_file_format="json")
+        assert settings.app_log_file_format == "json"
+
+    def test_text_accepted(self) -> None:
+        settings = Settings(app_log_file_format="text")
+        assert settings.app_log_file_format == "text"
+
+    def test_case_insensitive(self) -> None:
+        settings = Settings(app_log_file_format="JSON")
+        assert settings.app_log_file_format == "json"
+
+    def test_whitespace_stripped(self) -> None:
+        settings = Settings(app_log_file_format="  text  ")
+        assert settings.app_log_file_format == "text"
+
+    def test_unknown_value_rejected(self) -> None:
+        with pytest.raises(ValueError, match="json.*text"):
+            Settings(app_log_file_format="yaml")
+
+    def test_default_is_json(self) -> None:
+        settings = Settings()
+        assert settings.app_log_file_format == "json"

--- a/tests/unit/utils/test_logging_setup.py
+++ b/tests/unit/utils/test_logging_setup.py
@@ -1,6 +1,8 @@
 """Unit tests for registry/utils/logging_setup.py and mongodb_log_handler.py."""
 
+import json
 import logging
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 from unittest.mock import patch
 
@@ -137,6 +139,167 @@ class TestSetupLogging:
 
             # Should have exactly 2 handlers: console + file
             assert len(root.handlers) == 2
+
+
+# =============================================================================
+# JSONL FORMATTER TESTS (Issue #987)
+# =============================================================================
+
+
+class TestJsonlFormatter:
+    """Tests for the JsonlFormatter added in issue #987."""
+
+    def _make_record(
+        self,
+        name: str = "test.logger",
+        level: int = logging.INFO,
+        msg: str = "hello",
+        args: tuple = (),
+        exc_info=None,
+    ) -> logging.LogRecord:
+        return logging.LogRecord(
+            name=name,
+            level=level,
+            pathname="/app/example.py",
+            lineno=42,
+            msg=msg,
+            args=args,
+            exc_info=exc_info,
+        )
+
+    def test_mandatory_fields_present(self):
+        from registry.utils.logging_setup import JsonlFormatter
+
+        formatter = JsonlFormatter(service_name="registry")
+        rec = self._make_record(name="registry.core.config", msg="Starting on port %d", args=(8000,))
+        out = formatter.format(rec)
+        payload = json.loads(out)
+
+        assert payload["service"] == "registry"
+        assert payload["level"] == "INFO"
+        assert payload["logger"] == "registry.core.config"
+        assert payload["filename"] == "example.py"
+        assert payload["lineno"] == 42
+        assert payload["message"] == "Starting on port 8000"
+        assert "timestamp" in payload
+        assert isinstance(payload["process_id"], int)
+        assert {"exc_type", "exc_message", "stack_trace"}.isdisjoint(payload)
+
+    def test_timestamp_iso_utc_with_offset(self):
+        from registry.utils.logging_setup import JsonlFormatter
+
+        formatter = JsonlFormatter(service_name="auth-server")
+        out = formatter.format(self._make_record())
+        payload = json.loads(out)
+        dt = datetime.fromisoformat(payload["timestamp"])
+        assert dt.tzinfo is not None
+
+    def test_exception_fields_populated(self):
+        from registry.utils.logging_setup import JsonlFormatter
+
+        formatter = JsonlFormatter(service_name="registry")
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+        rec = self._make_record(level=logging.ERROR, msg="oh no", exc_info=exc_info)
+        out = formatter.format(rec)
+        payload = json.loads(out)
+
+        assert payload["exc_type"] == "ValueError"
+        assert payload["exc_message"] == "boom"
+        assert "Traceback" in payload["stack_trace"]
+
+    def test_output_is_single_line(self):
+        from registry.utils.logging_setup import JsonlFormatter
+
+        formatter = JsonlFormatter(service_name="registry")
+        rec = self._make_record(msg="line1\nline2")
+        out = formatter.format(rec)
+        # Raw output must be a single line; embedded newlines are JSON-escaped.
+        assert "\n" not in out
+        payload = json.loads(out)
+        assert payload["message"] == "line1\nline2"
+
+    def test_utf8_preserved(self):
+        from registry.utils.logging_setup import JsonlFormatter
+
+        formatter = JsonlFormatter(service_name="registry")
+        rec = self._make_record(msg="café résumé 中文")
+        out = formatter.format(rec)
+        payload = json.loads(out)
+        assert payload["message"] == "café résumé 中文"
+
+
+class TestSetupLoggingFileFormatSelection:
+    """Tests that APP_LOG_FILE_FORMAT selects the file handler formatter."""
+
+    def test_json_format_uses_jsonl_formatter(self, tmp_path):
+        with patch("registry.core.config.settings") as mock_settings:
+            mock_settings.app_log_level = "INFO"
+            mock_settings.app_log_max_bytes = 50 * 1024 * 1024
+            mock_settings.app_log_backup_count = 5
+            mock_settings.app_log_centralized_enabled = False
+            mock_settings.app_log_file_format = "json"
+            mock_settings.log_dir = tmp_path
+
+            from registry.utils.logging_setup import JsonlFormatter, setup_logging
+
+            setup_logging(service_name="registry", log_file=tmp_path / "registry.log")
+
+            root = logging.getLogger()
+            rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+            assert len(rotating) == 1
+            assert isinstance(rotating[0].formatter, JsonlFormatter)
+
+    def test_text_format_uses_plain_formatter(self, tmp_path):
+        with patch("registry.core.config.settings") as mock_settings:
+            mock_settings.app_log_level = "INFO"
+            mock_settings.app_log_max_bytes = 50 * 1024 * 1024
+            mock_settings.app_log_backup_count = 5
+            mock_settings.app_log_centralized_enabled = False
+            mock_settings.app_log_file_format = "text"
+            mock_settings.log_dir = tmp_path
+
+            from registry.utils.logging_setup import JsonlFormatter, setup_logging
+
+            setup_logging(service_name="registry", log_file=tmp_path / "registry.log")
+
+            root = logging.getLogger()
+            rotating = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+            assert len(rotating) == 1
+            # Text mode must NOT use JsonlFormatter; it should be plain logging.Formatter.
+            assert not isinstance(rotating[0].formatter, JsonlFormatter)
+            assert isinstance(rotating[0].formatter, logging.Formatter)
+
+    def test_jsonl_output_is_parseable_end_to_end(self, tmp_path):
+        log_path = tmp_path / "registry.log"
+
+        with patch("registry.core.config.settings") as mock_settings:
+            mock_settings.app_log_level = "INFO"
+            mock_settings.app_log_max_bytes = 50 * 1024 * 1024
+            mock_settings.app_log_backup_count = 5
+            mock_settings.app_log_centralized_enabled = False
+            mock_settings.app_log_file_format = "json"
+            mock_settings.log_dir = tmp_path
+
+            from registry.utils.logging_setup import setup_logging
+
+            setup_logging(service_name="registry", log_file=log_path)
+
+            logging.getLogger("registry.test").info("hello world")
+
+            for handler in logging.getLogger().handlers:
+                handler.flush()
+
+        content = log_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(content) >= 1
+        payload = json.loads(content[-1])
+        assert payload["service"] == "registry"
+        assert payload["message"] == "hello world"
+        assert payload["level"] == "INFO"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Move registry / auth-server / mcpgw log files to `/var/log/containers/ai-registry/` on the Docker host via bind mounts, so customer Splunk forwarders can ingest them from a single well-known directory.
- Introduce JSON Lines as the default on-disk log format with a fixed 8-field schema + 3 exception fields. Console output stays human-readable. Legacy comma-separated format still available via `APP_LOG_FILE_FORMAT=text`.
- Add file logging to mcpgw (previously stdout-only). Move nginx access/error logs into the same dir with daily logrotate (14-day retention, compressed).
- Two new env vars: `APP_LOG_DIR` (absolute path, validated; `..` rejected) and `APP_LOG_FILE_FORMAT` (json|text). Both exposed in the System Config admin panel.

Closes #987.

## Scope boundaries

- **No changes to Helm charts** - EKS pod stdout is already scraped by Splunk Connect for Kubernetes from node `/var/log/containers/<pod>_<ns>_<container>-<hash>.log`.
- **No changes to Terraform / ECS** - the `awslogs` CloudWatch driver continues to handle log shipping.
- **MongoDB centralized logging untouched** - third handler continues to work independently.
- **Audit logs untouched** - still live under `/app/logs/audit` via a separate `audit_log_path` property.

## Log format standard

Published as [`docs/logging-standard.md`](https://github.com/agentic-community/mcp-gateway-registry/blob/feat/987-var-log-containers-jsonl/docs/logging-standard.md) so customer log-aggregation teams can configure ingestion. Includes sample records and ready-to-paste Splunk `inputs.conf` + `props.conf`.

## Test plan

- [x] `uv run pytest tests/ -n 8` -- **2803 passed, 68 skipped**, zero regressions
- [x] 17 new unit tests covering `JsonlFormatter`, `APP_LOG_DIR` / `APP_LOG_FILE_FORMAT` validators, and formatter selection in `setup_logging`
- [x] `docker compose config --quiet` validates for all three compose files
- [x] `py_compile` clean on all 5 modified / new Python files
- [x] `bash -n` clean on all 3 modified shell scripts
- [ ] Local `docker compose up -d` -- verify log files land in `/var/log/containers/ai-registry/` with correct ownership and JSONL format (manual, pre-merge)
- [ ] Force-trigger `docker exec registry logrotate -f /etc/logrotate.d/nginx-mcp` -- verify nginx rotation works (manual, pre-merge)

## Upgrade notes for operators

On the Docker host, run once before first start after upgrade:

```bash
sudo mkdir -p /var/log/containers/ai-registry
sudo chown -R 1000:1000 /var/log/containers/ai-registry
sudo chmod 0750 /var/log/containers/ai-registry
```

`build_and_run.sh` does this automatically via `scripts/prepare-log-dirs.sh`. Operators who don't run that script will see a clear `ERROR` log at startup with the exact `chown` command to fix it; the service falls back to console-only logging so there's no crash.

Existing deployments that want to preserve the old on-disk format can set `APP_LOG_FILE_FORMAT=text` during a phased rollout.