### PR TITLE
fix(ui): JSON Upload now reads deployment and local_runtime

### DIFF
--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -17,6 +17,7 @@ import {
   type LocalRuntimeFormData,
   initialLocalRuntime,
   buildLocalRuntimeJson,
+  buildLocalRuntimeForm,
 } from '../utils/localRuntime';
 import LocalRuntimeFormPanel from '../components/LocalRuntimeFormPanel';
 
@@ -331,12 +332,25 @@ const RegisterPage: React.FC = () => {
             }
           };
 
+          // Resolve deployment first; the form's validator branches on it
+          // (remote requires proxy_pass_url; local requires local_runtime).
+          const parsedDeployment: 'remote' | 'local' =
+            parsed.deployment === 'local' ? 'local' : 'remote';
+
           setServerForm(prev => ({
             ...prev,
             name: parsed.server_name || parsed.name || prev.name,
             description: parsed.description || prev.description,
             path: parsed.path || prev.path,
+            deployment: parsedDeployment,
+            // Local servers must use auth_scheme='none' (the backend forces
+            // this; mirror it on the form so validation doesn't trip on a
+            // stale 'bearer'/'api_key' default).
+            auth_scheme: parsedDeployment === 'local' ? 'none' : (parsed.auth_scheme || prev.auth_scheme),
             proxy_pass_url: parsed.proxy_pass_url || parsed.proxyPassUrl || prev.proxy_pass_url,
+            local_runtime: parsedDeployment === 'local'
+              ? buildLocalRuntimeForm(parsed.local_runtime)
+              : prev.local_runtime,
             tags: Array.isArray(parsed.tags) ? parsed.tags.join(',') : (parsed.tags || prev.tags),
             visibility: parsed.visibility || prev.visibility,
             repository_url: parsed.repository_url || parsed.repositoryUrl || prev.repository_url,


### PR DESCRIPTION
Closes #1050

## Summary

The Quick Form's JSON Upload parser on RegisterPage only populated `server_name`, `description`, `path`, `proxy_pass_url`, etc., but ignored the `deployment` and `local_runtime` fields. Uploading a JSON for a local (stdio) server therefore left the form in remote mode, which then flagged 'Proxy URL is required for remote servers' on submit.

## Fix

In the JSON Upload handler:
- Read `deployment` from the parsed JSON (default `'remote'` to preserve existing behavior).
- When `deployment === 'local'`, populate `local_runtime` from the uploaded JSON via `buildLocalRuntimeForm`.
- Force `auth_scheme='none'` for local servers so validation does not trip on a stale `'bearer'` / `'api_key'` default (mirrors what the manual Local toggle button already does).

## How to test

1. Navigate to **Register New Service**, select **MCP Server**, switch to **JSON Upload**.
2. Upload a JSON fixture with `"deployment": "local"` and a `local_runtime` block, e.g. one of `.scratchpad/issue-1044/test-server-fixtures/{adeu-redliner,agenttrust-mcp,spotdb}.json`.
3. The form switches to **Local (stdio)** mode, the Launch Recipe panel populates with the runtime details, and Server Name / Path / Description / tags fill in.
4. Click **Register Server** - the form submits without complaining about a missing Proxy URL.

For remote servers (no `deployment` field, or `"deployment": "remote"`), behavior is unchanged.

## Backwards compatibility

JSON files without a `deployment` field fall through to `'remote'` and behave exactly as before. No backend or schema change.

## Diff

One file, +14 lines: `frontend/src/pages/RegisterPage.tsx`.