### PR TITLE
fix(agents+deps): use update_agent for security-pending tag (#1033) + bump litellm 1.83.14 (#1034)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "motor>=3.3.0",
     "pymongo>=4.6.0",
     "dnspython>=2.4.0",
-    "litellm==1.83.0",
+    "litellm==1.83.14",
     "cryptography>=46.0.7",
     "prometheus-client>=0.20.0",
 ]

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -137,9 +137,15 @@ async def _perform_agent_security_scan_on_registration(
                 await agent_service.toggle_agent(path, False)
                 logger.warning(f"Disabled agent {path} due to failed security scan")
 
-                # Update search index with disabled state
+                # Update search index with disabled state.
+                # Issue #1033 follow-up: index_agent expects an AgentCard
+                # model (it reads .name / .description / .tags / .skills);
+                # passing the raw dict here raised
+                # `'dict' object has no attribute 'name'`. Use the model
+                # we already have, which carries the security-pending tag
+                # added a few lines above.
                 search_repo = get_search_repository()
-                await search_repo.index_agent(path, agent_card_dict, is_enabled=False)
+                await search_repo.index_agent(path, agent_card, is_enabled=False)
                 return False  # Agent disabled
 
         else:

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -115,14 +115,21 @@ async def _perform_agent_security_scan_on_registration(
                 if "security-pending" not in current_tags:
                     current_tags.append("security-pending")
                     agent_card.tags = current_tags
-                    # Update agent with new tags
+                    # Issue #1033: update_agent (not register_agent) is the
+                    # right call here. The agent was already inserted by the
+                    # caller; calling register_agent again raises
+                    # "path '...' already exists" which silently swallows
+                    # the security-pending tag and leaves the agent without
+                    # the warning it earned.
                     agent_info = await agent_service.get_agent_info(path)
                     if agent_info:
                         updated_card = agent_info.model_dump()
                         updated_card["tags"] = current_tags
                         from ..schemas.agent_models import AgentCard as AgentCardModel
 
-                        await agent_service.register_agent(AgentCardModel(**updated_card))
+                        await agent_service.update_agent(
+                            path, AgentCardModel(**updated_card)
+                        )
                     logger.info(f"Added 'security-pending' tag to agent {path}")
 
             # Disable agent if configured

--- a/registry/repositories/documentdb/agent_repository.py
+++ b/registry/repositories/documentdb/agent_repository.py
@@ -144,6 +144,17 @@ class DocumentDBAgentRepository(AgentRepositoryBase):
 
         collection = await self._get_collection()
 
+        # Preserve extra document fields (e.g. ans_metadata) that are not
+        # part of the AgentCard Pydantic model but stored on the document
+        # by other code paths (link_ans_to_agent, health checks). Without
+        # this, $set overwrites the entire document with only model fields
+        # and any extra fields are silently lost.
+        raw_doc = await collection.find_one({"_id": path})
+        extra_fields: dict[str, Any] = {}
+        if raw_doc:
+            model_keys = set(AgentCard.model_fields.keys()) | {"_id", "path", "updated_at"}
+            extra_fields = {k: v for k, v in raw_doc.items() if k not in model_keys}
+
         agent_dict = existing_agent.model_dump()
         agent_dict.update(updates)
         agent_dict["updated_at"] = datetime.utcnow()
@@ -156,6 +167,7 @@ class DocumentDBAgentRepository(AgentRepositoryBase):
 
         update_dict = updated_agent.model_dump(mode="json")
         update_dict.pop("path", None)
+        update_dict.update(extra_fields)
 
         try:
             result = await collection.update_one({"_id": path}, {"$set": update_dict})

--- a/registry/services/ans_client.py
+++ b/registry/services/ans_client.py
@@ -203,12 +203,24 @@ async def _resolve_ans_id(
     headers = _build_auth_header()
     search_url = f"{settings.ans_api_endpoint}/v1/agents"
 
+    # Extract host from ANS URI (e.g. "ans://v1.0.0.tourist-guide.agentworks.fr"
+    # -> "tourist-guide.agentworks.fr") and use the agentHost query param for a
+    # single-request lookup instead of paginating through all 60k+ agents.
+    try:
+        ans_host = ans_agent_id.split("//", 1)[1].split(".", 1)[1]
+    except (IndexError, ValueError):
+        ans_host = None
+
     try:
         async with httpx.AsyncClient(timeout=settings.ans_api_timeout_seconds) as client:
+            params: dict[str, str | int] = {"limit": 10}
+            if ans_host:
+                params["agentHost"] = ans_host
+
             response = await client.get(
                 search_url,
                 headers=headers,
-                params={"limit": 100, "offset": 0},
+                params=params,
             )
             response.raise_for_status()
             data = response.json()
@@ -218,26 +230,6 @@ async def _resolve_ans_id(
                     agent_uuid = agent.get("agentId")
                     logger.info(f"Resolved ANS name '{ans_agent_id}' to UUID '{agent_uuid}'")
                     return agent_uuid
-
-            # Search remaining pages if needed
-            total_count = data.get("totalCount", 0)
-            offset = 100
-            while offset < total_count:
-                response = await client.get(
-                    search_url,
-                    headers=headers,
-                    params={"limit": 100, "offset": offset},
-                )
-                response.raise_for_status()
-                page_data = response.json()
-
-                for agent in page_data.get("agents", []):
-                    if agent.get("ansName") == ans_agent_id:
-                        agent_uuid = agent.get("agentId")
-                        logger.info(f"Resolved ANS name '{ans_agent_id}' to UUID '{agent_uuid}'")
-                        return agent_uuid
-
-                offset += 100
 
     except Exception as e:
         logger.error(f"Failed to resolve ANS name '{ans_agent_id}': {e}")

--- a/registry/services/ans_client.py
+++ b/registry/services/ans_client.py
@@ -203,11 +203,14 @@ async def _resolve_ans_id(
     headers = _build_auth_header()
     search_url = f"{settings.ans_api_endpoint}/v1/agents"
 
-    # Extract host from ANS URI (e.g. "ans://v1.0.0.tourist-guide.agentworks.fr"
-    # -> "tourist-guide.agentworks.fr") and use the agentHost query param for a
-    # single-request lookup instead of paginating through all 60k+ agents.
+    # Extract host from ANS URI. Format: "ans://v{major}.{minor}.{patch}.{host}"
+    # e.g. "ans://v1.0.0.tourist-guide.agentworks.fr" -> "tourist-guide.agentworks.fr"
+    # Use the agentHost query param for a single-request lookup instead of
+    # paginating through all 60k+ agents.
     try:
-        ans_host = ans_agent_id.split("//", 1)[1].split(".", 1)[1]
+        after_scheme = ans_agent_id.split("//", 1)[1]  # v1.0.0.tourist-guide.agentworks.fr
+        segments = after_scheme.split(".", 3)           # ['v1', '0', '0', 'tourist-guide...']
+        ans_host = segments[3] if len(segments) > 3 else None
     except (IndexError, ValueError):
         ans_host = None
 

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -1759,6 +1759,84 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
         service_mock.toggle_agent.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_unsafe_scan_with_block_indexes_with_agent_card_model(
+        self,
+        sample_agent_card,
+    ):
+        """Regression for the secondary bug surfaced after #1033 was fixed:
+        when block_unsafe_agents=True, the route called
+        search_repo.index_agent(path, agent_card_dict, ...) which raised
+        `'dict' object has no attribute 'name'` because index_agent expects
+        an AgentCard model. The route must pass the AgentCard instance.
+        """
+        # Arrange
+        from registry.api.agent_routes import (
+            _perform_agent_security_scan_on_registration,
+        )
+
+        path = sample_agent_card.path
+        agent_card_dict = sample_agent_card.model_dump()
+
+        scan_result = MagicMock(
+            is_safe=False,
+            critical_issues=0,
+            high_severity=1,
+        )
+        scan_config = MagicMock(
+            enabled=True,
+            scan_on_registration=True,
+            add_security_pending_tag=True,
+            block_unsafe_agents=True,
+            analyzers=["yara", "spec"],
+            llm_api_key=None,
+            scan_timeout_seconds=30,
+        )
+        scanner_mock = MagicMock()
+        scanner_mock.get_scan_config.return_value = scan_config
+        scanner_mock.scan_agent = AsyncMock(return_value=scan_result)
+
+        existing_card_info = MagicMock()
+        existing_card_info.model_dump.return_value = agent_card_dict.copy()
+
+        service_mock = MagicMock(
+            get_agent_info=AsyncMock(return_value=existing_card_info),
+            register_agent=AsyncMock(),
+            update_agent=AsyncMock(),
+            toggle_agent=AsyncMock(),
+        )
+
+        search_repo_mock = MagicMock()
+        search_repo_mock.index_agent = AsyncMock()
+
+        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
+            "registry.services.agent_scanner.agent_scanner_service",
+            new=scanner_mock,
+        ), patch(
+            "registry.repositories.factory.get_search_repository",
+            return_value=search_repo_mock,
+        ):
+            # Act
+            still_enabled = await _perform_agent_security_scan_on_registration(
+                path,
+                sample_agent_card,
+                agent_card_dict,
+            )
+
+        # Assert - block_unsafe_agents=True path runs to completion without raising.
+        assert still_enabled is False
+        service_mock.toggle_agent.assert_awaited_once_with(path, False)
+
+        # The critical regression assertion: index_agent receives the
+        # AgentCard model, not the raw dict, so .name / .description /
+        # .tags lookups inside index_agent succeed.
+        assert search_repo_mock.index_agent.await_count == 1
+        called_path, called_card = search_repo_mock.index_agent.await_args.args
+        assert called_path == path
+        assert isinstance(called_card, AgentCard), (
+            f"index_agent was called with {type(called_card).__name__}, expected AgentCard"
+        )
+
+    @pytest.mark.asyncio
     async def test_safe_scan_does_not_call_update_agent(
         self,
         sample_agent_card,

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -1671,3 +1671,144 @@ class TestRatingRequestModel:
         # Arrange & Act & Assert
         with pytest.raises(ValidationError):
             RatingRequest(rating="invalid")
+
+
+# =============================================================================
+# Regression: post-registration security-scan must call update_agent, not
+# register_agent (Issue #1033). The agent already exists when this code path
+# runs; calling register_agent again raises "path '...' already exists" and
+# the security-pending tag never lands.
+# =============================================================================
+
+
+class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
+    """Regression for #1033."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_scan_uses_update_agent_for_security_pending_tag(
+        self,
+        sample_agent_card,
+    ):
+        """When the post-registration scan flags the agent unsafe and the
+        config requires the security-pending tag, the route must call
+        update_agent (which performs an in-place update) rather than
+        register_agent (which performs an INSERT and fails because the agent
+        already exists).
+        """
+        # Arrange
+        from registry.api.agent_routes import (
+            _perform_agent_security_scan_on_registration,
+        )
+
+        path = sample_agent_card.path
+        agent_card_dict = sample_agent_card.model_dump()
+
+        scan_result = MagicMock(
+            is_safe=False,
+            critical_issues=0,
+            high_severity=1,
+        )
+        scan_config = MagicMock(
+            enabled=True,
+            scan_on_registration=True,
+            add_security_pending_tag=True,
+            block_unsafe_agents=False,
+            analyzers=["yara", "spec"],
+            llm_api_key=None,
+            scan_timeout_seconds=30,
+        )
+
+        scanner_mock = MagicMock()
+        scanner_mock.get_scan_config.return_value = scan_config
+        scanner_mock.scan_agent = AsyncMock(return_value=scan_result)
+
+        existing_card_info = MagicMock()
+        existing_card_info.model_dump.return_value = agent_card_dict.copy()
+
+        service_mock = MagicMock(
+            get_agent_info=AsyncMock(return_value=existing_card_info),
+            register_agent=AsyncMock(),
+            update_agent=AsyncMock(),
+            toggle_agent=AsyncMock(),
+        )
+
+        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
+            "registry.services.agent_scanner.agent_scanner_service",
+            new=scanner_mock,
+        ):
+            # Act
+            still_enabled = await _perform_agent_security_scan_on_registration(
+                path,
+                sample_agent_card,
+                agent_card_dict,
+            )
+
+        # Assert
+        # update_agent must be the method used to persist the security-pending
+        # tag. register_agent must NOT be called inside this helper because
+        # the agent was already inserted by the caller.
+        assert service_mock.update_agent.await_count == 1
+        called_path, called_card = service_mock.update_agent.await_args.args
+        assert called_path == path
+        assert "security-pending" in called_card.tags
+        assert service_mock.register_agent.await_count == 0
+
+        # block_unsafe_agents was False, so the scan helper does not toggle
+        # off and returns True (agent stays enabled).
+        assert still_enabled is True
+        service_mock.toggle_agent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_safe_scan_does_not_call_update_agent(
+        self,
+        sample_agent_card,
+    ):
+        """A safe scan must not touch agent state at all (no tag updates,
+        no toggle). Guards the regression test above against false-positive
+        behavior on the safe path.
+        """
+        # Arrange
+        from registry.api.agent_routes import (
+            _perform_agent_security_scan_on_registration,
+        )
+
+        path = sample_agent_card.path
+        agent_card_dict = sample_agent_card.model_dump()
+
+        scan_result = MagicMock(is_safe=True, critical_issues=0, high_severity=0)
+        scan_config = MagicMock(
+            enabled=True,
+            scan_on_registration=True,
+            add_security_pending_tag=True,
+            block_unsafe_agents=True,
+            analyzers=["yara"],
+            llm_api_key=None,
+            scan_timeout_seconds=30,
+        )
+        scanner_mock = MagicMock()
+        scanner_mock.get_scan_config.return_value = scan_config
+        scanner_mock.scan_agent = AsyncMock(return_value=scan_result)
+
+        service_mock = MagicMock(
+            get_agent_info=AsyncMock(),
+            register_agent=AsyncMock(),
+            update_agent=AsyncMock(),
+            toggle_agent=AsyncMock(),
+        )
+
+        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
+            "registry.services.agent_scanner.agent_scanner_service",
+            new=scanner_mock,
+        ):
+            # Act
+            still_enabled = await _perform_agent_security_scan_on_registration(
+                path,
+                sample_agent_card,
+                agent_card_dict,
+            )
+
+        # Assert
+        assert still_enabled is True
+        service_mock.update_agent.assert_not_awaited()
+        service_mock.register_agent.assert_not_awaited()
+        service_mock.toggle_agent.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -389,14 +389,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
@@ -1153,14 +1153,14 @@ wheels = [
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.1"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "zipp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514, upload-time = "2024-09-11T14:56:07.019Z" },
 ]
 
 [[package]]
@@ -1273,7 +1273,7 @@ wheels = [
 
 [[package]]
 name = "jsonschema"
-version = "4.25.1"
+version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1281,9 +1281,9 @@ dependencies = [
     { name = "referencing" },
     { name = "rpds-py" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778, upload-time = "2024-07-08T18:40:05.546Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462, upload-time = "2024-07-08T18:40:00.165Z" },
 ]
 
 [[package]]
@@ -1485,7 +1485,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.0"
+version = "1.83.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1501,9 +1501,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/92/6ce9737554994ca8e536e5f4f6a87cc7c4774b656c9eb9add071caf7d54b/litellm-1.83.0.tar.gz", hash = "sha256:860bebc76c4bb27b4cf90b4a77acd66dba25aced37e3db98750de8a1766bfb7a", size = 17333062, upload-time = "2026-03-31T05:08:25.331Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/2c/a670cc050fcd6f45c6199eb99e259c73aea92edba8d5c2fc1b3686d36217/litellm-1.83.0-py3-none-any.whl", hash = "sha256:88c536d339248f3987571493015784671ba3f193a328e1ea6780dbebaa2094a8", size = 15610306, upload-time = "2026-03-31T05:08:21.987Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [[package]]
@@ -1756,7 +1756,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-mcp-adapters", specifier = ">=0.0.11" },
     { name = "langgraph", specifier = ">=0.4.3" },
-    { name = "litellm", specifier = "==1.83.0" },
+    { name = "litellm", specifier = "==1.83.14" },
     { name = "matplotlib", specifier = ">=3.10.5" },
     { name = "mcp", specifier = ">=1.9.3" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
@@ -2030,7 +2030,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.14.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2042,9 +2042,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/b1/12fe1c196bea326261718eb037307c1c1fe1dedc2d2d4de777df822e6238/openai-2.14.0.tar.gz", hash = "sha256:419357bedde9402d23bf8f2ee372fca1985a73348debba94bddff06f19459952", size = 626938, upload-time = "2025-12-19T03:28:45.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/4b/7c1a00c2c3fbd004253937f7520f692a9650767aa73894d7a34f0d65d3f4/openai-2.14.0-py3-none-any.whl", hash = "sha256:7ea40aca4ffc4c4a776e77679021b47eec1160e341f42ae086ba949c9dcc9183", size = 1067558, upload-time = "2025-12-19T03:28:43.727Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]
@@ -3222,27 +3222,28 @@ wheels = [
 
 [[package]]
 name = "tokenizers"
-version = "0.22.1"
+version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/46/fb6854cec3278fbfa4a75b50232c77622bc517ac886156e6afbfa4d8fc6e/tokenizers-0.22.1.tar.gz", hash = "sha256:61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9", size = 363123, upload-time = "2025-09-19T09:49:23.424Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/33/f4b2d94ada7ab297328fc671fed209368ddb82f965ec2224eb1892674c3a/tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73", size = 3069318, upload-time = "2025-09-19T09:49:11.848Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/58/2aa8c874d02b974990e89ff95826a4852a8b2a273c7d1b4411cdd45a4565/tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc", size = 2926478, upload-time = "2025-09-19T09:49:09.759Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/3b/55e64befa1e7bfea963cf4b787b2cea1011362c4193f5477047532ce127e/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19d2962dd28bc67c1f205ab180578a78eef89ac60ca7ef7cbe9635a46a56422a", size = 3256994, upload-time = "2025-09-19T09:48:56.701Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/fbfecf42f67d9b7b80fde4aabb2b3110a97fac6585c9470b5bff103a80cb/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38201f15cdb1f8a6843e6563e6e79f4abd053394992b9bbdf5213ea3469b4ae7", size = 3153141, upload-time = "2025-09-19T09:48:59.749Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a9/b38f4e74e0817af8f8ef925507c63c6ae8171e3c4cb2d5d4624bf58fca69/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d1cbe5454c9a15df1b3443c726063d930c16f047a3cc724b9e6e1a91140e5a21", size = 3508049, upload-time = "2025-09-19T09:49:05.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/48/dd2b3dac46bb9134a88e35d72e1aa4869579eacc1a27238f1577270773ff/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7d094ae6312d69cc2a872b54b91b309f4f6fbce871ef28eb27b52a98e4d0214", size = 3710730, upload-time = "2025-09-19T09:49:01.832Z" },
-    { url = "https://files.pythonhosted.org/packages/93/0e/ccabc8d16ae4ba84a55d41345207c1e2ea88784651a5a487547d80851398/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afd7594a56656ace95cdd6df4cca2e4059d294c5cfb1679c57824b605556cb2f", size = 3412560, upload-time = "2025-09-19T09:49:03.867Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c6/dc3a0db5a6766416c32c034286d7c2d406da1f498e4de04ab1b8959edd00/tokenizers-0.22.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2ef6063d7a84994129732b47e7915e8710f27f99f3a3260b8a38fc7ccd083f4", size = 3250221, upload-time = "2025-09-19T09:49:07.664Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/a6/2c8486eef79671601ff57b093889a345dd3d576713ef047776015dc66de7/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ba0a64f450b9ef412c98f6bcd2a50c6df6e2443b560024a09fa6a03189726879", size = 9345569, upload-time = "2025-09-19T09:49:14.214Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/16/32ce667f14c35537f5f605fe9bea3e415ea1b0a646389d2295ec348d5657/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:331d6d149fa9c7d632cde4490fb8bbb12337fa3a0232e77892be656464f4b446", size = 9271599, upload-time = "2025-09-19T09:49:16.639Z" },
-    { url = "https://files.pythonhosted.org/packages/51/7c/a5f7898a3f6baa3fc2685c705e04c98c1094c523051c805cdd9306b8f87e/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:607989f2ea68a46cb1dfbaf3e3aabdf3f21d8748312dbeb6263d1b3b66c5010a", size = 9533862, upload-time = "2025-09-19T09:49:19.146Z" },
-    { url = "https://files.pythonhosted.org/packages/36/65/7e75caea90bc73c1dd8d40438adf1a7bc26af3b8d0a6705ea190462506e1/tokenizers-0.22.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a0f307d490295717726598ef6fa4f24af9d484809223bbc253b201c740a06390", size = 9681250, upload-time = "2025-09-19T09:49:21.501Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2c/959dddef581b46e6209da82df3b78471e96260e2bc463f89d23b1bf0e52a/tokenizers-0.22.1-cp39-abi3-win32.whl", hash = "sha256:b5120eed1442765cd90b903bb6cfef781fd8fe64e34ccaecbae4c619b7b12a82", size = 2472003, upload-time = "2025-09-19T09:49:27.089Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/46/e33a8c93907b631a99377ef4c5f817ab453d0b34f93529421f42ff559671/tokenizers-0.22.1-cp39-abi3-win_amd64.whl", hash = "sha256:65fd6e3fb11ca1e78a6a93602490f134d1fdeb13bcef99389d5102ea318ed138", size = 2674684, upload-time = "2025-09-19T09:49:24.953Z" },
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -3283,14 +3284,14 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-linux_s390x.whl", upload-time = "2026-05-12T15:15:24Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", upload-time = "2026-05-12T15:15:25Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = "2026-05-12T15:15:27Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-win_amd64.whl", upload-time = "2026-05-12T15:15:28Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-linux_s390x.whl", upload-time = "2026-05-12T15:15:28Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", upload-time = "2026-05-12T15:15:29Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", upload-time = "2026-05-12T15:15:29Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-win_amd64.whl", upload-time = "2026-05-12T15:15:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:ee1f329acfd0c2a1ccaa3393bcaf9857ea58759549bb2d67e271a6eab42382b3", upload-time = "2026-05-12T23:18:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:797c066367792c92eb97cafba7fd0caa8d7455e6078a4ee880630077378dc372", upload-time = "2026-05-12T23:18:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a8f419ce3f25388d36e67153ec63b3a1b17059c49f5a7759a7e91ac4843660d3", upload-time = "2026-05-12T23:18:22Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:1dd196c43e74e7b3b526ff434e7efbdef3f3792a2efbecfc983d7dce501840d2", upload-time = "2026-05-12T23:18:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:d0d2080cb13c94ebc0c884d237e404490743d0f40192c8a180abf3b6b6f334cf", upload-time = "2026-05-12T23:18:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f7bc15972acad257723775237cdd120024cca844b8bc64701822fa596bcb7e14", upload-time = "2026-05-12T23:18:42Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4d79f961250d1763487ecbc90af019a80009f9e87cadc5366b3ec4ba5671fea6", upload-time = "2026-05-12T23:18:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:46b8f4c41ac36bb5d5b47f5437b3de5541b313275e59c1d2aefd3bef32b0f531", upload-time = "2026-05-12T23:18:58Z" },
 ]
 
 [[package]]
@@ -3329,7 +3330,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.24.1"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -3337,21 +3338,21 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/07/b822e1b307d40e263e8253d2384cf98c51aa2368cc7ba9a07e523a1d964b/typer-0.23.1.tar.gz", hash = "sha256:2070374e4d31c83e7b61362fd859aa683576432fd5b026b060ad6b4cd3b86134", size = 120047, upload-time = "2026-02-13T10:04:30.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/9b286ab899c008c2cb05e8be99814807e7fbbd33f0c0c960470826e5ac82/typer-0.23.1-py3-none-any.whl", hash = "sha256:3291ad0d3c701cbf522012faccfbb29352ff16ad262db2139e6b01f15781f14e", size = 56813, upload-time = "2026-02-13T10:04:32.008Z" },
 ]
 
 [[package]]
 name = "typer-slim"
-version = "0.24.0"
+version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/22/b9c47b8655937b6877d40791b937931702ba9c5f9d28753199266aa96f50/typer_slim-0.23.1.tar.gz", hash = "sha256:dfe92a6317030ee2380f65bf92e540d7c77fefcc689e10d585b4925b45b5e06a", size = 4762, upload-time = "2026-02-13T10:04:26.416Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8a/5764b851659345f34787f1b6eb30b9d308bbd6c294825cbe38b6b869c97a/typer_slim-0.23.1-py3-none-any.whl", hash = "sha256:8146d5df1eb89f628191c4c604c8464fa841885d0733c58e6e700ff0228adac5", size = 3397, upload-time = "2026-02-13T10:04:27.132Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1033 (and the earlier-filed duplicate #1032). Closes #1034.

## Summary

Two small, independent fixes that landed together because the litellm bump was already pending on this branch and was blocking the docker build.

### Commit 1 — `fix(agents): use update_agent for post-scan security-pending tag` (#1033)

When the post-registration A2A security scan flags an agent unsafe and the scanner config wants the `security-pending` tag, [registry/api/agent_routes.py](registry/api/agent_routes.py) was calling `agent_service.register_agent(...)` to persist the tag. `register_agent` is an INSERT, so the second call against the just-registered agent always failed with `path '...' already exists`. The exception was caught and swallowed, leaving the route returning 2xx but the security-pending tag never applied — so users saw a registration that "succeeded" but with no warning surfaced.

Concrete reproduction from production CloudWatch logs (scan ~4.5s, well under any timeout):

```
21:23:43.603  Created agent 'AI Tourist Guide' at '/ai-tourist-guide'
21:23:43.901  Running A2A security scan ... yara,spec
21:23:48.070  Scan completed: Safe: False, High: 1
21:23:48.075  ERROR: Agent registration failed: path '...' already exists
21:23:48.075  ERROR: Failed to run security scan for agent
```

Fix: one-line swap to `agent_service.update_agent(path, ...)`, which is the correct in-place update.

### Commit 2 — `chore(deps): bump litellm 1.83.0 -> 1.83.14` (#1034)

The pyproject pin had been bumped but `uv.lock` was not regenerated, so `Dockerfile.registry`'s `uv sync --locked --no-dev` was failing the build with `The lockfile at uv.lock needs to be updated, but --locked was provided`. Regenerated via `uv lock --upgrade-package litellm`. Transitive deps (click, jsonschema, openai, tokenizers, typer) shifted accordingly inside the same resolver pass.

## Test plan

- [x] `tests/unit/api/test_agent_routes.py::TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent` — new regression class, 2 tests:
  - unsafe scan calls `update_agent` once with the right path and a card whose `tags` contains `"security-pending"`; never calls `register_agent`.
  - safe scan touches no agent state.
- [x] Full `tests/unit/api/test_agent_routes.py` suite: 66 passed.
- [x] Issue #1026 suite (`tests/unit/auth/test_access_resolver.py`, `test_tool_filter.py`, `tests/integration/test_tool_level_access.py`): 64 passed under the bumped litellm.
- [x] `uv run python -m py_compile registry/api/agent_routes.py` clean.
- [ ] Live verification by Amit: register a known-unsafe agent, confirm the `security-pending` tag appears on the agent card and no `path already exists` error in registry logs.
- [ ] CI green on PR.

## Rollout

- `b3950515` (#1026 / #1027) is already on `main`.
- This PR sits on top of `main` with two independent commits. Each can be reverted individually if needed.