### PR TITLE
fix(agentcore): runtime registration, Entra scope, .env autoload, doc fixes

### DIFF
--- a/cli/agentcore/registration.py
+++ b/cli/agentcore/registration.py
@@ -294,6 +294,10 @@ class RegistrationBuilder:
         if protocol == "A2A":
             tags.append("a2a")
 
+        # Registry AgentCreate requires supported_protocol with values "a2a" or "other".
+        # Map AgentCore serverProtocol -> registry supported_protocol.
+        supported_protocol = "a2a" if protocol == "A2A" else "other"
+
         return AgentRegistration(
             name=display,
             description=runtime.get("description", f"AgentCore Agent: {display}"),
@@ -301,6 +305,7 @@ class RegistrationBuilder:
             path=path,
             version="1.0.0",
             tags=tags,
+            supported_protocol=supported_protocol,
             # Agent validator accepts: public, private, group-restricted (not "internal").
             # MCP Servers use "internal" but A2A Agents use "public" as the default,
             # so we map "internal" -> "public" for Agent registrations.
@@ -487,6 +492,14 @@ class SyncOrchestrator:
                 "gateway_arn": gateway.get("gatewayArn", ""),
                 "discovery_url": discovery_url,
                 "allowed_clients": jwt_config.get("allowedClients", []),
+                # AgentCore returns either ``allowedAudience`` (singular) or
+                # ``allowedAudiences`` depending on the API version. Capture
+                # whichever is present so the token refresher can derive the
+                # OAuth2 ``scope`` value (Entra requires ``<aud>/.default``).
+                "allowed_audience": (
+                    jwt_config.get("allowedAudience")
+                    or jwt_config.get("allowedAudiences", [])
+                ),
                 "idp_vendor": _detect_idp_vendor(discovery_url),
             }
         )

