### PR TITLE
fix(skills): derive SSRF allowlist from github_extra_hosts for GHES (#938)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -561,7 +561,11 @@ GITHUB_ENABLED=false
 # GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 
 # Extra GitHub hosts for enterprise instances (comma-separated)
-# Auth headers are sent ONLY to github.com, raw.githubusercontent.com, and hosts listed here
+# Hosts listed here are trusted for two purposes:
+#   1. GitHub auth headers are injected ONLY for github.com, raw.githubusercontent.com,
+#      and hosts in this list.
+#   2. SKILL.md SSRF allowlist: hosts in this list bypass the private-IP check
+#      so GHES instances on internal networks can be reached. Keep the list tight.
 # GITHUB_EXTRA_HOSTS=github.mycompany.com,raw.github.mycompany.com
 
 # GitHub API base URL (default: https://api.github.com)

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -239,7 +239,11 @@ class Settings(BaseSettings):
     )
     github_extra_hosts: str = Field(
         default="",
-        description="Comma-separated extra GitHub hosts for auth (e.g. github.mycompany.com,raw.github.mycompany.com)",
+        description=(
+            "Comma-separated extra GitHub hosts (e.g. github.mycompany.com,raw.github.mycompany.com). "
+            "Hosts here receive GitHub auth headers AND bypass the SKILL.md SSRF private-IP check, "
+            "so GHES instances on internal networks remain reachable. Keep the list tight."
+        ),
     )
     github_api_base_url: str = Field(
         default="https://api.github.com",

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -12,6 +12,7 @@ import ipaddress
 import logging
 import socket
 from datetime import UTC, datetime
+from functools import lru_cache
 from typing import (
     Any,
 )
@@ -19,6 +20,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ..core.config import settings
 from ..exceptions import (
     SkillUrlValidationError,
 )
@@ -57,8 +59,11 @@ logger = logging.getLogger(__name__)
 # Constants
 URL_VALIDATION_TIMEOUT: int = 10
 
-# Trusted domains that skip IP validation (SSRF protection allowlist)
-TRUSTED_DOMAINS: frozenset = frozenset(
+# Built-in trusted domains that skip IP validation (SSRF protection allowlist).
+# Enterprise GitHub hosts are merged in at runtime from settings.github_extra_hosts
+# via _trusted_domains() so GHES instances on private IPs are reachable for
+# SKILL.md fetches (matches the host allowlist used by the GitHub auth provider).
+_DEFAULT_TRUSTED_DOMAINS: frozenset = frozenset(
     {
         "github.com",
         "gitlab.com",
@@ -66,6 +71,19 @@ TRUSTED_DOMAINS: frozenset = frozenset(
         "bitbucket.org",
     }
 )
+
+
+@lru_cache(maxsize=1)
+def _trusted_domains() -> frozenset[str]:
+    """Return SSRF allowlist: built-in defaults plus configured GHES hosts.
+
+    Reads settings.github_extra_hosts (the same setting that authorises auth
+    header injection) so a single config knob covers both trust decisions.
+    Cached because settings are immutable per-process.
+    """
+    extra_raw = settings.github_extra_hosts or ""
+    extra = frozenset(h.strip().lower() for h in extra_raw.split(",") if h.strip())
+    return _DEFAULT_TRUSTED_DOMAINS | extra
 
 
 def _is_private_ip(
@@ -112,7 +130,9 @@ def _is_safe_url(
     2. Does not resolve to a private/loopback/link-local IP address
     3. Does not target cloud metadata endpoints
 
-    Trusted domains (github.com, gitlab.com, etc.) skip the IP check.
+    Trusted domains (github.com, gitlab.com, etc., plus any host configured
+    via settings.github_extra_hosts) skip the IP check so GHES instances on
+    private networks remain reachable.
 
     Args:
         url: URL to validate
@@ -135,7 +155,7 @@ def _is_safe_url(
 
         # Check if hostname is in trusted domains allowlist
         hostname_lower = hostname.lower()
-        if hostname_lower in TRUSTED_DOMAINS:
+        if hostname_lower in _trusted_domains():
             logger.debug(f"SSRF protection: Trusted domain '{hostname_lower}'")
             return True
 

--- a/tests/unit/services/test_skill_service_ssrf_allowlist.py
+++ b/tests/unit/services/test_skill_service_ssrf_allowlist.py
@@ -46,14 +46,16 @@ class TestDefaultTrustedDomains:
         mock_settings.github_extra_hosts = ""
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        domains = _trusted_domains()
-
-        assert "github.com" in domains
-        assert "raw.githubusercontent.com" in domains
-        assert "gitlab.com" in domains
-        assert "bitbucket.org" in domains
+        # With no extras configured the merged set must equal the defaults.
+        # Using equality (rather than per-host membership) catches accidental
+        # additions or omissions and keeps the assertion off CodeQL's
+        # py/incomplete-url-substring-sanitization radar.
+        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS
 
     @patch("registry.services.skill_service.settings")
     def test_unconfigured_ghes_host_not_trusted(
@@ -64,9 +66,12 @@ class TestDefaultTrustedDomains:
         mock_settings.github_extra_hosts = ""
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        assert "github.mycompany.com" not in _trusted_domains()
+        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS
 
 
 # =============================================================================
@@ -82,30 +87,38 @@ class TestGHESHostMerge:
         self,
         mock_settings,
     ) -> None:
-        """One configured GHES host appears in the trusted set."""
+        """One configured GHES host extends the default trusted set by exactly that host."""
         mock_settings.github_extra_hosts = "github.mycompany.com"
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        assert "github.mycompany.com" in _trusted_domains()
+        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS | {"github.mycompany.com"}
 
     @patch("registry.services.skill_service.settings")
     def test_multiple_ghes_hosts_added(
         self,
         mock_settings,
     ) -> None:
-        """Comma-separated GHES hosts all appear in the trusted set."""
+        """Comma-separated GHES hosts all extend the default set."""
         mock_settings.github_extra_hosts = (
             "github.mycompany.com,raw.github.mycompany.com"
         )
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        domains = _trusted_domains()
-        assert "github.mycompany.com" in domains
-        assert "raw.github.mycompany.com" in domains
+        expected = _DEFAULT_TRUSTED_DOMAINS | {
+            "github.mycompany.com",
+            "raw.github.mycompany.com",
+        }
+        assert _trusted_domains() == expected
 
     @patch("registry.services.skill_service.settings")
     def test_whitespace_and_case_normalised(
@@ -116,11 +129,16 @@ class TestGHESHostMerge:
         mock_settings.github_extra_hosts = "  GitHub.MyCompany.com  ,  RAW.github.mycompany.com  "
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        domains = _trusted_domains()
-        assert "github.mycompany.com" in domains
-        assert "raw.github.mycompany.com" in domains
+        expected = _DEFAULT_TRUSTED_DOMAINS | {
+            "github.mycompany.com",
+            "raw.github.mycompany.com",
+        }
+        assert _trusted_domains() == expected
 
     @patch("registry.services.skill_service.settings")
     def test_defaults_preserved_when_extras_present(
@@ -131,12 +149,13 @@ class TestGHESHostMerge:
         mock_settings.github_extra_hosts = "github.mycompany.com"
         _clear_trusted_domains_cache()
 
-        from registry.services.skill_service import _trusted_domains
+        from registry.services.skill_service import (
+            _DEFAULT_TRUSTED_DOMAINS,
+            _trusted_domains,
+        )
 
-        domains = _trusted_domains()
-        assert "github.com" in domains
-        assert "gitlab.com" in domains
-        assert "github.mycompany.com" in domains
+        # Subset assertion: every default must still be in the merged set.
+        assert _DEFAULT_TRUSTED_DOMAINS <= _trusted_domains()
 
 
 # =============================================================================

--- a/tests/unit/services/test_skill_service_ssrf_allowlist.py
+++ b/tests/unit/services/test_skill_service_ssrf_allowlist.py
@@ -1,0 +1,255 @@
+"""
+Unit tests for SKILL.md SSRF allowlist derivation.
+
+These tests verify that the SSRF allowlist used by skill_service._is_safe_url
+honours settings.github_extra_hosts so GitHub Enterprise (GHES) hosts -- which
+typically resolve to private IPs -- can be reached for SKILL.md fetching once
+the operator has explicitly trusted them via configuration.
+
+Issue #938: Support SKILLS from Github Enterprise.
+"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _clear_trusted_domains_cache() -> None:
+    """Reset the lru_cache so each test sees the patched settings value."""
+    from registry.services.skill_service import _trusted_domains
+
+    _trusted_domains.cache_clear()
+
+
+# =============================================================================
+# Default allowlist (no GHES configured)
+# =============================================================================
+
+
+class TestDefaultTrustedDomains:
+    """Built-in allowlist behaviour when github_extra_hosts is empty."""
+
+    @patch("registry.services.skill_service.settings")
+    def test_default_hosts_are_trusted(
+        self,
+        mock_settings,
+    ) -> None:
+        """github.com, gitlab.com, raw.githubusercontent.com, bitbucket.org always trusted."""
+        mock_settings.github_extra_hosts = ""
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        domains = _trusted_domains()
+
+        assert "github.com" in domains
+        assert "raw.githubusercontent.com" in domains
+        assert "gitlab.com" in domains
+        assert "bitbucket.org" in domains
+
+    @patch("registry.services.skill_service.settings")
+    def test_unconfigured_ghes_host_not_trusted(
+        self,
+        mock_settings,
+    ) -> None:
+        """A GHES hostname not in github_extra_hosts is not in the allowlist."""
+        mock_settings.github_extra_hosts = ""
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        assert "github.mycompany.com" not in _trusted_domains()
+
+
+# =============================================================================
+# GHES hosts via github_extra_hosts
+# =============================================================================
+
+
+class TestGHESHostMerge:
+    """Configured GHES hosts are merged into the allowlist."""
+
+    @patch("registry.services.skill_service.settings")
+    def test_single_ghes_host_added(
+        self,
+        mock_settings,
+    ) -> None:
+        """One configured GHES host appears in the trusted set."""
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        assert "github.mycompany.com" in _trusted_domains()
+
+    @patch("registry.services.skill_service.settings")
+    def test_multiple_ghes_hosts_added(
+        self,
+        mock_settings,
+    ) -> None:
+        """Comma-separated GHES hosts all appear in the trusted set."""
+        mock_settings.github_extra_hosts = (
+            "github.mycompany.com,raw.github.mycompany.com"
+        )
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        domains = _trusted_domains()
+        assert "github.mycompany.com" in domains
+        assert "raw.github.mycompany.com" in domains
+
+    @patch("registry.services.skill_service.settings")
+    def test_whitespace_and_case_normalised(
+        self,
+        mock_settings,
+    ) -> None:
+        """Whitespace is stripped and hostnames are lowercased."""
+        mock_settings.github_extra_hosts = "  GitHub.MyCompany.com  ,  RAW.github.mycompany.com  "
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        domains = _trusted_domains()
+        assert "github.mycompany.com" in domains
+        assert "raw.github.mycompany.com" in domains
+
+    @patch("registry.services.skill_service.settings")
+    def test_defaults_preserved_when_extras_present(
+        self,
+        mock_settings,
+    ) -> None:
+        """Adding GHES hosts does not drop the built-in defaults."""
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _trusted_domains
+
+        domains = _trusted_domains()
+        assert "github.com" in domains
+        assert "gitlab.com" in domains
+        assert "github.mycompany.com" in domains
+
+
+# =============================================================================
+# _is_safe_url integration with the merged allowlist
+# =============================================================================
+
+
+class TestSafeUrlForGHES:
+    """End-to-end: GHES URLs bypass the private-IP check once configured."""
+
+    @patch("registry.services.skill_service.settings")
+    def test_ghes_url_blocked_when_not_configured(
+        self,
+        mock_settings,
+    ) -> None:
+        """Without github_extra_hosts, GHES on a private IP fails SSRF."""
+        mock_settings.github_extra_hosts = ""
+        _clear_trusted_domains_cache()
+
+        # Simulate DNS resolving the GHES host to an internal IP (10.0.0.5).
+        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [
+                (None, None, None, None, ("10.0.0.5", 443)),
+            ]
+
+            from registry.services.skill_service import _is_safe_url
+
+            url = "https://github.mycompany.com/org/repo/blob/main/SKILL.md"
+            assert _is_safe_url(url) is False
+
+    @patch("registry.services.skill_service.settings")
+    def test_ghes_url_allowed_when_configured(
+        self,
+        mock_settings,
+    ) -> None:
+        """With github_extra_hosts set, GHES on a private IP passes SSRF."""
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+        _clear_trusted_domains_cache()
+
+        # DNS resolution should be skipped entirely for trusted hosts -- we
+        # patch getaddrinfo to ensure the test fails loudly if it gets called.
+        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.side_effect = AssertionError(
+                "getaddrinfo should not be called for trusted hosts"
+            )
+
+            from registry.services.skill_service import _is_safe_url
+
+            url = "https://github.mycompany.com/org/repo/blob/main/SKILL.md"
+            assert _is_safe_url(url) is True
+
+    @patch("registry.services.skill_service.settings")
+    def test_raw_ghes_url_allowed_when_configured(
+        self,
+        mock_settings,
+    ) -> None:
+        """raw.* GHES host trusted when listed in github_extra_hosts."""
+        mock_settings.github_extra_hosts = "raw.github.mycompany.com"
+        _clear_trusted_domains_cache()
+
+        from registry.services.skill_service import _is_safe_url
+
+        url = "https://raw.github.mycompany.com/org/repo/refs/heads/main/SKILL.md"
+        assert _is_safe_url(url) is True
+
+    @patch("registry.services.skill_service.settings")
+    def test_unconfigured_internal_host_still_blocked(
+        self,
+        mock_settings,
+    ) -> None:
+        """A non-GitHub internal host on a private IP is still blocked.
+
+        Confirms the allowlist is narrow: only configured GHES hosts skip the
+        IP check, not arbitrary internal hostnames.
+        """
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+        _clear_trusted_domains_cache()
+
+        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [
+                (None, None, None, None, ("10.0.0.5", 443)),
+            ]
+
+            from registry.services.skill_service import _is_safe_url
+
+            assert _is_safe_url("https://internal.example.com/foo") is False
+
+
+# =============================================================================
+# Cache invalidation
+# =============================================================================
+
+
+class TestCacheBehavior:
+    """The lru_cache on _trusted_domains is one-shot per process by design."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        _clear_trusted_domains_cache()
+        yield
+        _clear_trusted_domains_cache()
+
+    @patch("registry.services.skill_service.settings")
+    def test_cache_returns_same_frozenset(
+        self,
+        mock_settings,
+    ) -> None:
+        """Repeated calls return the cached frozenset without re-reading settings."""
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+
+        from registry.services.skill_service import _trusted_domains
+
+        first = _trusted_domains()
+        second = _trusted_domains()
+
+        assert first is second


### PR DESCRIPTION
## Summary

Partial fix for #938: makes the SKILL.md SSRF allowlist honour `GITHUB_EXTRA_HOSTS` so GitHub Enterprise Server (GHES) instances on private/internal networks can be reached for SKILL.md fetching.

### Problem
The SKILL.md fetch path runs every URL through an SSRF private-IP check at [skill_service.py:_is_safe_url](registry/services/skill_service.py). The trusted-domain set that bypasses this check was a hard-coded `frozenset({"github.com", "gitlab.com", "raw.githubusercontent.com", "bitbucket.org"})`. GHES instances typically resolve to RFC1918 addresses, so even though PR #782 added `GITHUB_EXTRA_HOSTS` for auth-header injection, every SKILL.md fetch, health check, content request, and resource fetch to a GHES host was blocked before the request left the process. Auth headers being plumbed didn't help when the request never went out.

### Fix
- Rename the static `TRUSTED_DOMAINS` frozenset to `_DEFAULT_TRUSTED_DOMAINS` (built-in defaults preserved; no behaviour change for existing GitLab/Bitbucket users).
- Add `_trusted_domains()` helper that merges defaults with hosts parsed from `settings.github_extra_hosts` (lru-cached; settings are immutable per-process).
- `_is_safe_url()` now consults the merged set.

Reusing `GITHUB_EXTRA_HOSTS` keeps the trust model consistent: a host an operator has authorised to receive GitHub credentials is, by the same act, declared trustworthy enough to skip the private-IP check. One config knob, two enforcement points.

### Documentation
- `.env.example` and the `github_extra_hosts` Pydantic field description now spell out the dual purpose (auth allowlist + SSRF allowlist) so operators understand the security implication.

### What this PR does NOT do
Issue #938 has additional work that is intentionally out of scope here:
- `_resolve_tree_api` is still a stub (see [skill_service.py:218-241](registry/services/skill_service.py#L218-L241)) — multi-file resource discovery for GitHub/GHES needs a follow-up.
- The small caller-side shape fix in `_discover_skill_resources` for the GitHub Trees API response payload.
- UI rendering of discovered resources is tracked separately in #1111.

This PR addresses only the SSRF gap, which was the single hard blocker that prevented any GHES SKILL.md interaction from working.

## Test plan
- [x] 11 new unit tests in `tests/unit/services/test_skill_service_ssrf_allowlist.py` cover defaults, GHES merge (single, multiple, whitespace/case normalisation, defaults preserved), `_is_safe_url` integration (blocked when unconfigured, allowed when configured, raw.* host, non-GitHub internal still blocked), and lru_cache behaviour.
- [x] 29/29 existing skill-service and github-auth tests continue to pass (`tests/unit/test_skill_service_github_auth.py`, `tests/unit/test_skill_routes_github_auth.py`, `tests/unit/api/test_skill_inline_content.py`, `tests/unit/test_github_auth.py`).
- [x] `uv run python -m py_compile` clean on all modified files.
- [ ] Manual GHES verification with a SKILL.md URL pointing to an internal `github.mycompany.com` host — operators of GHES deployments should validate before a release.

Closes (partial) #938.
