### PR TITLE
feat(metrics): expose /api/metrics Prometheus endpoint on registry

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -12,4 +12,12 @@ scrape_configs:
       - targets: ['metrics-service:9465']
     scrape_interval: 10s
     metrics_path: /metrics
+
+  # Scrape in-process counters from the registry FastAPI app (issue #867).
+  # Requires the registry container to be on the same Docker network as Prometheus.
+  - job_name: 'mcp-registry'
+    static_configs:
+      - targets: ['registry:7860']
+    scrape_interval: 10s
+    metrics_path: /api/metrics
     

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -462,6 +462,22 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Prometheus metrics endpoint - no authentication required (issue #867)
+    location ^~ {{ROOT_PATH}}/api/metrics {
+        proxy_pass http://127.0.0.1:7860;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_pass_request_headers on;
+
+        # Timeouts
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
     location {{ROOT_PATH}}/api/ {
         # Authenticate request via auth server (validates JWT Bearer tokens)
         auth_request /validate;
@@ -1055,6 +1071,22 @@ server {
 
     # Public version endpoint - no authentication required (priority prefix match)
     location ^~ {{ROOT_PATH}}/api/version {
+        proxy_pass http://127.0.0.1:7860;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $real_scheme;
+        proxy_pass_request_headers on;
+
+        # Timeouts
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
+    # Prometheus metrics endpoint - no authentication required (issue #867)
+    location ^~ {{ROOT_PATH}}/api/metrics {
         proxy_pass http://127.0.0.1:7860;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -152,6 +152,20 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Prometheus metrics endpoint - no authentication required (issue #867)
+    location ^~ {{ROOT_PATH}}/api/metrics {
+        proxy_pass http://127.0.0.1:7860;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_pass_request_headers on;
+        proxy_connect_timeout 10s;
+        proxy_send_timeout 30s;
+        proxy_read_timeout 30s;
+    }
+
     # Protected API endpoints - require authentication
     location {{ROOT_PATH}}/api/ {
         # Authenticate request via auth server (validates JWT Bearer tokens)

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -947,6 +947,87 @@ docker compose logs metrics-service | grep -i otel
 | faiss_search_time_ms | REAL | Time for FAISS search |
 | created_at | TEXT | Record creation time |
 
+## Registry In-Process Metrics (`/api/metrics`)
+
+The registry process exposes its own Prometheus metrics at `/api/metrics` (issue #867). This endpoint is served directly by the FastAPI app and returns all in-process counters and gauges in Prometheus text exposition format.
+
+### Endpoint Details
+
+| Property | Value |
+|----------|-------|
+| Path | `GET /api/metrics` |
+| Authentication | None (unauthenticated) |
+| Content-Type | `text/plain; version=0.0.4; charset=utf-8` |
+| Scrape interval | 10s (configured in `config/prometheus.yml`) |
+
+### Auth Posture
+
+This endpoint is unauthenticated. It is scraped by the Prometheus container over the internal Docker network (`registry:7860`). It is also accessible externally through NGINX at `http://yourdomain/api/metrics`.
+
+**Security note for public deployments:** If your registry is internet-facing, consider restricting access at the NGINX or load-balancer level. Example NGINX snippet:
+
+```nginx
+location = /api/metrics {
+    allow 10.0.0.0/8;   # internal only — adjust to your network
+    deny all;
+    proxy_pass http://127.0.0.1:7860;
+}
+```
+
+### Counters and Gauges Exposed
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `registry_logout_id_token_hint_present_total` | Counter | — | Logouts where id_token hint was present |
+| `registry_logout_id_token_hint_missing_total` | Counter | — | Logouts where id_token hint was missing |
+| `registry_logout_jwt_validation_failed_total` | Counter | — | Logout JWT validation failures |
+| `registry_logout_url_length_warning_total` | Counter | — | Logout URLs exceeding recommended length |
+| `mcp_config_view_requests_total` | Counter | `user_type` | Config view API calls |
+| `mcp_config_export_requests_total` | Counter | `format`, `includes_sensitive` | Config export requests |
+| `registry_deployment_mode_info` | Gauge | `deployment_mode`, `registry_mode` | Current deployment mode |
+| `registry_nginx_updates_skipped_total` | Counter | `operation` | NGINX update skips |
+| `nginx_config_writes_total` | Counter | `status` | NGINX config file writes |
+| `registry_mode_blocked_requests_total` | Counter | `path_category`, `mode` | Requests blocked by registry mode |
+| `peer_sync_failures_total` | Counter | `peer_id`, `failure_type` | Federation peer sync failures |
+| `peer_token_missing_total` | Gauge | — | Peers missing federation tokens |
+| `peer_sync_duration_seconds` | Gauge | `peer_id`, `success` | Peer sync operation duration |
+| `app_log_mongodb_flush_failures_total` | Counter | `service` | MongoDB log flush failures |
+| `telemetry_sends_total` | Counter | `event`, `status` | Telemetry events sent |
+| `m2m_orphan_cleanups_total` | Counter | `idp_had_record` | M2M orphan token cleanups |
+| `mcp_registry_cloud_detection_total` | Counter | `cloud`, `method` | Cloud provider detection outcomes |
+| `m2m_management_requests_total` | Counter | `operation`, `outcome` | M2M management API calls |
+
+Python process metrics (`process_resident_memory_bytes`, GC stats, etc.) are also included automatically by the default collector.
+
+### Sample PromQL Queries
+
+```
+# Logout event rate (5-minute window)
+rate(registry_logout_id_token_hint_present_total[5m])
+
+# Config view request rate by user type
+rate(mcp_config_view_requests_total[5m])
+
+# M2M management error rate
+rate(m2m_management_requests_total{outcome!="success"}[5m])
+
+# Peer sync failure rate
+rate(peer_sync_failures_total[5m])
+
+# Current deployment mode
+registry_deployment_mode_info
+```
+
+### Activating the Scrape Job
+
+After deploying this change, restart Prometheus to pick up the new scrape job:
+
+```bash
+docker compose restart prometheus
+```
+
+Then verify the target is up at `http://localhost:9090/targets` — the `mcp-registry` job should show **State: UP**.
+
 ## Additional Resources
 
 - [Prometheus Documentation](https://prometheus.io/docs/)

--- a/registry/main.py
+++ b/registry/main.py
@@ -20,8 +20,10 @@ from uuid import uuid4
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.responses import FileResponse, HTMLResponse, Response
 from fastapi.staticfiles import StaticFiles
+import httpx
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from registry.api.agent_routes import router as agent_router
 from registry.api.ans_routes import router as ans_router
@@ -960,6 +962,31 @@ app.include_router(registry_router, prefix="/api/registry", tags=["Registry Card
 
 # Register well-known discovery router
 app.include_router(wellknown_router, prefix="/.well-known", tags=["Discovery"])
+
+# Expose in-process Prometheus metrics (issue #867).
+# NOTE: Must be registered before the SPA catch-all route below — Starlette evaluates
+# routes in order, and the catch-all raises 404 for api/ paths rather than falling through.
+# NOTE: Unauthenticated. Accessible through NGINX. See docs/OBSERVABILITY.md for operator guidance.
+# NOTE: Single-process only. If uvicorn is ever run with --workers N, each worker has its own
+# REGISTRY. To aggregate across workers set PROMETHEUS_MULTIPROC_DIR.
+# See https://prometheus.github.io/client_python/multiprocess/
+# NOTE: Unauthenticated. Accessible through NGINX. See docs/OBSERVABILITY.md for operator guidance.
+@app.get("/api/metrics", include_in_schema=False)
+async def metrics_endpoint() -> Response:
+    local_metrics = generate_latest()
+
+    metrics_url = os.getenv("METRICS_PROMETHEUS_URL", "http://metrics-service:9465/metrics")
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(metrics_url)
+            if resp.status_code == 200:
+                combined = local_metrics + resp.content
+            else:
+                combined = local_metrics
+    except Exception:
+        combined = local_metrics
+
+    return Response(combined, media_type=CONTENT_TYPE_LATEST)
 
 
 # Customize OpenAPI schema to add security schemes

--- a/tests/unit/api/test_metrics_endpoint.py
+++ b/tests/unit/api/test_metrics_endpoint.py
@@ -1,0 +1,48 @@
+"""Unit tests for the /api/metrics endpoint (issue #867)."""
+
+from fastapi.testclient import TestClient
+
+from registry.main import app
+
+client = TestClient(app)
+
+
+class TestMetricsEndpoint:
+    """Tests for the Prometheus metrics endpoint."""
+
+    def test_metrics_endpoint_returns_200(self):
+        """GET /api/metrics returns HTTP 200."""
+        response = client.get("/api/metrics")
+        assert response.status_code == 200
+
+    def test_metrics_endpoint_content_type_is_prometheus_text(self):
+        """Response Content-Type is Prometheus text exposition format."""
+        response = client.get("/api/metrics")
+        assert "text/plain" in response.headers["content-type"]
+
+    def test_metrics_endpoint_contains_help_and_type_lines(self):
+        """Response body contains # HELP and # TYPE lines."""
+        response = client.get("/api/metrics")
+        assert "# HELP" in response.text
+        assert "# TYPE" in response.text
+
+    def test_known_counters_present_in_output(self):
+        """All known in-process counters appear in scrape output (value 0 is fine).
+
+        These counters are declared at module level and register with the default
+        REGISTRY collector at import time, so they appear even before any events fire.
+        """
+        response = client.get("/api/metrics")
+        assert "registry_logout_id_token_hint_present_total" in response.text
+        assert "mcp_config_view_requests_total" in response.text
+        assert "m2m_management_requests_total" in response.text
+        assert "registry_deployment_mode_info" in response.text
+        assert "peer_sync_failures_total" in response.text
+        assert "nginx_config_writes_total" in response.text
+        assert "telemetry_sends_total" in response.text
+
+    def test_python_runtime_metrics_present(self):
+        """Default collector includes Python runtime metrics (GC stats, python_info)."""
+        response = client.get("/api/metrics")
+        # python_gc_* metrics are available on all platforms (Linux + macOS)
+        assert "python_gc_objects_collected_total" in response.text


### PR DESCRIPTION
**Issue #:** #867

**Description of changes:**

- Adds `GET /api/metrics` endpoint to the registry that serves Prometheus-format metrics
- Aggregates registry-local metrics (deployment mode, nginx config writes, logout counters, cloud detection) with application metrics from the metrics-service (auth requests, tool discovery, tool executions, health checks, protocol latency)
- Added unauthenticated NGINX location block (`location ^~ /api/metrics`) in both HTTP-only and HTTP+HTTPS templates so the endpoint is reachable without a JWT
- Updated `config/prometheus.yml` to add a scrape job targeting `registry:7860/api/metrics`
- Documented the endpoint in `docs/OBSERVABILITY.md`

**Test plan:**

- [ ] `uv run pytest tests/unit/api/test_metrics_endpoint.py` passes (5 tests)
- [ ] `curl http://localhost/api/metrics` returns HTTP 200 with Prometheus text
- [ ] Prometheus target `mcp-registry` shows state `UP` at `/targets`
- [ ] PromQL queries like `mcp_tool_executions_total` return results


