### PR TITLE
fix(telemetry): heartbeat schema v4 with deployment-shape fields + usage-report retention metrics

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -82,15 +82,26 @@ First, ensure matplotlib and seaborn are available on the system Python:
 /usr/bin/python3 -c "import matplotlib, seaborn" 2>/dev/null || pip install --break-system-packages matplotlib seaborn
 ```
 
-Then generate the **instance-based** deployment distribution chart (counts unique registry instances, not events):
+Then generate the **instance-based** deployment distribution chart (counts unique registry instances, not events). Run it twice -- once for the cumulative install base, once filtered to the previous complete day -- so the report can show "everyone who ever installed" alongside "who is running it right now":
 
 ```bash
+# Cumulative -- all customers ever
 /usr/bin/python3 .claude/skills/usage-report/generate_instance_distribution_chart.py \
   --csv $DATE_DIR/registry_metrics.csv \
   --output $DATE_DIR/instance-distribution-YYYY-MM-DD.png
+
+# Active-yesterday -- only customers that reported on the last complete day.
+# Pass YYYY-MM-DD - 1 (the previous day relative to report date) so today's
+# partial-day undercount doesn't bias the picture.
+/usr/bin/python3 .claude/skills/usage-report/generate_instance_distribution_chart.py \
+  --csv $DATE_DIR/registry_metrics.csv \
+  --output $DATE_DIR/instance-distribution-active-PREVIOUS-YYYY-MM-DD.png \
+  --active-on-date PREVIOUS-YYYY-MM-DD
 ```
 
-This produces a single faceted PNG with 6 subplots: Cloud Provider, Compute Platform, Storage Backend, Auth Provider, Architecture, and Deployment Mode. Each subplot shows unique instance counts and percentages.
+Each invocation produces a faceted PNG with 6 subplots: Cloud Provider, Compute Platform, Storage Backend, Auth Provider, Architecture, and Deployment Mode. Each subplot shows unique instance counts and percentages. The `--active-on-date` form filters the row set to instances that had at least one event on the given date (heartbeat or startup), then runs the same six-panel breakdown on that subset; the chart title is annotated to make the filter explicit.
+
+In the report, embed both PNGs in the "Deployment Distribution (by Unique Instances)" section and add a short narrative pointing out where the two views diverge -- typically the active-yesterday view shifts toward Kubernetes (vs Docker), enterprise IdP (vs the long-tail), and AWS dominance.
 
 ### Step 5b: Generate Timeseries Chart
 
@@ -139,11 +150,27 @@ Generate a density plot showing the distribution of instance lifetimes (age in d
   --output $DATE_DIR/instance-lifetime-YYYY-MM-DD.png
 ```
 
-This produces a PNG with two panels:
+This produces a PNG with three panels:
 - **Age Distribution** -- histogram with KDE density overlay showing instance ages in days, with stats annotation (mean, max, multi-day vs single-day counts)
+- **Age Spread** -- boxplot with Q1/median/Q3/max annotated and individual points overlaid, useful for spotting outliers and the long-tail of long-lived deployments
 - **Age Buckets** -- horizontal bar chart grouping instances into age ranges (0 days, 1-2 days, 3-5 days, etc.) with counts and percentages
 
 **Note**: Run this after Step 6 (telemetry analysis) since it reads the metrics JSON.
+
+### Step 5c-ts: Generate Lifetime-Bucket Retention Chart
+
+Plot per-snapshot **lifetime retention percentages** (one-day wonders vs >=3 / >=7 / >=14 / >=30 day cohorts) over time. Reads every `metrics-*.json` file under the base output directory and recomputes the buckets retroactively, so it works on snapshots that predate the `lifetime_bucket_pct` field. Produces a PNG plus a per-snapshot CSV sidecar that future reports can diff against.
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_lifetime_buckets_chart.py \
+  --csv-dir OUTPUT_DIR \
+  --output $DATE_DIR/lifetime-buckets-YYYY-MM-DD.png \
+  --csv-out $DATE_DIR/lifetime-buckets-YYYY-MM-DD.csv
+```
+
+Embed the chart in the report directly below the Registry Instance Lifetime section, alongside a narrative that quotes the latest CSV row (the report-date snapshot) and contrasts it with the earliest snapshot to show whether the customer-retention curve is improving over time.
+
+**Note**: Run this after Step 6 since it depends on `instance_lifetime` + `internal_instance_ids` keys in `metrics-*.json`.
 
 ### Step 5c2: Generate Customer-Active-Instances Chart
 
@@ -154,6 +181,12 @@ Generate a chart of customer engagement over time, with three overlaid series:
 - **7-day consistency streak (S7)** -- unique `registry_id`s that sent at least one event on EACH of the 7 days in the window `[D-6..D]`.
 
 Customer-only: internal instances loaded from `known-internal-instances.md` are excluded so the numbers align with the Liveness section (which is also customer-only). A CSV sidecar of the per-day values is written alongside the PNG so the report narrative can quote exact numbers and future reports can diff against it.
+
+The CSV also includes two **DAI percentage** columns derived from the same per-day registry-id sets:
+- `cumulative_installs`, `dai_pct_of_total` -- DAI / cumulative_installs through that day; the engagement rate of the full install funnel ever recorded
+- `likely_alive_7d`, `dai_pct_of_likely_alive` -- DAI / unique-active-in-trailing-7d; the engagement rate of the currently-active fleet (analog of a DAU/WAU ratio)
+
+Both percentages should be quoted side-by-side in the report's "DAI as a percentage of total installs" subsection so the reader sees the funnel-engagement number (low, because of one-day wonders) and the active-fleet engagement number (the healthier B2B-style read) together.
 
 ```bash
 /usr/bin/python3 .claude/skills/usage-report/generate_active_instances_chart.py \
@@ -349,12 +382,17 @@ Lead with new installs since last report, total unique installs, dominant cloud/
 
 Include an **instance stickiness** line: "N instances have been running for 3+ days (up/down from M in the previous report). The longest-running non-internal instance is `REGISTRY_ID` at D days (previously P days)." This signals real adoption beyond one-time trials.
 
+Include a **one-day-wonder** line. The exec-summary builder in `analyze_telemetry.py` already emits this sentence automatically when `stickiness` is supplied: e.g. "59.8% of customer instances (277 of 463) are one-day wonders -- their startup or heartbeat events fall on a single calendar day and that registry_id is never seen again. These represent operators trying out the solution once, out of curiosity, and not coming back." Compare against the previous report's `stickiness.one_day_wonder_pct` to show the trend (the goal is to drive this number down).
+
 These numbers are pre-computed by `analyze_telemetry.py` (when `--internal-instances` is provided) and available in `metrics-YYYY-MM-DD.json` under the `stickiness` key:
 - `stickiness.sticky_3plus_days`: count of non-internal instances where age_days >= 3
