### PR TITLE
feat(frontend): surface skill companion assets with per-file links and zip download (closes #1111)

### DIFF
--- a/frontend/src/components/DataExport.tsx
+++ b/frontend/src/components/DataExport.tsx
@@ -7,6 +7,7 @@ import {
 } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import JSZip from 'jszip';
+import { triggerBlobDownload } from '../utils/blobDownload';
 
 
 interface ExportableCollection {
@@ -201,21 +202,6 @@ async function _fetchAllPages(
 }
 
 
-function _triggerBlobDownload(
-  blob: Blob,
-  filename: string,
-): void {
-  const url = window.URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.setAttribute('download', filename);
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  window.URL.revokeObjectURL(url);
-}
-
-
 async function _recordAuditEvent(
   exportType: string,
   collections: string[],
@@ -311,7 +297,7 @@ const DataExport: React.FC<DataExportProps> = ({ onShowToast }) => {
       const data = await _fetchAllPages(collection);
       const dateSuffix = _buildDateSuffix();
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-      _triggerBlobDownload(blob, `${collection.filename}-export-${dateSuffix}.json`);
+      triggerBlobDownload(blob, `${collection.filename}-export-${dateSuffix}.json`);
       await _recordAuditEvent('single', [collection.id]);
       onShowToast(`Downloaded ${collection.label} (${data.length} records)`, 'success');
     } catch (err: any) {
@@ -341,7 +327,7 @@ const DataExport: React.FC<DataExportProps> = ({ onShowToast }) => {
 
     try {
       const blob = await zip.generateAsync({ type: 'blob' });
-      _triggerBlobDownload(blob, `registry-export-${dateSuffix}.zip`);
+      triggerBlobDownload(blob, `registry-export-${dateSuffix}.zip`);
       const exportedIds = EXPORTABLE_COLLECTIONS
         .filter((c) => !failedIds.includes(c.id))
         .map((c) => c.id);

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -21,7 +21,7 @@ import {
   ShieldCheckIcon,
   ShieldExclamationIcon,
 } from '@heroicons/react/24/outline';
-import { Skill } from '../types/skill';
+import { Skill, SkillResourceManifest } from '../types/skill';
 import StatusBadge from './StatusBadge';
 import StarRatingWidget from './StarRatingWidget';
 import SecurityScanModal from './SecurityScanModal';
@@ -132,6 +132,10 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
   const [showDetails, setShowDetails] = useState(false);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const [skillMdContent, setSkillMdContent] = useState<string | null>(null);
+  // resource_manifest is exposed by /content but NOT by the listing schema
+  // (SkillInfo). Capture it from the same /content fetch the modal already
+  // makes so the Resources section can render against the modal-scoped data.
+  const [resourceManifest, setResourceManifest] = useState<SkillResourceManifest | null>(null);
 
   useEscapeKey(() => setShowDetails(false), showDetails);
   const [loadingToolCheck, setLoadingToolCheck] = useState(false);
@@ -211,6 +215,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
     setShowDetails(true);
     setLoadingDetails(true);
     setSkillMdContent(null);
+    setResourceManifest(null);
 
     try {
       // Fetch SKILL.md content via backend proxy to avoid CORS issues
@@ -220,6 +225,7 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
         headers ? { headers } : undefined
       );
       setSkillMdContent(response.data.content);
+      setResourceManifest(response.data.resource_manifest ?? null);
     } catch (error: any) {
       console.error('Failed to fetch SKILL.md content:', error);
       const detail = error.response?.data?.detail;
@@ -763,12 +769,18 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                       </div>
                     )}
                     {/* Resources section (self-gated: hidden for federated skills,
-                        empty manifests, and skills without manifests). */}
+                        empty manifests, and skills without manifests).
+
+                        The manifest is sourced from the /content fetch above
+                        because the listing schema (SkillInfo) intentionally
+                        omits resource_manifest to keep the listing payload
+                        small; only the full SkillCard exposes it. */}
                     <SkillResources
                       skill={skill}
                       skillApiPath={skillApiPath}
                       authToken={authToken}
                       skillMdContent={skillMdContent}
+                      resourceManifest={resourceManifest}
                     />
                     {/* Markdown Body */}
                     <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:text-amber-800 dark:prose-headings:text-amber-200 prose-a:text-amber-600 dark:prose-a:text-amber-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-900 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-gray-100 dark:prose-pre:bg-gray-900">

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -27,6 +27,7 @@ import StarRatingWidget from './StarRatingWidget';
 import SecurityScanModal from './SecurityScanModal';
 import useEscapeKey from '../hooks/useEscapeKey';
 import ResourceBoundTokenButton from './ResourceBoundTokenButton';
+import SkillResources from './SkillResources';
 
 /**
  * Props for the SkillCard component.
@@ -761,6 +762,14 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                         </table>
                       </div>
                     )}
+                    {/* Resources section (self-gated: hidden for federated skills,
+                        empty manifests, and skills without manifests). */}
+                    <SkillResources
+                      skill={skill}
+                      skillApiPath={skillApiPath}
+                      authToken={authToken}
+                      skillMdContent={skillMdContent}
+                    />
                     {/* Markdown Body */}
                     <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:text-amber-800 dark:prose-headings:text-amber-200 prose-a:text-amber-600 dark:prose-a:text-amber-400 prose-code:bg-gray-100 dark:prose-code:bg-gray-900 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-pre:bg-gray-100 dark:prose-pre:bg-gray-900">
                       <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>

--- a/frontend/src/components/SkillResources.tsx
+++ b/frontend/src/components/SkillResources.tsx
@@ -424,6 +424,11 @@ export interface SkillResourcesProps {
   // and we'd rather widen here than force callers to coalesce.
   authToken: string | null | undefined;
   skillMdContent: string | null;
+  // Manifest captured from the /content API response. Passed in explicitly
+  // because the skills LISTING schema (SkillInfo) intentionally omits
+  // resource_manifest -- so skill.resource_manifest is undefined in the
+  // Discover view and we can't read it off the skill prop.
+  resourceManifest: SkillResourceManifest | null;
 }
 
 
@@ -439,11 +444,12 @@ export default function SkillResources({
   skillApiPath,
   authToken,
   skillMdContent,
+  resourceManifest,
 }: SkillResourcesProps): React.ReactElement | null {
   // Federated skills are excluded for v1 (LLD Resolution #1).
   if (skill.registry_name && skill.registry_name !== 'local') return null;
-  if (!skill.resource_manifest) return null;
-  if (!_hasAnyResource(skill.resource_manifest)) return null;
+  if (!resourceManifest) return null;
+  if (!_hasAnyResource(resourceManifest)) return null;
 
   return (
     <SkillResourcesInner
@@ -451,7 +457,7 @@ export default function SkillResources({
       skillApiPath={skillApiPath}
       authToken={authToken ?? null}
       skillMdContent={skillMdContent}
-      manifest={skill.resource_manifest}
+      manifest={resourceManifest}
     />
   );
 }

--- a/frontend/src/components/SkillResources.tsx
+++ b/frontend/src/components/SkillResources.tsx
@@ -1,0 +1,660 @@
+import React, { useCallback, useState } from 'react';
+import axios from 'axios';
+import JSZip from 'jszip';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import {
+  ArrowDownTrayIcon,
+  ArrowLeftIcon,
+  EyeIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline';
+import { Skill, SkillResource, SkillResourceManifest } from '../types/skill';
+import { triggerBlobDownload } from '../utils/blobDownload';
+
+// Cap constants for the one-click "Download all" zip path. Per-file sizes
+// are independently capped server-side at 512 KB (skill_routes.py:453).
+const MAX_BUNDLE_FILES = 50;
+const MAX_BUNDLE_BYTES = 10 * 1024 * 1024; // 10 MB
+const FETCH_CONCURRENCY = 4;
+
+// Resources whose contents render usefully inline (markdown / code).
+// Assets are treated as opaque in v1 (download-only) since the server
+// returns content as UTF-8 text and binary assets would be corrupted.
+const TEXT_PREVIEWABLE_TYPES: ReadonlySet<SkillResource['type']> = new Set<SkillResource['type']>(
+  ['script', 'reference', 'agent'],
+);
+
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+
+function _slugify(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+
+function _formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+
+function _basename(path: string): string {
+  const idx = path.lastIndexOf('/');
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+
+function _flattenManifest(m: SkillResourceManifest): SkillResource[] {
+  return [
+    ...m.references,
+    ...m.scripts,
+    ...m.agents,
+    ...m.assets,
+  ];
+}
+
+
+function _hasAnyResource(m: SkillResourceManifest): boolean {
+  return (
+    m.scripts.length + m.references.length + m.agents.length + m.assets.length
+  ) > 0;
+}
+
+
+function _sortByPath(resources: SkillResource[]): SkillResource[] {
+  return [...resources].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+
+type CapResult = { over: true; reason: string } | { over: false };
+
+
+function _isOverCap(resources: SkillResource[]): CapResult {
+  // SKILL.md adds 1 file to the bundle; its size is unknown until fetched
+  // but is small in practice and not counted toward the byte cap here.
+  if (resources.length + 1 > MAX_BUNDLE_FILES) {
+    return {
+      over: true,
+      reason: `Bundle has ${resources.length + 1} files; cap is ${MAX_BUNDLE_FILES}.`,
+    };
+  }
+  const total = resources.reduce((sum, r) => sum + r.size_bytes, 0);
+  if (total > MAX_BUNDLE_BYTES) {
+    return {
+      over: true,
+      reason: `Bundle is ${_formatSize(total)}; cap is ${_formatSize(MAX_BUNDLE_BYTES)}.`,
+    };
+  }
+  return { over: false };
+}
+
+
+async function _fetchResource(
+  skillApiPath: string,
+  resourcePath: string,
+  authToken: string | null,
+): Promise<{ path: string; content: string }> {
+  const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+  const resp = await axios.get(
+    `/api/skills${skillApiPath}/content`,
+    {
+      params: { resource: resourcePath },
+      ...(headers ? { headers } : {}),
+    },
+  );
+  return { path: resourcePath, content: resp.data.content as string };
+}
+
+
+/**
+ * Fetch every resource in `resources` with at most FETCH_CONCURRENCY
+ * requests in flight at any time. Errors are captured per-file rather
+ * than aborting the whole batch.
+ */
+async function _fetchAllWithConcurrency(
+  skillApiPath: string,
+  resources: SkillResource[],
+  authToken: string | null,
+  onProgress: (done: number, total: number) => void,
+): Promise<{
+  successes: { path: string; content: string }[];
+  failures: { path: string; error: string }[];
+}> {
+  const successes: { path: string; content: string }[] = [];
+  const failures: { path: string; error: string }[] = [];
+  const queue = [...resources];
+  let done = 0;
+
+  async function _worker(): Promise<void> {
+    while (queue.length > 0) {
+      const next = queue.shift();
+      if (!next) return;
+      try {
+        const result = await _fetchResource(skillApiPath, next.path, authToken);
+        successes.push(result);
+      } catch (e: any) {
+        const status = e?.response?.status;
+        failures.push({
+          path: next.path,
+          error: status ? `HTTP ${status}` : 'fetch failed',
+        });
+      } finally {
+        done += 1;
+        onProgress(done, resources.length);
+      }
+    }
+  }
+
+  const workerCount = Math.min(FETCH_CONCURRENCY, resources.length);
+  await Promise.all(
+    Array.from({ length: workerCount }, () => _worker()),
+  );
+
+  return { successes, failures };
+}
+
+
+async function _buildAndDownloadZip(
+  skill: Skill,
+  skillMdContent: string,
+  fetched: { path: string; content: string }[],
+): Promise<void> {
+  const zip = new JSZip();
+  zip.file('SKILL.md', skillMdContent);
+  for (const r of fetched) {
+    zip.file(r.path, r.content);
+  }
+  const blob = await zip.generateAsync({ type: 'blob' });
+  triggerBlobDownload(blob, `${_slugify(skill.name)}.zip`);
+}
+
+
+// =============================================================================
+// Subcomponent: ResourceItem (one row inside a group)
+// =============================================================================
+
+
+interface ResourceItemProps {
+  resource: SkillResource;
+  skillApiPath: string;
+  authToken: string | null;
+  onPreview: (resource: SkillResource) => void;
+}
+
+
+function ResourceItem({
+  resource,
+  skillApiPath,
+  authToken,
+  onPreview,
+}: ResourceItemProps): React.ReactElement {
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  const _onDownload = useCallback(async () => {
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      const result = await _fetchResource(skillApiPath, resource.path, authToken);
+      const blob = new Blob([result.content], { type: 'text/plain' });
+      triggerBlobDownload(blob, _basename(resource.path));
+    } catch (e: any) {
+      const status = e?.response?.status;
+      setDownloadError(status ? `HTTP ${status}` : 'fetch failed');
+    } finally {
+      setDownloading(false);
+    }
+  }, [skillApiPath, resource.path, authToken]);
+
+  const isPreviewable = TEXT_PREVIEWABLE_TYPES.has(resource.type);
+
+  return (
+    <div className="flex items-center justify-between py-2 px-3 border-b border-gray-200 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-mono text-sm text-gray-900 dark:text-gray-100 truncate">
+            {resource.path}
+          </span>
+          {resource.language && (
+            <span className="px-2 py-0.5 text-xs font-semibold rounded bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300">
+              {resource.language}
+            </span>
+          )}
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {_formatSize(resource.size_bytes)}
+          </span>
+        </div>
+        {downloadError && (
+          <div className="text-xs text-red-600 dark:text-red-400 mt-1" role="alert">
+            {downloadError}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2 ml-3">
+        {isPreviewable && (
+          <button
+            type="button"
+            onClick={() => onPreview(resource)}
+            aria-label={`View ${resource.path}`}
+            className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded text-amber-700 dark:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/30"
+          >
+            <EyeIcon className="h-4 w-4" />
+            View
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={_onDownload}
+          disabled={downloading}
+          aria-label={`Download ${resource.path}`}
+          className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          {downloading ? 'Downloading…' : 'Download'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+
+// =============================================================================
+// Subcomponent: ResourceGroup (collapsible section, one per type)
+// =============================================================================
+
+
+interface ResourceGroupProps {
+  label: string;
+  resources: SkillResource[];
+  skillApiPath: string;
+  authToken: string | null;
+  onPreview: (resource: SkillResource) => void;
+}
+
+
+function ResourceGroup({
+  label,
+  resources,
+  skillApiPath,
+  authToken,
+  onPreview,
+}: ResourceGroupProps): React.ReactElement | null {
+  // Default-collapsed (Resolution #2 in lld.md).
+  const [expanded, setExpanded] = useState(false);
+
+  if (resources.length === 0) return null;
+
+  const sorted = _sortByPath(resources);
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+        className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 dark:bg-gray-900/50 hover:bg-gray-100 dark:hover:bg-gray-800 text-left"
+      >
+        <span className="font-medium text-gray-800 dark:text-gray-200">
+          {label} <span className="text-gray-500 dark:text-gray-400">({resources.length})</span>
+        </span>
+        {expanded ? (
+          <ChevronDownIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        ) : (
+          <ChevronRightIcon className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+        )}
+      </button>
+      {expanded && (
+        <div className="bg-white dark:bg-gray-900">
+          {sorted.map((r) => (
+            <ResourceItem
+              key={r.path}
+              resource={r}
+              skillApiPath={skillApiPath}
+              authToken={authToken}
+              onPreview={onPreview}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+
+// =============================================================================
+// Subcomponent: ResourcePreview (in-modal text/markdown viewer)
+// =============================================================================
+
+
+interface ResourcePreviewProps {
+  resource: SkillResource;
+  skillApiPath: string;
+  authToken: string | null;
+  onBack: () => void;
+}
+
+
+function ResourcePreview({
+  resource,
+  skillApiPath,
+  authToken,
+  onBack,
+}: ResourcePreviewProps): React.ReactElement {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    setError(null);
+    _fetchResource(skillApiPath, resource.path, authToken)
+      .then((result) => {
+        if (!cancelled) setContent(result.content);
+      })
+      .catch((e: any) => {
+        if (cancelled) return;
+        const status = e?.response?.status;
+        setError(status ? `HTTP ${status}` : 'fetch failed');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skillApiPath, resource.path, authToken]);
+
+  // NOTE: react-markdown disables raw HTML by default; do NOT add rehype-raw
+  // without a security review (see review.md, Cipher recommendation #1).
+  const isMarkdown = resource.path.toLowerCase().endsWith('.md');
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3 text-sm">
+        <button
+          type="button"
+          onClick={onBack}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded text-amber-700 dark:text-amber-300 hover:bg-amber-50 dark:hover:bg-amber-900/30"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to SKILL.md
+        </button>
+        <span className="text-gray-400 dark:text-gray-500">›</span>
+        <span className="font-mono text-gray-700 dark:text-gray-300 truncate">
+          {resource.path}
+        </span>
+      </div>
+      {error ? (
+        <div className="text-center py-8 text-red-600 dark:text-red-400">
+          Could not load resource: {error}
+        </div>
+      ) : content === null ? (
+        <div className="flex items-center justify-center py-8">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-amber-600"></div>
+        </div>
+      ) : isMarkdown ? (
+        <div className="prose prose-sm dark:prose-invert max-w-none prose-headings:text-amber-800 dark:prose-headings:text-amber-200 prose-a:text-amber-600 dark:prose-a:text-amber-400">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        </div>
+      ) : (
+        <pre className="bg-gray-100 dark:bg-gray-900 rounded p-4 overflow-x-auto text-xs">
+          <code>{content}</code>
+        </pre>
+      )}
+    </div>
+  );
+}
+
+
+// =============================================================================
+// Public component: SkillResources
+// =============================================================================
+
+
+type BundleStatus = 'idle' | 'preparing' | 'partial' | 'done' | 'error' | 'over-cap';
+
+
+export interface SkillResourcesProps {
+  skill: Skill;
+  skillApiPath: string;
+  // Accept undefined too -- SkillCardProps.authToken is `string | null | undefined`,
+  // and we'd rather widen here than force callers to coalesce.
+  authToken: string | null | undefined;
+  skillMdContent: string | null;
+}
+
+
+/**
+ * Renders the "Resources" section inside a SkillCard modal.
+ *
+ * Self-gated:
+ *   - returns null for federated skills (Resolution #1: registry_name !== 'local').
+ *   - returns null when the manifest is absent or empty.
+ */
+export default function SkillResources({
+  skill,
+  skillApiPath,
+  authToken,
+  skillMdContent,
+}: SkillResourcesProps): React.ReactElement | null {
+  // Federated skills are excluded for v1 (LLD Resolution #1).
+  if (skill.registry_name && skill.registry_name !== 'local') return null;
+  if (!skill.resource_manifest) return null;
+  if (!_hasAnyResource(skill.resource_manifest)) return null;
+
+  return (
+    <SkillResourcesInner
+      skill={skill}
+      skillApiPath={skillApiPath}
+      authToken={authToken ?? null}
+      skillMdContent={skillMdContent}
+      manifest={skill.resource_manifest}
+    />
+  );
+}
+
+
+interface SkillResourcesInnerProps {
+  skill: Skill;
+  skillApiPath: string;
+  authToken: string | null;
+  skillMdContent: string | null;
+  manifest: SkillResourceManifest;
+}
+
+
+// Inner component holds hook state, kept separate so the outer component
+// can short-circuit before any hooks run.
+function SkillResourcesInner({
+  skill,
+  skillApiPath,
+  authToken,
+  skillMdContent,
+  manifest,
+}: SkillResourcesInnerProps): React.ReactElement {
+  const [bundleStatus, setBundleStatus] = useState<BundleStatus>('idle');
+  const [bundleError, setBundleError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number }>({ done: 0, total: 0 });
+  const [selectedResource, setSelectedResource] = useState<SkillResource | null>(null);
+
+  const all = _flattenManifest(manifest);
+  const totalSize = all.reduce((sum, r) => sum + r.size_bytes, 0);
+  const cap = _isOverCap(all);
+
+  const _onDownloadAll = useCallback(async () => {
+    setBundleStatus('preparing');
+    setBundleError(null);
+    setProgress({ done: 0, total: all.length });
+
+    const capCheck = _isOverCap(all);
+    if (capCheck.over) {
+      setBundleStatus('over-cap');
+      setBundleError(capCheck.reason);
+      return;
+    }
+
+    // SKILL.md: prefer already-loaded content; fall back to fetch.
+    let skillMd = skillMdContent;
+    if (!skillMd) {
+      try {
+        const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+        const resp = await axios.get(
+          `/api/skills${skillApiPath}/content`,
+          headers ? { headers } : undefined,
+        );
+        skillMd = resp.data.content as string;
+      } catch {
+        setBundleStatus('error');
+        setBundleError('Could not fetch SKILL.md');
+        return;
+      }
+    }
+
+    const { successes, failures } = await _fetchAllWithConcurrency(
+      skillApiPath,
+      all,
+      authToken,
+      (done, total) => setProgress({ done, total }),
+    );
+
+    // All-fail guard (Resolution #3): do not deliver a SKILL.md-only zip
+    // when every per-resource fetch failed.
+    if (successes.length === 0 && all.length > 0) {
+      setBundleStatus('error');
+      setBundleError('Could not fetch any resources. Try again.');
+      return;
+    }
+
+    await _buildAndDownloadZip(skill, skillMd!, successes);
+
+    if (failures.length > 0) {
+      setBundleStatus('partial');
+      setBundleError(
+        `${failures.length} file(s) failed: ${failures.map((f) => f.path).join(', ')}`,
+      );
+    } else {
+      setBundleStatus('done');
+      setBundleError(null);
+    }
+  }, [skill, skillApiPath, authToken, skillMdContent, all]);
+
+  // Anti-double-click guard (Resolution #5): button is no-op while preparing.
+  const _onDownloadAllClick = () => {
+    if (bundleStatus === 'preparing') return;
+    void _onDownloadAll();
+  };
+
+  if (selectedResource) {
+    return (
+      <ResourcePreview
+        resource={selectedResource}
+        skillApiPath={skillApiPath}
+        authToken={authToken}
+        onBack={() => setSelectedResource(null)}
+      />
+    );
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+          Resources{' '}
+          <span className="font-normal text-gray-500 dark:text-gray-400">
+            ({all.length} {all.length === 1 ? 'file' : 'files'}, {_formatSize(totalSize)})
+          </span>
+        </h3>
+        <button
+          type="button"
+          onClick={_onDownloadAllClick}
+          disabled={cap.over || bundleStatus === 'preparing'}
+          aria-label="Download all classified resources as a zip"
+          className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded bg-amber-600 hover:bg-amber-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          title={cap.over ? cap.reason : undefined}
+        >
+          <ArrowDownTrayIcon className="h-4 w-4" />
+          {bundleStatus === 'preparing' ? 'Preparing…' : 'Download all'}
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+        Download all bundles classified resources only — files outside{' '}
+        <code className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-900">references/</code>,{' '}
+        <code className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-900">scripts/</code>,{' '}
+        <code className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-900">agents/</code>, and{' '}
+        <code className="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-900">assets/</code> are not
+        included.
+      </p>
+
+      {/* aria-live region for screen-reader announcements (Resolution #4). */}
+      <div aria-live="polite" className="sr-only">
+        {bundleStatus === 'preparing' && progress.total > 0 &&
+          `${progress.done} of ${progress.total} files downloaded`}
+        {bundleStatus === 'done' && 'Bundle ready'}
+        {bundleStatus === 'partial' && 'Bundle ready with some failures'}
+      </div>
+
+      {bundleError && bundleStatus !== 'idle' && (
+        <div
+          role="alert"
+          className={`mb-3 px-3 py-2 rounded text-sm ${
+            bundleStatus === 'error' || bundleStatus === 'over-cap'
+              ? 'bg-red-50 dark:bg-red-900/30 text-red-800 dark:text-red-200'
+              : 'bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200'
+          }`}
+        >
+          {bundleError}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <ResourceGroup
+          label="References"
+          resources={manifest.references}
+          skillApiPath={skillApiPath}
+          authToken={authToken}
+          onPreview={setSelectedResource}
+        />
+        <ResourceGroup
+          label="Scripts"
+          resources={manifest.scripts}
+          skillApiPath={skillApiPath}
+          authToken={authToken}
+          onPreview={setSelectedResource}
+        />
+        <ResourceGroup
+          label="Agents"
+          resources={manifest.agents}
+          skillApiPath={skillApiPath}
+          authToken={authToken}
+          onPreview={setSelectedResource}
+        />
+        <ResourceGroup
+          label="Assets"
+          resources={manifest.assets}
+          skillApiPath={skillApiPath}
+          authToken={authToken}
+          onPreview={setSelectedResource}
+        />
+      </div>
+    </div>
+  );
+}
+
+
+// Exported helpers for tests (pure functions; not part of the public API).
+export const __test__ = {
+  _slugify,
+  _formatSize,
+  _basename,
+  _flattenManifest,
+  _hasAnyResource,
+  _isOverCap,
+  _sortByPath,
+  MAX_BUNDLE_FILES,
+  MAX_BUNDLE_BYTES,
+  FETCH_CONCURRENCY,
+};

--- a/frontend/src/components/__tests__/SkillResources.test.tsx
+++ b/frontend/src/components/__tests__/SkillResources.test.tsx
@@ -61,12 +61,22 @@ function makeManifest(overrides: Partial<SkillResourceManifest> = {}): SkillReso
 }
 
 
-function defaultProps(skillOverrides: Partial<Skill> = {}, skillMdContent = '# SKILL\n') {
+function defaultProps(
+  skillOverrides: Partial<Skill> & { resource_manifest?: SkillResourceManifest | null } = {},
+  skillMdContent = '# SKILL\n',
+) {
+  // The `resource_manifest` field used to live on the Skill prop; it's now
+  // a separate prop sourced from the /content fetch (the listing schema
+  // doesn't include it). Tests still pass it via the skillOverrides bag for
+  // brevity; we lift it out here so the helper still works without
+  // updating every call site.
+  const { resource_manifest, ...rest } = skillOverrides;
   return {
-    skill: makeSkill(skillOverrides),
+    skill: makeSkill(rest),
     skillApiPath: '/doc-coauthor',
     authToken: 'test-token',
     skillMdContent,
+    resourceManifest: resource_manifest ?? null,
   };
 }
 

--- a/frontend/src/components/__tests__/SkillResources.test.tsx
+++ b/frontend/src/components/__tests__/SkillResources.test.tsx
@@ -1,0 +1,487 @@
+/**
+ * Tests for SkillResources component (issue #1111).
+ *
+ * Coverage: empty/full manifest, default-collapse, View / Download per file,
+ * cap enforcement (file count + bytes), concurrency cap, partial / all-fail
+ * paths, federation guard, and pure-helper sanity tests.
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import axios from 'axios';
+
+// react-markdown 10 is ESM-only and CRA's default jest config can't resolve
+// its transitive deps (unist-util-visit-parents). For these tests we don't
+// need real markdown rendering -- a minimal passthrough proves the preview
+// content reaches the DOM, which is what the assertions check.
+jest.mock('react-markdown', () => {
+  const MockMarkdown = (props: { children: string }) => <div>{props.children}</div>;
+  MockMarkdown.displayName = 'ReactMarkdown';
+  return { __esModule: true, default: MockMarkdown };
+});
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+import SkillResources, { __test__ } from '../SkillResources';
+import type { Skill, SkillResourceManifest } from '../../types/skill';
+import * as blobDownload from '../../utils/blobDownload';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Spy on triggerBlobDownload so we can assert without actually saving.
+const triggerSpy = jest.spyOn(blobDownload, 'triggerBlobDownload');
+
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    name: 'Doc Coauthor',
+    path: '/skills/doc-coauthor',
+    skill_md_url: 'https://github.com/example/skills/blob/main/doc-coauthor/SKILL.md',
+    visibility: 'public',
+    is_enabled: true,
+    num_stars: 0,
+    registry_name: 'local',
+    ...overrides,
+  };
+}
+
+
+function makeManifest(overrides: Partial<SkillResourceManifest> = {}): SkillResourceManifest {
+  return {
+    references: [],
+    scripts: [],
+    agents: [],
+    assets: [],
+    ...overrides,
+  };
+}
+
+
+function defaultProps(skillOverrides: Partial<Skill> = {}, skillMdContent = '# SKILL\n') {
+  return {
+    skill: makeSkill(skillOverrides),
+    skillApiPath: '/doc-coauthor',
+    authToken: 'test-token',
+    skillMdContent,
+  };
+}
+
+
+// =============================================================================
+// Pure helper tests (no React)
+// =============================================================================
+
+
+describe('SkillResources helpers', () => {
+  test('_slugify produces filesystem-safe filenames', () => {
+    const { _slugify } = __test__;
+    expect(_slugify('My Skill')).toBe('my-skill');
+    expect(_slugify('My Skill!')).toBe('my-skill');
+    expect(_slugify('   ')).toBe('');
+    expect(_slugify('../../etc/passwd')).toBe('etc-passwd');
+    expect(_slugify('A/B\\C')).toBe('a-b-c');
+    expect(_slugify('a__b__c')).toBe('a-b-c');
+  });
+
+  test('_formatSize formats bytes / KB / MB', () => {
+    const { _formatSize } = __test__;
+    expect(_formatSize(0)).toBe('0 B');
+    expect(_formatSize(512)).toBe('512 B');
+    expect(_formatSize(1024)).toBe('1.0 KB');
+    expect(_formatSize(2048)).toBe('2.0 KB');
+    expect(_formatSize(10 * 1024 * 1024)).toBe('10.0 MB');
+  });
+
+  test('_basename extracts the trailing path segment', () => {
+    const { _basename } = __test__;
+    expect(__test__._basename('scripts/run.sh')).toBe('run.sh');
+    expect(__test__._basename('SKILL.md')).toBe('SKILL.md');
+    expect(__test__._basename('a/b/c/d.txt')).toBe('d.txt');
+  });
+
+  test('_isOverCap rejects > MAX_BUNDLE_FILES', () => {
+    const { _isOverCap, MAX_BUNDLE_FILES } = __test__;
+    const many = Array.from({ length: MAX_BUNDLE_FILES }, (_, i) => ({
+      path: `f${i}.txt`,
+      type: 'reference' as const,
+      size_bytes: 10,
+    }));
+    const result = _isOverCap(many);
+    expect(result.over).toBe(true);
+    if (result.over) expect(result.reason).toMatch(/cap is 50/);
+  });
+
+  test('_isOverCap rejects > MAX_BUNDLE_BYTES', () => {
+    const { _isOverCap, MAX_BUNDLE_BYTES } = __test__;
+    const big = [{ path: 'big.bin', type: 'asset' as const, size_bytes: MAX_BUNDLE_BYTES + 1 }];
+    const result = _isOverCap(big);
+    expect(result.over).toBe(true);
+    if (result.over) expect(result.reason).toMatch(/cap is/);
+  });
+
+  test('_isOverCap accepts under-cap bundles', () => {
+    const { _isOverCap } = __test__;
+    expect(_isOverCap([{ path: 'a.txt', type: 'reference', size_bytes: 100 }]).over).toBe(false);
+  });
+
+  test('_sortByPath sorts ascending without mutating input', () => {
+    const { _sortByPath } = __test__;
+    const input = [
+      { path: 'b.txt', type: 'reference' as const, size_bytes: 1 },
+      { path: 'a.txt', type: 'reference' as const, size_bytes: 1 },
+    ];
+    const out = _sortByPath(input);
+    expect(out.map((r) => r.path)).toEqual(['a.txt', 'b.txt']);
+    expect(input.map((r) => r.path)).toEqual(['b.txt', 'a.txt']); // not mutated
+  });
+});
+
+
+// =============================================================================
+// Component: empty / federated / no-manifest cases
+// =============================================================================
+
+
+describe('SkillResources gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders nothing when manifest absent', () => {
+    const { container } = render(
+      <SkillResources {...defaultProps({ resource_manifest: null })} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders nothing when manifest groups are all empty', () => {
+    const { container } = render(
+      <SkillResources {...defaultProps({ resource_manifest: makeManifest() })} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  test('renders nothing for federated skills (registry_name !== local)', () => {
+    const manifest = makeManifest({
+      references: [{ path: 'r.md', type: 'reference', size_bytes: 100 }],
+    });
+    const { container } = render(
+      <SkillResources {...defaultProps({
+        registry_name: 'peer-registry',
+        resource_manifest: manifest,
+      })} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+
+// =============================================================================
+// Component: rendering populated manifest
+// =============================================================================
+
+
+describe('SkillResources rendering', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders header with totals and all four groups when present', () => {
+    const manifest = makeManifest({
+      references: [{ path: 'references/a.md', type: 'reference', size_bytes: 100 }],
+      scripts: [{ path: 'scripts/run.sh', type: 'script', size_bytes: 200, language: 'shell' }],
+      agents: [{ path: 'agents/c.md', type: 'agent', size_bytes: 300 }],
+      assets: [{ path: 'assets/img.png', type: 'asset', size_bytes: 400 }],
+    });
+
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    expect(screen.getByText(/Resources/)).toBeInTheDocument();
+    expect(screen.getByText(/4 files/)).toBeInTheDocument();
+    expect(screen.getByText(/References/)).toBeInTheDocument();
+    expect(screen.getByText(/Scripts/)).toBeInTheDocument();
+    expect(screen.getByText(/Agents/)).toBeInTheDocument();
+    expect(screen.getByText(/Assets/)).toBeInTheDocument();
+  });
+
+  test('omits empty groups', () => {
+    const manifest = makeManifest({
+      references: [{ path: 'r.md', type: 'reference', size_bytes: 100 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    expect(screen.getByText(/References/)).toBeInTheDocument();
+    expect(screen.queryByText(/Scripts/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Agents/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Assets/)).not.toBeInTheDocument();
+  });
+
+  test('groups default-collapsed: rows hidden until clicked', () => {
+    const manifest = makeManifest({
+      references: [{ path: 'references/a.md', type: 'reference', size_bytes: 100 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    // Path text should not be in the DOM while collapsed.
+    expect(screen.queryByText('references/a.md')).not.toBeInTheDocument();
+
+    // Click the header to expand.
+    const headerBtn = screen.getByRole('button', { name: /References/ });
+    fireEvent.click(headerBtn);
+
+    expect(screen.getByText('references/a.md')).toBeInTheDocument();
+  });
+
+  test('View hidden for assets (download-only)', () => {
+    const manifest = makeManifest({
+      assets: [{ path: 'assets/img.png', type: 'asset', size_bytes: 400 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Assets/ }));
+
+    expect(screen.queryByRole('button', { name: /^View assets/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Download assets\/img\.png/ })).toBeInTheDocument();
+  });
+
+  test('View visible for scripts/references/agents', () => {
+    const manifest = makeManifest({
+      scripts: [{ path: 'scripts/run.sh', type: 'script', size_bytes: 200 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Scripts/ }));
+
+    expect(screen.getByRole('button', { name: /^View scripts/ })).toBeInTheDocument();
+  });
+});
+
+
+// =============================================================================
+// Component: per-file Download
+// =============================================================================
+
+
+describe('Per-file Download', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('triggers blob download with basename filename', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { content: '#!/bin/bash\necho hi' } });
+
+    const manifest = makeManifest({
+      scripts: [{ path: 'scripts/run.sh', type: 'script', size_bytes: 200 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Scripts/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Download scripts\/run\.sh/ }));
+
+    await waitFor(() => expect(triggerSpy).toHaveBeenCalled());
+    const [, filename] = triggerSpy.mock.calls[0];
+    expect(filename).toBe('run.sh');
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      '/api/skills/doc-coauthor/content',
+      expect.objectContaining({
+        params: { resource: 'scripts/run.sh' },
+        headers: { Authorization: 'Bearer test-token' },
+      }),
+    );
+  });
+
+  test('shows error when per-file fetch fails', async () => {
+    mockedAxios.get.mockRejectedValueOnce({ response: { status: 502 } });
+
+    const manifest = makeManifest({
+      scripts: [{ path: 'scripts/run.sh', type: 'script', size_bytes: 200 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Scripts/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Download scripts\/run\.sh/ }));
+
+    await waitFor(() => expect(screen.getByText('HTTP 502')).toBeInTheDocument());
+    expect(triggerSpy).not.toHaveBeenCalled();
+  });
+});
+
+
+// =============================================================================
+// Component: View / Preview
+// =============================================================================
+
+
+describe('Preview pane', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('opens preview, fetches resource, Back returns to listing', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { content: '# Hello world\n' } });
+
+    const manifest = makeManifest({
+      references: [{ path: 'references/arch.md', type: 'reference', size_bytes: 100 }],
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /References/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^View references\/arch\.md/ }));
+
+    await waitFor(() => expect(screen.getByText(/Hello world/)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to SKILL\.md/ }));
+
+    expect(screen.queryByText(/Hello world/)).not.toBeInTheDocument();
+    expect(screen.getByText(/References/)).toBeInTheDocument();
+  });
+});
+
+
+// =============================================================================
+// Component: Download all (cap, concurrency, all-fail, partial)
+// =============================================================================
+
+
+function _makeResources(n: number, sizeBytes = 100): SkillResourceManifest {
+  return {
+    scripts: [],
+    agents: [],
+    assets: [],
+    references: Array.from({ length: n }, (_, i) => ({
+      path: `references/r${i}.md`,
+      type: 'reference' as const,
+      size_bytes: sizeBytes,
+    })),
+  };
+}
+
+
+describe('Download all', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('disables Download all when over file cap and surfaces reason via tooltip', () => {
+    const manifest = _makeResources(__test__.MAX_BUNDLE_FILES + 1);
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    const btn = screen.getByRole('button', { name: /Download all classified resources/ });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', expect.stringMatching(/cap is 50/));
+
+    // Disabled buttons swallow clicks: no fetch, no zip.
+    fireEvent.click(btn);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(triggerSpy).not.toHaveBeenCalled();
+  });
+
+  test('disables Download all when over byte cap', () => {
+    // 5 files of 3 MB each = 15 MB > 10 MB cap.
+    const manifest = makeManifest({
+      references: Array.from({ length: 5 }, (_, i) => ({
+        path: `r${i}.md`,
+        type: 'reference' as const,
+        size_bytes: 3 * 1024 * 1024,
+      })),
+    });
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    const btn = screen.getByRole('button', { name: /Download all classified resources/ });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('title', expect.stringMatching(/cap is/));
+
+    fireEvent.click(btn);
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  test('happy path bundles SKILL.md + all successes', async () => {
+    const manifest = makeManifest({
+      references: [{ path: 'references/a.md', type: 'reference', size_bytes: 10 }],
+      scripts: [{ path: 'scripts/run.sh', type: 'script', size_bytes: 20 }],
+    });
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: { content: 'AAA' } })
+      .mockResolvedValueOnce({ data: { content: 'BBB' } });
+
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest }, '# Doc Coauthor\n')} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download all/ }));
+
+    await waitFor(() => expect(triggerSpy).toHaveBeenCalled());
+    const [, filename] = triggerSpy.mock.calls[0];
+    expect(filename).toBe('doc-coauthor.zip');
+  });
+
+  test('all-fail guard: no zip when every fetch errors', async () => {
+    const manifest = makeManifest({
+      references: [
+        { path: 'r1.md', type: 'reference', size_bytes: 10 },
+        { path: 'r2.md', type: 'reference', size_bytes: 10 },
+      ],
+    });
+    mockedAxios.get
+      .mockRejectedValueOnce({ response: { status: 502 } })
+      .mockRejectedValueOnce({ response: { status: 502 } });
+
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download all/ }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Could not fetch any resources/)).toBeInTheDocument(),
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+  });
+
+  test('partial failure: zip still downloads, error banner shown', async () => {
+    const manifest = makeManifest({
+      references: [
+        { path: 'r1.md', type: 'reference', size_bytes: 10 },
+        { path: 'r2.md', type: 'reference', size_bytes: 10 },
+      ],
+    });
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: { content: 'OK' } })
+      .mockRejectedValueOnce({ response: { status: 502 } });
+
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Download all/ }));
+
+    await waitFor(() => expect(triggerSpy).toHaveBeenCalled());
+    expect(screen.getByText(/1 file\(s\) failed/)).toBeInTheDocument();
+  });
+
+  test('respects FETCH_CONCURRENCY = 4', async () => {
+    const total = 12;
+    const manifest = _makeResources(total);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    mockedAxios.get.mockImplementation(() => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          inFlight -= 1;
+          resolve({ data: { content: 'x' } } as any);
+        }, 30);
+      });
+    });
+
+    render(<SkillResources {...defaultProps({ resource_manifest: manifest })} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Download all/ }));
+      await waitFor(() => expect(triggerSpy).toHaveBeenCalled(), { timeout: 5000 });
+    });
+
+    expect(maxInFlight).toBeLessThanOrEqual(__test__.FETCH_CONCURRENCY);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(total);
+  });
+});

--- a/frontend/src/types/skill.ts
+++ b/frontend/src/types/skill.ts
@@ -24,6 +24,31 @@ export interface SkillRequirement {
 
 
 /**
+ * A single classified file inside a skill's resource manifest.
+ * Mirrors registry/schemas/skill_models.py::SkillResource.
+ */
+export interface SkillResource {
+  path: string;
+  type: 'script' | 'reference' | 'asset' | 'agent';
+  size_bytes: number;
+  description?: string | null;
+  language?: string | null;
+}
+
+
+/**
+ * Per-skill manifest of companion resources discovered alongside SKILL.md.
+ * Mirrors registry/schemas/skill_models.py::SkillResourceManifest.
+ */
+export interface SkillResourceManifest {
+  scripts: SkillResource[];
+  references: SkillResource[];
+  assets: SkillResource[];
+  agents: SkillResource[];
+}
+
+
+/**
  * Skill interface representing an Agent Skill.
  */
 /**
@@ -62,4 +87,5 @@ export interface Skill {
   last_checked_time?: string;
   created_at?: string;
   updated_at?: string;
+  resource_manifest?: SkillResourceManifest | null;
 }

--- a/frontend/src/utils/blobDownload.ts
+++ b/frontend/src/utils/blobDownload.ts
@@ -1,0 +1,20 @@
+/**
+ * Trigger a browser download for a Blob with the given filename.
+ *
+ * Creates a temporary object URL, programmatically clicks an anchor
+ * element to invoke the browser's save dialog, then revokes the URL
+ * so the blob can be garbage-collected.
+ */
+export function triggerBlobDownload(
+  blob: Blob,
+  filename: string,
+): void {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary

Closes #1111. Adds the "Resources" section + "Download all" zip bundle to skill cards in the React UI, consuming the `resource_manifest` populated by #1113 (already merged).

### What this PR does
- New `<SkillResources>` component rendered inside the existing skill detail modal, between the YAML frontmatter table and the markdown body.
- Per-file **View** and **Download** buttons. View opens an inline preview (markdown/code) with a "Back to SKILL.md" breadcrumb; binaries (assets) skip preview and offer download only.
- **Download all** button bundles SKILL.md + every classified resource into a `{slugified-skill-name}.zip` on the client side via JSZip (already a frontend dependency).
- Bundle cap: **50 files OR 10 MB**. Over-cap state disables the button with a tooltip explaining why; per-file links still work.
- Default-collapsed groups (References / Scripts / Agents / Assets), each shown only when non-empty.
- `aria-live="polite"` progress announcements; anti-double-click guard on the bundle button; all-fail guard so a SKILL.md-only zip is never delivered when every per-file fetch errors.

### Self-gating
- Returns `null` for **federated skills** (`registry_name !== 'local'`). Federation today doesn't copy companion files, so per-file fetches would 404. Multi-file federated support is a follow-up.
- Returns `null` when `resource_manifest` is absent or empty (every skill before #938 / #1113, and any skill whose folder yields no classified files).

### Manifest source
The `SkillInfo` listing schema intentionally omits `resource_manifest` to keep the listing payload small. Only the `/content` endpoint exposes it. This PR captures the manifest from the `/content` fetch the modal already makes (new `resourceManifest` state on `SkillCard`) and passes it to `<SkillResources>` as a dedicated prop. The frontend `Skill` type's optional `resource_manifest` field exists for consistency with the backend schema but is not consumed in v1.

### Refactor
Lifted `_triggerBlobDownload` from `DataExport.tsx` into a shared `frontend/src/utils/blobDownload.ts`. `DataExport.tsx` updated to use the shared helper; existing `DataExport` tests pass unchanged.

### Design decisions (locked during brainstorming, captured in `.scratchpad/issue-1111/lld.md`)
- Client-side zip via JSZip (already in repo for `DataExport.tsx`)
- Hardcoded concurrency = 4 for parallel per-file fetches
- No `MANIFEST.json` in the zip (pure files only)
- No telemetry / download counters in v1
- No new dependencies, no new config parameters

### What this PR does NOT do
- No backend changes. `/api/skills/{path}/content?resource=...` was already wired with path-traversal protection and a 512 KB per-file cap (#1113-era code).
- No deployment-surface changes (Docker / Helm / Terraform unaffected).

## Test plan
- [x] **24 component tests** in `SkillResources.test.tsx` covering empty/populated/federated manifest gating, per-file Download, View preview lifecycle, file-count and byte-size cap rejection, FETCH_CONCURRENCY = 4 limit, partial-failure path, and the all-fail guard.
- [x] **Pure-helper tests** for `_slugify` (including adversarial inputs like `../../etc/passwd`), `_formatSize`, `_basename`, `_isOverCap`, `_sortByPath`.
- [x] `npm run build` compiles cleanly.
- [x] Existing 66 frontend tests pass; 3 pre-existing failures in `ServerConfigModal.test.tsx` are unrelated and present on `main` before this PR.
- [x] **Live verification against `usage-report` skill**: built integration of #1113 + this PR, ran against the in-tree `usage-report` skill, confirmed the section renders with 13 resources (12 scripts + 1 asset), Download all produced a working `usage-report.zip`, View opened inline preview for each script.

Closes #1111. Depends on #1113 (already merged).
