### PR TITLE
fix(build): regenerate uv.lock and pin uv==0.11.14 in Dockerfiles

### DIFF
--- a/auth_server/uv.lock
+++ b/auth_server/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofiles"
 version = "25.1.0"

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install uv and create venv (rarely changes)
-RUN pip install --no-cache-dir uv && \
+RUN pip install --no-cache-dir uv==0.11.14 && \
     uv venv .venv --python 3.14
 
 # Copy dependency manifests first so the install layer is cached on the

--- a/docker/Dockerfile.mcp-server
+++ b/docker/Dockerfile.mcp-server
@@ -23,7 +23,7 @@ RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 WORKDIR /app
 
 # Install uv as root (global tool)
-RUN pip install uv
+RUN pip install uv==0.11.14
 
 # Create /app directory with correct ownership from the start
 RUN chown appuser:appuser /app

--- a/docker/Dockerfile.mcp-server-cpu
+++ b/docker/Dockerfile.mcp-server-cpu
@@ -25,7 +25,7 @@ RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 WORKDIR /app
 
 # Install uv as root (global tool)
-RUN pip install uv
+RUN pip install uv==0.11.14
 
 # Create /app with correct ownership
 RUN chown appuser:appuser /app

--- a/docker/Dockerfile.mcp-server-light
+++ b/docker/Dockerfile.mcp-server-light
@@ -26,7 +26,7 @@ RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
 WORKDIR /app
 
 # Install uv as root (global tool)
-RUN pip install uv
+RUN pip install uv==0.11.14
 
 # Create /app with correct ownership
 RUN chown appuser:appuser /app

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install uv and create venv (rarely changes)
-RUN pip install --no-cache-dir uv && \
+RUN pip install --no-cache-dir uv==0.11.14 && \
     uv venv .venv --python 3.14
 
 # Copy dependency manifests FIRST so the install layer is cached on the

--- a/docker/Dockerfile.registry-cpu
+++ b/docker/Dockerfile.registry-cpu
@@ -31,7 +31,7 @@ ARG BUILD_VERSION="1.0.0"
 ENV BUILD_VERSION=$BUILD_VERSION
 
 # Install uv and create venv
-RUN pip install uv && uv venv .venv --python 3.14
+RUN pip install uv==0.11.14 && uv venv .venv --python 3.14
 
 # Copy dependency manifests FIRST so the install layer is cached on the
 # (pyproject, lock) pair, not on source changes. The root pyproject.toml

--- a/metrics-service/Dockerfile
+++ b/metrics-service/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv and create venv
-RUN pip install uv && uv venv .venv --python 3.14
+RUN pip install uv==0.11.14 && uv venv .venv --python 3.14
 
 # Copy dependency manifests first so the install layer is cached on the
 # (pyproject, lock) pair, not on source changes.

--- a/metrics-service/uv.lock
+++ b/metrics-service/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiosqlite"
 version = "0.22.1"

--- a/servers/currenttime/uv.lock
+++ b/servers/currenttime/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"

--- a/servers/example-server/uv.lock
+++ b/servers/example-server/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"

--- a/servers/fininfo/uv.lock
+++ b/servers/fininfo/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"

--- a/servers/mcpgw/uv.lock
+++ b/servers/mcpgw/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"

--- a/servers/realserverfaketools/uv.lock
+++ b/servers/realserverfaketools/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofile"
 version = "3.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ resolution-markers = [
     "sys_platform == 'darwin'",
 ]
 
-[options]
-exclude-newer = "2026-05-07T17:46:43Z"
-
 [[package]]
 name = "aiofiles"
 version = "25.1.0"


### PR DESCRIPTION
## Summary

- Closes #1064.
- Regenerates all 8 `uv.lock` files without `--exclude-newer` and pins `uv==0.11.14` in every Dockerfile that installs uv. Fixes a clean-build failure at `uv sync --locked` that was unrelated to (but blocking) #1061's CVE remediation.

## Root cause (one-line)

`uv 0.11.x` writes `[options].exclude-newer` to lockfiles when invoked with `--exclude-newer`, but does not honor that field on `uv sync --locked` — every clean build sees the recorded option as removed and refuses to install. Issue #1064 has the full investigation, including why we had to drop `exclude-newer` rather than refresh the anchor.

## Changes

15 files, all small:

| File | Change |
|---|---|
| `uv.lock` (root + 7 subprojects) | Removed orphaned `[options].exclude-newer` block. **Zero dependency versions changed** — the existing dep set is fully satisfied by versions older than the original 2026-05-07 anchor. |
| `Dockerfile.registry`, `Dockerfile.auth`, `Dockerfile.mcp-server`, `Dockerfile.mcp-server-light`, `Dockerfile.mcp-server-cpu`, `Dockerfile.registry-cpu`, `metrics-service/Dockerfile` | Changed `pip install uv` to `pip install uv==0.11.14`. The root `Dockerfile` is unchanged (it does not install `uv`). |

## Verification

- [x] `docker compose build metrics-service` succeeds. The original failure point (step 6/12, `uv sync --locked`) now passes.
- [x] Full-stack `build_and_run.sh` boots cleanly.
- [x] Smoke-tested 11 read-only API endpoints via `api/registry_management.py` (config, list, list-groups, server-search, agent-list, skill-list, peer-list, agent-search, vs-list, federation-list). 9 pass cleanly.
- [x] All 8 affected images build with the pinned uv.

Two pre-existing findings surfaced during API smoke-test and will be filed as separate issues (not regressions from this PR):

1. `health_status: "local"` returned by backend is rejected by client `ServerListResponse` Pydantic model.
2. `anthropic-list` (`/v0.1/servers`) returns 404 — endpoint not exposed on the localhost path.

## Trade-off accepted

This PR drops the time-anchored supply-chain hardening that `[options].exclude-newer` was providing. We considered refreshing the anchor (option 2 in #1064) but verification proved the field is orphaned in current `uv` — written but not read on `--locked`. Plan: file upstream with astral-sh/uv; revisit re-introducing a date anchor when the orphan-field issue is resolved. The audit posture for the interim is "rely on PyPI integrity controls + Dependabot/Renovate PR review of bumps," same as most open-source Python projects.

## Relationship to #1061 / PR #1062

Independent. PR #1062 (CVE-2026-4438) only changes apt-get behavior in Dockerfiles; it does not touch `pyproject.toml`, `uv.lock`, or `pip install uv` lines. Both PRs are needed for clean customer builds, but they review separately and either can be reverted without affecting the other.

## Test plan

- [ ] Reviewer: spot-check that each `uv.lock` diff is the exact 3-line removal of `[options]` + `exclude-newer` line + trailing blank, with no other content changed.
- [ ] Reviewer: confirm each Dockerfile pin is `uv==0.11.14`.
- [ ] CI: helm-test, registry-test, codeql, metrics-service tests all green.
- [ ] Customer rebuild against this branch + #1062 produces images that pass their scanner with no CVE-2026-4438 findings and no `uv sync --locked` failure.