+- `stickiness.one_day_wonders`: count of non-internal instances with age_days == 0
+- `stickiness.one_day_wonder_pct`: percentage form of the above
+- `stickiness.lifetime_bucket_counts` / `lifetime_bucket_pct`: cumulative thresholds at 3, 7, 14, 30 days; both the count and pct of customers whose age_days is at least each threshold (the customer survival curve)
 - `stickiness.longest_non_internal_id`: registry_id with max age_days (filtered)
 - `stickiness.longest_non_internal_days`: max age_days value
 
-Compare both numbers against the same `stickiness` values from the previous report's `metrics-*.json`.
+Compare these against the same `stickiness` values from the previous report's `metrics-*.json`.
 
 ![Registry Installs Timeseries](registry-installs-timeseries-YYYY-MM-DD.png)
 

--- a/.claude/skills/usage-report/analyze_telemetry.py
+++ b/.claude/skills/usage-report/analyze_telemetry.py
@@ -129,16 +129,58 @@ def _compute_stickiness(
     instance_lifetime: list[dict],
     internal_ids: set[str],
 ) -> dict:
-    """Compute stickiness metrics: 3+ day non-internal instances and longest-running."""
+    """Compute stickiness metrics for the customer (non-internal) fleet.
+
+    Returns:
+      sticky_3plus_days: count of instances with age_days >= 3 (legacy)
+      one_day_wonders / one_day_wonder_pct: instances seen on exactly one
+        calendar day, never seen again
+      lifetime_bucket_counts / lifetime_bucket_pct: nested dict with the
+        thresholds 3, 7, 14, 30 -> count and pct of customers whose
+        age_days >= threshold. Used to track the customer-retention curve
+        over time.
+      longest_non_internal_*: the customer instance with the largest
+        age_days value
+    """
     non_internal = [
         inst for inst in instance_lifetime if not _is_internal(inst["registry_id"], internal_ids)
     ]
     sticky = [inst for inst in non_internal if inst["age_days"] >= 3]
+    # One-day wonders: customer instances whose first_seen and last_seen fall on
+    # the same calendar day (age_days == 0). These represent "tried it once and
+    # never came back" deployments and are worth tracking as a leading
+    # indicator of evaluation-to-persistence conversion.
+    one_day_wonders = [inst for inst in non_internal if inst["age_days"] == 0]
+    total_non_internal = len(non_internal)
+    one_day_wonder_pct = (
+        round(100.0 * len(one_day_wonders) / total_non_internal, 1)
+        if total_non_internal
+        else 0.0
+    )
+    # Lifetime buckets (cumulative thresholds): for each threshold, what
+    # share of customer instances have an age_days >= that threshold? These
+    # form the survival curve we want to chart over time. Capped at >= 30
+    # days (no separate ">30" bucket).
+    lifetime_thresholds = [3, 7, 14, 30]
+    lifetime_bucket_counts = {
+        threshold: sum(1 for inst in non_internal if inst["age_days"] >= threshold)
+        for threshold in lifetime_thresholds
+    }
+    lifetime_bucket_pct = {
+        threshold: (
+            round(100.0 * count / total_non_internal, 1) if total_non_internal else 0.0
+        )
+        for threshold, count in lifetime_bucket_counts.items()
+    }
     longest = max(non_internal, key=lambda x: x["age_days"]) if non_internal else None
 
     return {
         "sticky_3plus_days": len(sticky),
-        "total_non_internal": len(non_internal),
+        "total_non_internal": total_non_internal,
+        "one_day_wonders": len(one_day_wonders),
+        "one_day_wonder_pct": one_day_wonder_pct,
+        "lifetime_bucket_counts": lifetime_bucket_counts,
+        "lifetime_bucket_pct": lifetime_bucket_pct,
         "longest_non_internal_id": longest["registry_id"] if longest else None,
         "longest_non_internal_days": longest["age_days"] if longest else 0,
     }
@@ -737,6 +779,7 @@ def _build_exec_summary_md(
     current_cloud_installs: dict[str, int],
     previous_cloud_installs: dict[str, int] | None,
     cloud_last_event: dict[str, dict[str, str]] | None = None,
+    stickiness: dict | None = None,
 ) -> str:
     """Build the executive summary markdown section with comparison."""
     lines = []
@@ -779,6 +822,22 @@ def _build_exec_summary_md(
             f"{curr['latest_ts'][:10]}."
         )
     lines.append("")
+
+    # One-day-wonder line: customers who tried it once and never came back.
+    # Always render this when stickiness data is available, regardless of
+    # whether there is a previous report to compare against.
+    if stickiness and stickiness.get("total_non_internal", 0) > 0:
+        odw_count = stickiness.get("one_day_wonders", 0)
+        odw_pct = stickiness.get("one_day_wonder_pct", 0.0)
+        odw_total = stickiness.get("total_non_internal", 0)
+        lines.append(
+            f"**{odw_pct}% of customer instances ({odw_count} of {odw_total}) "
+            f"are one-day wonders** -- their startup or heartbeat events fall "
+            f"on a single calendar day and that registry_id is never seen "
+            f"again. These represent operators trying out the solution once, "
+            f"out of curiosity, and not coming back."
+        )
+        lines.append("")
 
     if previous_metrics is None:
         lines.append("*No previous report available for comparison.*")
