### PR TITLE
Preserve MCP proxy response headers

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -3737,6 +3737,15 @@ _HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
     }
 )
 
+_RESPONSE_FRAMING_HEADERS: frozenset[str] = frozenset(
+    {
+        "content-length",
+        "content-encoding",
+        "transfer-encoding",
+        "connection",
+    }
+)
+
 
 async def _read_bounded(
     response: httpx.Response,
@@ -3777,6 +3786,17 @@ def _forward_headers(
             continue
         forwarded[key] = value
     return forwarded
+
+
+def _passthrough_response_headers(
+    upstream_headers: dict[str, str],
+) -> dict[str, str]:
+    """Preserve upstream end-to-end headers while letting Starlette frame the body."""
+    return {
+        key: value
+        for key, value in upstream_headers.items()
+        if key.lower() not in _RESPONSE_FRAMING_HEADERS
+    }
 
 
 @app.post("/mcp-proxy/{server_name:path}")
@@ -3848,6 +3868,7 @@ async def mcp_proxy(
                 # pathological upstream cannot DoS the proxy.
                 body_bytes = await _read_bounded(upstream_response, max_body_bytes)
                 status_code = upstream_response.status_code
+                upstream_headers = dict(upstream_response.headers)
                 content_type = upstream_response.headers.get("content-type", "application/json")
     except HTTPException:
         raise
@@ -3881,6 +3902,7 @@ async def mcp_proxy(
             content=body_bytes,
             status_code=status_code,
             media_type=content_type,
+            headers=_passthrough_response_headers(upstream_headers),
         )
 
     try:
@@ -3892,6 +3914,7 @@ async def mcp_proxy(
         return JSONResponse(
             content=_safe_parse_body(body_bytes),
             status_code=status_code,
+            headers=_passthrough_response_headers(upstream_headers),
         )
 
     result = parsed.get("result") if isinstance(parsed, dict) else None
@@ -3904,7 +3927,11 @@ async def mcp_proxy(
         result["tools"] = filtered
         parsed["result"] = result
 
-    return JSONResponse(content=parsed, status_code=status_code)
+    return JSONResponse(
+        content=parsed,
+        status_code=status_code,
+        headers=_passthrough_response_headers(upstream_headers),
+    )
 
 
 def _safe_parse_body(

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -413,6 +413,129 @@ class TestRateLimiting:
         assert f"{username}:{old_hour}" not in user_token_generation_counts
 
 
+class TestMcpProxyResponseHeaders:
+    """Regression tests for streamable-http MCP response headers."""
+
+    class _FakeUpstreamResponse:
+        def __init__(
+            self,
+            body: bytes,
+            headers: dict[str, str],
+            status_code: int = 200,
+        ):
+            self._body = body
+            self.headers = headers
+            self.status_code = status_code
+
+        async def aiter_bytes(self, chunk_size: int):
+            yield self._body
+
+    class _FakeStream:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self.response
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _FakeAsyncClient:
+        def __init__(self, response):
+            self.response = response
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def stream(self, *args, **kwargs):
+            return TestMcpProxyResponseHeaders._FakeStream(self.response)
+
+    def test_passthrough_response_headers_preserves_mcp_session_id(self):
+        import auth_server.server as server_module
+
+        headers = server_module._passthrough_response_headers(
+            {
+                "content-type": "application/json",
+                "Mcp-Session-Id": "session-123",
+                "Retry-After": "2",
+                "content-length": "999",
+                "transfer-encoding": "chunked",
+                "connection": "keep-alive",
+                "content-encoding": "gzip",
+            }
+        )
+
+        assert headers["Mcp-Session-Id"] == "session-123"
+        assert headers["Retry-After"] == "2"
+        assert headers["content-type"] == "application/json"
+        assert "content-length" not in {key.lower() for key in headers}
+        assert "transfer-encoding" not in {key.lower() for key in headers}
+        assert "connection" not in {key.lower() for key in headers}
+        assert "content-encoding" not in {key.lower() for key in headers}
+
+    def test_mcp_proxy_preserves_session_header_on_passthrough_response(self):
+        import auth_server.server as server_module
+
+        upstream = self._FakeUpstreamResponse(
+            b'{"jsonrpc":"2.0","id":1,"result":{}}',
+            {
+                "content-type": "application/json",
+                "Mcp-Session-Id": "session-123",
+                "content-length": "999",
+            },
+        )
+
+        with patch(
+            "auth_server.server.httpx.AsyncClient",
+            return_value=self._FakeAsyncClient(upstream),
+        ):
+            client = TestClient(server_module.app)
+            response = client.post(
+                "/mcp-proxy/test-server",
+                headers={"X-Upstream-Url": "https://upstream.example/mcp"},
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            )
+
+        assert response.status_code == 200
+        assert response.headers["mcp-session-id"] == "session-123"
+        assert response.json()["result"] == {}
+        assert response.headers["content-length"] != "999"
+
+    def test_mcp_proxy_preserves_session_header_when_tools_filter_disabled(self):
+        import auth_server.server as server_module
+
+        upstream = self._FakeUpstreamResponse(
+            b'{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}',
+            {
+                "content-type": "application/json",
+                "Mcp-Session-Id": "session-abc",
+                "transfer-encoding": "chunked",
+            },
+        )
+
+        with (
+            patch("auth_server.server._read_mcp_filter_enabled", return_value=False),
+            patch(
+                "auth_server.server.httpx.AsyncClient",
+                return_value=self._FakeAsyncClient(upstream),
+            ),
+        ):
+            client = TestClient(server_module.app)
+            response = client.post(
+                "/mcp-proxy/test-server",
+                headers={"X-Upstream-Url": "https://upstream.example/mcp"},
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+
+        assert response.status_code == 200
+        assert response.headers["mcp-session-id"] == "session-abc"
+        assert response.json()["result"]["tools"] == []
+        assert "transfer-encoding" not in response.headers
+
+
 # =============================================================================
 # SESSION COOKIE VALIDATION TESTS
 # =============================================================================


### PR DESCRIPTION
## Summary
- snapshot upstream MCP response headers while still inside the `httpx` stream context
- pass end-to-end headers such as `Mcp-Session-Id` through all `/mcp-proxy` response branches
- strip framing headers so Starlette can recompute body framing safely
- add regression coverage for passthrough responses and `MCP_TOOLS_LIST_FILTER_ENABLED=false`

## Why
Fixes #1096. Streamable-http MCP clients need the upstream `Mcp-Session-Id` from `initialize` before they can send follow-up requests. The auth proxy currently forwards body/status/content-type but drops that session header, so clients see a successful initialize response but cannot bind later JSON-RPC calls to the session.

## Verification
- `uv run pytest tests/auth_server/unit/test_server.py::TestMcpProxyResponseHeaders -q --no-cov`
- `uv run --with ruff ruff check auth_server/server.py tests/auth_server/unit/test_server.py`

Prepared by an AI agent operator; scope kept to the response-header regression described in #1096.