### PR TITLE
fix(security): remediate CVE-2026-4438 (glibc) in container base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies including nginx with lua module
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install system dependencies including nginx with lua module.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
     lua-cjson \

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -6,8 +6,11 @@ FROM python:3.14-slim AS builder
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
-# Install build dependencies (only needed for compiling wheels)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install build dependencies (only needed for compiling wheels).
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     && rm -rf /var/lib/apt/lists/*
@@ -33,8 +36,11 @@ FROM python:3.14-slim
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1
 
-# Install only runtime system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install only runtime system dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.mcp-server
+++ b/docker/Dockerfile.mcp-server
@@ -8,8 +8,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     UV_NO_CACHE=1
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install system dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \
     build-essential \

--- a/docker/Dockerfile.mcp-server-cpu
+++ b/docker/Dockerfile.mcp-server-cpu
@@ -10,8 +10,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     UV_NO_CACHE=1
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install system dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     git \
     build-essential \

--- a/docker/Dockerfile.mcp-server-light
+++ b/docker/Dockerfile.mcp-server-light
@@ -13,8 +13,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     UV_NO_CACHE=1
 
-# Install minimal system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install minimal system dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     netcat-openbsd \
     && apt-get clean \

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -20,8 +20,11 @@ ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     DEBIAN_FRONTEND=noninteractive
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install build dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     git \
     ca-certificates \
@@ -71,7 +74,10 @@ ARG BUILD_VERSION="1.0.0"
 # Install runtime dependencies including nginx with lua module.
 # logrotate is used by the entrypoint's daily rotation loop for nginx logs
 # at /var/log/containers/ai-registry/nginx-*.log (issue #987).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
     lua-cjson \

--- a/docker/Dockerfile.registry-cpu
+++ b/docker/Dockerfile.registry-cpu
@@ -8,7 +8,10 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Install system dependencies including nginx with lua module and Node.js.
 # logrotate rotates /var/log/containers/ai-registry/nginx-*.log daily (issue #987).
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
     lua-cjson \

--- a/metrics-service/Dockerfile
+++ b/metrics-service/Dockerfile
@@ -5,8 +5,11 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y \
+# Install system dependencies.
+# apt-get upgrade pulls in security patches against the base image's
+# already-installed packages (e.g. libc6 / glibc CVE updates) that would
+# otherwise stay at whatever version was baked into python:3.14-slim.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

- Closes #1061.
- Inserts `apt-get upgrade -y` before `apt-get install` in every Dockerfile stage that builds on `python:3.14-slim`, so already-installed base-image packages (`libc-bin`, `libc6`, `libc-dev-bin`, `libc6-dev`) pick up the Debian 13 security point release `2.41-12+deb13u3` instead of staying at the vulnerable `2.41-12+deb13u2`.
- Remediates a customer-reported scanner failure caused by **CVE-2026-4438** (Critical, CVSS 5.4, Debian fix dated 2026-05-16). All six rows in the customer's report are the same CVE against the same source package (`glibc`); a single fix clears them all.

## Why

Our Dockerfiles run `apt-get update && apt-get install <our extras>` but never `apt-get upgrade`. `apt-get install` does not upgrade unrelated already-installed packages, so glibc stays at whatever version was baked into upstream `python:3.14-slim` even after `apt-get update` refreshes the package index. Adding `apt-get upgrade -y` is the standard CIS-aligned pattern for slim Debian base images and also automatically remediates the next inherited base-image CVE without a per-CVE Dockerfile patch.

## Files changed

10 apt blocks across 8 Dockerfiles:

- `Dockerfile`
- `docker/Dockerfile.registry` (builder + runtime stages)
- `docker/Dockerfile.auth` (builder + runtime stages)
- `docker/Dockerfile.mcp-server`
- `docker/Dockerfile.mcp-server-light`
- `docker/Dockerfile.mcp-server-cpu`
- `docker/Dockerfile.registry-cpu`
- `metrics-service/Dockerfile`

Not affected (different OS / package manager): `docker/Dockerfile.metrics-db` (Alpine, musl), `docker/Dockerfile.scopes-init` (busybox), `docker/keycloak/Dockerfile` (UBI), `terraform/aws-ecs/grafana/Dockerfile` (Grafana base).

## Test plan

- [ ] Rebuild every affected image and confirm `dpkg -l libc6 libc-bin` reports `2.41-12+deb13u3` (or newer) in every stage that has glibc installed.
- [ ] Run the customer's container scanner against the rebuilt images; confirm all six CVE-2026-4438 findings are cleared.
- [ ] Smoke test: `docker compose up` boots cleanly and registry / auth-server / mcpgw healthchecks pass.
- [ ] Helm chart unittest suite still passes (`helm unittest charts/mcpgw charts/auth-server charts/registry charts/mcp-gateway-registry-stack`) — no chart templates were touched, but worth confirming.
- [ ] CI: registry-test workflow stays green.

## Tradeoffs noted in #1061

- Slightly less reproducible across rebuilds (a feature in this case — we want patches).
- Slightly slower / larger builds (small for a slim Debian base, typically a few MB).
- Targeted-only `apt-get install --only-upgrade libc6 ...` was rejected as brittle; would need a Dockerfile change for every base-image CVE.