### PR TITLE
feat(skills): implement GitHub Trees API resource discovery (#938)

### DIFF
--- a/registry/services/github_auth.py
+++ b/registry/services/github_auth.py
@@ -25,11 +25,15 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Default GitHub hosts that receive auth headers
+# Default GitHub hosts that receive auth headers.
+# api.github.com is included so resource discovery's Trees API calls
+# (registry.services.skill_service._discover_skill_resources) authenticate
+# correctly against private repos and avoid the unauthenticated rate limit.
 _DEFAULT_GITHUB_HOSTS: frozenset[str] = frozenset(
     {
         "github.com",
         "raw.githubusercontent.com",
+        "api.github.com",
     }
 )
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -10,6 +10,7 @@ Simplified design:
 import hashlib
 import ipaddress
 import logging
+import re
 import socket
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -235,30 +236,144 @@ _LANG_BY_EXT: dict[str, str] = {
 }
 
 
+# SKILL.md URL path patterns. Public GitHub blob and raw URLs differ;
+# enterprise GitHub instances mirror the public path layout.
+_BLOB_PATH_PATTERN = re.compile(r"^/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$")
+_RAW_PATH_PATTERN = re.compile(r"^/([^/]+)/([^/]+)/refs/heads/([^/]+)/(.+)$")
+
+
+def _api_base_for_skill_host(
+    hostname: str,
+) -> str | None:
+    """Map a SKILL.md hostname (raw or blob, public or GHES) to its REST API base.
+
+    Public GitHub maps to https://api.github.com.  GHES maps to the
+    configured ``settings.github_api_base_url`` only when the configured
+    host matches the SKILL.md host (modulo the optional ``raw.`` prefix).
+
+    Returns None when the hostname is not a recognised GitHub instance.
+    """
+    hostname_lower = hostname.lower()
+    if hostname_lower in ("github.com", "raw.githubusercontent.com"):
+        return "https://api.github.com"
+
+    if "github" not in hostname_lower:
+        return None
+
+    skill_host = hostname_lower[4:] if hostname_lower.startswith("raw.") else hostname_lower
+    configured = settings.github_api_base_url.rstrip("/")
+    configured_host = (urlparse(configured).hostname or "").lower()
+    if configured_host and configured_host == skill_host:
+        return configured
+
+    return None
+
+
 def _resolve_tree_api(
     skill_md_url: str,
 ) -> tuple[str, str, str, str] | None:
-    """Resolve a tree/directory listing API endpoint for a skill URL.
+    """Resolve the GitHub/GHES Trees API endpoint for a SKILL.md URL.
 
-    Returns (tree_api_url, encoded_project, ref, skill_dir) or None
-    when no hosting-platform provider handles the URL.  Override or
-    extend this function to add support for specific Git platforms.
+    Parses both blob-style URLs (``github.com/{owner}/{repo}/blob/{ref}/...``)
+    and raw-content URLs (``raw.githubusercontent.com/{owner}/{repo}/refs/heads/{ref}/...``),
+    plus the corresponding GHES variants.
 
-    .. note::
-       **This is intentionally a stub.**  The default implementation
-       always returns ``None``, which means :func:`_discover_skill_resources`
-       will not find any companion files until a deployment provides a
-       platform-specific implementation (e.g. GitHub Trees API, GitLab
-       Repository Tree, Bitbucket source listing).
+    Returns:
+        (tree_api_url, encoded_project, ref, skill_dir) when the URL is a
+        recognised GitHub/GHES SKILL.md URL, else None.
 
-       Multi-file resource support is fully wired through the rest of the
-       stack (manifest storage, ``/content?resource=...`` serving, drift
-       detection); only the discovery step is gated on this hook.
-       Replace this function — or monkey-patch it from a deployment
-       module — with a provider that returns the tuple described above
-       to enable resource discovery for your hosting platform.
+        - ``tree_api_url``: full Trees API URL with ``recursive=1``.
+        - ``encoded_project``: ``{owner}/{repo}`` (kept for backward compat
+          with the documented contract; GitHub's API uses owner+repo
+          separately so callers can ignore this).
+        - ``ref``: branch name resolved from the SKILL.md URL.
+        - ``skill_dir``: directory portion of the path leading up to
+          ``SKILL.md`` (``""`` when SKILL.md is at the repo root).
     """
-    return None
+    parsed = urlparse(skill_md_url)
+    hostname = parsed.hostname or ""
+    if not hostname:
+        return None
+
+    match = _BLOB_PATH_PATTERN.match(parsed.path) or _RAW_PATH_PATTERN.match(parsed.path)
+    if not match:
+        return None
+
+    owner, repo, ref, file_path = match.groups()
+    skill_dir = file_path.rsplit("/", 1)[0] if "/" in file_path else ""
+
+    api_base = _api_base_for_skill_host(hostname)
+    if not api_base:
+        return None
+
+    tree_url = f"{api_base}/repos/{owner}/{repo}/git/trees/{ref}?recursive=1"
+    return tree_url, f"{owner}/{repo}", ref, skill_dir
+
+
+# Files that live in the skill folder but should never be classified as
+# resources (the SKILL.md itself, plus standard repo metadata).
+_SKILL_DIR_EXCLUDED_FILENAMES: frozenset[str] = frozenset({
+    "SKILL.MD",
+    "README.MD",
+    "LICENSE",
+    "LICENSE.TXT",
+    "LICENSE.MD",
+})
+
+
+def _classify_resource(
+    path: str,
+    skill_dir: str,
+) -> str | None:
+    """Classify a file's resource type given its repo-relative path.
+
+    Two-tier classification:
+      1. Subfolder convention (Anthropic style): if the immediate parent
+         directory is one of references/scripts/agents/assets, use that.
+      2. Flat-skill fallback: when the file lives directly under
+         ``skill_dir`` (no recognised subfolder), classify by extension:
+         ``.py``/``.sh``/``.bash``/``.js``/``.ts`` -> script,
+         ``.md``/``.txt``/``.rst``                 -> reference,
+         everything else                           -> asset.
+
+    Returns None when the file should be excluded from the manifest
+    (e.g. nested test/ directories or build outputs that don't fit the
+    convention).
+    """
+    parts = path.split("/")
+
+    # Subfolder convention -- works regardless of nesting depth.
+    if len(parts) >= 2:
+        subdir = parts[-2]
+        resource_type = _RESOURCE_TYPE_MAP.get(subdir)
+        if resource_type:
+            return resource_type
+
+    # Flat-skill fallback: only files DIRECTLY under skill_dir qualify.
+    # We don't want to vacuum up nested test/, build/, __pycache__/ trees.
+    parent = "/".join(parts[:-1])
+    if parent != skill_dir:
+        return None
+
+    name = parts[-1]
+    if "." not in name:
+        return None
+    ext = "." + name.rsplit(".", 1)[-1].lower()
+
+    if ext in {".py", ".sh", ".bash", ".js", ".ts"}:
+        return "script"
+    if ext in {".md", ".txt", ".rst"}:
+        return "reference"
+    return "asset"
+
+
+def _bucket_for_type(
+    manifest: "SkillResourceManifest",
+    resource_type: str,
+) -> "list[SkillResource] | None":
+    """Return the manifest list corresponding to a resource type."""
+    attr = "references" if resource_type == "reference" else f"{resource_type}s"
+    return getattr(manifest, attr, None)
 
 
 async def _discover_skill_resources(
@@ -269,9 +384,16 @@ async def _discover_skill_resources(
 ) -> "SkillResourceManifest | None":
     """Discover companion resource files in the skill directory.
 
-    Calls the hosting platform's tree/directory listing API to find files
-    alongside SKILL.md and classifies them into the resource manifest.
-    Returns None when the platform is not recognised or on any failure.
+    Calls the hosting platform's tree/directory listing API (currently
+    GitHub / GHES via :func:`_resolve_tree_api`) to find files alongside
+    SKILL.md and classifies them into the resource manifest.
+
+    Classification falls back to extension-based heuristics for skills
+    that keep all files at the skill root (no references/ scripts/ etc.
+    subfolders).  See :func:`_classify_resource`.
+
+    Returns None when the platform is not recognised, the tree fetch
+    fails, or no files classify as resources.
     """
     from ..schemas.skill_models import SkillResource, SkillResourceManifest
 
@@ -286,14 +408,31 @@ async def _discover_skill_resources(
 
     try:
         async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.get(tree_url, headers=headers)
+            # Merge global GitHub auth headers (PAT / GitHub App) so private
+            # repos and rate-limited public repos work.
+            github_headers = await _github_auth.get_auth_headers(tree_url)
+            merged_headers = {**github_headers, **headers}
+            resp = await client.get(tree_url, headers=merged_headers)
             if resp.status_code >= 400:
                 logger.warning("Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url)
                 return None
-            items = resp.json()
+            payload = resp.json()
     except Exception as e:
         logger.warning("Resource discovery error for %s: %s", tree_url, e)
         return None
+
+    # GitHub's Trees API returns {"sha": ..., "url": ..., "tree": [...], "truncated": bool}.
+    # Extract the file list from the "tree" key; fall back to top-level list
+    # so a future hosting-platform provider that returns a bare array still works.
+    if isinstance(payload, dict):
+        items = payload.get("tree")
+        if payload.get("truncated"):
+            logger.warning(
+                "Trees API response truncated for %s; manifest may be incomplete",
+                tree_url,
+            )
+    else:
+        items = payload
 
     if not isinstance(items, list):
         return None
@@ -303,20 +442,32 @@ async def _discover_skill_resources(
         if item.get("type") != "blob":
             continue
         path = item.get("path", "")
-        name = item.get("name", "")
-        if name.upper() == "SKILL.MD" or name.upper() == "README.MD" or name.upper() == "LICENSE.TXT":
+        if not path:
             continue
 
-        parts = path.split("/")
-        if len(parts) < 2:
+        # Restrict to files inside the skill directory so we don't
+        # surface unrelated repo content.
+        if skill_dir_prefix and not path.startswith(skill_dir_prefix):
             continue
-        subdir = parts[-2]  # immediate parent directory
-        resource_type = _RESOURCE_TYPE_MAP.get(subdir)
+
+        # Skip the SKILL.md itself and standard repo metadata files.
+        name = path.rsplit("/", 1)[-1]
+        if name.upper() in _SKILL_DIR_EXCLUDED_FILENAMES:
+            continue
+
+        # Drop hidden files / directories (e.g. __pycache__/, .DS_Store)
+        # WITHIN the skill folder. Don't reject parts of the path that
+        # appear in skill_dir itself (e.g. ".claude/skills/usage-report"
+        # is a perfectly valid skill location).
+        relative_path = path[len(skill_dir_prefix):] if path.startswith(skill_dir_prefix) else path
+        if any(part.startswith(".") or part.startswith("__") for part in relative_path.split("/")):
+            continue
+
+        resource_type = _classify_resource(path, skill_dir)
         if not resource_type:
             continue
 
         ext = "." + name.rsplit(".", 1)[-1].lower() if "." in name else ""
-        relative_path = path[len(skill_dir_prefix):] if path.startswith(skill_dir_prefix) else path
 
         resource = SkillResource(
             path=relative_path,
@@ -325,7 +476,7 @@ async def _discover_skill_resources(
             language=_LANG_BY_EXT.get(ext),
         )
 
-        bucket = getattr(manifest, f"{resource_type}s" if resource_type != "reference" else "references", None)
+        bucket = _bucket_for_type(manifest, resource_type)
         if bucket is not None:
             bucket.append(resource)
 

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -365,13 +365,10 @@ class TestDiscoverSkillResources:
             "https://github.com/foo/bar/blob/main/x/SKILL.md",
         )
 
-        # Locate the AsyncClient.get call and confirm auth header was passed.
-        with patch("registry.services.skill_service.httpx.AsyncClient"):
-            pass  # client mock is already configured by the fixture
-        # The fixture's get is invoked once per call; inspect via the mock.
-        # The fixture exposes the response, but the get is on the client_instance.
-        # Re-import the fixture's parent client_instance for assertion:
-        # Easier route: ensure get_auth_headers was invoked with the tree URL.
-        mock_github_auth.get_auth_headers.assert_awaited()
-        call_arg = mock_github_auth.get_auth_headers.await_args.args[0]
-        assert "api.github.com" in call_arg
+        # Confirm get_auth_headers was awaited against the exact Trees API URL
+        # (full-equality assertion -- avoids CodeQL's
+        # py/incomplete-url-substring-sanitization rule, and is also stricter
+        # because it would catch a regression that called the wrong endpoint).
+        mock_github_auth.get_auth_headers.assert_awaited_once_with(
+            "https://api.github.com/repos/foo/bar/git/trees/main?recursive=1",
+        )

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -1,0 +1,377 @@
+"""
+Unit tests for resource discovery (issue #938 follow-up).
+
+Covers:
+  - _resolve_tree_api: blob URLs, raw URLs, GHES URLs, malformed input.
+  - _classify_resource: subfolder convention + flat-skill fallback.
+  - _discover_skill_resources: GitHub Trees API response shape, auth
+    header merge, flat-skill happy path, mixed-classification, hidden
+    file exclusion.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from registry.schemas.skill_models import SkillResourceManifest
+from registry.services.skill_service import (
+    _classify_resource,
+    _discover_skill_resources,
+    _resolve_tree_api,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# _resolve_tree_api
+# =============================================================================
+
+
+class TestResolveTreeApi:
+    """URL parsing for the GitHub/GHES Trees API."""
+
+    def test_public_blob_url(self):
+        url = "https://github.com/anthropics/skills/blob/main/example/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        tree_url, project, ref, skill_dir = result
+        assert tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        assert project == "anthropics/skills"
+        assert ref == "main"
+        assert skill_dir == "example"
+
+    def test_public_raw_url(self):
+        url = "https://raw.githubusercontent.com/anthropics/skills/refs/heads/main/example/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        tree_url, _, ref, skill_dir = result
+        assert tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        assert ref == "main"
+        assert skill_dir == "example"
+
+    def test_skill_at_repo_root_yields_empty_skill_dir(self):
+        url = "https://github.com/foo/bar/blob/main/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        _, _, _, skill_dir = result
+        assert skill_dir == ""
+
+    def test_nested_skill_path(self):
+        url = (
+            "https://raw.githubusercontent.com/agentic-community/mcp-gateway-registry/"
+            "refs/heads/main/.claude/skills/usage-report/SKILL.md"
+        )
+        result = _resolve_tree_api(url)
+        assert result is not None
+        _, project, _, skill_dir = result
+        assert project == "agentic-community/mcp-gateway-registry"
+        assert skill_dir == ".claude/skills/usage-report"
+
+    def test_branch_name_with_special_chars_is_preserved(self):
+        url = "https://github.com/foo/bar/blob/feature%2Fnew/skill/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        _, _, ref, _ = result
+        # Branch is taken verbatim from the URL path (already URL-encoded).
+        assert ref == "feature%2Fnew"
+
+    def test_non_github_returns_none(self):
+        url = "https://gitlab.com/foo/bar/blob/main/SKILL.md"
+        assert _resolve_tree_api(url) is None
+
+    def test_malformed_path_returns_none(self):
+        url = "https://github.com/just/two-segments/SKILL.md"
+        assert _resolve_tree_api(url) is None
+
+    def test_missing_hostname_returns_none(self):
+        assert _resolve_tree_api("not a url at all") is None
+
+    @patch("registry.services.skill_service.settings")
+    def test_ghes_blob_url_with_matching_api_base(
+        self,
+        mock_settings,
+    ):
+        mock_settings.github_api_base_url = "https://github.mycompany.com/api/v3"
+        url = "https://github.mycompany.com/team/repo/blob/develop/skills/x/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        tree_url, project, ref, skill_dir = result
+        assert tree_url == (
+            "https://github.mycompany.com/api/v3/repos/team/repo/git/trees/develop?recursive=1"
+        )
+        assert project == "team/repo"
+        assert ref == "develop"
+        assert skill_dir == "skills/x"
+
+    @patch("registry.services.skill_service.settings")
+    def test_ghes_raw_url_with_matching_api_base(
+        self,
+        mock_settings,
+    ):
+        mock_settings.github_api_base_url = "https://github.mycompany.com/api/v3"
+        url = "https://raw.github.mycompany.com/team/repo/refs/heads/main/skills/x/SKILL.md"
+        result = _resolve_tree_api(url)
+        assert result is not None
+        tree_url, _, _, _ = result
+        assert tree_url.startswith("https://github.mycompany.com/api/v3/")
+
+    @patch("registry.services.skill_service.settings")
+    def test_ghes_url_when_api_base_does_not_match(
+        self,
+        mock_settings,
+    ):
+        # Configured api base host (github.acme.com) doesn't match the
+        # SKILL.md host (github.mycompany.com) -- we cannot safely guess
+        # the API endpoint, so return None.
+        mock_settings.github_api_base_url = "https://github.acme.com/api/v3"
+        url = "https://github.mycompany.com/team/repo/blob/main/SKILL.md"
+        assert _resolve_tree_api(url) is None
+
+
+# =============================================================================
+# _classify_resource
+# =============================================================================
+
+
+class TestClassifyResource:
+    """Two-tier classification: subfolder convention then extension fallback."""
+
+    def test_subfolder_references(self):
+        assert _classify_resource("example/references/arch.md", "example") == "reference"
+
+    def test_subfolder_scripts(self):
+        assert _classify_resource("example/scripts/run.sh", "example") == "script"
+
+    def test_subfolder_agents(self):
+        assert _classify_resource("example/agents/coder.md", "example") == "agent"
+
+    def test_subfolder_assets(self):
+        assert _classify_resource("example/assets/diagram.png", "example") == "asset"
+
+    def test_flat_skill_python_is_script(self):
+        assert _classify_resource("usage-report/run.py", "usage-report") == "script"
+
+    def test_flat_skill_shell_is_script(self):
+        assert _classify_resource("usage-report/install.sh", "usage-report") == "script"
+
+    def test_flat_skill_markdown_is_reference(self):
+        assert _classify_resource("usage-report/notes.md", "usage-report") == "reference"
+
+    def test_flat_skill_unknown_extension_is_asset(self):
+        assert _classify_resource("usage-report/style.css", "usage-report") == "asset"
+
+    def test_flat_skill_root_skill_dir(self):
+        # SKILL.md is at the repo root; flat fallback uses skill_dir == "".
+        assert _classify_resource("run.py", "") == "script"
+
+    def test_nested_unrecognised_subfolder_returns_none(self):
+        # tests/test_run.py is not a recognised resource subfolder, and it's
+        # not directly under the skill_dir, so it should not be classified.
+        assert _classify_resource("usage-report/tests/test_run.py", "usage-report") is None
+
+    def test_file_without_extension_returns_none(self):
+        assert _classify_resource("usage-report/Makefile", "usage-report") is None
+
+
+# =============================================================================
+# _discover_skill_resources (integration-style with mocked HTTP)
+# =============================================================================
+
+
+def _trees_payload(items: list[dict], truncated: bool = False) -> dict:
+    """Build a GitHub Trees API response envelope."""
+    return {
+        "sha": "deadbeef",
+        "url": "https://api.github.com/...",
+        "tree": items,
+        "truncated": truncated,
+    }
+
+
+class TestDiscoverSkillResources:
+    """End-to-end discovery: URL -> tree fetch -> classified manifest."""
+
+    @pytest.fixture
+    def mock_github_auth(self):
+        with patch(
+            "registry.services.skill_service._github_auth",
+        ) as auth:
+            auth.get_auth_headers = AsyncMock(return_value={})
+            yield auth
+
+    @pytest.fixture
+    def mock_async_client(self):
+        """Patch httpx.AsyncClient and yield the mock response object."""
+        with patch("registry.services.skill_service.httpx.AsyncClient") as client_cls:
+            response = MagicMock()
+            response.status_code = 200
+            response.json = MagicMock()
+
+            client_instance = MagicMock()
+            client_instance.get = AsyncMock(return_value=response)
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            client_cls.return_value = client_instance
+
+            yield response
+
+    async def test_returns_none_when_url_unrecognised(self):
+        result = await _discover_skill_resources("https://gitlab.com/foo/bar/SKILL.md")
+        assert result is None
+
+    async def test_subfolder_skill_classified_correctly(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        mock_async_client.json.return_value = _trees_payload([
+            {"type": "blob", "path": "example/SKILL.md", "size": 1000},
+            {"type": "blob", "path": "example/references/arch.md", "size": 200},
+            {"type": "blob", "path": "example/scripts/run.sh", "size": 300},
+            {"type": "blob", "path": "example/agents/coder.md", "size": 400},
+            {"type": "blob", "path": "example/assets/diagram.png", "size": 500},
+            # Tree entries other than the skill folder must be ignored.
+            {"type": "blob", "path": "other-skill/SKILL.md", "size": 999},
+            {"type": "tree", "path": "example/references", "size": 0},
+        ])
+
+        manifest = await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/example/SKILL.md",
+        )
+        assert isinstance(manifest, SkillResourceManifest)
+        assert [r.path for r in manifest.references] == ["references/arch.md"]
+        assert [r.path for r in manifest.scripts] == ["scripts/run.sh"]
+        assert [r.path for r in manifest.agents] == ["agents/coder.md"]
+        assert [r.path for r in manifest.assets] == ["assets/diagram.png"]
+
+    async def test_flat_skill_extension_fallback(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        # Mirrors the agentic-community/mcp-gateway-registry usage-report layout.
+        mock_async_client.json.return_value = _trees_payload([
+            {"type": "blob", "path": ".claude/skills/usage-report/SKILL.md", "size": 1000},
+            {"type": "blob", "path": ".claude/skills/usage-report/analyze.py", "size": 200},
+            {"type": "blob", "path": ".claude/skills/usage-report/install.sh", "size": 50},
+            {"type": "blob", "path": ".claude/skills/usage-report/notes.md", "size": 80},
+            {"type": "blob", "path": ".claude/skills/usage-report/style.css", "size": 60},
+            # Hidden / pycache content should be filtered.
+            {"type": "blob", "path": ".claude/skills/usage-report/__pycache__/x.pyc", "size": 90},
+            {"type": "blob", "path": ".claude/skills/usage-report/.DS_Store", "size": 5},
+        ])
+
+        manifest = await _discover_skill_resources(
+            "https://raw.githubusercontent.com/agentic-community/mcp-gateway-registry/"
+            "refs/heads/main/.claude/skills/usage-report/SKILL.md",
+        )
+        assert isinstance(manifest, SkillResourceManifest)
+        assert {r.path for r in manifest.scripts} == {"analyze.py", "install.sh"}
+        assert {r.path for r in manifest.references} == {"notes.md"}
+        assert {r.path for r in manifest.assets} == {"style.css"}
+        assert manifest.agents == []
+
+    async def test_excludes_skill_md_readme_license(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        mock_async_client.json.return_value = _trees_payload([
+            {"type": "blob", "path": "x/SKILL.md", "size": 100},
+            {"type": "blob", "path": "x/README.md", "size": 100},
+            {"type": "blob", "path": "x/LICENSE", "size": 100},
+            {"type": "blob", "path": "x/run.py", "size": 100},
+        ])
+        manifest = await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/x/SKILL.md",
+        )
+        assert manifest is not None
+        assert {r.path for r in manifest.scripts} == {"run.py"}
+        assert manifest.references == []
+
+    async def test_returns_none_when_no_classified_resources(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        mock_async_client.json.return_value = _trees_payload([
+            {"type": "blob", "path": "x/SKILL.md", "size": 100},
+            {"type": "blob", "path": "x/Makefile", "size": 100},  # no extension
+        ])
+        result = await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/x/SKILL.md",
+        )
+        assert result is None
+
+    async def test_truncated_response_logs_warning(
+        self,
+        mock_github_auth,
+        mock_async_client,
+        caplog,
+    ):
+        mock_async_client.json.return_value = _trees_payload(
+            [{"type": "blob", "path": "x/r.py", "size": 1}],
+            truncated=True,
+        )
+        with caplog.at_level(logging.WARNING):
+            manifest = await _discover_skill_resources(
+                "https://github.com/foo/bar/blob/main/x/SKILL.md",
+            )
+        assert manifest is not None
+        assert any("truncated" in m for m in caplog.messages)
+
+    async def test_http_error_returns_none(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        mock_async_client.status_code = 502
+        result = await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/x/SKILL.md",
+        )
+        assert result is None
+
+    async def test_top_level_array_response_still_works(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        # Forward-compat: a hosting platform that returns a bare array
+        # rather than the GitHub envelope shape should still work.
+        mock_async_client.json.return_value = [
+            {"type": "blob", "path": "x/SKILL.md", "size": 100},
+            {"type": "blob", "path": "x/r.py", "size": 100},
+        ]
+        manifest = await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/x/SKILL.md",
+        )
+        assert manifest is not None
+        assert {r.path for r in manifest.scripts} == {"r.py"}
+
+    async def test_github_auth_headers_merged_into_request(
+        self,
+        mock_github_auth,
+        mock_async_client,
+    ):
+        mock_github_auth.get_auth_headers.return_value = {"Authorization": "Bearer ghs_xxx"}
+        mock_async_client.json.return_value = _trees_payload([
+            {"type": "blob", "path": "x/SKILL.md", "size": 100},
+            {"type": "blob", "path": "x/r.py", "size": 100},
+        ])
+
+        await _discover_skill_resources(
+            "https://github.com/foo/bar/blob/main/x/SKILL.md",
+        )
+
+        # Locate the AsyncClient.get call and confirm auth header was passed.
+        with patch("registry.services.skill_service.httpx.AsyncClient"):
+            pass  # client mock is already configured by the fixture
+        # The fixture's get is invoked once per call; inspect via the mock.
+        # The fixture exposes the response, but the get is on the client_instance.
+        # Re-import the fixture's parent client_instance for assertion:
+        # Easier route: ensure get_auth_headers was invoked with the tree URL.
+        mock_github_auth.get_auth_headers.assert_awaited()
+        call_arg = mock_github_auth.get_auth_headers.await_args.args[0]
+        assert "api.github.com" in call_arg


### PR DESCRIPTION
## Summary

Closes the resource-discovery half of #938 by replacing the long-standing `_resolve_tree_api` stub with a working GitHub / GHES implementation. Combined with the SSRF-allowlist fix in #1112 (already merged), `#938` is now complete for the GitHub family of hosts.

### Problem
Discovery was wired through the rest of the stack (manifest persistence, `/content?resource=...` serving, drift detection, content integrity) but the upstream tree-fetch hook always returned `None`. Every skill in the registry got `resource_manifest = null`, regardless of how many companion files it had. The PR #1110 `_discover_skill_resources` body even acknowledged this with an in-code note.

### Fix
1. **`_resolve_tree_api`**: parses both blob (`github.com/{o}/{r}/blob/{ref}/...`) and raw (`raw.githubusercontent.com/{o}/{r}/refs/heads/{ref}/...`) URLs, plus their GHES equivalents. Returns the Trees API URL with `recursive=1`.
2. **`_api_base_for_skill_host`**: maps the SKILL.md hostname to its REST API base. Public github.com → `api.github.com`. GHES → `settings.github_api_base_url` only when the configured host matches the SKILL.md host (modulo `raw.` prefix). Refuses to guess.
3. **Trees API response-shape fix in `_discover_skill_resources`**: GitHub returns `{"tree": [...], "truncated": ...}`, not a top-level array. The previous code did `if not isinstance(items, list): return None` and bailed. New code extracts `payload["tree"]`, falls back to a top-level array for forward-compat with other hosting platforms, and warns on truncation.
4. **`_classify_resource`** extracted as a helper with two-tier logic:
   - (a) Anthropic subfolder convention: `references/`, `scripts/`, `agents/`, `assets/` — works at any nesting depth.
   - (b) Flat-skill fallback: files **directly under `skill_dir`** classified by extension (`.py/.sh` → script, `.md/.txt` → reference, else asset). Crucial because real-world skills like the in-tree `usage-report` flatten everything at the skill root rather than using subfolders.
5. **GitHub auth merge**: `_github_auth.get_auth_headers()` now runs against the Trees API URL so private repos and rate-limited public repos authenticate correctly.
6. **`api.github.com` added to default GitHub auth hosts** so the auth headers actually reach the Trees endpoint.

### What this PR does NOT do
- No changes to other hosting platforms (GitLab, Bitbucket). The `_resolve_tree_api` contract is left extensible — a deployment can monkey-patch it for additional providers as documented in the original docstring.
- No backend schema changes; manifests use the existing `SkillResourceManifest` shape.
- No frontend changes. The UI work that consumes manifests lives in #1111 (separate PR, depends on this).

### Live verification
Re-discovered the in-tree `usage-report` skill against `agentic-community/mcp-gateway-registry`:

```
$ curl -X POST .../api/skills/usage-report/refresh-resources
{
  "resources_discovered": 13,
  "by_type": {"refs": 0, "scripts": 12, "agents": 0, "assets": 1}
}
```

All 12 Python files (`analyze_*.py`, `generate_*.py`) classified as scripts with `language: python`; `report-style.css` classified as an asset; SKILL.md correctly excluded. Hidden-file filter rejects `__pycache__/` content correctly.

## Test plan
- [x] 31 new unit tests in `tests/unit/services/test_skill_resource_discovery.py` covering URL parsing (blob, raw, GHES, malformed, missing API base), classifier behaviour (subfolder + flat fallback + nested-folder rejection), and discovery integration (envelope shape, top-level array fallback, truncation warning, exclusion of SKILL.md/README/LICENSE, hidden-file filter, auth-header merge).
- [x] 38 existing related tests pass (`test_github_auth.py`, `test_skill_service_ssrf_allowlist.py`, `test_skill_service_github_auth.py`, `test_skill_inline_content.py`).
- [x] Live `POST /refresh-resources` against `agentic-community/mcp-gateway-registry` returns the correct 13-file manifest.
- [x] `uv run python -m py_compile` clean on both modified files.
- [ ] Manual GHES verification — operators of GHES deployments should validate before a release.

Closes #938.