--- a/cli/agentcore/token_refresher.py
+++ b/cli/agentcore/token_refresher.py
@@ -231,10 +231,52 @@ def _get_token_endpoint(
         return None
 
 
+def _build_scope(
+    idp_vendor: str,
+    allowed_audience: str | list[str] | None,
+) -> str | None:
+    """Derive the OAuth2 ``scope`` parameter for the token request.
+
+    Microsoft Entra requires ``scope=<audience>/.default`` on the
+    client_credentials grant; without it Entra returns
+    ``AADSTS900144: scope is required``. Other vendors (Cognito, Auth0,
+    Okta, Keycloak) do not require a scope for client_credentials and
+    will work with ``None``.
+
+    Args:
+        idp_vendor: Detected IdP vendor name.
+        allowed_audience: ``allowedAudience`` from the gateway's
+            customJWTAuthorizer config -- string or list-of-strings.
+
+    Returns:
+        Scope string to send in the token request, or None to omit it.
+    """
+    if idp_vendor != "entra":
+        return None
+
+    audience: str | None = None
+    if isinstance(allowed_audience, str):
+        audience = allowed_audience
+    elif isinstance(allowed_audience, list) and allowed_audience:
+        audience = allowed_audience[0]
+
+    if not audience:
+        logger.warning(
+            "Entra gateway has no allowedAudience -- token request will likely fail "
+            "(Entra requires scope=<audience>/.default for client_credentials)"
+        )
+        return None
+
+    if audience.endswith("/.default"):
+        return audience
+    return f"{audience.rstrip('/')}/.default"
+
+
 def _request_token(
     token_endpoint: str,
     client_id: str,
     client_secret: str,
+    scope: str | None = None,
 ) -> str | None:
     """Request access token via OAuth2 client_credentials grant.
 
@@ -242,19 +284,25 @@ def _request_token(
         token_endpoint: OAuth2 token endpoint URL.
         client_id: OAuth2 client ID.
         client_secret: OAuth2 client secret.
+        scope: Optional OAuth2 scope parameter. Required for Entra
+            (``<audience>/.default``); omitted for other vendors.
 
     Returns:
         Access token string, or None on failure.
     """
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    if scope:
+        data["scope"] = scope
+
     try:
         response = requests.post(
             token_endpoint,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data={
-                "grant_type": "client_credentials",
-                "client_id": client_id,
-                "client_secret": client_secret,
-            },
+            data=data,
             timeout=TOKEN_REQUEST_TIMEOUT,
         )
         response.raise_for_status()
@@ -478,8 +526,9 @@ def refresh_all(
             failure_count += 1
             continue
 
-        # Step 3: Request token
-        token = _request_token(token_endpoint, client_id, client_secret)
+        # Step 3: Request token (Entra requires scope=<audience>/.default)
+        scope = _build_scope(idp_vendor, entry.get("allowed_audience"))
+        token = _request_token(token_endpoint, client_id, client_secret, scope=scope)
         if not token:
             failure_count += 1
             continue
@@ -528,6 +577,16 @@ def refresh_all(
 
 def main() -> None:
     """Parse arguments and run token refresh."""
+    # Load .env before anything reads os.environ so OAUTH_CLIENT_SECRET_*,
+    # AUTH0_CLIENT_SECRET, OKTA_CLIENT_SECRET, etc. resolve from the project
+    # .env file without requiring the caller to export them.
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv()
+    except ImportError:
+        pass
+
     parser = argparse.ArgumentParser(
         description="Refresh auth tokens for AgentCore CUSTOM_JWT gateways",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -36,7 +36,7 @@ uv run python -m cli.agentcore list
 ```
 
 The sync command:
-1. Discovers all READY gateways and runtimes via AWS Bedrock AgentCore API
+1. Discovers all READY gateways and runtimes via the Amazon Bedrock AgentCore API
 2. Registers each gateway as an MCP Server and each runtime as an MCP Server (protocol=MCP) or A2A Agent (protocol=HTTP/A2A)
 3. Writes `token_refresh_manifest.json` listing all CUSTOM_JWT gateways that need token refresh
 
@@ -64,6 +64,8 @@ Secret resolution priority:
 2. Cognito auto-retrieval via AWS API (Cognito only)
 3. Vendor-specific env var: `AUTH0_CLIENT_SECRET`, etc.
 
+**Microsoft Entra gateways** also need an `allowedAudience` configured on the AgentCore gateway's `customJWTAuthorizer`. The token refresher automatically derives the OAuth2 `scope` parameter as `<allowedAudience>/.default`, which Entra requires for the `client_credentials` grant. If `allowedAudience` is empty, the token request will fail with `AADSTS900144: scope is required`.
+
 ### Step 3: Run Token Refresher
 
 The token refresher reads the manifest, resolves secrets, fetches OAuth2 tokens, PATCHes them into the registry, and triggers a security rescan for each updated server (enabled by default, requires admin privileges on the registry token):
@@ -83,15 +85,28 @@ uv run python -m cli.agentcore.token_refresher \
     --loop --interval 2700
 ```
 
-Or set up a cron job:
+Or set up a cron job. Cron does not support shell line continuations, so the entire command must be on a single line. The cleanest pattern is a small wrapper script invoked from the crontab:
 
 ```bash
-# Refresh every 45 minutes (tokens typically expire in 60 min)
-*/45 * * * * cd /app && uv run python -m cli.agentcore.token_refresher \
+# /usr/local/bin/refresh-agentcore-tokens.sh
+#!/bin/bash
+cd /app
+uv run python -m cli.agentcore.token_refresher \
     --manifest token_refresh_manifest.json \
     --registry-url https://registry.example.com \
-    --token-file .token \
-    >> /var/log/token-refresher.log 2>&1
+    --token-file .token
+```
+
+```cron
+# /etc/cron.d/agentcore-token-refresher
+# Refresh every 45 minutes (tokens typically expire in 60 min)
+*/45 * * * * root /usr/local/bin/refresh-agentcore-tokens.sh >> /var/log/token-refresher.log 2>&1
+```
+
+If you prefer to inline the command, keep it on one physical line:
+
+```cron
+*/45 * * * * root cd /app && uv run python -m cli.agentcore.token_refresher --manifest token_refresh_manifest.json --registry-url https://registry.example.com --token-file .token >> /var/log/token-refresher.log 2>&1
 ```
 
 ### Scanner CLI Reference
@@ -185,6 +200,7 @@ uv run python -m cli.agentcore.token_refresher \
 # Enable debug logging
 uv run python -m cli.agentcore.token_refresher \
     --manifest token_refresh_manifest.json \
+    --registry-url https://registry.example.com \
     --token-file .token \
     --debug
 ```
@@ -320,7 +336,7 @@ This approach is useful when:
 ### How It Works
 
 1. **Create a JSON config file** describing the gateway or agent (path, proxy URL, auth scheme, tags, tool list)
-2. **Register with the CLI**: `./cli/service_mgmt.sh add gateway-config.json`
+2. **Register with the CLI**: `./cli/service_mgmt.sh add gateway-config.json` (this script prints a deprecation banner pointing to `api/registry_management.py register`; the banner is informational and the `add` command still works)
 3. **Provide a JWT token** when calling the gateway -- the IdP does not matter, just provide a valid bearer token at call time via `--token-file`
 4. **Refresh the token** when it expires -- how you obtain the token is up to you (curl, SDK, script)
 
@@ -338,11 +354,9 @@ The identity provider is irrelevant for manual registration. The registry uses p
   "auth_scheme": "bearer",
   "supported_transports": ["streamable-http"],
   "tags": ["bedrock", "agentcore", "customer-support"],
-  "headers": [
-    {
-      "Authorization": "Bearer $CUSTOMER_SUPPORT_AUTH_TOKEN"
-    }
-  ],
+  "headers": {
+    "Authorization": "Bearer REPLACE_WITH_VALID_JWT"
+  },
   "num_tools": 2,
   "is_python": false,
   "tool_list": [
@@ -372,6 +386,7 @@ The identity provider is irrelevant for manual registration. The registry uses p
 | `auth_provider` | Set to `bedrock-agentcore` for passthrough authentication -- the registry forwards the bearer token without validating it |
 | `tags` | Searchable tags used by `intelligent_tool_finder` for hybrid search (semantic + tag-based) |
 | `tool_list` | Tool definitions with names, descriptions, and JSON schemas. Enables the registry to catalog tools for dynamic discovery by AI agents |
+| `headers` | Optional JSON object of header name -> value pairs used for the security scan and as defaults for the registered service. Replace `REPLACE_WITH_VALID_JWT` with a real bearer token before registering -- shell-style `$VAR` references inside the JSON file are not expanded |
 
 ### Register and Call
 


### PR DESCRIPTION
## Summary
- Fix bulk AgentCore scanner so runtime/agent registration actually succeeds (missing `supported_protocol` was causing HTTP 422 on every runtime).
- Fix Entra client_credentials flow by capturing `allowedAudience` during scan and sending `scope=<audience>/.default` on token refresh; without this, Entra gateways fail with `AADSTS900144: scope is required`.
- Auto-load `.env` in the token refresher so `OAUTH_CLIENT_SECRET_*`, `AUTH0_CLIENT_SECRET`, etc. work without manual export.
- Correct six inaccuracies in `docs/agentcore.md` (Bedrock naming, cron line-continuations, headers JSON shape, deprecation note, missing `--registry-url`, headers parameter row). Add a note explaining Entra audience handling.

## Why this matters
A customer was running the bulk-scanner walkthrough today. Without these fixes, runtime registration is 100% broken (HTTP 422 from the registry on every runtime), and any Entra-backed gateway would silently fail on token refresh.

## Verified live
Tested against `mcpgateway.ddns.net` with an account containing 5 Cognito CUSTOM_JWT gateways and 8 runtimes:
- `sync`: 5/5 gateways and 8/8 runtimes register successfully
- `sync --overwrite`: correctly updates existing entries
- `token_refresher`: 4/5 gateways refreshed (the fifth points at a deleted Cognito user pool and is correctly reported as skipped)
- All 78 agentcore unit tests pass

## Test plan
- [x] `uv run python -m py_compile cli/agentcore/registration.py cli/agentcore/token_refresher.py`
- [x] `uv run pytest tests/unit/cli/test_agentcore_registration.py tests/unit/cli/test_agentcore_token_refresher.py` (78 passed)
- [x] Live `sync` against the registry (5 gateways + 8 runtimes registered)
- [x] Live `token_refresher` against the registry (4 succeeded, 1 skipped due to deleted pool)
- [ ] Reviewer to confirm Entra change doesn't regress non-Entra vendors (Cognito flow re-tested above; Auth0/Okta/Keycloak unchanged because `_build_scope` returns `None` for them)