### PR TITLE
fix(audit): log authenticated users by name

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,16 @@
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "no-restricted-syntax": [
+        "error",
+        {
+          "selector": "CallExpression[callee.name='fetch'][arguments.0.callee.name='apiUrl']",
+          "message": "Use the configured axios client instead of bare fetch(apiUrl(...)) so requests inherit withCredentials and identity is recorded in the audit log. Rule is intentionally narrow: it catches the fetch(apiUrl(...)) pattern that caused audit-anonymous regressions. A blanket fetch ban would false-positive on non-API fetches (external URLs, SKILL.md content)."
+        }
+      ]
+    }
   },
   "browserslist": {
     "production": [

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, Fragment } from 'react';
+import axios from 'axios';
 import { Menu, Transition } from '@headlessui/react';
 import { Link } from 'react-router-dom';
 import {
@@ -12,7 +13,6 @@ import Sidebar from './Sidebar';
 import UptimeDisplay from './UptimeDisplay';
 import { useServerStats } from '../hooks/useServerStats';
 import { useAuth } from '../contexts/AuthContext';
-import { apiUrl } from '../utils/basePath';
 import logo from '../assets/logo.png';
 
 interface LayoutProps {
@@ -34,17 +34,15 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   }, []);
 
   const fetchTags = useCallback(() => {
-    fetch(apiUrl('/api/search/tags'))
-      .then(res => res.json())
-      .then(data => setAvailableTags(data.tags || []))
+    axios.get<{ tags?: string[] }>('/api/search/tags')
+      .then(res => setAvailableTags(res.data.tags || []))
       .catch(err => console.error('Failed to fetch tags:', err));
   }, []);
 
   useEffect(() => {
     // Fetch version from API
-    fetch(apiUrl('/api/version'))
-      .then(res => res.json())
-      .then(data => setVersion(data.version))
+    axios.get<{ version: string }>('/api/version')
+      .then(res => setVersion(res.data.version))
       .catch(err => console.error('Failed to fetch version:', err));
 
     // Initial tag fetch

--- a/frontend/src/components/UptimeDisplay.tsx
+++ b/frontend/src/components/UptimeDisplay.tsx
@@ -2,10 +2,10 @@ import React, {
   useState,
   useEffect,
 } from 'react';
+import axios from 'axios';
 import {
   SystemStats,
 } from '../types/stats';
-import { apiUrl } from '../utils/basePath';
 
 
 /**
@@ -33,12 +33,8 @@ const UptimeDisplay: React.FC = () => {
   useEffect(() => {
     const fetchStats = async () => {
       try {
-        const response = await fetch(apiUrl('/api/stats'));
-        if (!response.ok) {
-          throw new Error('Failed to fetch stats');
-        }
-        const data = await response.json();
-        setStats(data);
+        const response = await axios.get<SystemStats>('/api/stats');
+        setStats(response.data);
         setError(false);
       } catch (err) {
         console.error('Error fetching stats:', err);
@@ -49,12 +45,8 @@ const UptimeDisplay: React.FC = () => {
     // Telemetry detection is cached server-side, so fetch once per mount.
     const fetchDetection = async () => {
       try {
-        const response = await fetch(apiUrl('/api/system/telemetry-detection'));
-        if (!response.ok) {
-          return;
-        }
-        const data = await response.json();
-        setDetection(data);
+        const response = await axios.get<TelemetryDetection>('/api/system/telemetry-detection');
+        setDetection(response.data);
       } catch (err) {
         console.error('Error fetching telemetry detection:', err);
       }

--- a/frontend/src/utils/basePath.ts
+++ b/frontend/src/utils/basePath.ts
@@ -14,8 +14,3 @@ export const getBaseURL = (): string => {
 export const getBasename = (): string => {
   return getBaseURL() || '/';
 };
-
-export const apiUrl = (path: string): string => {
-  const normalized = path.startsWith('/') ? path : `/${path}`;
-  return `${getBaseURL()}${normalized}`;
-};

--- a/registry/api/system_routes.py
+++ b/registry/api/system_routes.py
@@ -7,9 +7,11 @@ These endpoints provide system-level information for monitoring and display.
 import logging
 import os
 from datetime import UTC, datetime
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
+from ..auth.dependencies import nginx_proxied_auth
 from ..core.config import settings
 from ..version import __version__
 
@@ -319,7 +321,12 @@ async def get_version():
 
 
 @router.get("/api/system/telemetry-detection")
-async def get_telemetry_detection_info() -> dict:
+async def get_telemetry_detection_info(
+    # Declared for its side effects: rejects unauthenticated callers with 401
+    # and populates request.state.user_context so the audit middleware logs
+    # the caller's real username instead of "anonymous".
+    _: Annotated[dict, Depends(nginx_proxied_auth)],
+) -> dict:
     """Return the telemetry cloud-detection result for the current process.
 
     Reads from the cached result in the telemetry module; no additional probes
@@ -338,7 +345,12 @@ async def get_telemetry_detection_info() -> dict:
 
 
 @router.get("/api/stats")
-async def get_system_stats():
+async def get_system_stats(
+    # Declared for its side effects: rejects unauthenticated callers with 401
+    # and populates request.state.user_context so the audit middleware logs
+    # the caller's real username instead of "anonymous".
+    _: Annotated[dict, Depends(nginx_proxied_auth)],
+):
     """Get system statistics including uptime, deployment info, and registry metrics.
 
     This endpoint provides operational information for monitoring and display:

--- a/registry/audit/middleware.py
+++ b/registry/audit/middleware.py
@@ -164,12 +164,50 @@ class AuditMiddleware(BaseHTTPMiddleware):
 
         return None
 
+    def _best_effort_session_identity(self, request: Request) -> dict | None:
+        """Decode the session cookie to recover the caller's username.
+
+        Used only when no auth dependency has populated request.state.user_context
+        (e.g. endpoints declared without Depends(...) such as /api/version). The
+        cookie is validated with the same URLSafeTimedSerializer + max_age check
+        as get_user_session_data — a forged or expired cookie yields None. This
+        is strictly read-only: the method must not mutate request.state, extend
+        the session, or issue any cookie.
+
+        Returns None on missing, tampered, or expired cookies so callers can
+        stamp anonymous identity.
+        """
+        from ..auth.dependencies import signer
+        from ..core.config import settings
+
+        session = request.cookies.get(settings.session_cookie_name)
+        if not session:
+            return None
+
+        try:
+            data = signer.loads(session, max_age=settings.session_max_age_seconds)
+        except Exception:
+            return None
+
+        if not isinstance(data, dict):
+            return None
+        username = data.get("username")
+        if not username:
+            return None
+
+        return {
+            "username": username,
+            "auth_method": "session-cookie-fallback",
+            "provider": data.get("provider"),
+        }
+
     def _extract_identity(self, request: Request) -> Identity:
         """
         Extract identity information from the request.
 
-        Looks for user context in request.state (set by auth dependency)
-        or falls back to anonymous identity.
+        Looks for user context in request.state (set by auth dependency),
+        then falls back to a best-effort session-cookie decode for endpoints
+        declared without an auth dependency, and finally to anonymous.
 
         Args:
             request: The FastAPI request object
@@ -192,7 +230,19 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 credential_hint=self._get_credential_hint(request),
             )
 
-        # Fallback to anonymous identity
+        # Fallback 1: decode session cookie ourselves (read-only) so audit
+        # logs tell the truth on endpoints without an auth dependency.
+        fallback = self._best_effort_session_identity(request)
+        if fallback:
+            return Identity(
+                username=fallback["username"],
+                auth_method=fallback["auth_method"],
+                provider=fallback.get("provider"),
+                credential_type=self._get_credential_type(request),
+                credential_hint=self._get_credential_hint(request),
+            )
+
+        # Fallback 2: anonymous identity
         return Identity(
             username="anonymous",
             auth_method="anonymous",

--- a/tests/unit/audit/test_middleware.py
+++ b/tests/unit/audit/test_middleware.py
@@ -146,3 +146,104 @@ class TestDispatch:
 
     async def _async_return(self, value):
         return value
+
+
+class TestBestEffortSessionIdentity:
+    """Tests for the session-cookie fallback used when no auth dep ran.
+
+    These cover the /api/version case: a public endpoint with no auth
+    dependency still gets logged under the caller's real username when
+    the browser presents a valid session cookie.
+    """
+
+    def setup_method(self):
+        from registry.auth.dependencies import signer
+        from registry.core.config import settings
+
+        self.tmpdir = tempfile.mkdtemp()
+        self.audit_logger = AuditLogger(log_dir=self.tmpdir)
+        self.middleware = AuditMiddleware(MagicMock(), self.audit_logger)
+        self.signer = signer
+        self.cookie_name = settings.session_cookie_name
+
+    def _make_cookie(self, **overrides) -> str:
+        payload = {
+            "username": "alice",
+            "auth_method": "oauth2",
+            "provider": "keycloak",
+        }
+        payload.update(overrides)
+        return self.signer.dumps(payload)
+
+    def test_fallback_recovers_username_from_valid_cookie(self):
+        cookie = self._make_cookie()
+        request = MockRequest(cookies={self.cookie_name: cookie})
+
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "alice"
+        assert identity.auth_method == "session-cookie-fallback"
+        assert identity.provider == "keycloak"
+        assert identity.credential_type == "session_cookie"
+
+    def test_fallback_anonymous_on_missing_cookie(self):
+        request = MockRequest(cookies={})
+
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "anonymous"
+        assert identity.auth_method == "anonymous"
+
+    def test_fallback_anonymous_on_tampered_cookie(self):
+        request = MockRequest(cookies={self.cookie_name: "garbage.value.here"})
+
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "anonymous"
+        assert identity.auth_method == "anonymous"
+
+    def test_auth_dependency_wins_over_fallback(self):
+        """If a dep populated user_context, do NOT overwrite with fallback."""
+        cookie = self._make_cookie(username="alice")
+        request = MockRequest(cookies={self.cookie_name: cookie})
+        request.state.user_context = {
+            "username": "bob",
+            "auth_method": "oauth2",
+            "provider": "keycloak",
+        }
+
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "bob"
+        assert identity.auth_method == "oauth2"
+
+    def test_fallback_does_not_mutate_request_state(self):
+        cookie = self._make_cookie()
+        request = MockRequest(cookies={self.cookie_name: cookie})
+
+        self.middleware._extract_identity(request)
+
+        assert request.state.user_context is None
+
+    def test_fallback_anonymous_when_cookie_missing_username(self):
+        payload = self.signer.dumps({"auth_method": "oauth2"})
+        request = MockRequest(cookies={self.cookie_name: payload})
+
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "anonymous"
+        assert identity.auth_method == "anonymous"
+
+    def test_fallback_anonymous_on_expired_cookie(self, monkeypatch):
+        """max_age=-1 forces SignatureExpired on any cookie regardless of age,
+        exercising the expired-cookie branch without waiting real time."""
+        from registry.core.config import settings
+
+        cookie = self._make_cookie()
+        request = MockRequest(cookies={self.cookie_name: cookie})
+
+        monkeypatch.setattr(settings, "session_max_age_seconds", -1)
+        identity = self.middleware._extract_identity(request)
+
+        assert identity.username == "anonymous"
+        assert identity.auth_method == "anonymous"

--- a/tests/unit/test_stats_endpoint.py
+++ b/tests/unit/test_stats_endpoint.py
@@ -377,14 +377,29 @@ class TestStatsEndpoint:
     """Tests for /api/stats endpoint."""
 
     @pytest.mark.asyncio
-    async def test_stats_endpoint_success(self, mock_repositories):
-        """Test successful stats endpoint call."""
+    async def test_stats_endpoint_success_when_authenticated(self, mock_repositories):
+        """Authenticated caller sees full stats payload."""
         import registry.api.system_routes
+        from registry.auth.dependencies import nginx_proxied_auth
 
         # Reset cache
         registry.api.system_routes._stats_cache = None
         registry.api.system_routes._stats_cache_time = None
         registry.api.system_routes._server_start_time = datetime.now(UTC)
+
+        user_context = {
+            "username": "alice",
+            "groups": ["mcp-registry-user"],
+            "scopes": [],
+            "auth_method": "oauth2",
+            "provider": "keycloak",
+            "accessible_servers": [],
+            "accessible_services": [],
+            "accessible_agents": [],
+            "ui_permissions": {},
+            "can_modify_servers": False,
+            "is_admin": False,
+        }
 
         with patch(
             "registry.repositories.factory.get_server_repository",
@@ -404,12 +419,13 @@ class TestStatsEndpoint:
 
                         from registry.main import app
 
-                        client = TestClient(app)
+                        app.dependency_overrides[nginx_proxied_auth] = lambda: user_context
+                        try:
+                            client = TestClient(app)
+                            response = client.get("/api/stats")
+                        finally:
+                            app.dependency_overrides.pop(nginx_proxied_auth, None)
 
-                        # Act
-                        response = client.get("/api/stats")
-
-                        # Assert
                         assert response.status_code == 200
                         data = response.json()
                         assert "uptime_seconds" in data
@@ -417,3 +433,26 @@ class TestStatsEndpoint:
                         assert "version" in data
                         assert "deployment_type" in data
                         assert "registry_stats" in data
+
+    def test_stats_endpoint_rejects_unauthenticated_callers(self):
+        """Unauthenticated callers must get 401, not an anonymous-logged 200.
+
+        Regression guard for the audit-anonymous bug: /api/stats previously
+        had no auth dependency and logged authenticated users as anonymous.
+        """
+        from registry.main import app
+
+        client = TestClient(app)
+        response = client.get("/api/stats")
+
+        assert response.status_code == 401
+
+    def test_telemetry_detection_rejects_unauthenticated_callers(self):
+        """Regression guard: /api/system/telemetry-detection now requires auth
+        for the same audit-attribution reason as /api/stats."""
+        from registry.main import app
+
+        client = TestClient(app)
+        response = client.get("/api/system/telemetry-detection")
+
+        assert response.status_code == 401


### PR DESCRIPTION
Authenticated users polling /api/stats from the uptime widget were logged as username=anonymous in the audit log, because the endpoint had no auth dependency and the UI's bare fetch() was stripping the session cookie.

Three-layer fix:

- Require nginx_proxied_auth on /api/stats and /api/system/telemetry-detection. /api/version stays public (CLI callers + dedicated nginx location block).
- Add a best-effort session-cookie fallback in the audit middleware. When no auth dependency has populated request.state.user_context, decode the cookie with the same URLSafeTimedSerializer + max_age check as the auth path and stamp auth_method=session-cookie-fallback so the fallback is distinguishable in audit queries. Read-only; never mutates request state.
- Migrate five bare fetch(apiUrl(...)) call sites in UptimeDisplay and Layout to the axios client so they inherit withCredentials=true. Add an eslint no-restricted-syntax rule to prevent the pattern from returning.

Breaking change: /api/stats and /api/system/telemetry-detection now return 401 to unauthenticated callers. External monitoring should use /api/version for liveness checks.

Fixes #939 