### PR TITLE
fix(api): loosen Server.health_status to str + expand list emoji map

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -120,7 +120,7 @@ class Server(BaseModel):
     display_name: str = Field(..., description="Service display name")
     description: str = Field(..., description="Service description")
     is_enabled: bool = Field(..., description="Whether service is enabled")
-    health_status: HealthStatus = Field(..., description="Health status")
+    health_status: str = Field(..., description="Health status")
     status: str = Field(
         default="active",
         description="Lifecycle status (active, deprecated, draft, beta)",

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -664,19 +664,26 @@ def cmd_list(args: argparse.Namespace) -> int:
 
         for server in response.servers:
             status_icon = "✓" if server.is_enabled else "✗"
-            health_icon = {
-                "healthy": "🟢",
-                "unhealthy": "🔴",
-                "unknown": "⚪",
-                "disabled": "⚫",
-            }.get(server.health_status.value, "⚪")
+            status = server.health_status
+            if status.startswith("healthy"):
+                health_icon = "🟢"
+            elif status.startswith("unhealthy"):
+                health_icon = "🔴"
+            elif status == "checking":
+                health_icon = "🟡"
+            elif status == "local":
+                health_icon = "🔵"
+            elif status == "disabled":
+                health_icon = "⚫"
+            else:
+                health_icon = "⚪"
 
             lifecycle = f" [{server.status}]" if server.status != "active" else ""
             print(f"{status_icon} {health_icon} {server.path}{lifecycle}")
             print(f"   Name: {server.display_name}")
             print(f"   Description: {server.description}")
             print(f"   Enabled: {server.is_enabled}")
-            print(f"   Health: {server.health_status.value}")
+            print(f"   Health: {server.health_status}")
             if server.status != "active":
                 print(f"   Lifecycle: {server.status}")
             print()

--- a/frontend/src/components/SemanticSearchResults.tsx
+++ b/frontend/src/components/SemanticSearchResults.tsx
@@ -1005,7 +1005,7 @@ const SemanticSearchResults: React.FC<SemanticSearchResultsProps> = ({
                       ))}
                     </ul>
                   </div>
-                ) : server.is_enabled && server.health_status === 'healthy' ? (
+                ) : server.is_enabled && (server.health_status === 'healthy' || server.health_status === 'healthy-auth-expired') ? (
                   <div className="mt-4 border-t border-dashed border-gray-200 dark:border-gray-700 pt-3">
                     <p className="text-sm text-gray-500 dark:text-gray-300">
                       No tools available to you on this server. Ask your administrator if you need access.

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -29,6 +29,7 @@ import { ANSBadge } from './ANSBadge';
 import ServerDetailsModal from './ServerDetailsModal';
 import useEscapeKey from '../hooks/useEscapeKey';
 import { formatRelativeTime } from '../utils/dateUtils';
+import { normalizeHealthStatus } from '../utils/healthStatus';
 import { useAuth } from '../contexts/AuthContext';
 import type { LocalRuntime } from '../types/server';
 
@@ -275,10 +276,7 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
       // Update just this server instead of triggering global refresh
       if (onServerUpdate && response.data) {
         const updates: Partial<Server> = {
-          status: response.data.status === 'healthy' ? 'healthy' :
-                  response.data.status === 'healthy-auth-expired' ? 'healthy-auth-expired' :
-                  response.data.status === 'unhealthy' ? 'unhealthy' :
-                  response.data.status === 'local' ? 'local' : 'unknown',
+          status: normalizeHealthStatus(response.data.status),
           last_checked_time: response.data.last_checked_iso,
           num_tools: response.data.num_tools
         };
@@ -352,9 +350,7 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
           description: serverData.description,
           enabled: serverData.is_enabled,
           tags: serverData.tags,
-          status: serverData.health_status === 'healthy' ? 'healthy' :
-                  serverData.health_status === 'healthy-auth-expired' ? 'healthy-auth-expired' :
-                  serverData.health_status === 'unhealthy' ? 'unhealthy' : 'unknown',
+          status: normalizeHealthStatus(serverData.health_status),
           last_checked_time: serverData.last_checked_iso,
           num_tools: serverData.num_tools,
           proxy_pass_url: serverData.proxy_pass_url,
@@ -900,7 +896,7 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
                     </div>
                   );
                 })
