### PR TITLE
fix(nginx): serialize config regeneration + atomic writes; fix MCP proxy SSE passthrough

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -31,7 +31,7 @@ import uvicorn
 import yaml
 from botocore.exceptions import ClientError
 from fastapi import APIRouter, Cookie, Depends, FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from jwt.api_jwk import PyJWK
 
@@ -3885,9 +3885,14 @@ async def mcp_proxy(
     )
 
     if not should_filter:
-        return JSONResponse(
-            content=_safe_parse_body(body_bytes),
+        # Forward the upstream body and content_type unchanged. Many MCP
+        # servers reply with text/event-stream (SSE) rather than plain JSON;
+        # wrapping that in {"raw": "..."} via JSONResponse breaks every
+        # MCP client that expects either JSON-RPC or SSE.
+        return Response(
+            content=body_bytes,
             status_code=status_code,
+            media_type=content_type,
         )
 
     try:

--- a/registry/api/federation_routes.py
+++ b/registry/api/federation_routes.py
@@ -454,7 +454,8 @@ async def remove_anthropic_server(
                 enabled_servers = {
                     p: info for p, info in all_servers.items() if info.get("is_enabled", False)
                 }
-                await nginx_service.generate_config_async(enabled_servers)
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
     except Exception as e:
         logger.error(f"Failed to remove server from mcp_servers_default: {e}")
 

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -355,7 +355,8 @@ async def _perform_security_scan_on_registration(
 
                     if server_info:
                         enabled_servers[server_path] = server_info
-                await nginx_service.generate_config_async(enabled_servers)
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
         else:
             logger.info(f"Server {path} passed security scan")
 
@@ -787,7 +788,8 @@ async def toggle_service_route(
 
         if server_info:
             enabled_servers[path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(service_path)
@@ -1084,7 +1086,8 @@ async def register_service(
 
         if server_info:
             enabled_servers[server_path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(path)
@@ -1394,7 +1397,8 @@ async def internal_register_service(
 
         if server_info:
             enabled_servers[server_path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     logger.warning(
         "INTERNAL REGISTER: Broadcasting health status update"
@@ -1583,7 +1587,8 @@ async def internal_remove_service(
 
         if server_info:
             enabled_servers[server_path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     logger.warning("INTERNAL REMOVE: Broadcasting health status update")  # TODO: replace with debug
 
@@ -1714,7 +1719,8 @@ async def internal_toggle_service(
 
         if server_info:
             enabled_servers[path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(service_path)
@@ -2160,7 +2166,8 @@ async def edit_server_submit(
 
         if server_info:
             enabled_servers[path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     logger.info(f"Server '{name}' ({service_path}) updated by user '{user_context['username']}'")
 
@@ -2516,7 +2523,8 @@ async def refresh_service(service_path: str, user_context: Annotated[dict, Depen
 
             if path_server_info:
                 enabled_servers[path] = path_server_info
-        await nginx_service.generate_config_async(enabled_servers)
+        async with nginx_service.reload_lock:
+            await nginx_service.generate_config_async(enabled_servers)
 
     except Exception as e:
         logger.error(f"ERROR during manual refresh check for {service_path}: {e}")
@@ -3805,7 +3813,8 @@ async def toggle_service_api(
 
         if server_info:
             enabled_servers[server_path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(path)
@@ -3941,7 +3950,8 @@ async def remove_service_api(
 
         if server_info:
             enabled_servers[server_path] = server_info
-    await nginx_service.generate_config_async(enabled_servers)
+    async with nginx_service.reload_lock:
+        await nginx_service.generate_config_async(enabled_servers)
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(path)

--- a/registry/core/metrics.py
+++ b/registry/core/metrics.py
@@ -29,6 +29,16 @@ NGINX_UPDATES_SKIPPED = Counter(
     ["operation"],  # generate_config, reload
 )
 
+# Counter for nginx config file writes (issue #1044)
+# status="success" when atomic write completes; status="failure" when temp file
+# creation, write, or os.replace raises. Lets operators detect disk-full,
+# permission, or replace failures (page on rate-of-change > 0).
+NGINX_CONFIG_WRITES = Counter(
+    "nginx_config_writes_total",
+    "Total nginx config file writes performed by the registry, by outcome.",
+    ["status"],  # success, failure
+)
+
 # Counter for blocked requests due to registry mode
 MODE_BLOCKED_REQUESTS = Counter(
     "registry_mode_blocked_requests_total",

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -12,9 +13,107 @@ import httpx
 from registry.constants import REGISTRY_CONSTANTS, DeploymentType, HealthStatus
 
 from .config import settings
-from .metrics import NGINX_UPDATES_SKIPPED
+from .metrics import NGINX_CONFIG_WRITES, NGINX_UPDATES_SKIPPED
 
 logger = logging.getLogger(__name__)
+
+
+# Default mode applied to a fresh nginx config file when no destination
+# exists yet. Subsequent writes preserve whatever mode the destination
+# currently has so an operator's chmod isn't silently reverted.
+DEFAULT_NGINX_CONFIG_MODE: int = 0o644
+
+
+def _atomic_write_text(
+    path: Path,
+    content: str,
+) -> None:
+    """Write content to path atomically (issue #1044).
+
+    Writes to a temporary file in the same directory as ``path`` and uses
+    ``os.replace()`` to swap it into place. ``os.replace()`` is atomic on POSIX
+    when source and destination are on the same filesystem, so any reader
+    (including ``nginx -t``) sees either the old config or the new one - never
+    a truncated mid-write file.
+
+    The temp file's mode is set to match the destination's existing mode, or
+    ``DEFAULT_NGINX_CONFIG_MODE`` when the destination does not yet exist.
+    Without this, ``tempfile.NamedTemporaryFile`` defaults to ``0o600`` and
+    silently tightens permissions across atomic writes.
+
+    On any failure the temp file is removed and the destination is left
+    unchanged. ``NGINX_CONFIG_WRITES`` is incremented with
+    ``status="success"`` or ``status="failure"`` accordingly.
+
+    Args:
+        path: Destination path.
+        content: Text content to write.
+
+    Raises:
+        OSError: If the temp file cannot be created, written, or replaced.
+    """
+    dest_dir = path.parent
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    if path.exists():
+        target_mode = path.stat().st_mode & 0o777
+    else:
+        target_mode = DEFAULT_NGINX_CONFIG_MODE
+
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        dir=dest_dir,
+        prefix=f".{path.name}.tmp.",
+        delete=False,
+        encoding="utf-8",
+    )
+    tmp_path = Path(tmp.name)
+    try:
+        tmp.write(content)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp.close()
+        os.chmod(tmp_path, target_mode)
+        os.replace(tmp_path, path)
+        NGINX_CONFIG_WRITES.labels(status="success").inc()
+    except Exception:
+        NGINX_CONFIG_WRITES.labels(status="failure").inc()
+        try:
+            tmp.close()
+        except Exception:
+            pass
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _cleanup_stale_temp_files(config_path: Path) -> None:
+    """Remove leftover ``.{config_name}.tmp.*`` files from a crashed write.
+
+    On a clean write, the temp file is renamed away by ``os.replace()``. If the
+    process was killed mid-write (SIGKILL, OOM kill, host reboot), a temp file
+    matching ``.{config_name}.tmp.*`` can remain. Container restarts on
+    ECS/EKS typically clean this up naturally, but long-lived hosts (local
+    dev, EC2 without container ephemerality) need explicit cleanup.
+
+    Best-effort: logs warnings but does not raise on failure.
+    """
+    dest_dir = config_path.parent
+    pattern = f".{config_path.name}.tmp.*"
+    try:
+        leftovers = list(dest_dir.glob(pattern))
+    except OSError as e:
+        logger.warning(f"Could not scan {dest_dir} for stale temp files: {e}")
+        return
+
+    for stale in leftovers:
+        try:
+            stale.unlink()
+            logger.info(f"Removed stale nginx config temp file: {stale}")
+        except OSError as e:
+            logger.warning(f"Failed to remove stale temp file {stale}: {e}")
 
 
 def _ensure_mcp_compliant_schema(input_schema: dict[str, Any]) -> dict[str, Any]:
@@ -64,6 +163,17 @@ class NginxConfigService:
     """Service for generating Nginx configuration for registered servers."""
 
     def __init__(self):
+        # Contract: every call site that invokes generate_config_async() or
+        # reload_nginx() (directly or transitively) MUST acquire this lock for
+        # the duration of those calls. The lock prevents:
+        #   1. Two writers racing on the nginx config path (lost-update).
+        #   2. nginx -t in one writer reading a partial file written by another.
+        #   3. Two `nginx -s reload` signals in flight simultaneously.
+        # The lock is intentionally coarse-grained because regen + reload is
+        # bounded (~150-300ms) and infrequent (tens per minute). See issue
+        # #1044 and .scratchpad/issue-1044/lld.md for the full rationale.
+        self.reload_lock: asyncio.Lock = asyncio.Lock()
+
         # Determine which template to use based on SSL certificate availability
         ssl_cert_path = Path(REGISTRY_CONSTANTS.SSL_CERT_PATH)
         ssl_key_path = Path(REGISTRY_CONSTANTS.SSL_KEY_PATH)
@@ -507,9 +617,10 @@ class NginxConfigService:
             root_path = os.environ.get("ROOT_PATH", "").rstrip("/")
             config_content = config_content.replace("{{ROOT_PATH}}", root_path)
 
-            # Write config file
-            with open(settings.nginx_config_path, "w") as f:
-                f.write(config_content)
+            # Write config file atomically (temp file + os.replace) so
+            # nginx -t and concurrent writers never see a truncated file.
+            # See issue #1044.
+            _atomic_write_text(settings.nginx_config_path, config_content)
 
             logger.info(
                 f"Generated Nginx configuration with {len(location_blocks)} location blocks and additional server names: {additional_server_names}"

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -392,7 +392,8 @@ class HealthMonitoringService:
                     server_info = await server_service.get_server_info(path)
                     if server_info:
                         enabled_servers[path] = server_info
-                await nginx_service.generate_config_async(enabled_servers)
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
                 logger.info("Nginx configuration regenerated due to health status changes")
             except Exception as e:
                 logger.error(
@@ -1291,7 +1292,8 @@ class HealthMonitoringService:
                     server_info = await server_service.get_server_info(path)
                     if server_info:
                         enabled_servers[path] = server_info
-                await nginx_service.generate_config_async(enabled_servers)
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
                 logger.info(
                     f"Nginx configuration regenerated due to status change for {service_path}: {previous_status} -> {current_status}"
                 )

--- a/registry/main.py
+++ b/registry/main.py
@@ -689,6 +689,13 @@ async def lifespan(app: FastAPI):
                 f"Registration gate connectivity check failed (continuing with startup): {e}"
             )
 
+        # Clean up any stale nginx config temp files left behind by a
+        # SIGKILL-interrupted previous run (issue #1044). Best-effort: this
+        # is a no-op on fresh container filesystems.
+        from registry.core.nginx_service import _cleanup_stale_temp_files
+
+        _cleanup_stale_temp_files(settings.nginx_config_path)
+
         # Always generate nginx configuration at startup to ensure placeholders are replaced
         # In registry-only mode, generate base config without MCP server location blocks
         if settings.nginx_updates_enabled:
@@ -699,11 +706,13 @@ async def lifespan(app: FastAPI):
                 server_info = await server_service.get_server_info(path)
                 if server_info:
                     enabled_servers[path] = server_info
-            await nginx_service.generate_config_async(enabled_servers)
+            async with nginx_service.reload_lock:
+                await nginx_service.generate_config_async(enabled_servers)
         else:
             logger.info("Generating base Nginx configuration (registry-only mode)...")
             # Generate base config with empty location blocks but substitute all placeholders
-            await nginx_service.generate_config_async({}, force_base_config=True)
+            async with nginx_service.reload_lock:
+                await nginx_service.generate_config_async({}, force_base_config=True)
 
         logger.info("✅ All services initialized successfully!")
 

--- a/registry/services/federation_reconciliation.py
+++ b/registry/services/federation_reconciliation.py
@@ -193,7 +193,8 @@ async def reconcile_anthropic_servers(
             enabled_servers = {
                 p: info for p, info in all_servers.items() if info.get("is_enabled", False)
             }
-            await nginx_service.generate_config_async(enabled_servers)
+            async with nginx_service.reload_lock:
+                await nginx_service.generate_config_async(enabled_servers)
             logger.info("Reconciliation: nginx config regenerated")
         except Exception as e:
             logger.error(f"Reconciliation: failed to regenerate nginx config: {e}")

--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -160,8 +160,9 @@ class ServerService:
                         service_path: await self.get_server_info(service_path)
                         for service_path in await self.get_enabled_services()
                     }
-                    await nginx_service.generate_config_async(enabled_servers)
-                    nginx_service.reload_nginx()
+                    async with nginx_service.reload_lock:
+                        await nginx_service.generate_config_async(enabled_servers)
+                        nginx_service.reload_nginx()
                     logger.info(f"Regenerated nginx config due to server update: {path}")
                 except Exception as e:
                     logger.error(
@@ -183,8 +184,9 @@ class ServerService:
                     service_path: await self.get_server_info(service_path)
                     for service_path in await self.get_enabled_services()
                 }
-                await nginx_service.generate_config_async(enabled_servers)
-                nginx_service.reload_nginx()
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
+                    nginx_service.reload_nginx()
             except Exception as e:
                 logger.error(f"Failed to update nginx configuration after toggle: {e}")
 
@@ -490,8 +492,9 @@ class ServerService:
                     service_path: await self.get_server_info(service_path)
                     for service_path in await self.get_enabled_services()
                 }
-                await nginx_service.generate_config_async(enabled_servers)
-                nginx_service.reload_nginx()
+                async with nginx_service.reload_lock:
+                    await nginx_service.generate_config_async(enabled_servers)
+                    nginx_service.reload_nginx()
                 logger.info("Regenerated nginx config due to state reload")
             except Exception as e:
                 logger.error(f"Failed to regenerate nginx configuration after state reload: {e}")
@@ -895,8 +898,9 @@ class ServerService:
                 if server_info:
                     enabled_servers[service_path] = server_info
 
-            await nginx_service.generate_config_async(enabled_servers)
-            nginx_service.reload_nginx()
+            async with nginx_service.reload_lock:
+                await nginx_service.generate_config_async(enabled_servers)
+                nginx_service.reload_nginx()
             logger.info("Regenerated nginx config after version change")
 
         except Exception as e:

--- a/registry/services/virtual_server_service.py
+++ b/registry/services/virtual_server_service.py
@@ -51,8 +51,9 @@ logger = logging.getLogger(__name__)
 # Singleton instance
 _virtual_server_service: Optional["VirtualServerService"] = None
 
-# Lock to serialize nginx config regeneration across concurrent mutations
-_nginx_reload_lock = asyncio.Lock()
+# Note: the nginx reload lock now lives on the shared NginxConfigService
+# singleton (see registry/core/nginx_service.py), so every call site - not
+# just virtual servers - can serialize regen+reload through it. See #1044.
 
 
 def _generate_path_from_name(
@@ -615,9 +616,10 @@ class VirtualServerService:
             The CRUD operation itself has already succeeded at this point,
             so callers should treat False as a non-fatal warning.
         """
-        async with _nginx_reload_lock:
+        from ..core.nginx_service import nginx_service
+
+        async with nginx_service.reload_lock:
             try:
-                from ..core.nginx_service import nginx_service
                 from ..services.server_service import server_service
 
                 # Get currently enabled servers for the full config generation

--- a/tests/unit/core/test_nginx_atomic_write.py
+++ b/tests/unit/core/test_nginx_atomic_write.py
@@ -1,0 +1,120 @@
+"""Tests for the atomic-write helper in registry/core/nginx_service.py.
+
+Covers issue #1044: nginx config writes must be atomic at the filesystem
+level so concurrent ``nginx -t`` calls and other readers never see a
+truncated mid-write file.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from registry.core.nginx_service import _atomic_write_text
+
+
+class TestAtomicWrite:
+    def test_creates_file_when_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "nginx.conf"
+        _atomic_write_text(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_replaces_existing_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "nginx.conf"
+        target.write_text("old content")
+        _atomic_write_text(target, "new content")
+        assert target.read_text() == "new content"
+
+    def test_uses_temp_file_in_same_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "nginx.conf"
+        captured: dict[str, str] = {}
+        original_replace = os.replace
+
+        def fake_replace(src: str, dst: str) -> None:
+            captured["src"] = str(src)
+            captured["dst"] = str(dst)
+            original_replace(src, dst)
+
+        monkeypatch.setattr("os.replace", fake_replace)
+        _atomic_write_text(target, "data")
+        assert Path(captured["src"]).parent == tmp_path
+        assert captured["dst"] == str(target)
+
+    def test_cleans_up_temp_on_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "nginx.conf"
+        target.write_text("preserved")
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("os.replace", boom)
+        with pytest.raises(OSError):
+            _atomic_write_text(target, "should not appear")
+
+        # Original file unchanged
+        assert target.read_text() == "preserved"
+        # No leftover temp files
+        leftovers = list(tmp_path.glob(".nginx.conf.tmp.*"))
+        assert leftovers == []
+
+    def test_preserves_existing_file_permissions(self, tmp_path: Path) -> None:
+        target = tmp_path / "nginx.conf"
+        target.write_text("old")
+        target.chmod(0o644)
+        _atomic_write_text(target, "new")
+        mode = target.stat().st_mode & 0o777
+        assert mode == 0o644
+
+    def test_default_mode_when_destination_missing(self, tmp_path: Path) -> None:
+        target = tmp_path / "nginx.conf"
+        _atomic_write_text(target, "content")
+        mode = target.stat().st_mode & 0o777
+        assert mode == 0o644
+
+    def test_creates_parent_directory(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "nginx.conf"
+        assert not target.parent.exists()
+        _atomic_write_text(target, "content")
+        assert target.read_text() == "content"
+
+
+class TestCleanupStaleTempFiles:
+    def test_removes_leftover_temp_files(self, tmp_path: Path) -> None:
+        from registry.core.nginx_service import _cleanup_stale_temp_files
+
+        config = tmp_path / "nginx.conf"
+        # Simulate two crashed writes
+        (tmp_path / ".nginx.conf.tmp.aaa").write_text("partial1")
+        (tmp_path / ".nginx.conf.tmp.bbb").write_text("partial2")
+        # And one unrelated file that should NOT be removed
+        (tmp_path / "other.txt").write_text("keep me")
+
+        _cleanup_stale_temp_files(config)
+
+        leftovers = list(tmp_path.glob(".nginx.conf.tmp.*"))
+        assert leftovers == []
+        assert (tmp_path / "other.txt").exists()
+
+    def test_no_op_when_no_temp_files(self, tmp_path: Path) -> None:
+        from registry.core.nginx_service import _cleanup_stale_temp_files
+
+        config = tmp_path / "nginx.conf"
+        config.write_text("config content")
+        # Should not raise
+        _cleanup_stale_temp_files(config)
+        assert config.read_text() == "config content"
+
+    def test_no_op_when_directory_missing(self, tmp_path: Path) -> None:
+        from registry.core.nginx_service import _cleanup_stale_temp_files
+
+        # Pass a path under a non-existent dir; should warn but not raise
+        config = tmp_path / "nope" / "nginx.conf"
+        _cleanup_stale_temp_files(config)

--- a/tests/unit/core/test_nginx_local_skip.py
+++ b/tests/unit/core/test_nginx_local_skip.py
@@ -8,6 +8,18 @@ from registry.constants import HealthStatus
 from registry.core.nginx_service import NginxConfigService
 
 
+@pytest.fixture(autouse=True)
+def mock_atomic_write():
+    """Stub _atomic_write_text so tests don't touch the real config path (#1044).
+
+    Tests can declare this fixture as a parameter to inspect what was
+    written: each call is _atomic_write_text(path, content), so
+    mock_atomic_write.call_args_list[i][0][1] is the content string.
+    """
+    with patch("registry.core.nginx_service._atomic_write_text") as m:
+        yield m
+
+
 @pytest.fixture
 def nginx_service():
     with patch("registry.core.nginx_service.Path") as mock_path_class:
@@ -31,7 +43,9 @@ def mock_health_service():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_local_server_excluded_from_location_blocks(nginx_service, mock_health_service):
+async def test_local_server_excluded_from_location_blocks(
+    nginx_service, mock_health_service, mock_atomic_write
+):
     """Local servers must not produce a proxy_pass location block."""
     template_content = "server { {{LOCATION_BLOCKS}} }"
     servers = {
@@ -53,27 +67,15 @@ async def test_local_server_excluded_from_location_blocks(nginx_service, mock_he
         "/local": HealthStatus.LOCAL,
     }
 
-    captured_writes: list[str] = []
-
-    def _open_side_effect(path, *args, **kwargs):
-        m = mock_open(read_data=template_content)()
-        original_write = m.write
-
-        def write(content):
-            captured_writes.append(content)
-            return original_write(content)
-
-        m.write = write
-        return m
-
-    with patch("builtins.open", side_effect=_open_side_effect):
+    with patch("builtins.open", mock_open(read_data=template_content)):
         with patch("registry.health.service.health_service", mock_health_service):
             with patch.object(nginx_service, "get_additional_server_names", return_value=""):
                 with patch.object(nginx_service, "reload_nginx", return_value=True):
                     with patch("os.environ.get", return_value="http://keycloak:8080"):
                         await nginx_service.generate_config_async(servers)
 
-    rendered = "\n".join(captured_writes)
+    # Inspect what was passed to _atomic_write_text
+    rendered = "\n".join(call.args[1] for call in mock_atomic_write.call_args_list)
     # Remote upstream should appear in the config; local server's path must NOT.
     assert "http://upstream" in rendered or "/remote" in rendered
     # Critically, the local server should not produce a proxy_pass block keyed on its path

--- a/tests/unit/core/test_nginx_reload_lock.py
+++ b/tests/unit/core/test_nginx_reload_lock.py
@@ -1,0 +1,57 @@
+"""Tests for the shared reload lock on the NginxConfigService singleton.
+
+Covers issue #1044: every call site that invokes ``generate_config_async``
+or ``reload_nginx`` must acquire ``nginx_service.reload_lock`` so concurrent
+CRUD operations cannot race on the config file or on ``nginx -s reload``.
+"""
+
+import asyncio
+
+import pytest
+
+from registry.core.nginx_service import nginx_service
+
+
+class TestReloadLock:
+    @pytest.mark.asyncio
+    async def test_lock_serializes_concurrent_acquires(self) -> None:
+        """Three concurrent acquires complete one at a time."""
+        in_critical_section: list[int] = []
+        max_concurrent = [0]
+
+        async def acquirer(idx: int) -> None:
+            async with nginx_service.reload_lock:
+                in_critical_section.append(idx)
+                max_concurrent[0] = max(max_concurrent[0], len(in_critical_section))
+                await asyncio.sleep(0.05)
+                in_critical_section.remove(idx)
+
+        await asyncio.gather(acquirer(1), acquirer(2), acquirer(3))
+        # If the lock works, only one task ever held the critical section
+        assert max_concurrent[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_lock_released_on_exception(self) -> None:
+        """An exception inside the lock block must still release the lock."""
+        with pytest.raises(RuntimeError):
+            async with nginx_service.reload_lock:
+                raise RuntimeError("boom")
+
+        assert not nginx_service.reload_lock.locked()
+
+    def test_virtual_server_does_not_define_its_own_lock(self) -> None:
+        """The previous module-level _nginx_reload_lock has been removed.
+
+        virtual_server_service used to declare its own lock; this PR
+        consolidated all call sites onto the shared nginx_service.reload_lock.
+        """
+        from registry.services import virtual_server_service
+
+        assert not hasattr(virtual_server_service, "_nginx_reload_lock"), (
+            "virtual_server_service should no longer define its own lock; "
+            "it must use nginx_service.reload_lock"
+        )
+
+    def test_lock_is_asyncio_lock(self) -> None:
+        """Sanity check on the lock type."""
+        assert isinstance(nginx_service.reload_lock, asyncio.Lock)

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -19,6 +19,24 @@ from registry.core.nginx_service import NginxConfigService
 # =============================================================================
 
 
+@pytest.fixture(autouse=True)
+def mock_atomic_write():
+    """Stub _atomic_write_text so tests don't touch /etc/nginx (#1044).
+
+    The real helper does tempfile + os.replace against
+    settings.nginx_config_path. In unit tests the path is a fixture
+    string ('/etc/nginx/conf.d/nginx_rev_proxy.conf') that the test
+    user typically can't write to. Patching here keeps every test
+    that reaches generate_config_async hermetic.
+
+    Tests that need to inspect what was written can declare this
+    fixture as a parameter and read mock_atomic_write.call_args_list -
+    each call is (path, content).
+    """
+    with patch("registry.core.nginx_service._atomic_write_text") as mock_write:
+        yield mock_write
+
+
 @pytest.fixture
 def nginx_service():
     """Create a NginxConfigService instance."""
@@ -607,8 +625,7 @@ def test_create_location_block_direct_transport(nginx_service):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_keycloak_parsing(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test Keycloak URL parsing in configuration generation."""
     template_content = """
 server {
@@ -640,9 +657,9 @@ server {
                             assert result is True
 
                             # Verify file was written with parsed Keycloak values
-                            write_calls = list(mock_file().write.call_args_list)
+                            write_calls = list(mock_atomic_write.call_args_list)
                             assert len(write_calls) > 0
-                            written_content = write_calls[0][0][0]
+                            written_content = write_calls[0][0][1]
                             # Verify the template variables were substituted with
                             # the parsed Keycloak URL components
                             parsed_keycloak = urlparse("https://keycloak.example.com:8443")
@@ -692,8 +709,7 @@ server {
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_strips_keycloak_locations_for_entra(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test that Keycloak location blocks are stripped when AUTH_PROVIDER is entra."""
     template_content = """
 server {
@@ -738,9 +754,9 @@ server {
                             assert result is True
 
                             # Verify the written config does not contain keycloak locations
-                            write_calls = mock_file().write.call_args_list
+                            write_calls = mock_atomic_write.call_args_list
                             assert len(write_calls) > 0
-                            written_content = write_calls[0][0][0]
+                            written_content = write_calls[0][0][1]
                             assert "/keycloak/" not in written_content
                             assert "/realms/" not in written_content
                             assert "KEYCLOAK_LOCATIONS_START" not in written_content
@@ -749,8 +765,7 @@ server {
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_keeps_keycloak_locations_for_keycloak(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test that Keycloak location blocks are kept when AUTH_PROVIDER is keycloak."""
     template_content = """
 server {
@@ -795,9 +810,9 @@ server {
                             assert result is True
 
                             # Verify the written config contains keycloak locations with substituted values
-                            write_calls = mock_file().write.call_args_list
+                            write_calls = mock_atomic_write.call_args_list
                             assert len(write_calls) > 0
-                            written_content = write_calls[0][0][0]
+                            written_content = write_calls[0][0][1]
                             assert "/keycloak/" in written_content
                             assert "/realms/" in written_content
                             # Verify the template variables were substituted with
@@ -810,8 +825,7 @@ server {
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_strips_keycloak_locations_for_cognito(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test that Keycloak location blocks are stripped when AUTH_PROVIDER is cognito."""
     template_content = """
 server {
@@ -848,17 +862,16 @@ server {
 
                             assert result is True
 
-                            write_calls = mock_file().write.call_args_list
+                            write_calls = mock_atomic_write.call_args_list
                             assert len(write_calls) > 0
-                            written_content = write_calls[0][0][0]
+                            written_content = write_calls[0][0][1]
                             assert "/keycloak/" not in written_content
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_keycloak_https_default_port(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test Keycloak URL parsing defaults to port 443 for HTTPS without explicit port."""
     template_content = """
 server {
@@ -887,7 +900,7 @@ server {
                             result = await nginx_service.generate_config_async(sample_servers)
 
                             assert result is True
-                            written_content = mock_file().write.call_args_list[0][0][0]
+                            written_content = mock_atomic_write.call_args_list[0][0][1]
                             assert "https" in written_content
                             assert "443" in written_content
 
@@ -895,8 +908,7 @@ server {
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_keycloak_hostname_fallback(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test Keycloak hostname fallback when hostname resolves to bare 'keycloak'."""
     template_content = """
 server {
@@ -925,7 +937,7 @@ server {
                             result = await nginx_service.generate_config_async(sample_servers)
 
                             assert result is True
-                            written_content = mock_file().write.call_args_list[0][0][0]
+                            written_content = mock_atomic_write.call_args_list[0][0][1]
                             # Should still contain keycloak as the host (netloc fallback)
                             assert "keycloak" in written_content
 
@@ -933,8 +945,7 @@ server {
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_generate_config_async_keycloak_url_parse_exception(
-    nginx_service, sample_servers, mock_health_service
-):
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write):
     """Test Keycloak URL parsing falls back to defaults on exception."""
     template_content = """
 server {
@@ -968,7 +979,7 @@ server {
                                 result = await nginx_service.generate_config_async(sample_servers)
 
                                 assert result is True
-                                written_content = mock_file().write.call_args_list[0][0][0]
+                                written_content = mock_atomic_write.call_args_list[0][0][1]
                                 # Should fall back to defaults
                                 assert "http" in written_content
                                 assert "keycloak" in written_content

--- a/tests/unit/test_virtual_server_service.py
+++ b/tests/unit/test_virtual_server_service.py
@@ -1373,17 +1373,24 @@ class TestNginxReloadLock:
 
     @pytest.mark.asyncio
     async def test_reload_lock_exists(self):
-        """Test that the module-level nginx reload lock is an asyncio.Lock."""
+        """The reload lock now lives on the shared NginxConfigService singleton."""
         import asyncio
 
-        from registry.services.virtual_server_service import _nginx_reload_lock
+        from registry.core.nginx_service import nginx_service
 
-        assert isinstance(_nginx_reload_lock, asyncio.Lock)
+        assert isinstance(nginx_service.reload_lock, asyncio.Lock)
 
     @pytest.mark.asyncio
     async def test_concurrent_reloads_are_serialized(self, service):
-        """Test that concurrent nginx reloads are serialized by the lock."""
+        """Test that concurrent nginx reloads are serialized by the lock.
+
+        Patch only the methods being exercised - keep the real
+        nginx_service singleton (and its real reload_lock) so the lock
+        actually serializes the calls.
+        """
         import asyncio
+
+        from registry.core.nginx_service import nginx_service
 
         call_order = []
 
@@ -1393,16 +1400,11 @@ class TestNginxReloadLock:
             call_order.append("end")
             return True
 
-        mock_nginx = AsyncMock()
-        mock_nginx.generate_config_async = mock_generate
         mock_server_svc = AsyncMock()
         mock_server_svc.get_enabled_services = AsyncMock(return_value=[])
 
         with (
-            patch(
-                "registry.core.nginx_service.nginx_service",
-                mock_nginx,
-            ),
+            patch.object(nginx_service, "generate_config_async", mock_generate),
             patch(
                 "registry.services.server_service.server_service",
                 mock_server_svc,


### PR DESCRIPTION
Closes #1044
Closes #1051

## Summary

Two related gateway fixes for the 1.24.1 patch release:

### 1. Nginx reload serialization + atomic config writes (#1044)

Eliminates race conditions during concurrent server CRUD operations.

`nginx_service.generate_config_async()` and `nginx_service.reload_nginx()` were called from 20+ sites; only one (virtual_server_service) acquired an asyncio lock. The other call sites could:
- Two parallel regenerations both reading the enabled-server set, both writing the config file, with the second write overwriting the first.
- One writer's partial output read by `nginx -t` invoked from a second writer.
- Two `nginx -s reload` signals in flight simultaneously.

This change:
- Adds a shared `asyncio.Lock` on the `NginxConfigService` singleton; every call site (server CRUD, federation, health checks, startup) now wraps regen + reload through it.
- Replaces the truncate-on-write file open with `_atomic_write_text` (temp file + `os.replace()`).
- Preserves existing destination file permissions across atomic swaps (was silently regressing to `0o600`).
- Adds startup cleanup of stale `.tmp.*` files left from SIGKILL-interrupted writes.
- Adds `NGINX_CONFIG_WRITES` Prometheus counter with `status=success|failure`.
- Removes the duplicate `_nginx_reload_lock` from `virtual_server_service`.

14 new unit tests cover atomic write, permission preservation, stale temp file cleanup, lock serialization, and exception release.

### 2. MCP proxy SSE passthrough (#1051)

The auth_server's `/mcp_proxy` endpoint was forcing every upstream response into `application/json` via `JSONResponse(_safe_parse_body(...))`. When the upstream MCP server returned `text/event-stream` (SSE) - which is the recommended transport for streamable-http MCP - the SSE bytes got wrapped in `{\"raw\": \"...\"}` with `Content-Type: application/json`. MCP clients (Roo Code, Cursor, Claude Code) then failed JSON-RPC schema validation.

Fix: when not running tools/list filtering, forward the upstream body and content_type unchanged via `fastapi.Response`. The tools/list filtering path is unchanged (its `should_filter` gate already requires `application/json`).

Affects servers like `cloudflare-docs`, `context7`, `exa-exa` - any MCP server whose upstream returns SSE.

## Files changed

- `registry/core/nginx_service.py` - lock + `_atomic_write_text` + `_cleanup_stale_temp_files`
- `registry/core/metrics.py` - new `NGINX_CONFIG_WRITES` counter
- `registry/main.py` - startup cleanup, wraps startup regen with lock
- `registry/services/{server_service,virtual_server_service,federation_reconciliation}.py` - wrap call sites
- `registry/api/{server_routes,federation_routes}.py` - wrap call sites
- `registry/health/service.py` - wrap call sites
- `auth_server/server.py` - SSE passthrough fix (8 lines)
- `tests/unit/core/test_nginx_atomic_write.py` - 10 new tests (new file)
- `tests/unit/core/test_nginx_reload_lock.py` - 4 new tests (new file)
- Existing nginx and virtual_server unit tests updated to match the shared lock and atomic write

## Test results

- Unit suite: 3222 passed, 69 skipped, 0 failures
- 14 new unit tests pass
- Manual: 10 concurrent toggles produced no nginx -t failures, no truncated config, no errors in registry log
- Manual: cloudflare-docs MCP now connects from Roo Code without Zod validation errors

## Backwards compatibility

No API or schema changes. The lock is process-local (`asyncio.Lock`), so single-task ECS / single-worker deployments are fully covered. Multi-task ECS synchronization is documented as out-of-scope (separate design exists in `.scratchpad/nginx-config-sync/`).

## Discussion artifact

`.scratchpad/issue-1044/proxy-replacement-alternatives.md` documents OpenResty and Envoy as future alternatives if/when scale or features outgrow the current nginx-with-lock approach.