### PR TITLE
ci: add MongoDB service container to registry test workflow

### DIFF
--- a/.github/workflows/registry-test.yml
+++ b/.github/workflows/registry-test.yml
@@ -31,6 +31,22 @@ jobs:
         python-version: ["3.14"]
       fail-fast: false
 
+    services:
+      mongodb:
+        image: mongo:8.2
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd "mongosh --eval 'db.runCommand({ping:1})' --quiet"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DOCUMENTDB_HOST: localhost
+      DOCUMENTDB_PORT: "27017"
+      APP_LOG_MONGODB_ENABLED: "false"
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -593,11 +593,11 @@ Run the complete test suite with parallel execution:
 # Run all tests in parallel (using 8 workers)
 uv run pytest tests/ -n 8
 
-# Expected output (as of 2026-01-06):
-# - 701 passed
-# - 57 skipped
-# - Coverage: ~39.50%
-# - Execution time: ~30 seconds
+# Expected output:
+# - 3000+ tests passing
+# - Some tests skipped (known integration limitations)
+# - Coverage: above the configured minimum (~35%)
+# - Execution time: a few minutes (well under the 30-minute CI timeout)
 ```
 
 #### Test Execution Options


### PR DESCRIPTION
## Summary
- Adds a `mongo:8.2` service container to the `test` job in `.github/workflows/registry-test.yml` with a health check on `db.runCommand({ping:1})`.
- Sets `DOCUMENTDB_HOST=localhost`, `DOCUMENTDB_PORT=27017`, and `APP_LOG_MONGODB_ENABLED=false` so the suite connects to the sidecar without trying to ship logs.

## Why
Tests that touched MongoDB were hitting the default 20s connection timeout because the runner had no MongoDB instance, dragging the full suite to 20-30 minutes per run. With a real MongoDB sidecar, those connections succeed immediately and the suite returns to its normal ~30s wall-clock.

Closes #1053. Targeted at milestone 1.24.1.

## Test plan
- [ ] CI run on this PR completes in well under 5 minutes (compare against the prior 20-30 min baseline).
- [ ] All previously passing tests still pass; no new MongoDB-related failures.
- [ ] Coverage report still uploads.