-              ) : server.enabled && server.status === 'healthy' ? (
+              ) : server.enabled && (server.status === 'healthy' || server.status === 'healthy-auth-expired') ? (
                 <p className="text-gray-500 dark:text-gray-300">
                   No tools available to you on this server. Ask your administrator if you need access.
                 </p>

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -136,8 +136,12 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
   const [loadingToolCheck, setLoadingToolCheck] = useState(false);
   const [toolCheckResult, setToolCheckResult] = useState<any>(null);
   const [loadingHealthCheck, setLoadingHealthCheck] = useState(false);
+  const toSkillHealth = (raw: string | undefined): 'healthy' | 'unhealthy' | 'unknown' => {
+    if (raw === 'healthy' || raw === 'unhealthy' || raw === 'unknown') return raw;
+    return 'unknown';
+  };
   const [healthStatus, setHealthStatus] = useState<'healthy' | 'unhealthy' | 'unknown'>(
-    skill.health_status || 'unknown'
+    toSkillHealth(skill.health_status)
   );
   const [lastCheckedTime, setLastCheckedTime] = useState<string | null>(
     skill.last_checked_time || null
@@ -148,7 +152,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
 
   // Sync health status from props when skill changes
   useEffect(() => {
-    setHealthStatus(skill.health_status || 'unknown');
+    setHealthStatus(toSkillHealth(skill.health_status));
     setLastCheckedTime(skill.last_checked_time || null);
   }, [skill.health_status, skill.last_checked_time]);
 

--- a/frontend/src/hooks/useSemanticSearch.ts
+++ b/frontend/src/hooks/useSemanticSearch.ts
@@ -30,7 +30,7 @@ export interface SemanticServerHit {
   tags: string[];
   num_tools: number;
   is_enabled: boolean;
-  health_status?: 'healthy' | 'unhealthy' | 'unknown';
+  health_status?: string;
   relevance_score: number;
   match_context?: string;
   matching_tools: MatchingToolHit[];
@@ -90,7 +90,7 @@ export interface SemanticSkillHit {
   visibility?: string;
   owner?: string;
   is_enabled?: boolean;
-  health_status?: 'healthy' | 'unhealthy' | 'unknown';
+  health_status?: string;
   last_checked_time?: string;
   relevance_score: number;
   match_context?: string;

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -58,7 +58,7 @@ export interface Skill {
   auth_header_name?: string;
   num_stars?: number;
   status?: 'active' | 'draft' | 'deprecated' | 'beta';
-  health_status?: 'healthy' | 'unhealthy' | 'unknown';
+  health_status?: string;
   last_checked_time?: string;
   created_at?: string;
   updated_at?: string;

--- a/frontend/src/utils/healthStatus.ts
+++ b/frontend/src/utils/healthStatus.ts
@@ -1,0 +1,19 @@
+// Backend `registry/constants.py` HealthStatus emits 9 distinct values
+// including `local`, `checking`, and granular `unhealthy: <reason>` strings.
+// The UI groups these into a smaller display set for icons / labels.
+export type DisplayStatus =
+  | 'healthy'
+  | 'healthy-auth-expired'
+  | 'unhealthy'
+  | 'unknown'
+  | 'local';
+
+
+export function normalizeHealthStatus(raw: string | undefined | null): DisplayStatus {
+  if (!raw) return 'unknown';
+  if (raw === 'healthy') return 'healthy';
+  if (raw === 'healthy-auth-expired') return 'healthy-auth-expired';
+  if (raw === 'local') return 'local';
+  if (raw.startsWith('unhealthy')) return 'unhealthy';
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary

- Closes #1066.
- Fixes both the **CLI** (`api/registry_management.py list`) and the **frontend** (server card / search result rendering) handling of backend `HealthStatus` values that are wider than the narrow client-side enums had assumed.

The original report was a Pydantic enum validation error in the CLI when any registered server reported `health_status="local"` (or `"checking"`, or a granular `"unhealthy: <reason>"` string). After investigating, the same drift existed in the frontend's TypeScript literal unions — runtime-safe (didn't crash) but lossy (states collapsed to "unknown" in render-side code). Bundling both into one PR keeps the fix coherent.

## CLI changes (commit 1)

| File | Change |
|---|---|
| `api/registry_client.py:123` | `Server.health_status: HealthStatus` -> `Server.health_status: str`. Matches the existing pattern in 4 other client models in the same file. The `HealthStatus` enum class remains for back-compat. |
| `api/registry_management.py` | Replace the `.get()` emoji dict with a prefix/exact-match chain that handles all 9 backend statuses + a graceful fallback. Drops two `.value` attribute accesses since the field is no longer an Enum. |

## Frontend changes (commit 2)

| File | Change |
|---|---|
| `frontend/src/utils/healthStatus.ts` (new) | `normalizeHealthStatus()` helper mapping any backend value into the UI's `DisplayStatus` union (`healthy / healthy-auth-expired / unhealthy / unknown / local`). |
| `frontend/src/types/skill.ts`, `frontend/src/hooks/useSemanticSearch.ts` | Widen `health_status` field types from narrow literal unions to plain `string`. |
| `frontend/src/components/ServerCard.tsx` | Replace two 3-arm ternary mappings with `normalizeHealthStatus()` calls. Update the "no tools available" message guard to also match `healthy-auth-expired`. |
| `frontend/src/components/SemanticSearchResults.tsx` | Same `healthy-auth-expired` fix on the equivalent guard. |
| `frontend/src/components/SkillCard.tsx` | Add inline `toSkillHealth()` coercion since the local `useState` is intentionally narrow (skill health endpoint returns a boolean). |

## Verification

CLI:
- [x] `list` now returns all servers, including `health_status="local"` rows that previously broke the response.
- [x] New emoji semantics render correctly: green for healthy/*, red for unhealthy:*, yellow for checking, blue for local, black for disabled, white for any unknown future value.
- [x] `py_compile` clean for both files.
- [x] Smoke-tested 5 sibling commands (config, server-search, agent-list, skill-list, peer-list) - no regressions.

Frontend:
- [x] `npm run build` succeeds with no new TypeScript errors. Pre-existing react-hooks/exhaustive-deps and no-unused-vars lint warnings on unrelated lines (1645, 1694, 1696) remain unchanged.

## Trade-off

We lose enum-level type safety on `health_status` fields in both Python and TypeScript. Both languages now treat these as `string`. This is consistent with the rest of the client codebase and reflects what the backend can actually emit. The alternative (manually keeping enums in lockstep across Python + TypeScript + Python again) is the very drift problem we're fixing. A single-source-of-truth approach (e.g. generated types from the backend enum) would be cleaner long-term but is out of scope for a 1.24.1 fix.

## Test plan

- [ ] CI: registry-test, codeql, metrics-service tests, frontend lint all green.
- [ ] Reviewer: confirm the new `normalizeHealthStatus()` covers all 9 backend `HealthStatus` values from `registry/constants.py`.
- [ ] Reviewer: confirm `Server.health_status` field type change is consistent with the other 4 health_status fields in `api/registry_client.py`.
- [ ] Manual UI spot-check: verify a server with backend `health_status="local"` now renders as "Local" (blue) in the UI rather than "Unknown".