### PR TITLE
fix: make registry appuser home directory writable

### DIFF
--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -92,7 +92,7 @@ WORKDIR /app
 
 # Create non-root user EARLY for security (CIS Docker Benchmark 4.1)
 # This allows us to use --chown in COPY commands, avoiding slow chown -R later
-RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser
+RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser -m appuser
 
 # Copy Python virtual environment from backend builder (large but stable layer)
 # Use --chown to set ownership during copy (much faster than chown -R afterward)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The docker home is not writable on the containers; this causes an issue for the registry pod trying to download a model on startup. This PR makes the container's user's home directory writable so that the model can download

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
