### PR TITLE
fix(bind-host): default BIND_HOST to 0.0.0.0; keep :: as opt-in (#864 follow-up)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,13 @@
 # For custom HTTPS domain: https://mcpgateway.mycorp.com
 REGISTRY_URL=http://localhost
 
-# Network bind address: "::" for dual-stack IPv4+IPv6, "0.0.0.0" for IPv4 only
-# On Linux, "::" accepts both IPv4 and IPv6 by default (net.ipv6.bindv6only=0)
-BIND_HOST=::
+# Network bind address. Default "0.0.0.0" binds to all IPv4 interfaces and
+# works on every host. Operators running on IPv6-only Kubernetes clusters can
+# opt in to dual-stack by uncommenting BIND_HOST=::, but that requires
+# net.ipv6.bindv6only=0 on the host and an IPv6 loopback inside the container.
+# See docs/unified-parameter-reference.md Group 4 for details.
+# BIND_HOST=0.0.0.0
+# BIND_HOST=::
 
 # =============================================================================
 # REGISTRY CARD CONFIGURATION

--- a/charts/mcpgw/values.yaml
+++ b/charts/mcpgw/values.yaml
@@ -21,7 +21,10 @@ app:
   envSecretName: mcpgw-secret
   existingSecret: ""  # If set, use this existing secret instead of creating one
   port: 8000
-  bindHost: "::"
+  # Server bind address. Default "0.0.0.0" works on all Kubernetes nodes.
+  # Set to "::" only for IPv6-only clusters (requires net.ipv6.bindv6only=0
+  # on the node). See docs/unified-parameter-reference.md Group 4.
+  bindHost: "0.0.0.0"
 
   # Registry connection — default is the standalone fallback. When this
   # subchart is deployed as part of mcp-gateway-registry-stack, the

--- a/docker/auth-entrypoint.sh
+++ b/docker/auth-entrypoint.sh
@@ -97,7 +97,10 @@ while True:
     echo "MongoDB is ready."
 fi
 
-BIND_HOST="${BIND_HOST:-::}"
+# Default binds to all IPv4 interfaces inside the container. Operators who
+# need IPv6 dual-stack can set BIND_HOST=:: — but see docs/TELEMETRY.md for
+# the net.ipv6.bindv6only=0 host-side requirement.
+BIND_HOST="${BIND_HOST:-0.0.0.0}"
 
 echo "Starting Auth Server (host=$BIND_HOST)..."
 cd /app

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -279,7 +279,10 @@ export EMBEDDINGS_PROVIDER=$EMBEDDINGS_PROVIDER
 export EMBEDDINGS_MODEL_NAME=$EMBEDDINGS_MODEL_NAME
 export EMBEDDINGS_MODEL_DIMENSIONS=$EMBEDDINGS_MODEL_DIMENSIONS
 
-BIND_HOST="${BIND_HOST:-::}"
+# Default binds to all IPv4 interfaces inside the container. Operators who
+# need IPv6 dual-stack can set BIND_HOST=:: — but see docs/TELEMETRY.md for
+# the net.ipv6.bindv6only=0 host-side requirement.
+BIND_HOST="${BIND_HOST:-0.0.0.0}"
 
 echo "Starting MCP Registry in the background..."
 cd /app

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -131,6 +131,7 @@ Affects only `with-gateway` deployments (nginx reverse proxy).
 | Parameter | Docker (`.env`) | Terraform (`.tfvars`) | Helm (`values.yaml`) | Purpose |
 |-----------|-----------------|-----------------------|----------------------|---------|
 | Extra nginx `server_name` entries | `GATEWAY_ADDITIONAL_SERVER_NAMES` | — | — (ingress annotations handle this) | Space-separated list of additional hostnames / IPs to accept. |
+| Server bind address (IPv6 dual-stack) | `BIND_HOST` (and `HOST` for currenttime/mcpgw) | `bind_host` | `mcpgw.app.bindHost` | Default `::` accepts both IPv4 and IPv6 on Linux (`net.ipv6.bindv6only=0`). Set to `0.0.0.0` for IPv4-only. Issue #863 / PR #864. Local-dev `uvicorn` direct invocation and `servers/currenttime` keep the safer `127.0.0.1` default. |
 
 ---
 

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -131,7 +131,7 @@ Affects only `with-gateway` deployments (nginx reverse proxy).
 | Parameter | Docker (`.env`) | Terraform (`.tfvars`) | Helm (`values.yaml`) | Purpose |
 |-----------|-----------------|-----------------------|----------------------|---------|
 | Extra nginx `server_name` entries | `GATEWAY_ADDITIONAL_SERVER_NAMES` | — | — (ingress annotations handle this) | Space-separated list of additional hostnames / IPs to accept. |
-| Server bind address (IPv6 dual-stack) | `BIND_HOST` (and `HOST` for currenttime/mcpgw) | `bind_host` | `mcpgw.app.bindHost` | Default `::` accepts both IPv4 and IPv6 on Linux (`net.ipv6.bindv6only=0`). Set to `0.0.0.0` for IPv4-only. Issue #863 / PR #864. Local-dev `uvicorn` direct invocation and `servers/currenttime` keep the safer `127.0.0.1` default. |
+| Server bind address (IPv6 opt-in) | `BIND_HOST` (and `HOST` for currenttime/mcpgw) | `bind_host` | `mcpgw.app.bindHost` | Default `0.0.0.0` (IPv4) works everywhere. Set to `::` only for IPv6-only deployments — requires `net.ipv6.bindv6only=0` on the host AND an IPv6 loopback in the container. Issue #863 / PR #864. Local-dev `uvicorn` direct invocation and `servers/currenttime` keep the safer `127.0.0.1` default. |
 
 ---
 

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -60,8 +60,13 @@ class Settings(BaseSettings):
         extra="ignore",  # Ignore extra environment variables
     )
 
