### PR TITLE
fix(test): reset nginx_service.reload_lock per-test to fix xdist flake

### DIFF
--- a/tests/unit/test_virtual_server_service.py
+++ b/tests/unit/test_virtual_server_service.py
@@ -1345,6 +1345,22 @@ class TestPathAutoGenerationCollision:
 class TestNginxReloadLock:
     """Tests verifying nginx reload lock serializes concurrent operations."""
 
+    @pytest.fixture(autouse=True)
+    def _reset_nginx_reload_lock(self):
+        # The nginx_service singleton is instantiated at module-import time and
+        # its asyncio.Lock is therefore bound to whichever event loop existed
+        # when the singleton was first imported. pytest-asyncio creates a fresh
+        # event loop per test (function scope), so a lock created in test A's
+        # loop fails with "bound to a different event loop" when test B tries
+        # to acquire it. Replace the lock with a fresh one bound to *this*
+        # test's loop. Issue #1072.
+        import asyncio
+
+        from registry.core.nginx_service import nginx_service
+
+        nginx_service.reload_lock = asyncio.Lock()
+        yield
+
     @pytest.fixture
     def mock_vs_repo(self):
         """Create mock virtual server repository."""


### PR DESCRIPTION
## Summary

- Closes #1072.
- Fixes the intermittent `RuntimeError: Lock is bound to a different event loop` failure in `TestNginxReloadLock::test_concurrent_reloads_are_serialized`.

## Root cause

`registry/core/nginx_service.py:1315` instantiates `nginx_service` as a module-level singleton. Its `reload_lock` (line 175) is created during `__init__()` at module-import time, which means the lock is bound to whichever event loop existed when the singleton was first imported.

`pytest-asyncio` defaults to a function-scoped event loop, so each `@pytest.mark.asyncio` test gets a fresh loop. When test A (running in loop A) acquires the singleton's lock, the lock is bound to loop A. When test B (running in loop B) tries to acquire that same lock, asyncio rejects it with the cross-loop binding error.

Under `pytest-xdist`'s 8-worker parallelism, the scheduling of tests across workers and loops is non-deterministic — which is why the suite was green on commit `938ef5cc` and red on the immediately-following commit `fd231a28` despite no production code change between them.

## Fix

Add an `autouse=True` fixture to `TestNginxReloadLock` that replaces `nginx_service.reload_lock` with a fresh `asyncio.Lock()` before each test. The replacement happens inside the test's own loop, so the lock is correctly bound there.

The fix is test-side; production code is unchanged. In a running registry process the singleton lives in a single event loop for the process's lifetime, so the original lock pattern is correct outside of tests.

```python
@pytest.fixture(autouse=True)
def _reset_nginx_reload_lock(self):
    import asyncio
    from registry.core.nginx_service import nginx_service
    nginx_service.reload_lock = asyncio.Lock()
    yield
```

## Validation

Local runs against this branch:

```
$ uv run pytest tests/unit/test_virtual_server_service.py::TestNginxReloadLock
2 passed

$ uv run pytest tests/unit/test_virtual_server_service.py -n 8
71 passed in 37.08s
```

Both targeted-test and xdist-parallel runs pass. The xdist run is the configuration where the flake originally manifested, so this is the meaningful signal.

## Why not "fix nginx_service to lazy-init the lock"?

That would also work, and would arguably be cleaner. I went with the test-side fix because:

1. The production code is correct as written — the singleton-lock pattern is a perfectly fine design for a long-running process where a single event loop exists for the lifetime of the registry. The bug is purely a test-isolation artifact.
2. Touching the test is a 16-line change in one file; touching production code introduces a different lock-init pattern (lazy-init or context-var) that needs its own review and risk assessment.
3. Issue #1072 explicitly suggests the test-side approach as option 1 of three.

If the maintainers prefer a lazy-init in `nginx_service` instead, happy to follow up — but I'd argue the test fix is the right minimal-risk change for 1.24.1 / immediate stability of CI.

## Test plan

- [ ] CI: registry-test workflow stays green across 5+ consecutive runs.
- [ ] Reviewer: confirm the autouse fixture only affects tests in `TestNginxReloadLock` (it's class-scoped via `self`).
- [ ] Reviewer: confirm production `registry/core/nginx_service.py` is genuinely unchanged.