### PR TITLE
feat(usage-report): emit per-platform compute snapshot markdown table

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -108,19 +108,22 @@ This produces a PNG with two subplots:
 
 ### Step 5b2: Generate Compute Platform Timeseries Chart
 
-Generate a second timeseries chart, parallel to the cloud-provider one, showing unique registry installs per **compute platform** (docker, kubernetes, ecs, ec2, etc.) over time. Same data-sourcing behavior (scans all CSV files across dated subdirectories):
+Generate a second timeseries chart, parallel to the cloud-provider one, showing unique registry installs per **compute platform** (docker, kubernetes, ecs, ec2, etc.) over time. Same data-sourcing behavior (scans all CSV files across dated subdirectories). Pass `--snapshots-table` to also emit a markdown per-snapshot table ready to embed in the report:
 
 ```bash
 /usr/bin/python3 .claude/skills/usage-report/generate_compute_timeseries_chart.py \
   --csv-dir OUTPUT_DIR \
-  --output $DATE_DIR/compute-installs-timeseries-YYYY-MM-DD.png
+  --output $DATE_DIR/compute-installs-timeseries-YYYY-MM-DD.png \
+  --snapshots-table $DATE_DIR/compute-platform-snapshots-YYYY-MM-DD.md
 ```
 
-This produces a PNG with two subplots:
-- **Cumulative Unique Registry Installs per Compute Platform** -- running total of unique registry_ids per platform
-- **Daily Active Registry Installs per Compute Platform** -- unique registry_ids seen each day per platform
+This produces:
+- A PNG with two subplots:
+  - **Cumulative Unique Registry Installs per Compute Platform** -- running total of unique registry_ids per platform
+  - **Daily Active Registry Installs per Compute Platform** -- unique registry_ids seen each day per platform
+- A markdown file with the **Per-Platform Growth (Unique Installs)** table, one row per dated CSV snapshot, sorted **descending by date** (newest first, bolded). The column order is `docker | kubernetes | ecs | ec2 | unknown` when present, plus any other platforms alphabetically. Unique-instance counts per snapshot are computed directly from each dated CSV using the `compute` column (not `compute_platform` -- that's the schema key but not the CSV column name).
 
-Embed this chart in the report's "Deployment Distribution" section (or a dedicated "Compute Platform Growth" section) with a short narrative on which platforms are growing fastest in absolute and percentage terms.
+Embed the chart in the report's "Compute Platform Growth" section and drop the contents of the snapshots-table markdown file in under the "Per-Platform Growth (Unique Installs)" subheading. Add a short narrative on which platforms are growing fastest in absolute and percentage terms; the newest (bolded) row is the current total for the report.
 
 ### Step 5c: Generate Instance Lifetime Chart
 
@@ -439,6 +442,7 @@ Output saved to `/tmp/reports/2026-04-18/`.
     instance-distribution-2026-04-16.png
     registry-installs-timeseries-2026-04-16.png
     compute-installs-timeseries-2026-04-16.png
+    compute-platform-snapshots-2026-04-16.md
     instance-lifetime-2026-04-16.png
     tables-2026-04-16.md
     metrics-2026-04-16.json

--- a/.claude/skills/usage-report/generate_compute_timeseries_chart.py
+++ b/.claude/skills/usage-report/generate_compute_timeseries_chart.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import logging
 import os
+import re
 from collections import defaultdict
 from datetime import datetime
 
@@ -158,6 +159,78 @@ def _compute_daily_unique_installs(
     return result
 
 
+def _compute_snapshot_table(
+    csv_files: list[str],
+) -> tuple[list[str], list[tuple[str, dict[str, int]]]]:
+    """Build per-snapshot unique-instance counts grouped by compute platform.
+
+    For each CSV file whose parent directory is named YYYY-MM-DD, read the file
+    and count unique registry_ids per compute value. Returns the ordered list
+    of platform columns and a list of (snapshot_date, counts_by_platform)
+    tuples sorted descending by date (newest first).
+    """
+    date_re = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+    per_date: list[tuple[str, dict[str, int]]] = []
+    all_platforms: set[str] = set()
+    for csv_path in csv_files:
+        parent = os.path.basename(os.path.dirname(csv_path))
+        if not date_re.match(parent):
+            continue
+        seen: dict[str, str] = {}
+        with open(csv_path, newline="") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                rid = (row.get("registry_id") or "").strip()
+                if not rid or rid.lower() == "null":
+                    continue
+                platform = row.get("compute") or "unknown"
+                seen[rid] = platform
+        counts: dict[str, int] = defaultdict(int)
+        for platform in seen.values():
+            counts[platform] += 1
+            all_platforms.add(platform)
+        per_date.append((parent, dict(counts)))
+
+    preferred_order = ["docker", "kubernetes", "ecs", "ec2", "unknown"]
+    columns = [p for p in preferred_order if p in all_platforms]
+    columns += sorted(p for p in all_platforms if p not in preferred_order)
+
+    per_date.sort(key=lambda item: item[0], reverse=True)
+    return columns, per_date
+
+
+def _write_snapshot_table(
+    columns: list[str],
+    rows: list[tuple[str, dict[str, int]]],
+    output_path: str,
+) -> None:
+    """Write a markdown per-platform snapshot table, sorted descending by date.
+
+    The newest row is bolded so future reports can drop it straight into the
+    "Per-Platform Growth (Unique Installs)" section.
+    """
+    header_cells = ["Date"] + columns + ["Total"]
+    align_cells = ["------"] + ["-----:"] * len(columns) + ["-----:"]
+    lines = [
+        "| " + " | ".join(header_cells) + " |",
+        "|" + "|".join(align_cells) + "|",
+    ]
+    for idx, (date_str, counts) in enumerate(rows):
+        total = sum(counts.values())
+        if idx == 0:
+            values = [f"**{counts.get(c, 0)}**" for c in columns]
+            lines.append(
+                f"| **{date_str}** | " + " | ".join(values) + f" | **{total}** |"
+            )
+        else:
+            values = [str(counts.get(c, 0)) for c in columns]
+            lines.append(f"| {date_str} | " + " | ".join(values) + f" | {total} |")
+
+    with open(output_path, "w") as f:
+        f.write("\n".join(lines) + "\n")
+    logger.info(f"Per-platform snapshot table written to {output_path}")
+
+
 def _generate_chart(
     cumulative_data: dict[str, list[tuple[str, int]]],
     daily_data: dict[str, list[tuple[str, int]]],
@@ -245,6 +318,15 @@ def main() -> None:
         required=True,
         help="Path to save the output PNG",
     )
+    parser.add_argument(
+        "--snapshots-table",
+        default=None,
+        help=(
+            "Optional path to write a markdown per-platform snapshot table "
+            "(unique instance counts by compute platform, sorted descending "
+            "by date). Reads one CSV per dated subdirectory under --csv-dir."
+        ),
+    )
     args = parser.parse_args()
 
     if not os.path.isdir(args.csv_dir):
@@ -271,6 +353,15 @@ def main() -> None:
         raise SystemExit(1)
 
     _generate_chart(cumulative_data, daily_data, args.output)
+
+    if args.snapshots_table:
+        columns, rows = _compute_snapshot_table(csv_files)
+        if not rows:
+            logger.warning(
+                "No dated-subfolder CSVs found; skipping snapshot table output"
+            )
+        else:
+            _write_snapshot_table(columns, rows, args.snapshots_table)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `--snapshots-table` flag to [`.claude/skills/usage-report/generate_compute_timeseries_chart.py`](.claude/skills/usage-report/generate_compute_timeseries_chart.py). When supplied, the script writes a markdown table of unique registry installs per compute platform (`docker | kubernetes | ecs | ec2 | unknown` first, then any others alphabetically) with one row per dated CSV snapshot, sorted **descending by date**. The newest row is bolded so it can be pasted straight into the "Per-Platform Growth (Unique Installs)" section of a usage report.
- Update [`.claude/skills/usage-report/SKILL.md`](.claude/skills/usage-report/SKILL.md) Step 5b2 to document the new flag, show an example invocation, describe the markdown file's shape (column order, bolded newest row, uses the `compute` column in the CSV — not `compute_platform`), and include the new file in the expected output folder listing.

## Test plan

- [ ] Run the command in Step 5b2 against a populated `OUTPUT_DIR` with multiple dated subfolders: a PNG chart and a markdown table are both produced.
- [ ] Confirm the markdown table has `Date | docker | kubernetes | ecs | ec2 | unknown | Total` columns (subset if some platforms absent), newest row bolded, rows sorted newest-first.
- [ ] Run without `--snapshots-table` — behavior unchanged (no markdown file, chart still produced).
- [ ] Run against a directory with no dated subfolders — chart produced, warning logged ("No dated-subfolder CSVs found; skipping snapshot table output"), no markdown file written.