@@ -979,6 +1038,13 @@ def _compute_instance_table(
         first_ts = events[0].get("ts", "")[:10]
         latest_ts = events[-1].get("ts", "")[:10]
 
+        # auth: heartbeat events don't carry the field, so picking
+        # latest.get("auth") would be empty for any instance whose latest
+        # event is a heartbeat -- mislabeling 80%+ of customers as "none"
+        # auth provider when really we just lack the field on that event.
+        # Use _latest_nonempty to walk back to the most recent startup event.
+        auth = _latest_nonempty(events, "auth")
+
         result.append(
             {
                 "registry_id": rid[:12] + "...",
@@ -987,7 +1053,7 @@ def _compute_instance_table(
                 "cloud_detection_method": cloud_detection_method,
                 "compute": latest.get("compute") or "unknown",
                 "storage": latest.get("storage") or "unknown",
-                "auth": latest.get("auth") or "none",
+                "auth": auth,
                 "federation": latest.get("federation", "").strip().lower() == "true",
                 "arch": latest.get("arch") or "unknown",
                 "mode": latest.get("mode") or "unknown",
@@ -1017,6 +1083,9 @@ def _compute_unidentified_profiles(
     unidentified = [r for r in rows if not r.get("registry_id", "").strip()]
 
     # Group by (cloud, compute, arch, storage, auth, mode)
+    # Note: heartbeat events don't carry the `auth` field, so an empty
+    # auth here means "we don't know" not "no auth provider configured".
+    # Use "unknown" rather than "none" so we don't mislabel.
     profiles = defaultdict(list)
     for row in unidentified:
         key = (
@@ -1024,7 +1093,7 @@ def _compute_unidentified_profiles(
             row.get("compute") or "unknown",
             row.get("arch") or "unknown",
             row.get("storage") or "unknown",
-            row.get("auth") or "none",
+            row.get("auth") or "unknown",
             row.get("mode") or "unknown",
         )
         profiles[key].append(row)
@@ -1781,6 +1850,10 @@ def main() -> None:
         if previous_metrics:
             previous_cloud_installs = previous_metrics.get("per_cloud_unique_installs", None)
 
+    # Compute stickiness BEFORE the exec-summary build so the one-day-wonder
+    # line can be emitted in the lead paragraph.
+    stickiness = _compute_stickiness(instance_lifetime, internal_ids)
+
     # Build executive summary
     exec_summary_md = _build_exec_summary_md(
         metrics,
@@ -1788,9 +1861,8 @@ def main() -> None:
         cloud_installs,
         previous_cloud_installs,
         cloud_last_event=cloud_last_event,
+        stickiness=stickiness,
     )
-
-    stickiness = _compute_stickiness(instance_lifetime, internal_ids)
 
     upgrade_trajectories = _compute_upgrade_trajectories(rows, internal_ids)
 

--- a/.claude/skills/usage-report/generate_active_instances_chart.py
+++ b/.claude/skills/usage-report/generate_active_instances_chart.py
@@ -172,14 +172,29 @@ def _date_range(
 
 def _compute_series(
     by_day: dict[str, set[str]],
-) -> tuple[list[str], list[int], list[float | None], list[int | None]]:
-    """Compute DAI, MA7, and 7-day consistency streak series.
+) -> tuple[
+    list[str],
+    list[int],
+    list[float | None],
+    list[int | None],
+    list[int],
+    list[int],
+]:
+    """Compute DAI, MA7, S7, plus the two denominators for percentage views.
 
-    Returns a tuple of (dates, dai, ma7, streak7). ma7 and streak7 contain
-    None for the first 6 days (insufficient window).
+    Returns (dates, dai, ma7, streak7, cumulative_installs, likely_alive_7d):
+      cumulative_installs[i] = count of distinct registry_ids ever seen on
+        full_dates[0..i]. The cumulative install funnel through day i.
+      likely_alive_7d[i]      = count of distinct registry_ids that sent any
+        event in the trailing 7 days [i-6..i]. Mirrors the "Likely Alive"
+        tier from analyze_liveness.py and acts as the denominator for an
+        engagement-of-currently-active-fleet view.
+
+    ma7 and streak7 contain None for the first 6 days (insufficient window).
+    cumulative_installs and likely_alive_7d are populated for every day.
     """
     if not by_day:
-        return [], [], [], []
+        return [], [], [], [], [], []
 
     sorted_dates = sorted(by_day.keys())
     full_dates = _date_range(sorted_dates[0], sorted_dates[-1])
@@ -203,7 +218,21 @@ def _compute_series(
             common = set.intersection(*window_sets) if window_sets else set()
             streak7.append(len(common))
 
-    return full_dates, dai, ma7, streak7
+    cumulative_installs: list[int] = []
+    seen_ever: set[str] = set()
+    for i in range(len(full_dates)):
+        seen_ever.update(by_day.get(full_dates[i], set()))
+        cumulative_installs.append(len(seen_ever))
+
+    likely_alive_7d: list[int] = []
+    for i in range(len(full_dates)):
+        start_idx = max(0, i - 6)
+        union: set[str] = set()
+        for j in range(start_idx, i + 1):
+            union.update(by_day.get(full_dates[j], set()))
+        likely_alive_7d.append(len(union))
+
+    return full_dates, dai, ma7, streak7, cumulative_installs, likely_alive_7d
 
 
 def _write_csv_sidecar(
@@ -211,16 +240,39 @@ def _write_csv_sidecar(
     dai: list[int],
     ma7: list[float | None],
     streak7: list[int | None],
+    cumulative_installs: list[int],
+    likely_alive_7d: list[int],
     path: str,
 ) -> None:
-    """Write the daily series as a CSV sidecar next to the chart."""
+    """Write the daily series as a CSV sidecar next to the chart.
+
+    Columns:
+      date, daily_active, ma7, streak7,
+      cumulative_installs       -- distinct registry_ids ever seen by this day
+      dai_pct_of_total          -- DAI / cumulative_installs (engagement of full funnel)
+      likely_alive_7d           -- distinct registry_ids active in trailing 7d
+      dai_pct_of_likely_alive   -- DAI / likely_alive_7d (engagement of currently-active fleet)
+    """
     with open(path, "w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(["date", "daily_active", "ma7", "streak7"])
+        w.writerow([
+            "date",
+            "daily_active",
+            "ma7",
+            "streak7",
+            "cumulative_installs",
+            "dai_pct_of_total",
+            "likely_alive_7d",
+            "dai_pct_of_likely_alive",
+        ])
         for i, d in enumerate(dates):
             ma_cell = "" if ma7[i] is None else f"{ma7[i]:.2f}"
             s_cell = "" if streak7[i] is None else str(streak7[i])
-            w.writerow([d, dai[i], ma_cell, s_cell])
+            cum = cumulative_installs[i]
+            la = likely_alive_7d[i]
+            pct_total = f"{(100.0 * dai[i] / cum):.1f}" if cum else ""
+            pct_alive = f"{(100.0 * dai[i] / la):.1f}" if la else ""
+            w.writerow([d, dai[i], ma_cell, s_cell, cum, pct_total, la, pct_alive])
     logger.info(f"CSV sidecar written to {path}")
 
 
@@ -322,7 +374,7 @@ def main() -> None:
     unique_rows = _dedupe_by_id_ts(all_rows)
     by_day = _build_daily_index(unique_rows, internal_ids, args.exclude_incomplete_day)
 
-    dates, dai, ma7, streak7 = _compute_series(by_day)
+    dates, dai, ma7, streak7, cumulative, likely_alive = _compute_series(by_day)
     if not dates:
         logger.error("No customer events found after filtering")
         raise SystemExit(1)
@@ -330,7 +382,9 @@ def main() -> None:
     _generate_chart(dates, dai, ma7, streak7, args.output)
 
     if args.csv_out:
-        _write_csv_sidecar(dates, dai, ma7, streak7, args.csv_out)
+        _write_csv_sidecar(
+            dates, dai, ma7, streak7, cumulative, likely_alive, args.csv_out
+        )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/usage-report/generate_instance_distribution_chart.py
+++ b/.claude/skills/usage-report/generate_instance_distribution_chart.py
@@ -49,20 +49,45 @@ def _get_latest_per_instance(
 
     Rows without a registry_id are excluded since they cannot be reliably
     deduplicated and would inflate the instance count.
-    """
-    instance_latest: dict[str, dict[str, str]] = {}
 
+    NOTE: Heartbeat events do not carry the `auth` field (the heartbeat
+    schema only emits runtime metrics, not deployment shape for that
+    column). For the latest-per-instance row we therefore copy the auth
+    value forward from the most recent event that did populate it -- which
+    is almost always a startup event. Without this patch any instance
+    whose latest event is a heartbeat would get auth="" and end up
+    mislabeled as "no auth provider".
+    """
+    rows_sorted = sorted(rows, key=lambda r: r.get("ts", ""))
+
+    instance_latest: dict[str, dict[str, str]] = {}
+    instance_latest_auth: dict[str, str] = {}
     skipped = 0
-    for row in rows:
+    for row in rows_sorted:
         rid = (row.get("registry_id") or "").strip()
         if not rid:
             skipped += 1
             continue
 
-        ts = row.get("ts", "")
+        # Track latest event in general (for cloud/compute/etc which heartbeat
+        # events DO carry).
         existing = instance_latest.get(rid)
-        if existing is None or ts > existing.get("ts", ""):
+        if existing is None or row.get("ts", "") > existing.get("ts", ""):
             instance_latest[rid] = row
+
+        # Separately track the most recent non-empty auth value, since
+        # heartbeats leave it empty.
+        auth = (row.get("auth") or "").strip()
+        if auth:
+            instance_latest_auth[rid] = auth
+
+    # Stitch the latest auth back onto the latest-event row so downstream
+    # code can keep using a single row per instance.
+    for rid, latest in instance_latest.items():
+        if rid in instance_latest_auth:
+            latest = dict(latest)
+            latest["auth"] = instance_latest_auth[rid]
+            instance_latest[rid] = latest
 
     logger.info(
         f"Deduplicated {len(rows)} events to {len(instance_latest)} unique instances "
@@ -94,7 +119,12 @@ def _compute_distributions(
         storage = row.get("storage", "unknown") or "unknown"
         dimensions["Storage Backend"][storage] += 1
 
-        auth = row.get("auth", "none") or "none"
+        # auth comes from the most recent startup event for the instance;
+        # see _get_latest_per_instance. If it is genuinely missing (e.g.
+        # an instance that only ever sent heartbeats during the window)
+        # bucket it as "unknown" rather than "none" so it does not get
+        # confused with deployments that explicitly set auth_provider=none.
+        auth = (row.get("auth") or "").strip() or "unknown"
         dimensions["Auth Provider"][auth] += 1
 
         arch = row.get("arch", "unknown") or "unknown"
@@ -141,11 +171,51 @@ def _plot_single_facet(
     ax.set_xlim(0, max_count * 1.4)
 
 
+def _filter_rows_active_on_date(
+    rows: list[dict[str, str]],
+    active_date: str,
+) -> list[dict[str, str]]:
+    """Restrict the row set to instances that had an event on active_date.
+
+    Returns ALL events for the surviving registry_ids (not just the ones on
+    that day) so the latest-per-instance and auth-stitching logic in
+    _get_latest_per_instance still work. Without this, an instance that
+    last sent a startup event two weeks ago and only sent heartbeats on
+    active_date would lose its auth value.
+    """
+    active_ids: set[str] = set()
+    for row in rows:
+        if (row.get("ts") or "")[:10] != active_date:
+            continue
+        rid = (row.get("registry_id") or "").strip()
+        if rid:
+            active_ids.add(rid)
+
+    if not active_ids:
+        logger.warning(
+            f"No instances reported on {active_date}; returning empty row set",
+        )
+        return []
+
+    kept = [r for r in rows if (r.get("registry_id") or "").strip() in active_ids]
+    logger.info(
+        f"Active on {active_date}: {len(active_ids)} unique instances "
+        f"(filtered {len(rows)} -> {len(kept)} events for those instances' full history)"
+    )
+    return kept
+
+
 def _generate_chart(
     rows: list[dict[str, str]],
     output_path: str,
+    active_on_date: str | None = None,
 ) -> None:
-    """Generate and save the faceted distribution chart."""
+    """Generate and save the faceted distribution chart.
+
+    When active_on_date (YYYY-MM-DD) is provided, the chart shows only
+    those instances that reported at least one event on that date. The
+    title is annotated to make this explicit.
+    """
     instances = _get_latest_per_instance(rows)
     total = len(instances)
 
@@ -154,8 +224,12 @@ def _generate_chart(
     sns.set_theme(style="whitegrid")
 
     fig, axes = plt.subplots(2, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+    if active_on_date:
+        title_suffix = f"\n(Active on {active_on_date}: {total} unique instances)"
+    else:
+        title_suffix = f"\n({total} unique instances)"
     fig.suptitle(
-        f"{CHART_TITLE}\n({total} unique instances)",
+        f"{CHART_TITLE}{title_suffix}",
         fontsize=14,
         fontweight="bold",
         y=0.98,
@@ -197,6 +271,16 @@ def main() -> None:
         required=True,
         help="Path to save the output PNG",
     )
+    parser.add_argument(
+        "--active-on-date",
+        default=None,
+        help=(
+            "Optional YYYY-MM-DD. When provided, the chart is restricted to "
+            "instances that had at least one event on that date. Use the last "
+            "complete day (typically today - 1) to get a 'who is currently "
+            "deployed' snapshot rather than 'who has ever been deployed'."
+        ),
+    )
     args = parser.parse_args()
 
     if not os.path.exists(args.csv):
@@ -209,7 +293,13 @@ def main() -> None:
         logger.error("No data in CSV file")
         raise SystemExit(1)
 
-    _generate_chart(rows, args.output)
+    if args.active_on_date:
+        rows = _filter_rows_active_on_date(rows, args.active_on_date)
+        if not rows:
+            logger.error(f"No instances active on {args.active_on_date}")
+            raise SystemExit(1)
+
+    _generate_chart(rows, args.output, active_on_date=args.active_on_date)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/usage-report/generate_lifetime_buckets_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_buckets_chart.py
@@ -1,0 +1,282 @@
+"""Plot lifetime-bucket retention percentages over time.
+
+Reads every `metrics-*.json` file in the dated subdirectories under a base
+output dir, retroactively computes per-snapshot lifetime-bucket percentages
+for the customer (non-internal) fleet, and produces:
+
+  1. A multi-line chart with one series per threshold:
+       - >= 3 days
+       - >= 7 days
+       - >= 14 days
+       - >= 30 days
+     Each line is the percentage of non-internal customer instances whose
+     age_days (last_seen - first_seen) was at least the threshold on that
+     snapshot date. Plus a separate one-day-wonder line on a secondary axis.
+
+  2. An optional CSV sidecar of the per-snapshot values so future reports
+     can diff and the report narrative can quote exact numbers.
+
+The percentages are recomputed from `instance_lifetime` + `internal_instance_ids`
+so old snapshot files (written before lifetime_bucket_pct existed) are
+handled transparently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+from datetime import datetime
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = (
+    "AI Registry -- Customer Lifetime Retention Over Time "
+    "(% of customer instances surviving N days)"
+)
+FIGURE_WIDTH: int = 14
+FIGURE_HEIGHT: int = 7
+THRESHOLDS: list[int] = [3, 7, 14, 30]
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _find_metrics_files(
+    base_dir: str,
+) -> list[tuple[str, str]]:
+    """Return sorted list of (date_str, metrics_path) for each dated subfolder."""
+    out: list[tuple[str, str]] = []
+    for entry in sorted(os.listdir(base_dir)):
+        full = os.path.join(base_dir, entry)
+        if not os.path.isdir(full) or not DATE_RE.match(entry):
+            continue
+        candidate = os.path.join(full, f"metrics-{entry}.json")
+        if os.path.exists(candidate):
+            out.append((entry, candidate))
+    logger.info(f"Found {len(out)} metrics files in {base_dir}")
+    return out
+
+
+def _is_internal_id(
+    registry_id: str,
+    internal_ids: set[str],
+) -> bool:
+    """Match an instance row's registry_id (which may be truncated like 'abc...') to internal IDs."""
+    if not registry_id:
+        return False
+    if registry_id in internal_ids:
+        return True
+    if registry_id.endswith("..."):
+        prefix = registry_id[:-3]
+        for full in internal_ids:
+            if full.startswith(prefix):
+                return True
+    return False
+
+
+def _compute_bucket_pct_from_metrics(
+    metrics_path: str,
+) -> dict | None:
+    """Re-derive lifetime-bucket percentages from a metrics-*.json file.
+
+    Falls back to instance_lifetime + internal_instance_ids so old snapshots
+    that predate the lifetime_bucket_pct field still produce numbers.
+    Returns None if the file is missing the lifetime data.
+    """
+    with open(metrics_path) as f:
+        data = json.load(f)
+
+    lifetime = data.get("instance_lifetime") or []
+    if not lifetime:
+        return None
+    internal_ids = set(data.get("internal_instance_ids") or [])
+
+    non_internal = [
+        inst for inst in lifetime if not _is_internal_id(inst.get("registry_id", ""), internal_ids)
+    ]
+    total = len(non_internal)
+    if total == 0:
+        return None
+
+    one_day_wonders = sum(1 for inst in non_internal if inst.get("age_days", 0) == 0)
+    one_day_pct = round(100.0 * one_day_wonders / total, 1)
+
+    bucket_pct = {
+        threshold: round(
+            100.0 * sum(1 for inst in non_internal if inst.get("age_days", 0) >= threshold) / total,
+            1,
+        )
+        for threshold in THRESHOLDS
+    }
+
+    return {
+        "total_non_internal": total,
+        "one_day_wonder_pct": one_day_pct,
+        "bucket_pct": bucket_pct,
+    }
+
+
+def _build_timeseries(
+    metrics_files: list[tuple[str, str]],
+) -> list[dict]:
+    """Build per-snapshot rows of bucket percentages."""
+    out: list[dict] = []
+    for date_str, path in metrics_files:
+        derived = _compute_bucket_pct_from_metrics(path)
+        if not derived:
+            continue
+        out.append(
+            {
+                "date": date_str,
+                "total": derived["total_non_internal"],
+                "one_day_wonder_pct": derived["one_day_wonder_pct"],
+                **{f"pct_ge_{t}d": derived["bucket_pct"][t] for t in THRESHOLDS},
+            }
+        )
+    return out
+
+
+def _write_csv_sidecar(
+    rows: list[dict],
+    path: str,
+) -> None:
+    """Write the per-snapshot bucket-percentage rows to a CSV sidecar."""
+    if not rows:
+        return
+    fieldnames = ["date", "total", "one_day_wonder_pct"] + [f"pct_ge_{t}d" for t in THRESHOLDS]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k) for k in fieldnames})
+    logger.info(f"CSV sidecar written to {path}")
+
+
+def _generate_chart(
+    rows: list[dict],
+    output_path: str,
+) -> None:
+    """Render the multi-line retention chart."""
+    sns.set_theme(style="whitegrid")
+    fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+    fig.suptitle(CHART_TITLE, fontsize=14, fontweight="bold", y=0.97)
+
+    parsed = [datetime.strptime(r["date"], "%Y-%m-%d") for r in rows]
+    palette = sns.color_palette("Blues_d", len(THRESHOLDS))[::-1]
+
+    # Survival-curve series: percentage of customer fleet whose age_days >= threshold
+    for idx, threshold in enumerate(THRESHOLDS):
+        key = f"pct_ge_{threshold}d"
+        values = [r[key] for r in rows]
+        ax.plot(
+            parsed,
+            values,
+            marker="o",
+            markersize=5,
+            linewidth=2,
+            color=palette[idx],
+            label=f">= {threshold} days",
+        )
+
+    ax.set_ylabel("% of customer instances", fontsize=11)
+    ax.set_xlabel("Snapshot date", fontsize=11)
+    ax.legend(
+        title="Lifetime threshold",
+        loc="upper left",
+    )
+    ax.set_ylim(0, max(35, max((r["pct_ge_3d"] for r in rows), default=35) + 5))
+
+    # One-day-wonder line on a secondary axis (typically much higher than the
+    # survival curves, so a shared axis would compress the signal).
+    ax_odw = ax.twinx()
+    odw_vals = [r["one_day_wonder_pct"] for r in rows]
+    ax_odw.plot(
+        parsed,
+        odw_vals,
+        marker="s",
+        markersize=4,
+        linewidth=2,
+        linestyle="--",
+        color=sns.color_palette("Reds_d")[2],
+        label="one-day wonders",
+    )
+    ax_odw.set_ylabel("% one-day wonders", fontsize=11, color=sns.color_palette("Reds_d")[2])
+    ax_odw.tick_params(axis="y", labelcolor=sns.color_palette("Reds_d")[2])
+    ax_odw.set_ylim(0, 100)
+
+    # Combined legend across both axes
+    h1, l1 = ax.get_legend_handles_labels()
+    h2, l2 = ax_odw.get_legend_handles_labels()
+    ax.legend(h1 + h2, l1 + l2, loc="upper left", fontsize=9)
+
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax.xaxis.set_major_locator(mdates.DayLocator(interval=max(1, len(parsed) // 14)))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout(rect=[0, 0, 1, 0.94])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Lifetime-bucket chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments and generate the lifetime-bucket retention chart."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot lifetime-bucket retention percentages over time. "
+            "Reads metrics-*.json files from each dated subdirectory under "
+            "--csv-dir and renders one line per >=N day threshold."
+        ),
+    )
+    parser.add_argument(
+        "--csv-dir",
+        required=True,
+        help="Base output directory (contains dated subfolders with metrics-*.json)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG chart",
+    )
+    parser.add_argument(
+        "--csv-out",
+        default=None,
+        help="Optional path to write a per-snapshot CSV sidecar of the bucket percentages",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.csv_dir):
+        logger.error(f"Directory not found: {args.csv_dir}")
+        raise SystemExit(1)
+
+    metrics_files = _find_metrics_files(args.csv_dir)
+    if not metrics_files:
+        logger.error(f"No metrics-*.json files found under {args.csv_dir}")
+        raise SystemExit(1)
+
+    rows = _build_timeseries(metrics_files)
+    if not rows:
+        logger.error("No bucket data could be computed from metrics files")
+        raise SystemExit(1)
+
+    _generate_chart(rows, args.output)
+    if args.csv_out:
+        _write_csv_sidecar(rows, args.csv_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/usage-report/generate_lifetime_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_chart.py
@@ -25,7 +25,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 CHART_TITLE: str = "AI Registry -- Instance Lifetime Distribution"
-FIGURE_WIDTH: int = 12
+FIGURE_WIDTH: int = 16
 FIGURE_HEIGHT: int = 6
 
 
@@ -53,11 +53,11 @@ def _generate_chart(
     """Generate and save the lifetime density chart."""
     sns.set_theme(style="whitegrid")
 
-    fig, (ax_hist, ax_bar) = plt.subplots(
+    fig, (ax_hist, ax_box, ax_bar) = plt.subplots(
         1,
-        2,
+        3,
         figsize=(FIGURE_WIDTH, FIGURE_HEIGHT),
-        gridspec_kw={"width_ratios": [3, 2]},
+        gridspec_kw={"width_ratios": [3, 1, 2]},
     )
 
     fig.suptitle(
@@ -125,6 +125,53 @@ def _generate_chart(
         horizontalalignment="right",
         bbox={"boxstyle": "round,pad=0.5", "facecolor": "wheat", "alpha": 0.8},
     )
+
+    # Middle panel: boxplot of instance ages
+    box_color = sns.color_palette("Blues_d")[2]
+    sns.boxplot(
+        y=ages,
+        ax=ax_box,
+        color=box_color,
+        width=0.5,
+        fliersize=4,
+    )
+    # Overlay individual points so the cluster at 0 is visible
+    sns.stripplot(
+        y=ages,
+        ax=ax_box,
+        color=sns.color_palette("deep")[3],
+        size=2.5,
+        alpha=0.4,
+        jitter=0.15,
+    )
+
+    # Quartile annotations
+    if ages:
+        sorted_ages = sorted(ages)
+        n = len(sorted_ages)
+        median = sorted_ages[n // 2] if n % 2 else (sorted_ages[n // 2 - 1] + sorted_ages[n // 2]) / 2
+        q1 = sorted_ages[n // 4]
+        q3 = sorted_ages[(3 * n) // 4]
+        box_stats = (
+            f"Q1: {q1} d\n"
+            f"Median: {median:.1f} d\n"
+            f"Q3: {q3} d\n"
+            f"Max: {max_age} d"
+        )
+        ax_box.text(
+            0.95,
+            0.97,
+            box_stats,
+            transform=ax_box.transAxes,
+            fontsize=9,
+            verticalalignment="top",
+            horizontalalignment="right",
+            bbox={"boxstyle": "round,pad=0.4", "facecolor": "wheat", "alpha": 0.8},
+        )
+
+    ax_box.set_ylabel("Instance Age (days)", fontsize=11)
+    ax_box.set_title("Age Spread", fontsize=12, fontweight="bold")
+    ax_box.set_xticks([])
 
     # Right panel: horizontal bar showing age buckets
     buckets = {

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -75,10 +75,14 @@ Host: m3ijrhd020.execute-api.us-east-1.amazonaws.com
 Content-Type: application/json
 X-Telemetry-Signature: 5b7e1a...d4f2c3
 
-{"agents_count":8,"cloud":"aws","compute":"ecs","embeddings_backend_kind":"sentence-transformers","embeddings_provider":"sentence-transformers","event":"heartbeat","peers_count":2,"registry_id":"c546a650-8af9-4721-9efb-7df221b2a0d9","schema_version":"2","search_backend":"documentdb","search_queries_1h":3,"search_queries_24h":12,"search_queries_total":150,"servers_count":15,"skills_count":23,"ts":"2026-03-18T12:00:00+00:00","uptime_hours":48,"v":"1.0.22"}
+{"agents_count":8,"arch":"x86_64","auth":"keycloak","cloud":"aws","compute":"ecs","embeddings_backend_kind":"sentence-transformers","embeddings_provider":"sentence-transformers","event":"heartbeat","federation":true,"mode":"with-gateway","os":"linux","peers_count":2,"py":"3.12","registry_id":"c546a650-8af9-4721-9efb-7df221b2a0d9","registry_mode":"full","schema_version":"4","search_backend":"documentdb","search_queries_1h":3,"search_queries_24h":12,"search_queries_total":150,"servers_count":15,"skills_count":23,"storage":"documentdb","ts":"2026-03-18T12:00:00+00:00","uptime_hours":48,"v":"1.0.22"}
 ```
 
-Registries running versions earlier than v1.0.22 emit `schema_version":"1"` events without `embeddings_backend_kind`. The collector accepts both versions.
+Schema versions:
+- `"1"` (pre-v1.0.22): no `embeddings_backend_kind`
+- `"2"` (v1.0.22+): adds `embeddings_backend_kind`
+- `"3"` (v1.23.0+): adds `cloud_detection_method`
+- `"4"` (this version): adds `auth`, `arch`, `os`, `py`, `mode`, `registry_mode`, `storage`, `federation` to **heartbeat** events. Startup payload shape is unchanged from v3 -- the bump just signals to downstream tooling that heartbeats now carry the same deployment-shape fields. The collector accepts all four versions.
 
 Notes:
 - JSON body keys are sorted alphabetically (`sort_keys=True`) and compact (`separators=(",",":")`) for deterministic HMAC computation

--- a/registry/core/telemetry.py
+++ b/registry/core/telemetry.py
@@ -581,7 +581,7 @@ async def _build_startup_payload() -> dict:
 
     return {
         "event": "startup",
-        "schema_version": "3",
+        "schema_version": "4",
         "registry_id": registry_id,
         "v": __version__,
         "py": f"{sys.version_info.major}.{sys.version_info.minor}",
@@ -670,9 +670,22 @@ async def _build_heartbeat_payload() -> dict:
 
     return {
         "event": "heartbeat",
-        "schema_version": "3",
+        "schema_version": "4",
         "registry_id": registry_id,
         "v": __version__,
+        # Deployment-shape fields (schema v4+). Carrying them on every
+        # heartbeat lets the analyzer attribute auth/arch/etc to long-lived
+        # instances whose original startup event predates the report
+        # collection window. Without this, those instances fall into the
+        # "unknown" bucket on the report's auth and architecture panels.
+        "py": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "os": platform.system().lower(),
+        "arch": platform.machine(),
+        "mode": settings.deployment_mode.value,
+        "registry_mode": settings.registry_mode.value,
+        "storage": settings.storage_backend,
+        "auth": settings.auth_provider,
+        "federation": settings.federation_static_token_auth_enabled,
         "cloud": cloud,
         "cloud_detection_method": detection_method,
         "compute": _detect_compute_platform(),

--- a/terraform/telemetry-collector/bastion-scripts/telemetry_db.py
+++ b/terraform/telemetry-collector/bastion-scripts/telemetry_db.py
@@ -69,13 +69,29 @@ STARTUP_COLUMNS = [
     "source_ip_hash",
 ]
 
-# Column order for heartbeat events
+# Column order for heartbeat events.
+#
+# Schema v4+ (registry v1.24.0+) adds the deployment-shape fields
+# (py/os/arch/mode/registry_mode/storage/auth/federation) to heartbeat
+# payloads so long-lived instances whose original startup event predates
+# the report window can still contribute that metadata. Pre-v4 clients
+# leave these blank in the CSV (the export uses extrasaction="ignore"
+# but Pydantic emits None for unset optional fields, so the column
+# header is always present).
 HEARTBEAT_COLUMNS = [
     "event",
     "registry_id",
     "v",
+    "py",
+    "os",
+    "arch",
     "cloud",
     "compute",
+    "mode",
+    "registry_mode",
+    "storage",
+    "auth",
+    "federation",
     "servers_count",
     "agents_count",
     "skills_count",

--- a/terraform/telemetry-collector/lambda/collector/schemas.py
+++ b/terraform/telemetry-collector/lambda/collector/schemas.py
@@ -178,11 +178,60 @@ class HeartbeatEvent(BaseModel):
     - Search backend usage
     - Embeddings provider
     - Instance uptime
+    - Deployment-shape fields (auth, arch, os, py, mode, registry_mode,
+      storage, federation) -- added in schema v4. Pre-v4 clients omit
+      these and the report's analyzer treats the absence as "unknown
+      auth/arch/etc" rather than mislabeling the instance.
     """
 
     event: str = Field(..., pattern="^heartbeat$")
     registry_id: str | None = Field(default=None, max_length=36, description="Registry card UUID")
     v: str = Field(..., min_length=1, max_length=200, description="Registry version")
+    # Deployment-shape fields (schema v4+). Optional because pre-v4 clients
+    # (the existing fleet) don't send them; the heartbeat schema before v4
+    # only carried runtime metrics. By accepting them here, an instance whose
+    # last startup event predates the report window can still contribute its
+    # auth/arch/etc to the analyzer instead of falling into the unknown
+    # bucket. See registry/core/telemetry.py:_build_heartbeat_payload.
+    py: str | None = Field(
+        default=None,
+        pattern=r"^\d+\.\d+$",
+        description="Python version (major.minor). Added in schema v4.",
+    )
+    os: str | None = Field(
+        default=None,
+        pattern="^(linux|darwin|windows)$",
+        description="Operating system. Added in schema v4.",
+    )
+    arch: str | None = Field(
+        default=None,
+        max_length=20,
+        description="CPU architecture. Added in schema v4.",
+    )
+    mode: str | None = Field(
+        default=None,
+        pattern="^(with-gateway|registry-only)$",
+        description="Deployment mode. Added in schema v4.",
+    )
+    registry_mode: str | None = Field(
+        default=None,
+        pattern="^(full|skills-only|mcp-servers-only|agents-only)$",
+        description="Registry operating mode. Added in schema v4.",
+    )
+    storage: str | None = Field(
+        default=None,
+        pattern="^(file|documentdb|mongodb-ce)$",
+        description="Storage backend. Added in schema v4.",
+    )
+    auth: str | None = Field(
+        default=None,
+        max_length=50,
+        description="Auth provider. Added in schema v4.",
+    )
+    federation: bool | None = Field(
+        default=None,
+        description="Federation enabled. Added in schema v4.",
+    )
     cloud: str = Field(
         default="unknown",
         pattern="^(aws|gcp|azure|unknown)$",

--- a/tests/unit/core/test_telemetry.py
+++ b/tests/unit/core/test_telemetry.py
@@ -887,7 +887,7 @@ class TestEmbeddingsTelemetryFields:
 
             assert payload["embeddings_provider"] == "litellm"
             assert payload["embeddings_backend_kind"] == "bedrock"
-            assert payload["schema_version"] == "3"
+            assert payload["schema_version"] == "4"
 
     @pytest.mark.asyncio
     async def test_startup_payload_omits_raw_model_name_and_dimensions(self):
@@ -956,6 +956,13 @@ class TestEmbeddingsTelemetryFields:
             mock_settings.embeddings_provider = "sentence-transformers"
             mock_settings.embeddings_model_name = "all-MiniLM-L6-v2"
             mock_settings.embeddings_model_dimensions = 384
+            # Deployment-shape fields the v4 heartbeat payload now reads.
+            # Without these the payload would contain MagicMock objects and
+            # fail json.dumps below.
+            mock_settings.deployment_mode = MagicMock(value="with-gateway")
+            mock_settings.registry_mode = MagicMock(value="full")
+            mock_settings.auth_provider = "keycloak"
+            mock_settings.federation_static_token_auth_enabled = False
 
             # Mock repository methods
             for repo_mock in (mock_server_repo, mock_agent_repo, mock_skill_repo):
@@ -970,7 +977,12 @@ class TestEmbeddingsTelemetryFields:
 
             assert payload["embeddings_provider"] == "sentence-transformers"
             assert payload["embeddings_backend_kind"] == "sentence-transformers"
-            assert payload["schema_version"] == "3"
+            assert payload["schema_version"] == "4"
+            # New v4 deployment-shape fields surface on heartbeat too.
+            assert payload["auth"] == "keycloak"
+            assert payload["mode"] == "with-gateway"
+            assert payload["storage"] == "documentdb"
+            assert payload["federation"] is False
 
             # Privacy assertions
             assert "embeddings_model_name" not in payload

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -128,16 +128,33 @@ async def test_ws_manager_broadcast_update_no_connections(ws_manager):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_ws_manager_broadcast_update_rate_limiting(ws_manager, mock_websocket, mock_settings):
-    """Test that broadcasts are rate-limited."""
-    mock_settings.websocket_broadcast_interval_ms = 1000  # 1 second
+    """Test that broadcasts are rate-limited.
 
-    with patch("registry.health.service.settings", mock_settings):
+    The clock is mocked so the test does not depend on real wall-clock
+    timing. Without the mock, a slow CI runner could spend more than the
+    rate-limit interval (1s) between the two awaits, the second broadcast
+    would go through (clearing pending_updates), and the assertion would
+    fail intermittently. This was a known flake on main.
+    """
+    mock_settings.websocket_broadcast_interval_ms = 1000  # 1 second
+    ws_manager.min_broadcast_interval = 1.0
+
+    with (
+        patch("registry.health.service.settings", mock_settings),
+        patch("registry.health.service.time") as mock_time,
+    ):
+        # First call sees t=100; second call sees t=100.1 (well within the 1s
+        # window). Use a list-driven side_effect so each call to time()
+        # returns the next scripted value.
+        mock_time.side_effect = [100.0, 100.0, 100.1, 100.1]
+
         ws_manager.connections.add(mock_websocket)
 
-        # First broadcast should go through
+        # First broadcast should go through (clock=100, last=0, delta=100s > 1s)
         await ws_manager.broadcast_update("test-path", {"status": "healthy"})
 
-        # Immediate second broadcast should be queued (not sent)
+        # Immediate second broadcast should be queued (clock=100.1,
+        # last=100, delta=0.1s < 1s).
         await ws_manager.broadcast_update("test-path-2", {"status": "unhealthy"})
 
         # Check that update was queued

--- a/tests/unit/lambda/test_collector.py
+++ b/tests/unit/lambda/test_collector.py
@@ -239,6 +239,41 @@ class TestSchemas:
         with pytest.raises(ValidationError):
             StartupEvent(**payload)
 
+    # ---- Schema v4 deployment-shape fields on heartbeat events ----
+
+    def test_heartbeat_accepts_v4_payload_with_deployment_shape(self):
+        """Schema v4 heartbeat carries auth/arch/os/py/mode/registry_mode/storage/federation."""
+        payload = self._v2_heartbeat_payload()
+        payload["schema_version"] = "4"
+        payload["py"] = "3.12"
+        payload["os"] = "linux"
+        payload["arch"] = "x86_64"
+        payload["mode"] = "with-gateway"
+        payload["registry_mode"] = "full"
+        payload["storage"] = "documentdb"
+        payload["auth"] = "keycloak"
+        payload["federation"] = True
+        event = HeartbeatEvent(**payload)
+        assert event.auth == "keycloak"
+        assert event.arch == "x86_64"
+        assert event.federation is True
+        assert event.mode == "with-gateway"
+
+    def test_heartbeat_v4_fields_are_optional(self):
+        """Pre-v4 clients omit the new fields; the schema must still accept them."""
+        event = HeartbeatEvent(**self._v2_heartbeat_payload())
+        assert event.auth is None
+        assert event.arch is None
+        assert event.federation is None
+
+    def test_heartbeat_rejects_invalid_auth_storage(self):
+        """v4 fields are still validated when present (storage pattern, etc)."""
+        payload = self._v2_heartbeat_payload()
+        payload["schema_version"] = "4"
+        payload["storage"] = "redis"  # not in the allowed pattern
+        with pytest.raises(ValidationError):
+            HeartbeatEvent(**payload)
+
 
 class TestIPHashing:
     """Test IP hashing for privacy-preserving rate limiting."""


### PR DESCRIPTION
Closes #1059

## Summary

- Bumps telemetry schema to **v4**: heartbeat events now carry `auth`, `arch`, `os`, `py`, `mode`, `registry_mode`, `storage`, `federation` (the same deployment-shape fields startup events have always carried). Fixes the analytics gap where long-lived instances whose original startup event predates the report window were bucketed as `unknown` for those fields.
- Pre-v4 clients still validate against the collector unchanged. The eight new fields are `Optional[X] = None` in `HeartbeatEvent`.
- Adds five usage-report skill improvements that ride on this fix: one-day-wonder metric, lifetime-bucket survival curve over time, boxplot in the instance-lifetime chart, DAI percentage columns (DAU/WAU analog), and an `--active-on-date` filter on the deployment-distribution chart.
- Fixes a pre-existing analyzer bug where `latest.get(\"auth\") or \"none\"` mislabeled most customers as no-auth because heartbeats don't carry the field. Switched to `_latest_nonempty()` (already used for `embeddings_provider`, `search_backend`, etc).

## Files changed

| Layer | File | Change |
|---|---|---|
| Registry | `registry/core/telemetry.py` | `_build_heartbeat_payload` emits 8 new fields; both payload builders bump to `schema_version=4` |
| Collector schema | `terraform/telemetry-collector/lambda/collector/schemas.py` | `HeartbeatEvent` gains 8 optional fields with same validators as `StartupEvent` |
| Lambda handler | `terraform/telemetry-collector/lambda/collector/index.py` | **No change** -- Pydantic-driven, new fields flow through automatically |
| Bastion export | `terraform/telemetry-collector/bastion-scripts/telemetry_db.py` | `HEARTBEAT_COLUMNS` extended |
| Docs | `docs/TELEMETRY.md` | Heartbeat example refreshed, schema-version table extended |
| Tests | `tests/unit/core/test_telemetry.py`, `tests/unit/lambda/test_collector.py` | `schema_version` assertions bumped to `\"4\"` where appropriate; mock_settings extended; 3 new test cases for v4 happy path / optional-when-absent / invalid-value rejection |
| Skill | `.claude/skills/usage-report/analyze_telemetry.py` | One-day-wonder + lifetime-bucket metrics; auth-attribution bug fix |
| Skill | `.claude/skills/usage-report/generate_lifetime_chart.py` | Adds boxplot panel |
| Skill | `.claude/skills/usage-report/generate_lifetime_buckets_chart.py` | New chart: survival curve over time |
| Skill | `.claude/skills/usage-report/generate_active_instances_chart.py` | CSV gains 4 percentage columns |
| Skill | `.claude/skills/usage-report/generate_instance_distribution_chart.py` | New `--active-on-date` flag; auth-bug fix |
| Skill | `.claude/skills/usage-report/SKILL.md` | Documents all of the above |

## Test plan

- [x] `uv run pytest tests/unit/core/test_telemetry.py` -- 73/73 pass
- [x] `uv run pytest tests/integration/test_telemetry_e2e.py` -- 18/18 pass
- [x] Manual REPL exercise of `HeartbeatEvent`: v2 backwards-compat, v4 happy path, v4 invalid-value rejection -- all pass
- [x] Manual REPL exercise of `StartupEvent` v3 backwards-compat -- passes
- [x] `_compute_daily_spend` and `_compute_stickiness` rebuilt against current 22,965-event CSV; numbers match expected (130 sticky / 277 one-day-wonders / 12 actually-no-auth / 293 keycloak)
- [x] All four time-series chart scripts rerun against current CSV; PNGs render
- [x] `pandoc` re-renders the report HTML cleanly (1.9 MB)
- [x] `git status` clean on `main`; commit lives on this branch only

## Deployment notes

- The lambda collector and the registry can ship in either order. Pydantic schema is permissive of older clients; older lambdas would silently drop new fields (Pydantic's default `extra=\"ignore\"`) but neither side breaks.
- The bastion CSV export script needs to be redeployed before a v4 instance's heartbeat fields will appear in usage reports. Without that update, the new columns would be silently truncated by the CSV writer's `extrasaction=\"ignore\"`.
- The `unknown` auth/arch/etc bucket in usage reports will gradually shrink as customers upgrade to v1.24.0+. Until then, the analyzer's `_latest_nonempty()` fix already covers instances whose latest event happens to be a heartbeat -- they pick up auth from a prior startup event in the same window.