### PR TITLE
fix(build): pass BUILD_VERSION as explicit build-arg to docker compose build

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -480,7 +480,7 @@ else
     fi
 
     # Build with parallel jobs and build cache
-    $COMPOSE_CMD $COMPOSE_FILES build --parallel --progress=auto || handle_error "Compose build failed"
+    $COMPOSE_CMD $COMPOSE_FILES build --parallel --progress=auto --build-arg BUILD_VERSION="$BUILD_VERSION" || handle_error "Compose build failed"
     log "Container images built successfully with optimization"
 fi
 


### PR DESCRIPTION
## Summary

`/api/version` always returns `1.0.0` instead of the actual release version after running `./build_and_run.sh`.

`build_and_run.sh` exports `BUILD_VERSION` from `git describe --tags` but `docker-compose.yml` uses `${BUILD_VERSION:-1.0.0}` as a default. When `docker compose build` runs in a subprocess that does not inherit the exported variable, the fallback `1.0.0` gets baked into the image.

Fix: pass `BUILD_VERSION` as an explicit `--build-arg` so it does not depend on shell environment inheritance.

## Issue

Fixes #1057
