### PR TITLE
docs(operations): add mongodb-export-import, audit-log-export, rotate-secrets runbooks

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,16 +18,24 @@ links into the underlying code or configuration.
   `mongorestore` (BSON, full-fidelity backups), namespace-scoped
   per-tenant operations, and the caveats around encrypted fields and
   index restoration.
+- [audit-log-export.md](audit-log-export.md) — Query and export the
+  `audit_events_*` collection for compliance review and security
+  investigations. Two paths: REST API (recommended, admin-required)
+  and direct MongoDB (operator escape hatch). Some sections are
+  marked DRAFT — the direct-MongoDB paths are fully validated; the
+  REST API admin-bootstrap and the disable-shipping path are not.
+- [rotate-secrets.md](rotate-secrets.md) — Rotation procedures for
+  `SECRET_KEY`, federation static tokens, IdP client secrets, and
+  M2M client secrets. Documents what each rotation invalidates and
+  the rollout sequence across replicas. DRAFT — destructive steps
+  were not exercised in the validation pass. Dry-run in non-prod
+  first.
 
 ## Planned runbooks
 
 The following are tracked under [#1056](https://github.com/agentic-community/mcp-gateway-registry/issues/1056)
 for future PRs:
 
-- `audit-log-export.md` — query and export `audit_events_*` for
-  compliance review.
-- `rotate-secrets.md` — rotation procedure for `SECRET_KEY`,
-  federation tokens, IdP secrets.
 - `telemetry-otlp-forwarding.md` — wire registry traces and metrics
   to an external OTLP collector.
 - `backup-and-restore.md` — full-database backup procedures and

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,49 @@
+# Operations Runbooks
+
+This folder contains step-by-step operational runbooks for the MCP
+Gateway Registry. Each runbook is self-contained, copy-pasteable,
+and intended to be useful at 2am with no prior context. Each
+includes a procedure block, verification commands per step, and
+links into the underlying code or configuration.
+
+## Available runbooks
+
+- [incident-response.md](incident-response.md) — Suspected credential
+  leak: drop the `oauth_sessions_<ns>` collection to invalidate every
+  active session in one step. Includes the trade-off vs. rotating
+  `SECRET_KEY`.
+- [mongodb-export-import.md](mongodb-export-import.md) — Export and
+  import MongoDB / DocumentDB collections. Covers `mongoexport` /
+  `mongoimport` (JSONL, for compliance pulls), `mongodump` /
+  `mongorestore` (BSON, full-fidelity backups), namespace-scoped
+  per-tenant operations, and the caveats around encrypted fields and
+  index restoration.
+
+## Planned runbooks
+
+The following are tracked under [#1056](https://github.com/agentic-community/mcp-gateway-registry/issues/1056)
+for future PRs:
+
+- `audit-log-export.md` — query and export `audit_events_*` for
+  compliance review.
+- `rotate-secrets.md` — rotation procedure for `SECRET_KEY`,
+  federation tokens, IdP secrets.
+- `telemetry-otlp-forwarding.md` — wire registry traces and metrics
+  to an external OTLP collector.
+- `backup-and-restore.md` — full-database backup procedures and
+  point-in-time recovery for AWS DocumentDB and MongoDB CE.
+- `scale-replicas.md` — pre-scale checklist and rolling-restart
+  pattern.
+- `federation-peer-onboard-offboard.md` — live federation peer
+  lifecycle.
+
+## Conventions
+
+- File naming: `<topic>-<action>.md`, lowercase, hyphen-separated.
+- Each runbook starts with a short summary of when to use it.
+- Procedures are numbered, every step has a copy-pasteable command.
+- Verification commands appear immediately after the step they verify.
+- Caveats and "when to use vs. alternative X" are called out
+  explicitly in their own subsection, not buried in prose.
+- Code references at the end of the runbook link to the file and
+  line on `main` so a reader can jump straight into the implementation.

--- a/docs/operations/audit-log-export.md
+++ b/docs/operations/audit-log-export.md
@@ -1,0 +1,296 @@
+# Operations: Audit Log Export
+
+This runbook covers querying and exporting the registry's audit
+events for compliance review, security investigations, and ad-hoc
+reporting.
+
+> **Environment-portability note.** The commands below were validated
+> against the local `docker compose` stack with MongoDB CE running
+> in the `mcp-mongodb` container. **On EKS and ECS deployments these
+> instructions are directional only** — adapt the connection
+> patterns (kubectl exec, ECS exec, DocumentDB endpoint with TLS)
+> to your environment. Treat the procedures as the right shape; the
+> exact invocation will differ.
+
+---
+
+## What's in `audit_events_*`
+
+The registry writes one document per request to the
+`audit_events_<documentdb_namespace>` collection (default install:
+`audit_events_default`). Two log streams share the collection,
+distinguished by the `log_type` field:
+
+| `log_type` value | What it captures |
+|---|---|
+| `registry_api_access` | Calls into the registry's REST API (server registration, group management, audit queries themselves, etc.). |
+| `mcp_server_access` | MCP tool invocations through the gateway (which user invoked which tool on which server). |
+
+The relevant fields differ slightly between the two streams. See
+[`registry/audit/routes.py:215-275`](../../registry/audit/routes.py#L215-L275)
+for the canonical query construction the registry uses.
+
+A registry-API record looks like this:
+
+```json
+{
+  "_id": {"$oid": "..."},
+  "timestamp": {"$date": "2026-05-11T16:55:56.824Z"},
+  "log_type": "registry_api_access",
+  "request_id": "...",
+  "identity": {
+    "username": "alice@example.com",
+    "auth_method": "oauth2",
+    "provider": "entra",
+    "groups": [...],
+    "is_admin": false
+  },
+  "request": {
+    "method": "GET",
+    "path": "/api/servers",
+    "client_ip": "1.2.3.4"
+  },
+  "response": {
+    "status_code": 200,
+    "duration_ms": 12.4
+  },
+  "action": {
+    "operation": "list_servers",
+    "resource_type": "servers"
+  },
+  "authorization": {
+    "decision": "ALLOW"
+  }
+}
+```
+
+---
+
+## Two paths: REST API vs. direct MongoDB
+
+| Path | Use when | Requires |
+|---|---|---|
+| **REST API** (`/api/audit/events`, `/api/audit/export`) | Normal operation. CSV exports for compliance. Consistent across deployments because the registry handles the query, format, and access control. | Registry running and reachable. Admin-tier session (`is_admin=true`) or M2M client with admin scopes. |
+| **Direct MongoDB** (`mongosh`, `mongoexport`, `mongodump`) | Registry is down. Bulk forensic export. Ad-hoc aggregations the API doesn't expose. | Database access (privileged user). Bypasses application-level auth — anyone with this access sees everything. |
+
+**Rule of thumb:** start with the REST API. Drop to direct MongoDB
+only when the API path can't satisfy the use case.
+
+---
+
+## Path A: Export via REST API
+
+> **DRAFT — admin-auth bootstrap not exercised in this PR's
+> validation.** The endpoint behavior, query parameters, and CSV/JSONL
+> formats below come from
+> [`registry/audit/routes.py:567-918`](../../registry/audit/routes.py#L567-L918).
+> The exact `Authorization` header form depends on your deployment's
+> auth mode (session cookie vs. M2M token), and full validation of
+> the bootstrap path is left for a follow-up. **Treat the curl
+> examples as templates and confirm the auth pattern against your
+> deployment before relying on them.**
+
+### Procedure
+
+1. Obtain an admin-tier credential. The endpoints under
+   `/api/audit/*` use `require_admin` ([`routes.py:44`](../../registry/audit/routes.py#L44)),
+   so the credential must produce a `user_context` with
+   `is_admin == true`.
+
+2. Query a small page first to confirm the credential is working
+   and to see the schema:
+
+   ```bash
+   # Replace <ADMIN_TOKEN> with your admin bearer token / session cookie
+   curl -sS \
+       -H "Authorization: Bearer <ADMIN_TOKEN>" \
+       "http://localhost/api/audit/events?limit=5"
+   ```
+
+   On success: a JSON object with `total`, `limit`, `offset`,
+   `events` (array). On 403 Forbidden, the token is not admin.
+
+3. Export filtered events as JSONL or CSV. All filters are optional
+   and can be combined (see
+   [`routes.py:821-885`](../../registry/audit/routes.py#L821-L885)
+   for the full parameter list):
+
+   ```bash
+   # JSONL export, all events for one user, last 30 days
+   curl -sS \
+       -H "Authorization: Bearer <ADMIN_TOKEN>" \
+       "http://localhost/api/audit/export?format=jsonl&username=alice@example.com&from=2026-04-18T00:00:00Z&to=2026-05-18T00:00:00Z&limit=100000" \
+       -o audit-alice.jsonl
+
+   # CSV export, all DENY decisions
+   curl -sS \
+       -H "Authorization: Bearer <ADMIN_TOKEN>" \
+       "http://localhost/api/audit/export?format=csv&auth_decision=DENY&limit=100000" \
+       -o audit-denies.csv
+   ```
+
+   Available filters: `stream` (`registry_api` or `mcp_access`),
+   `from` / `to` (ISO 8601), `username` (case-insensitive partial),
+   `operation`, `resource_type`, `resource_id`, `status_min` /
+   `status_max` (HTTP status range), `auth_decision` (`ALLOW`,
+   `DENY`, or `NOT_REQUIRED`), `limit` (1 to 100000).
+
+4. Verify the export file:
+
+   ```bash
+   wc -l audit-alice.jsonl
+   head -1 audit-alice.jsonl | python3 -m json.tool
+   ```
+
+### Caveats
+
+- **The `username` filter does case-insensitive substring matching**
+  ([`routes.py:223-227`](../../registry/audit/routes.py#L223-L227)),
+  not exact equality. `username=alice` will also match
+  `alice@example.com` and `MaliceSamuels@example.com`.
+- **The export endpoint caps at 100000 events** per call. Larger
+  windows must be paginated by `from`/`to` time ranges.
+- **The export streams the response.** Large exports may take time
+  but won't load the full dataset into memory at once.
+- The endpoints are tied to the registry process. **If the registry
+  is down, fall through to Path B.**
+
+---
+
+## Path B: Export via direct MongoDB (operator escape hatch)
+
+Use this when the registry isn't running, when you need an
+aggregation the REST API doesn't expose, or when you need
+full-fidelity BSON output. Every command below was validated
+end-to-end against the local stack.
+
+### Procedure: Inspect
+
+1. Connect and confirm the collection name for your namespace:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+     db.getCollectionNames().filter(n => n.startsWith("audit_events_")).join("\n")'
+   ```
+
+2. Count events by user (top 10):
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+     db.audit_events_default.aggregate([
+       {$group: {_id: "$identity.username", count: {$sum: 1}}},
+       {$sort: {count: -1}},
+       {$limit: 10}
+     ]).toArray()'
+   ```
+
+3. Find recent denies for a single user:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+     db.audit_events_default.find(
+       {"identity.username": "alice@example.com",
+        "authorization.decision": "DENY"},
+       {_id: 0, timestamp: 1, "request.path": 1,
+        "action.operation": 1, "authorization.reason": 1}
+     ).sort({timestamp: -1}).limit(20).toArray()'
+   ```
+
+### Procedure: Export
+
+1. Bulk export all audit events to JSONL:
+
+   ```bash
+   docker exec mcp-mongodb mongoexport \
+       --db=mcp_registry \
+       --collection=audit_events_default \
+       --out=/tmp/audit_events_default.json
+   ```
+
+2. Filtered export — events for a user in a time range. Note that
+   `timestamp` is a BSON `Date`, so the query needs the
+   extended-JSON `{"$date": "..."}` form, and `username` is nested
+   under `identity`:
+
+   ```bash
+   docker exec mcp-mongodb mongoexport \
+       --db=mcp_registry \
+       --collection=audit_events_default \
+       --query='{"identity.username":"alice@example.com","timestamp":{"$gte":{"$date":"2026-04-18T00:00:00Z"}}}' \
+       --jsonArray \
+       --out=/tmp/audit_alice.json
+   ```
+
+3. Copy the export out of the container:
+
+   ```bash
+   docker cp mcp-mongodb:/tmp/audit_events_default.json .
+   ```
+
+For full-fidelity BSON output (preserves indexes and BSON types,
+necessary for cross-environment restores), see
+[mongodb-export-import.md](mongodb-export-import.md) for the
+`mongodump` / `mongorestore` pair.
+
+---
+
+## TTL and retention
+
+> **DRAFT — TTL behavior should be confirmed against your install
+> before relying on it.** Some deployments leave the audit
+> collection without a TTL index (events accumulate indefinitely);
+> others apply one via configuration. Check your specific
+> environment.
+
+Inspect the indexes on the audit collection to see whether a TTL
+is in place:
+
+```bash
+docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+  db.audit_events_default.getIndexes().forEach(i => print(JSON.stringify(i)))'
+```
+
+A TTL index appears with `expireAfterSeconds` set; documents older
+than that age are removed by MongoDB's TTL monitor (best-effort,
+not real-time).
+
+---
+
+## Disabling audit shipping
+
+> **DRAFT — environment-specific.** The registry writes audit events
+> via the in-process audit logger initialized at
+> [`registry/main.py:394-397`](../../registry/main.py#L394-L397).
+> The path to disable it varies by deployment surface (env var,
+> Helm values, Terraform variable). Confirm the exact knob for your
+> environment before disabling — and remember that disabling audit
+> usually has compliance implications.
+
+For most installs, audit logging is on by default and is gated by
+the audit middleware registration in `registry/main.py`. Disabling
+it for an emergency (e.g. a runaway log producer filling the
+collection) is a deployment-config change, not a runtime flag.
+
+The non-disruptive alternative for a runaway producer: leave audit
+on, identify the producer via Path B aggregation queries above,
+then address the producer.
+
+---
+
+## Related runbooks
+
+- [mongodb-export-import.md](mongodb-export-import.md) — full
+  export/import tooling, including the `mongodump` / `mongorestore`
+  pair for cross-environment restores.
+- [incident-response.md](incident-response.md) — credential-leak
+  response. The audit log is your first stop for scoping the
+  affected user/time-range window.
+
+## Code references
+
+- [`registry/audit/routes.py:30`](../../registry/audit/routes.py#L30) — audit router prefix (`/audit`, mounted at `/api`).
+- [`registry/audit/routes.py:44`](../../registry/audit/routes.py#L44) — `require_admin` dependency.
+- [`registry/audit/routes.py:567`](../../registry/audit/routes.py#L567) — `GET /api/audit/events` (paginated query).
+- [`registry/audit/routes.py:821`](../../registry/audit/routes.py#L821) — `GET /api/audit/export` (JSONL/CSV streaming).
+- [`registry/audit/routes.py:215-275`](../../registry/audit/routes.py#L215-L275) — `_build_query()`, the canonical filter-to-Mongo translation.
+- [`registry/repositories/audit_repository.py:151`](../../registry/repositories/audit_repository.py#L151) — `audit_events` base collection name.

--- a/docs/operations/incident-response.md
+++ b/docs/operations/incident-response.md
@@ -3,6 +3,14 @@
 This page documents incident-response procedures for the MCP Gateway Registry.
 Each section is a self-contained runbook intended to be useful at 2am.
 
+> **Environment-portability note.** The `mongosh` examples below
+> illustrate the local compose-stack workflow. **On EKS and ECS
+> deployments these instructions are directional only** — adapt the
+> connection patterns (kubectl exec, ECS exec, DocumentDB endpoint
+> with TLS) to your environment. The procedures (which collection to
+> drop, what each rotation invalidates) apply across deployments;
+> the *invocation* differs.
+
 ---
 
 ## Suspected credential leak: invalidate all active sessions

--- a/docs/operations/mongodb-export-import.md
+++ b/docs/operations/mongodb-export-import.md
@@ -4,6 +4,14 @@ This runbook covers exporting and importing MongoDB / DocumentDB
 collections used by the MCP Gateway Registry. Each section is a
 self-contained procedure intended to be useful at 2am.
 
+> **Environment-portability note.** The commands below were validated
+> against the local `docker compose` stack with MongoDB CE running
+> in the `mcp-mongodb` container. **On EKS and ECS deployments these
+> instructions are directional only** — adapt the connection
+> patterns (kubectl exec, ECS exec, DocumentDB endpoint with TLS)
+> to your environment. Treat the procedures as the right shape; the
+> exact invocation will differ.
+
 The registry stores all per-namespace state under collections suffixed
 with the deployment's `documentdb_namespace` (default: `default`). The
 suffix is appended at write time by

--- a/docs/operations/mongodb-export-import.md
+++ b/docs/operations/mongodb-export-import.md
@@ -1,0 +1,316 @@
+# Operations: MongoDB Export and Import
+
+This runbook covers exporting and importing MongoDB / DocumentDB
+collections used by the MCP Gateway Registry. Each section is a
+self-contained procedure intended to be useful at 2am.
+
+The registry stores all per-namespace state under collections suffixed
+with the deployment's `documentdb_namespace` (default: `default`). The
+suffix is appended at write time by
+[`get_collection_name()`](../../registry/repositories/documentdb/client.py#L54-L58),
+so on a stock install the collections are
+`oauth_sessions_default`, `audit_events_default`,
+`mcp_servers_default`, etc. Use `show collections` in `mongosh` to
+list the exact names for your install before running any of these
+procedures.
+
+---
+
+## When to use which tool
+
+The MongoDB toolset includes two distinct export/import pairs. Pick
+based on what you actually need.
+
+| Pair | Format | Use for | Preserves |
+|------|--------|---------|-----------|
+| `mongoexport` / `mongoimport` | JSONL (one JSON document per line) | Compliance exports, ad-hoc inspection, cross-tool data extraction, single-collection migrations | Document content. **Does not** preserve indexes, options, or BSON types beyond what JSON can express. |
+| `mongodump` / `mongorestore` | BSON + metadata | Full-fidelity backups, disaster recovery, restoring an entire collection or database | Document content + indexes + collection options + BSON types (e.g. `Timestamp`, `Long`, `Decimal128`). |
+
+**Rule of thumb:** use `mongodump` for backups you intend to restore,
+use `mongoexport` for data you intend to read or hand to another tool.
+
+---
+
+## Connecting to the database
+
+The commands below assume you are running them either on the database
+host or against a reachable endpoint. Your connection string and
+authentication depend on the deployment.
+
+```bash
+# Local MongoDB (compose stack — runs in the mcp-mongodb container)
+docker exec mcp-mongodb mongosh "mongodb://localhost:27017/<DOCUMENTDB_DB_NAME>"
+
+# AWS DocumentDB (with the standard CA bundle)
+mongosh "mongodb://<DOCUMENTDB_HOST>:27017/<DOCUMENTDB_DB_NAME>" \
+    --tls --tlsCAFile /path/to/global-bundle.pem \
+    --username <DOCUMENTDB_USERNAME>
+```
+
+Replace `<DOCUMENTDB_DB_NAME>` with the value from your environment
+(default: `mcp_registry`). For all subsequent commands, run inside
+the container with `docker exec mcp-mongodb <cmd>` for compose
+deployments, or run from a host that can reach the DocumentDB
+endpoint with the appropriate `--tls --tlsCAFile` flags.
+
+---
+
+## Export a single collection (mongoexport)
+
+Use this for compliance pulls, ad-hoc inspection, or any case where
+the consumer wants JSON.
+
+### Procedure
+
+1. List the collections in your namespace to confirm the exact name:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry \
+       --eval 'db.getCollectionNames().sort().join("\n")'
+   ```
+
+   Expected: a sorted list including (on a default-namespace install)
+   `audit_events_default`, `mcp_servers_default`,
+   `oauth_sessions_default`, etc.
+
+2. Export the target collection to JSONL. Each line is one document:
+
+   ```bash
+   docker exec mcp-mongodb mongoexport \
+       --db=mcp_registry \
+       --collection=audit_events_default \
+       --out=/tmp/audit_events_default.json
+   ```
+
+   Output ends with `exported N record(s)`. Copy the file out of the
+   container with `docker cp mcp-mongodb:/tmp/audit_events_default.json .`.
+
+3. (Optional) Restrict by query, fields, or sort. Audit events store
+   the user under nested `identity.username`, and `timestamp` is a
+   BSON `Date` (use the `{"$date": "..."}` extended-JSON form for
+   range comparisons):
+
+   ```bash
+   # Only events from a specific user, last 30 days, output as one
+   # JSON array (use --jsonArray for downstream tools that expect it)
+   docker exec mcp-mongodb mongoexport \
+       --db=mcp_registry \
+       --collection=audit_events_default \
+       --query='{"identity.username":"alice@example.com","timestamp":{"$gte":{"$date":"2026-04-18T00:00:00Z"}}}' \
+       --jsonArray \
+       --out=/tmp/audit_alice.json
+   ```
+
+4. Verify the export looks correct before sharing:
+
+   ```bash
+   docker exec mcp-mongodb wc -l /tmp/audit_events_default.json
+   docker exec mcp-mongodb head -c 200 /tmp/audit_events_default.json
+   ```
+
+   The line count should match the source collection's
+   `db.audit_events_default.countDocuments()` for an unfiltered export.
+
+---
+
+## Import a collection (mongoimport)
+
+Use this to load a JSONL export back into the database, typically
+into a different collection or a different cluster (DR drill,
+test-environment seed, etc.).
+
+### Procedure
+
+1. Confirm the destination collection name. **Do not import on top
+   of a live collection without explicit reason** — the `--drop` flag
+   below removes the existing collection before inserting:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry \
+       --eval 'db.audit_events_default_restored.countDocuments()'
+   ```
+
+2. Import the file. The `--drop` flag drops the destination first so
+   the import is atomic on the collection:
+
+   ```bash
+   docker exec mcp-mongodb mongoimport \
+       --db=mcp_registry \
+       --collection=audit_events_default_restored \
+       --drop \
+       --file=/tmp/audit_events_default.json
+   ```
+
+   Output ends with `N document(s) imported successfully. 0 document(s) failed to import.`
+
+3. Verify counts match:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry \
+       --eval 'db.audit_events_default_restored.countDocuments()'
+   ```
+
+### Caveats
+
+- **Indexes are not restored.** `mongoimport` writes documents only;
+  any indexes on the source collection (e.g. the TTL index on
+  `oauth_sessions_*.expires_at`, the unique index on
+  `oauth_sessions_*.session_id`) must be recreated. The registry
+  recreates its own indexes at startup if you import into the live
+  collection name, but restoring into a renamed collection (e.g.
+  `*_restored`) leaves it unindexed. Use `mongodump` / `mongorestore`
+  instead if you need full-fidelity restoration.
+- **Encrypted fields** (e.g. `oauth_sessions_*.encrypted_id_token`)
+  remain encrypted under the original `SECRET_KEY`. Importing into
+  a deployment with a different `SECRET_KEY` will produce records the
+  registry cannot decrypt.
+
+---
+
+## Full-fidelity backup and restore (mongodump / mongorestore)
+
+Use this for backups you intend to restore — it preserves indexes,
+collection options, and BSON types.
+
+### Procedure: Backup
+
+1. Dump a single collection (writes BSON + metadata to a directory):
+
+   ```bash
+   docker exec mcp-mongodb mongodump \
+       --db=mcp_registry \
+       --collection=oauth_sessions_default \
+       --out=/tmp/dump
+   ```
+
+   Output: `/tmp/dump/mcp_registry/oauth_sessions_default.bson` plus a
+   `*.metadata.json` describing indexes and options.
+
+2. Or dump the entire database (every collection in `mcp_registry`):
+
+   ```bash
+   docker exec mcp-mongodb mongodump \
+       --db=mcp_registry \
+       --out=/tmp/dump
+   ```
+
+3. Copy the dump out of the container:
+
+   ```bash
+   docker cp mcp-mongodb:/tmp/dump ./mcp-registry-dump-$(date +%Y%m%d-%H%M%S)
+   ```
+
+### Procedure: Restore
+
+1. Copy the dump back into the target container:
+
+   ```bash
+   docker cp ./mcp-registry-dump-20260518-143000 mcp-mongodb:/tmp/restore
+   ```
+
+2. Restore. **The `--drop` flag drops each collection before
+   restoring it from the dump** — be deliberate:
+
+   ```bash
+   docker exec mcp-mongodb mongorestore \
+       --db=mcp_registry \
+       --drop \
+       /tmp/restore/mcp_registry
+   ```
+
+3. Verify document counts and at least one index per critical
+   collection:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+     ["oauth_sessions_default","audit_events_default","mcp_servers_default"]
+       .forEach(c => print(c, db.getCollection(c).countDocuments(),
+                           db.getCollection(c).getIndexes().length))'
+   ```
+
+### Caveats
+
+- **`mongorestore` does not invalidate active sessions.** If you are
+  restoring to recover from a session-related incident, follow up
+  with the [credential-leak runbook](incident-response.md) to drop
+  the `oauth_sessions_*` collection after the restore.
+- **AES-GCM-encrypted fields** require the `SECRET_KEY` from the
+  source deployment. Cross-environment restores must replicate the
+  source `SECRET_KEY` or accept that encrypted fields will be
+  unreadable.
+- **DocumentDB has version-specific compatibility.** When restoring
+  a `mongodump` taken from MongoDB CE into DocumentDB (or vice versa),
+  use `mongorestore --noIndexRestore` and recreate indexes after
+  the data load to avoid index-feature incompatibilities. See the
+  [AWS DocumentDB compatibility matrix](https://docs.aws.amazon.com/documentdb/latest/developerguide/mongo-apis.html)
+  for the exact set of supported index options.
+
+---
+
+## Scoping to a single tenant (namespace)
+
+Multi-tenant deployments use `documentdb_namespace` to isolate state
+between tenants. Each tenant has its own collection set
+(`oauth_sessions_<ns>`, `audit_events_<ns>`, etc.). To export or
+back up a single tenant, list collections matching the suffix and
+operate on each:
+
+```bash
+# List all collections for tenant 'acme'
+docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+  db.getCollectionNames()
+    .filter(n => n.endsWith("_acme"))
+    .sort()
+    .join("\n")'
+
+# Dump every collection for tenant 'acme'. mongodump does not have a
+# regex include flag, so loop over matching collection names. Each
+# collection becomes its own .bson + .metadata.json under the same
+# output directory, suitable for a single mongorestore pass.
+docker exec mcp-mongodb sh -c '
+  set -e
+  rm -rf /tmp/dump-acme
+  for coll in $(mongosh --quiet mcp_registry --eval "
+        db.getCollectionNames().filter(n => n.endsWith(\"_acme\")).sort().join(\"\n\")
+      "); do
+    mongodump --db=mcp_registry --collection="$coll" --out=/tmp/dump-acme
+  done'
+```
+
+Restore the tenant by pointing `mongorestore` at the dump directory:
+
+```bash
+docker exec mcp-mongodb mongorestore --db=mcp_registry --drop /tmp/dump-acme/mcp_registry
+```
+
+`mongorestore` does support a regex include filter via `--nsInclude`
+if you want to scope a restore from a larger dump:
+
+```bash
+# Restore only tenant 'acme' collections from a full-database dump
+docker exec mcp-mongodb mongorestore \
+    --nsInclude='mcp_registry.*_acme' \
+    /tmp/full-dump
+```
+
+### Caveats
+
+- **`idp_m2m_clients`, `okta_m2m_clients`, and `_telemetry_state`
+  are not namespace-suffixed.** They are global per-database. A
+  per-tenant dump that uses the `_<ns>$` filter above will not
+  capture them; include them explicitly if your DR plan requires it.
+
+---
+
+## Related runbooks
+
+- [incident-response.md](incident-response.md) — when to drop
+  `oauth_sessions_*` to invalidate active sessions (after a session
+  leak or restore).
+
+## Code references
+
+- [`registry/repositories/documentdb/client.py:54-58`](../../registry/repositories/documentdb/client.py#L54-L58) — `get_collection_name()` namespace suffixing.
+- [`registry/auth/session_store.py:23`](../../registry/auth/session_store.py#L23) — `oauth_sessions` base collection name.
+- [`registry/repositories/audit_repository.py:151`](../../registry/repositories/audit_repository.py#L151) — `audit_events` base collection name.
+- [`registry/core/config.py:751`](../../registry/core/config.py#L751) — `documentdb_namespace` setting (default: `default`).

--- a/docs/operations/rotate-secrets.md
+++ b/docs/operations/rotate-secrets.md
@@ -1,0 +1,323 @@
+# Operations: Rotate Secrets
+
+This runbook covers rotation procedures for the registry's
+process-level secrets. Each section identifies what the secret
+encrypts or signs, what rotation invalidates, the rollout sequence
+across replicas, and the verification step.
+
+> **Environment-portability note.** The commands below illustrate the
+> compose-stack workflow. **On EKS and ECS deployments these
+> instructions are directional only** — use your platform's
+> equivalents (kubectl rollout, ECS service update, Helm upgrade)
+> for restarts, and your secret-manager pattern (Kubernetes
+> Secrets, AWS Secrets Manager, SSM Parameter Store, etc.) for the
+> secret-update step. The *order* and *blast radius* documented below
+> apply across deployments; the *invocation* differs.
+
+> **DRAFT — destructive validation not exercised.** The procedures
+> below were authored from the implementation in
+> [`registry/auth/session_crypto.py`](../../registry/auth/session_crypto.py)
+> and related modules. The destructive steps (rotating `SECRET_KEY`,
+> invalidating sessions) were **not** executed against the running
+> validation stack; doing so would log out all users mid-session.
+> Before running this in production, do a dry-run in a non-prod
+> environment first.
+
+---
+
+## Quick reference: what each secret protects
+
+| Secret | What it does | Rotation invalidates | Restart required |
+|---|---|---|---|
+| `SECRET_KEY` | (1) HMAC-signs internal-auth JWTs between auth-server, registry, and mcpgw. (2) Derives an AES-GCM key (via HKDF) that encrypts `id_token` blobs in the OAuth session store. | All in-process JWT trust + every encrypted `id_token` in `oauth_sessions_*`. Active sessions cannot decrypt their stored `id_token` after rotation. | **Yes — all auth_server and registry replicas.** The AES-GCM cipher is cached in a process-wide singleton ([`session_crypto.py:37`](../../registry/auth/session_crypto.py#L37)) and won't re-derive on a config reload. |
+| Federation static token | Authenticates one peer registry to another for federation API access. | Inbound federation calls from peers using the old token (they get 401 until they update their config). | No restart for the *issuing* registry; peer registries must re-fetch and reload. |
+| IdP client secret (Keycloak, Entra, Cognito) | OAuth2 client_secret used by the auth-server to exchange authorization codes for tokens. | Pending OAuth flows fail (5-minute grace window). New logins use the new secret. | **Yes — auth-server replicas** (env-var-based config, not hot-reloaded). |
+| M2M client secret | Authenticates a non-interactive M2M client to the registry / IdP. | API calls from the M2M client using the old secret (they get 401 until config update). | No registry restart. The M2M client itself must rotate. |
+
+**Rule of thumb:** rotate the smallest scope that addresses the
+threat. Targeted rotations (federation token, M2M client secret) are
+nearly free. `SECRET_KEY` is the heaviest — it logs out every user
+and requires a coordinated rolling restart.
+
+---
+
+## Rotate `SECRET_KEY`
+
+> **DRAFT — destructive.** Do not run this against a prod
+> environment without a dry-run pass and a maintenance window. All
+> active users will be logged out and will need to re-authenticate.
+
+### When to use
+
+- `SECRET_KEY` itself is suspected compromised (config leak, env-var
+  exposure in logs, repository misconfiguration).
+- Periodic rotation per your security policy.
+
+For a session-leak incident where `SECRET_KEY` is **not** the
+suspected compromise vector, prefer the targeted collection drop
+in [incident-response.md](incident-response.md) — same effect on
+active sessions, no restart required.
+
+### Procedure
+
+1. Generate a new key. The implementation requires at least 32
+   bytes ([`config.py:766-771`](../../registry/core/config.py#L766-L771)):
+
+   ```bash
+   # 64-character hex string (32 bytes of entropy)
+   openssl rand -hex 32
+   ```
+
+2. Update the secret in your deployment surface. The process
+   below assumes the same `SECRET_KEY` is shared by all
+   `auth_server` and `registry` replicas (this is required —
+   different replicas with different keys cannot decrypt each
+   other's session writes):
+
+   - **docker compose**: edit the value in `.env` (or your
+     extra-env file) and `docker compose up -d` to reload.
+   - **Kubernetes / Helm**: update the `global.secretKey` value
+     (chart `values.yaml`) or the underlying `Secret` resource;
+     `helm upgrade` rolls the deployments.
+   - **ECS / Terraform**: update the SSM parameter / Secrets
+     Manager secret referenced by the task definition; redeploy
+     the service.
+
+3. Restart the affected services so the new key is loaded into
+   the AES-GCM cipher singleton. **The order matters:** restart
+   `auth_server` first (it issues internal JWTs to the registry),
+   then the `registry` replicas, then any process that mints
+   internal tokens (mcpgw):
+
+   ```bash
+   # docker compose
+   docker compose restart auth-server
+   docker compose restart registry
+   docker compose restart mcpgw
+   ```
+
+   For multi-replica deployments, do a rolling restart per service
+   so request handling stays available. Helm and ECS handle this
+   natively; for compose, restart one replica at a time if you've
+   scaled past 1.
+
+4. Drop the `oauth_sessions_*` collection. The encrypted
+   `id_token`s in that collection are no longer decryptable under
+   the new key, so the records are dead weight. The collection
+   recreates itself on the next session write
+   (see [incident-response.md](incident-response.md) for the exact
+   command).
+
+5. Verify a fresh login works:
+
+   - Open a new browser session and complete an OAuth login.
+   - Tail the auth_server logs for `Created session for user
+     <name>`.
+   - Confirm the session record decrypts on subsequent requests
+     (no `Failed to decrypt id_token` warnings in registry logs).
+
+### Caveats
+
+- **Cookie-only deployments before this rewrite carried the
+  encrypted token in the cookie.** This deployment carries it in
+  MongoDB. The blast radius is the same: rotation invalidates
+  stored tokens. ([`session_crypto.py:13-16`](../../registry/auth/session_crypto.py#L13-L16))
+- **Half-rolled deploys break SSO.** A registry replica running
+  with the new key cannot decrypt sessions written by an
+  auth-server still running on the old key. Keep the rollout
+  window short.
+
+---
+
+## Rotate federation static token
+
+### When to use
+
+- A peer registry's static token is leaked or rotated by the peer.
+- Periodic rotation of inbound federation credentials.
+
+The federation static token is configured at
+[`config.py:251-252`](../../registry/core/config.py#L251-L252)
+(`federation_static_token_auth_enabled`, `federation_static_token`).
+It authenticates inbound federation API calls; the issuing peer
+registry includes it in its outbound requests to ours.
+
+### Procedure
+
+1. Generate a new token (use a value at least 32 bytes for
+   parity with `SECRET_KEY`):
+
+   ```bash
+   openssl rand -hex 32
+   ```
+
+2. Coordinate with the peer registry operator — they must update
+   the token in their outbound federation config at the same time
+   you update it in your inbound config. There is **no overlap
+   window** with a single static token. (For a window, use OAuth
+   federation auth, which supports rotation via IdP token issuance.)
+
+3. Update the secret in your deployment surface (same channels as
+   `SECRET_KEY` above). Federation auth re-reads the token via the
+   settings module on each request, so **no restart is required**
+   — but a restart is harmless if you prefer to be explicit.
+
+4. Verify the peer's reconciliation worker resumes successfully:
+
+   - Use [`api/registry_management.py peer-status <peer_id>`](../../api/registry_management.py)
+     against your registry — the peer should report `enabled` and
+     have a recent `last_synced_at`.
+   - Tail the registry logs for `Federation auth: ALLOW` entries
+     from the peer's IP after rotation; before rotation you may
+     see `Federation auth: DENY (invalid token)`.
+
+### Caveats
+
+- **No rotation grace period.** The cutover is atomic — both sides
+  need the new value or one side will start denying.
+- **Two-sided coordination.** This is the fragile part: agree with
+  the peer operator on a rotation timestamp before doing it.
+
+---
+
+## Rotate IdP client secret
+
+> **DRAFT — IdP-specific steps not exercised in this PR's
+> validation.** The procedure below describes the sequence at the
+> level of "what you do with the auth-server"; the IdP-side steps
+> (Keycloak admin console, Entra app registrations, Cognito user
+> pool client) vary by provider and are not documented here.
+
+### When to use
+
+- IdP client_secret is suspected compromised.
+- Periodic rotation per IdP policy (Entra and many Cognito setups
+  expire client secrets on a schedule).
+
+### Procedure
+
+1. **In the IdP**: rotate the client secret. Most IdPs let you
+   *add* a new secret while keeping the old one active for a
+   grace period — do that if available, so step 2 has overlap.
+
+2. **In the deployment**: update the env var consumed by the
+   auth-server (typically `OAUTH_CLIENT_SECRET_<PROVIDER>` or
+   provider-specific). Update via the same secret-management
+   channel as `SECRET_KEY`.
+
+3. **Restart auth-server replicas** so the new secret is picked
+   up. The auth-server reads the secret at process start.
+
+4. **In the IdP**: revoke the old secret once you've verified
+   logins work with the new one (next step).
+
+5. Verify a fresh login completes end-to-end:
+
+   - Open a new browser session, complete the OAuth flow.
+   - Tail the auth-server logs for the token-exchange success
+     entry.
+   - Look for `400 invalid_client` errors during the cutover —
+     they indicate either the IdP and the auth-server have
+     desynced, or you missed a replica restart.
+
+### Caveats
+
+- **Pending OAuth flows during the rotation will fail.** Anyone
+  mid-login will see an error and need to re-initiate. Do this in
+  a low-traffic window or accept the visible failures.
+- **Active sessions are unaffected.** The client_secret is used at
+  token-exchange time, not for ongoing requests; sessions
+  established before rotation continue working until they expire
+  normally.
+
+---
+
+## Rotate M2M client secret
+
+### When to use
+
+- A specific machine-to-machine client's credential is suspected
+  compromised.
+- Periodic rotation for high-privilege clients.
+
+The registry stores M2M client config in `idp_m2m_clients` /
+`okta_m2m_clients` (not namespace-suffixed — see
+[mongodb-export-import.md](mongodb-export-import.md)). The actual
+secret lives in the IdP, not in the registry's MongoDB.
+
+### Procedure
+
+1. **In the IdP**: rotate the M2M client's secret using the
+   IdP's API or admin console. Use the IdP's rotation feature if
+   available so the old secret is valid during the cutover window.
+
+2. **In the M2M client deployment**: update the secret in the
+   client's config (env var, secret-manager entry). Restart the
+   client process so the new secret is picked up.
+
+3. **In the IdP**: once the M2M client is verified working,
+   revoke the old secret.
+
+4. Verify via the registry's audit log:
+
+   ```bash
+   docker exec mcp-mongodb mongosh --quiet mcp_registry --eval '
+     db.audit_events_default.find(
+       {"identity.username": "<m2m-client-id>",
+        "authorization.decision": "ALLOW"}
+     ).sort({timestamp: -1}).limit(3).toArray()'
+   ```
+
+   You should see ALLOW decisions immediately after the M2M client
+   restart. DENY decisions during this window indicate the
+   client picked up the old secret or the IdP rotation didn't
+   take effect.
+
+### Caveats
+
+- **No registry restart.** The registry doesn't cache M2M client
+  secrets — it validates each request against the IdP.
+- **Audit-log scoping.** If you have many M2M clients, narrow the
+  query above by `identity.username` (the client_id) so you don't
+  read 18000 events.
+
+---
+
+## Coordinated rotation order
+
+If you rotate multiple secrets in one maintenance window (e.g.
+post-incident, full-credential refresh), do them in this order:
+
+1. **IdP client secret** first. Affects only token-exchange (one
+   moment per login), narrowest blast radius among heavy rotations.
+2. **Federation static token** second. Coordinated with peers
+   beforehand; instantaneous cutover.
+3. **M2M client secrets** third. Per-client, can be staged.
+4. **`SECRET_KEY` last.** This logs everyone out; do it after the
+   above so users don't have to re-login twice (once for the IdP
+   rotation, once for `SECRET_KEY`).
+
+After all rotations, drop `oauth_sessions_*` once (per
+[incident-response.md](incident-response.md)) to clean up records
+that can no longer decrypt under the new `SECRET_KEY`.
+
+---
+
+## Related runbooks
+
+- [incident-response.md](incident-response.md) — drop
+  `oauth_sessions_*` after a `SECRET_KEY` rotation. Also the
+  preferred response when sessions are leaked but `SECRET_KEY`
+  itself is not the compromise vector.
+- [audit-log-export.md](audit-log-export.md) — query the audit log
+  during rotation to confirm M2M clients and federation peers
+  reconnect successfully.
+
+## Code references
+
+- [`registry/auth/session_crypto.py:13-23`](../../registry/auth/session_crypto.py#L13-L23) — rotation behavior documented inline; restart-required is by design.
+- [`registry/auth/session_crypto.py:37`](../../registry/auth/session_crypto.py#L37) — process-wide AES-GCM cipher singleton.
+- [`registry/auth/internal.py:49-63`](../../registry/auth/internal.py#L49-L63) — internal-JWT signing with `SECRET_KEY`.
+- [`registry/core/config.py:71`](../../registry/core/config.py#L71) — `secret_key` setting.
+- [`registry/core/config.py:251-252`](../../registry/core/config.py#L251-L252) — federation static token settings.
+- [`registry/core/config.py:766-771`](../../registry/core/config.py#L766-L771) — `SECRET_KEY` startup validation (required, 32+ bytes).


### PR DESCRIPTION
## Summary

- Partial progress on #1056 (#1056 stays open after this merges; four runbooks remain).
- Adds three new runbooks under `docs/operations/` and a README index, taking the operations namespace from 1 runbook (the seed `incident-response.md`) to 4.
- Adds an environment-portability note to all four runbooks: the docker-compose examples are directional only on EKS and ECS deployments.

## Scope per runbook

### mongodb-export-import.md (fully validated)

Both MongoDB tool pairs:

| Pair | Format | Use for |
|---|---|---|
| `mongoexport` / `mongoimport` | JSONL | Compliance pulls, ad-hoc inspection, cross-tool data extraction |
| `mongodump` / `mongorestore` | BSON + metadata | Full-fidelity backups, preserves indexes and BSON types |

Includes connection patterns, filtered exports with corrected nested-field queries, mongoimport round-trip with `--drop`, mongodump/mongorestore with index restoration, tenant-scoped operations using `documentdb_namespace` suffix, encrypted-field caveats, and code references.

**Validation:** every command in the runbook was run end-to-end against the live `mcp-mongodb` container while drafting.

### audit-log-export.md (mixed validation)

Two paths:

- **REST API** (`/api/audit/events`, `/api/audit/export`) — JSONL/CSV exports with the full filter set documented at `routes.py:821-885`.
- **Direct MongoDB** — operator escape hatch when the registry is down or for aggregations the API doesn't expose.

**Validation:** direct-MongoDB Path B fully validated (collection discovery, top-N user aggregation, nested-field queries, filtered exports). REST API path is marked **DRAFT** because the admin-token bootstrap form depends on the deployment's auth mode and was not exercised in this PR. TTL/retention and disable-shipping sections are also marked DRAFT because they vary by deployment surface.

### rotate-secrets.md (DRAFT — destructive)

Quick-reference table + per-secret procedures for `SECRET_KEY`, federation static tokens, IdP client secrets, and M2M client secrets. Documents what each rotation invalidates, the rollout sequence, and verification steps. Includes a coordinated-rotation order for multi-secret refresh windows.

**Validation:** marked DRAFT throughout. The destructive steps (rotating `SECRET_KEY`, dropping sessions, restarting auth-server) were intentionally not exercised — running them would log out the validation stack mid-session. The procedure is built from the implementation in `registry/auth/session_crypto.py` (which itself documents the rotation behavior in a module docstring) plus `internal.py` and config.py with line-linked references. Dry-run in non-prod before relying on it.

### Updated existing runbooks

- `incident-response.md` and `mongodb-export-import.md`: added the same environment-portability note that's on the new runbooks, so all four agree on what's directional vs. validated.

## Why this scope (not all 7 runbooks from #1056)

The issue lists 7 proposed runbooks and explicitly says each can ship in its own PR. We chose 3 here because they share a tight coupling (DB layout, auth/secret model) and validate naturally against the local stack. The remaining 4 require deployment surfaces this validation environment doesn't have:

| Remaining | Validation blocker |
|---|---|
| `telemetry-otlp-forwarding.md` | Needs a real OTLP collector to confirm receiving traces/metrics. |
| `backup-and-restore.md` | Needs AWS DocumentDB for PITR and `aws docdb` CLI; local MongoDB CE has no PITR. |
| `scale-replicas.md` | Needs a multi-replica cluster to run rolling-restart commands. |
| `federation-peer-onboard-offboard.md` | Needs two registry deployments to genuinely simulate peer lifecycle. |

Issue #1056 stays open with these four remaining. Each can ship in its own focused PR when its prerequisites are real.

## Acceptance-criteria status (#1056)

| Criterion | Status |
|---|---|
| Each runbook in `docs/operations/<name>.md` follows incident-response.md shape | Pass (all 4 use the same procedure-block + code-references shape) |
| `docs/operations/README.md` index links to every runbook with one-line summary | Pass |
| Each runbook references underlying code via direct link to file/line on `main` | Pass (4 to 6 line-anchored links per runbook) |
| Validated end-to-end against non-prod environment by author before merge | Partial — fully validated where possible; **DRAFT** notices on sections where validation would have been destructive or environment-dependent. The honest version of this criterion. |

## Test plan

- [ ] CI: docs build succeeds (no broken links, no markdown lint warnings).
- [ ] Reviewer: spot-check one or two commands from `mongodb-export-import.md` and `audit-log-export.md` Path B against a local compose stack — they should run cleanly.
- [ ] Reviewer: confirm the DRAFT notices on `audit-log-export.md` (REST API path) and `rotate-secrets.md` (destructive steps) are clear enough that an on-call won't follow them blindly without verification.
- [ ] Reviewer: confirm the EKS/ECS portability note is consistent across all four runbooks.