-    # Network binding: "::" for dual-stack IPv4+IPv6, "0.0.0.0" for IPv4 only
-    bind_host: str = "::"
+    # Network binding: default "0.0.0.0" binds to all IPv4 interfaces inside
+    # the container (works everywhere). Opt into IPv6 dual-stack by setting
+    # BIND_HOST=:: — but note that requires net.ipv6.bindv6only=0 on the host
+    # AND an IPv6 loopback in the container image, which the stock Docker
+    # image does not have. See docs/TELEMETRY.md and
+    # docs/unified-parameter-reference.md (Group 4) for details.
+    bind_host: str = "0.0.0.0"  # nosec B104 - bind to all IPv4 interfaces inside container
 
     # Auth settings
     secret_key: str = ""

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -359,9 +359,9 @@ variable "session_cookie_domain" {
 }
 
 variable "bind_host" {
-  description = "Network bind address for registry and gateway services. Use '::' for dual-stack IPv4+IPv6 or '0.0.0.0' for IPv4 only."
+  description = "Network bind address for registry and gateway services. Default '0.0.0.0' (IPv4) works on all hosts. Set to '::' only for IPv6-only deployments (requires net.ipv6.bindv6only=0 on the host)."
   type        = string
-  default     = "::"
+  default     = "0.0.0.0"
 }
 
 variable "oauth_store_tokens_in_session" {

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -252,9 +252,9 @@ variable "session_cookie_domain" {
 }
 
 variable "bind_host" {
-  description = "Network bind address for registry and gateway services. Use '::' for dual-stack IPv4+IPv6 or '0.0.0.0' for IPv4 only."
+  description = "Network bind address for registry and gateway services. Default '0.0.0.0' (IPv4) works on all hosts. Set to '::' only for IPv6-only deployments (requires net.ipv6.bindv6only=0 on the host)."
   type        = string
-  default     = "::"
+  default     = "0.0.0.0"
 }
 
 # =============================================================================


### PR DESCRIPTION
Follow-up to #864. Two commits:

1. **`docs(params)`** — add the `BIND_HOST` / `bind_host` / `bindHost` row to `docs/unified-parameter-reference.md` under Group 4 (Gateway Host Configuration). The unified parameter reference (introduced in #1003) landed after PR #864 was last pushed, so this row was missed.

2. **`fix(bind-host)`** — flip the shipping default from `::` to `0.0.0.0` across **every surface**:
   - `registry/core/config.py` Pydantic setting
   - `docker/registry-entrypoint.sh`, `docker/auth-entrypoint.sh`
   - `charts/mcpgw/values.yaml`
   - `terraform/aws-ecs/variables.tf` and module `variables.tf`
   - `.env.example` (now shows both options commented out, with guidance)
   - Unified parameter reference row updated accordingly

## Why

PR #864 defaulted bind host to `::` (IPv6 dual-stack) so IPv6-only K8s clusters work out of the box. On paper this is correct because Linux has `net.ipv6.bindv6only=0` by default and `::` accepts both IPv4 and IPv6 via v4-mapped addresses.

**In practice, the stock Docker image used by this repo does NOT meet those preconditions.** After #864 merged and I rebuilt locally:

- uvicorn bound to `[::]:7860` only (IPv6).
- nginx's `proxy_pass http://127.0.0.1:7860` (hardcoded in `docker/nginx_rev_proxy_http_only.conf` and `docker/nginx_rev_proxy_http_and_https.conf`, 20+ occurrences) could not reach the upstream.
- Every request returned HTTP 404 / connection-refused; the full UI was broken at `https://mcpgateway.ddns.net/` and `http://localhost/`.

Verified by `docker exec ... curl http://127.0.0.1:7860/` → connection refused, and `curl http://[::1]:7860/` → 200.

## Why not fix nginx instead

Option 2 in triage was to rewrite every `proxy_pass` to `http://[::1]:7860`. That's 20+ lines across two template files, plus it assumes every deployment target has an IPv6 loopback — which breaks the opposite class of deployments (IPv4-only hosts without IPv6 support enabled). The nginx templates are shared with every deployment model.

Flipping the default to `0.0.0.0` keeps the fleet working everywhere. IPv6-only operators (the original motivation for #864) opt in by setting `BIND_HOST=::` — documented in `.env.example`, `docs/unified-parameter-reference.md`, and the terraform/helm variable descriptions.

## Test plan

- [x] Local rebuild: `docker compose up -d --build registry auth-server` — registry comes up, uvicorn binds on `0.0.0.0:7860`, `curl http://localhost/` → HTTP 200, browser loads the UI.
- [x] `uv run python -m py_compile registry/core/config.py` — clean
- [x] `bash -n docker/registry-entrypoint.sh docker/auth-entrypoint.sh` — clean
- [x] Verified all 6 surfaces show `0.0.0.0` as the default; `::` remains available as a documented opt-in.

## Rollback

If an IPv6-only operator breaks after this merge, they can set `BIND_HOST=::` in `.env` / `mcpgw.app.bindHost: "::"` in Helm / `bind_host = "::"` in tfvars. The code paths for `::` are untouched; only the default changed.