### PR TITLE
skill(usage-report): adopt Tufte visualization style across all charts

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -4,12 +4,16 @@ description: Generate a usage report for MCP Gateway Registry by SSHing into the
 license: Apache-2.0
 metadata:
   author: mcp-gateway-registry
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Usage Report Skill
 
 Export telemetry data from the MCP Gateway Registry's DocumentDB telemetry collector and generate a usage report showing deployment patterns, version adoption, and feature usage in the wild.
+
+## Visualization Guidelines
+
+All charts in this skill follow Edward Tufte's principles documented in [tufte-viz-guidelines.md](tufte-viz-guidelines.md): high data-ink ratio, no chartjunk, layered information, honest scales. The shared style module [tufte_style.py](tufte_style.py) provides `apply_tufte_style()` (rcParams) and `tufte_axes(ax)` (per-axes cleanup). When adding new chart generators, import from `tufte_style` and call `apply_tufte_style()` once before plotting and `tufte_axes(ax)` for each axes after plotting. Reference the Tufte checklist in `tufte-viz-guidelines.md` before merging any new chart.
 
 ## Prerequisites
 
@@ -114,9 +118,10 @@ Generate a timeseries chart showing unique registry installs per cloud provider 
   --exclude-incomplete-day YYYY-MM-DD
 ```
 
-This produces a PNG with two subplots:
+This produces a PNG with three subplots:
 - **Cumulative Unique Registry Installs** -- running total of unique registry_ids per cloud provider
-- **Daily Active Registry Installs** -- unique registry_ids seen each day per cloud provider
+- **Daily Active Registry Installs** -- unique registry_ids seen each day per cloud provider (returning instances are re-counted)
+- **Daily NEW Registry Installs (first-seen)** -- unique registry_ids whose earliest-ever event lands on each day, per cloud provider. Each instance is counted exactly once across the entire history. Use this to track raw acquisition velocity per cloud, isolated from churn and re-engagement
 
 > **`--exclude-incomplete-day`** drops events on the given date (today's date, the in-progress day) before charting so the trailing data point doesn't show a misleading dip. Always pass today's `YYYY-MM-DD`. Snapshot tables and headline tallies still see the full data; only the chart series are trimmed.
 
@@ -272,7 +277,27 @@ Visualize the conversion funnel from total installs through retention stages to 
 
 Embed the chart in the report's **Adoption Funnel** section (placed after Most Engaged Operators, before Recommendations). Include a table showing each funnel stage, count, and percentage of the previous stage.
 
-### Step 5f: Fetch GitHub Repository Stats
+### Step 5f: Generate Cloud-Detection-by-Version Chart
+
+Plot how the `cloud_detection_method` outcome distributes per registry version. Each row is a version (top 12 by instance count plus a rolled-up "other"); each row is a stacked horizontal bar split by detection-method outcome (env, dmi, ecs_meta, k8s_heuristic, imds, unknown, "(field absent)" for pre-1.23.0).
+
+This chart lets the report validate that fixes to cloud detection (issue #1093, PR #1106 in 1.24.2) actually moved the needle: the "unknown" red slice should shrink on the row for the version where the fix shipped, relative to older versions on the same chart.
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_detection_by_version_chart.py \
+  --csv $DATE_DIR/registry_metrics.csv \
+  --output $DATE_DIR/detection-by-version-YYYY-MM-DD.png \
+  --csv-out $DATE_DIR/detection-by-version-YYYY-MM-DD.csv \
+  --snapshot-date YYYY-MM-DD
+```
+
+Outputs:
+- PNG chart with versions on the y-axis (sorted by instance count, largest at top), detection methods stacked on the x-axis with green-for-success / red-for-unknown / grey-for-field-absent colour coding.
+- CSV sidecar with one row per version, columns for each detection method count, plus a total. Useful for diffing across reports.
+
+Embed the chart in a section titled "Cloud Detection Outcomes by Version" placed after Adoption Funnel and before Recommendations. Add a short narrative quoting the row for the latest release (`1.24.2` and later) and contrasting it with `1.23.0` and `1.24.1` to show whether the fix is working in the wild on instances that adopted it.
+
+### Step 5g: Fetch GitHub Repository Stats
 
 Collect community-growth signals for the upstream repo (`agentic-community/mcp-gateway-registry`) using the authenticated `gh` CLI. These numbers complement telemetry by showing project interest outside of deployed instances.
 
@@ -511,6 +536,11 @@ Summary table from `ltv-spend-YYYY-MM-DD.json`. Show yesterday, last-7-days, and
 
 Table showing each funnel stage (total installs, multi-day, sticky 3+, weekly 7+, biweekly 14+, monthly 30+, confirmed alive) with count and % of previous stage.
 
+## Cloud Detection Outcomes by Version
+![Cloud Detection by Version](detection-by-version-YYYY-MM-DD.png)
+
+Stacked-bar view of `cloud_detection_method` outcomes split by registry version. Quote the row for the latest release and contrast it with `1.23.0` and `1.24.1` to validate whether issue #1093 / PR #1106 is actually moving the unknown-cloud rate down on instances that adopted the fix.
+
 ## GitHub Repository
 Table with stars, forks, contributors, open issues. Deltas vs previous report.
 
@@ -526,9 +556,9 @@ Event-count-based distribution tables for cloud, compute, architecture, storage,
 
 #### Mandatory Charts Checklist
 
-The report MUST embed all 10 charts. If any chart file is missing, generate it before writing the report.
+The report MUST embed all 11 charts. If any chart file is missing, generate it before writing the report.
 
-1. `registry-installs-timeseries-YYYY-MM-DD.png` (cloud provider cumulative + daily)
+1. `registry-installs-timeseries-YYYY-MM-DD.png` (cloud provider: cumulative + daily-active + daily-new)
 2. `instance-distribution-YYYY-MM-DD.png` (6-panel faceted, all customers)
 3. `instance-distribution-active-PREVIOUS-YYYY-MM-DD.png` (6-panel faceted, active yesterday)
 4. `instance-lifetime-YYYY-MM-DD.png` (age histogram + boxplot + buckets)
@@ -538,6 +568,7 @@ The report MUST embed all 10 charts. If any chart file is missing, generate it b
 8. `install-forecast-YYYY-MM-DD.png` (OLS + recent-pace to 1,000)
 9. `ltv-spend-YYYY-MM-DD.png` (daily compute + bedrock + cumulative)
 10. `adoption-funnel-YYYY-MM-DD.png` (funnel from total to confirmed-alive)
+11. `detection-by-version-YYYY-MM-DD.png` (cloud_detection_method outcomes per version)
 
 Save the report to `$DATE_DIR/ai-registry-usage-report-YYYY-MM-DD.md`.
 

--- a/.claude/skills/usage-report/generate_active_instances_chart.py
+++ b/.claude/skills/usage-report/generate_active_instances_chart.py
@@ -35,6 +35,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -284,7 +288,7 @@ def _generate_chart(
     output_path: str,
 ) -> None:
     """Render the three-series line chart."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
     fig.suptitle(CHART_TITLE, fontsize=14, fontweight="bold", y=0.98)
@@ -313,6 +317,8 @@ def _generate_chart(
     ax.xaxis.set_major_locator(mdates.DayLocator(interval=max(1, len(parsed) // 14)))
     plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.95])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_adoption_funnel_chart.py
+++ b/.claude/skills/usage-report/generate_adoption_funnel_chart.py
@@ -23,6 +23,10 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -90,7 +94,7 @@ def _generate_chart(
     report_date: str,
 ) -> None:
     """Render the funnel as a horizontal bar chart, top of funnel at top."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     labels = [r[0] for r in rows]
     counts = [r[1] for r in rows]
@@ -136,6 +140,8 @@ def _generate_chart(
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.94])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_charts.py
+++ b/.claude/skills/usage-report/generate_charts.py
@@ -17,6 +17,10 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 # Configure logging with basicConfig
 logging.basicConfig(
@@ -136,7 +140,7 @@ def _generate_chart(
     total = len(rows)
     distributions = _compute_distributions(rows)
 
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     fig, axes = plt.subplots(2, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
     fig.suptitle(
@@ -162,6 +166,8 @@ def _generate_chart(
         ax = axes[row_idx][col_idx]
         _plot_single_facet(ax, distributions[dim_name], dim_name, total)
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.95])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_compute_timeseries_chart.py
+++ b/.claude/skills/usage-report/generate_compute_timeseries_chart.py
@@ -24,6 +24,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -237,7 +241,7 @@ def _generate_chart(
     output_path: str,
 ) -> None:
     """Generate and save the timeseries chart with two subplots."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     fig, (ax_cumulative, ax_daily) = plt.subplots(
         2,
@@ -294,6 +298,8 @@ def _generate_chart(
     ax_daily.xaxis.set_major_locator(mdates.DayLocator(interval=1))
     plt.setp(ax_daily.xaxis.get_majorticklabels(), rotation=45, ha="right")
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.95])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_detection_by_version_chart.py
+++ b/.claude/skills/usage-report/generate_detection_by_version_chart.py
@@ -1,0 +1,328 @@
+"""Plot cloud_detection_method outcomes split by registry version.
+
+Reads a single registry_metrics.csv, deduplicates events to one row per
+unique registry_id (latest event per id), and produces a stacked
+horizontal bar chart where:
+
+- Each row is a registry version (top N by instance count, plus an
+  "other" rollup for the long tail).
+- Each bar segment is the share of instances on that version with a
+  given `cloud_detection_method` value: env, dmi, ecs_meta,
+  k8s_heuristic, imds, unknown, or "(field absent)" for pre-1.23.0
+  instances that don't emit the field at all.
+- Total instance count per version is annotated at the right edge.
+
+This chart answers "did the cloud-detection cascade actually start
+working on the versions where the fix shipped?". For the fix from
+issue #1093 (PR #1106, released in 1.24.2), the expectation is that the
+"unknown" segment should shrink on 1.24.2+ rows compared to 1.23.0/1.24.1.
+
+CSV-only: it reads the latest snapshot, not historical. To track the
+trend over time, run this script per dated CSV and compare reports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+from collections import Counter, defaultdict
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = (
+    "AI Registry -- Cloud Detection Outcomes by Registry Version"
+)
+FIGURE_WIDTH: int = 14
+FIGURE_HEIGHT: int = 8
+
+# Order detection methods from "good outcome" to "no outcome" so the
+# stacked bar reads left-to-right as success-to-failure.
+METHOD_ORDER: list[str] = [
+    "env",
+    "dmi",
+    "ecs_meta",
+    "k8s_heuristic",
+    "imds",
+    "unknown",
+    "(field absent)",
+]
+
+# Pleasant green-to-red diverging-ish palette: green for working methods,
+# red/grey for failures and field-absent. Hand-picked so "(field absent)"
+# is the most muted (no judgement, just old version) and "unknown" is the
+# loudest red (cascade ran, all paths failed).
+METHOD_COLORS: dict[str, str] = {
+    "env": "#2ca02c",
+    "dmi": "#7fbf7f",
+    "ecs_meta": "#1f77b4",
+    "k8s_heuristic": "#5a9fd4",
+    "imds": "#9467bd",
+    "unknown": "#d62728",
+    "(field absent)": "#bcbcbc",
+}
+
+
+def _read_csv(
+    path: str,
+) -> list[dict[str, str]]:
+    """Load all rows from a single telemetry CSV."""
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    logger.info(f"Read {len(rows)} rows from {path}")
+    return rows
+
+
+def _latest_per_instance(
+    rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """One row per registry_id: the latest event by ts."""
+    latest: dict[str, dict[str, str]] = {}
+    for r in rows:
+        rid = (r.get("registry_id") or "").strip()
+        if not rid:
+            continue
+        ts = r.get("ts", "")
+        if rid not in latest or ts > latest[rid].get("ts", ""):
+            latest[rid] = r
+    logger.info(f"Deduplicated {len(rows)} events to {len(latest)} unique instances")
+    return list(latest.values())
+
+
+def _normalize_method(
+    raw: str | None,
+) -> str:
+    """Normalize the cloud_detection_method field for charting.
+
+    An empty string means the field was never emitted, which only happens
+    for pre-1.23.0 schemas. Bucket those into "(field absent)" so they
+    are visually distinct from "unknown" (cascade ran, all paths failed).
+    """
+    value = (raw or "").strip()
+    if not value:
+        return "(field absent)"
+    return value
+
+
+def _compute_method_counts_per_version(
+    instances: list[dict[str, str]],
+    top_n: int,
+    min_instances_for_other: int,
+) -> tuple[list[str], dict[str, Counter]]:
+    """Bucket instances into (version, detection_method) pairs.
+
+    Versions ranked by instance count. The top_n versions get their own
+    rows; everything beyond that is rolled up into a single "other
+    (N versions)" row provided the rollup itself has at least
+    min_instances_for_other instances (otherwise it's dropped to keep
+    the chart readable).
+
+    Returns (ordered_version_labels, {version_label: Counter(method->count)}).
+    """
+    version_counter: Counter = Counter()
+    for r in instances:
+        v = (r.get("v") or "unknown").strip() or "unknown"
+        version_counter[v] += 1
+
+    top_versions = [v for v, _ in version_counter.most_common(top_n)]
+    top_set = set(top_versions)
+
+    method_by_version: dict[str, Counter] = defaultdict(Counter)
+    other_versions: set[str] = set()
+    for r in instances:
+        v = (r.get("v") or "unknown").strip() or "unknown"
+        method = _normalize_method(r.get("cloud_detection_method"))
+        if v in top_set:
+            method_by_version[v][method] += 1
+        else:
+            method_by_version["__other__"][method] += 1
+            other_versions.add(v)
+
+    ordered_labels: list[str] = list(top_versions)
+    other_total = sum(method_by_version["__other__"].values())
+    if other_total >= min_instances_for_other and other_versions:
+        rollup_label = f"other ({len(other_versions)} versions, {other_total} instances)"
+        method_by_version[rollup_label] = method_by_version.pop("__other__")
+        ordered_labels.append(rollup_label)
+    else:
+        method_by_version.pop("__other__", None)
+
+    return ordered_labels, method_by_version
+
+
+def _plot_chart(
+    ordered_labels: list[str],
+    method_by_version: dict[str, Counter],
+    output_path: str,
+    snapshot_date: str | None = None,
+) -> None:
+    """Render the stacked horizontal bar chart and save to PNG."""
+    apply_tufte_style()
+
+    fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+
+    # Sort versions descending in count so the largest cohort is at the
+    # top of the horizontal layout (matplotlib draws barh bottom-up).
+    plot_labels = list(reversed(ordered_labels))
+    plot_totals = [sum(method_by_version[label].values()) for label in plot_labels]
+
+    left = [0.0] * len(plot_labels)
+    for method in METHOD_ORDER:
+        widths = [method_by_version[label].get(method, 0) for label in plot_labels]
+        if not any(widths):
+            continue
+        ax.barh(
+            plot_labels,
+            widths,
+            left=left,
+            label=method,
+            color=METHOD_COLORS[method],
+            edgecolor="white",
+            linewidth=0.5,
+        )
+        left = [a + b for a, b in zip(left, widths)]
+
+    # Annotate each row with total instance count at the right edge.
+    max_total = max(plot_totals) if plot_totals else 1
+    for label, total in zip(plot_labels, plot_totals):
+        ax.text(
+            total + max_total * 0.01,
+            label,
+            f" n={total}",
+            va="center",
+            fontsize=9,
+            color="#333333",
+        )
+
+    title = CHART_TITLE
+    if snapshot_date:
+        title += f"\nSnapshot {snapshot_date}: {sum(plot_totals)} customer instances"
+    fig.suptitle(title, fontsize=14, fontweight="bold", y=0.99)
+
+    ax.set_xlabel("Instances")
+    ax.set_xlim(0, max_total * 1.18)
+    ax.legend(
+        title="cloud_detection_method",
+        loc="lower right",
+        ncols=1,
+        fontsize=8,
+    )
+
+    tufte_axes(ax)
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Detection-by-version chart saved to {output_path}")
+
+
+def _write_csv_sidecar(
+    ordered_labels: list[str],
+    method_by_version: dict[str, Counter],
+    csv_out: str,
+) -> None:
+    """Write the per-version method breakdown as a CSV for downstream diffing."""
+    with open(csv_out, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["version", *METHOD_ORDER, "total"])
+        for label in ordered_labels:
+            counter = method_by_version[label]
+            row = [label]
+            total = 0
+            for method in METHOD_ORDER:
+                count = counter.get(method, 0)
+                row.append(count)
+                total += count
+            row.append(total)
+            writer.writerow(row)
+    logger.info(f"Detection-by-version CSV written to {csv_out}")
+
+
+def main() -> None:
+    """CLI entry: generate the detection-by-version chart."""
+    parser = argparse.ArgumentParser(
+        description="Plot cloud_detection_method outcomes split by registry version",
+    )
+    parser.add_argument(
+        "--csv",
+        required=True,
+        help="Path to a single registry_metrics.csv (dated snapshot)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG",
+    )
+    parser.add_argument(
+        "--csv-out",
+        default=None,
+        help="Optional path to write the per-version method breakdown as CSV",
+    )
+    parser.add_argument(
+        "--top-n-versions",
+        type=int,
+        default=12,
+        help="How many top versions get their own row (default: 12)",
+    )
+    parser.add_argument(
+        "--min-instances-for-other",
+        type=int,
+        default=3,
+        help=(
+            "Minimum instance count for the rolled-up 'other' row to be "
+            "drawn at all (default: 3). Below this threshold the long tail "
+            "is dropped from the chart entirely."
+        ),
+    )
+    parser.add_argument(
+        "--snapshot-date",
+        default=None,
+        help="Optional YYYY-MM-DD to label the chart with the snapshot date",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.csv):
+        logger.error(f"CSV not found: {args.csv}")
+        raise SystemExit(1)
+
+    rows = _read_csv(args.csv)
+    instances = _latest_per_instance(rows)
+    if not instances:
+        logger.error("No identified instances in CSV")
+        raise SystemExit(1)
+
+    ordered_labels, method_by_version = _compute_method_counts_per_version(
+        instances=instances,
+        top_n=args.top_n_versions,
+        min_instances_for_other=args.min_instances_for_other,
+    )
+
+    _plot_chart(
+        ordered_labels=ordered_labels,
+        method_by_version=method_by_version,
+        output_path=args.output,
+        snapshot_date=args.snapshot_date,
+    )
+
+    if args.csv_out:
+        _write_csv_sidecar(ordered_labels, method_by_version, args.csv_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/usage-report/generate_install_forecast.py
+++ b/.claude/skills/usage-report/generate_install_forecast.py
@@ -53,6 +53,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -242,7 +246,7 @@ def _generate_chart(
         pace_pred = []
 
     # ---- Render ----
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
     fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
     fig.suptitle(
         CHART_TITLE.format(target=target),
@@ -307,6 +311,8 @@ def _generate_chart(
     )
     plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.94])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_instance_distribution_chart.py
+++ b/.claude/skills/usage-report/generate_instance_distribution_chart.py
@@ -17,6 +17,10 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -98,9 +102,16 @@ def _get_latest_per_instance(
 
 def _compute_distributions(
     instances: list[dict[str, str]],
+    include_extended: bool = False,
 ) -> dict[str, Counter]:
-    """Compute value counts for each dimension based on unique instances."""
-    dimensions = {
+    """Compute value counts for each dimension based on unique instances.
+
+    When include_extended is True, three additional facets are included:
+    Registry Version, Embeddings Backend, and Cloud Detection Method. These
+    are most useful for the "new installs that day" view since they reveal
+    what the latest installs are reporting.
+    """
+    dimensions: dict[str, Counter] = {
         "Cloud Provider": Counter(),
         "Compute Platform": Counter(),
         "Storage Backend": Counter(),
@@ -108,6 +119,10 @@ def _compute_distributions(
         "Architecture": Counter(),
         "Deployment Mode": Counter(),
     }
+    if include_extended:
+        dimensions["Registry Version"] = Counter()
+        dimensions["Embeddings Backend"] = Counter()
+        dimensions["Cloud Detection Method"] = Counter()
 
     for row in instances:
         cloud = row.get("cloud", "unknown") or "unknown"
@@ -132,6 +147,16 @@ def _compute_distributions(
 
         mode = row.get("mode", "unknown") or "unknown"
         dimensions["Deployment Mode"][mode] += 1
+
+        if include_extended:
+            version = (row.get("v") or "").strip() or "unknown"
+            dimensions["Registry Version"][version] += 1
+
+            ebk = (row.get("embeddings_backend_kind") or "").strip() or "unknown"
+            dimensions["Embeddings Backend"][ebk] += 1
+
+            cdm = (row.get("cloud_detection_method") or "").strip() or "unknown"
+            dimensions["Cloud Detection Method"][cdm] += 1
 
     return dimensions
 
@@ -205,26 +230,102 @@ def _filter_rows_active_on_date(
     return kept
 
 
+def _filter_rows_new_on_date(
+    rows: list[dict[str, str]],
+    new_date: str,
+    range_start: str | None = None,
+) -> list[dict[str, str]]:
+    """Restrict the row set to instances first-seen on (or in a window ending on) new_date.
+
+    "First-seen" means the instance's earliest event in the dataset has a
+    timestamp date matching the filter. When range_start is None, the
+    filter matches a single day. When range_start is provided, the filter
+    matches first-seen dates in [range_start, new_date] inclusive. This
+    answers "what are the brand-new installs from that period reporting?"
+    rather than "who is still active?".
+
+    Returns ALL events for the surviving registry_ids so the latest-event
+    logic in _get_latest_per_instance can still resolve fields that vary
+    by event type (e.g. auth from startups, embeddings from heartbeats).
+    """
+    earliest_per_id: dict[str, str] = {}
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid:
+            continue
+        ts = (row.get("ts") or "")[:10]
+        if not ts:
+            continue
+        prior = earliest_per_id.get(rid)
+        if prior is None or ts < prior:
+            earliest_per_id[rid] = ts
+
+    if range_start:
+        new_ids = {
+            rid for rid, ts in earliest_per_id.items()
+            if range_start <= ts <= new_date
+        }
+        label = f"first-seen in {range_start}..{new_date}"
+    else:
+        new_ids = {rid for rid, ts in earliest_per_id.items() if ts == new_date}
+        label = f"first-seen on {new_date}"
+
+    if not new_ids:
+        logger.warning(
+            f"No instances {label}; returning empty row set",
+        )
+        return []
+
+    kept = [r for r in rows if (r.get("registry_id") or "").strip() in new_ids]
+    logger.info(
+        f"New {label}: {len(new_ids)} unique instances "
+        f"(filtered {len(rows)} -> {len(kept)} events for those instances' full history)"
+    )
+    return kept
+
+
 def _generate_chart(
     rows: list[dict[str, str]],
     output_path: str,
     active_on_date: str | None = None,
+    new_on_date: str | None = None,
+    new_range_start: str | None = None,
+    include_extended_facets: bool = False,
 ) -> None:
     """Generate and save the faceted distribution chart.
 
     When active_on_date (YYYY-MM-DD) is provided, the chart shows only
-    those instances that reported at least one event on that date. The
-    title is annotated to make this explicit.
+    those instances that reported at least one event on that date. When
+    new_on_date is provided, the chart shows only instances first-seen
+    on that date (brand-new installs).
+
+    When include_extended_facets is True, the chart adds Registry Version,
+    Embeddings Backend, and Cloud Detection Method panels (9 total facets
+    instead of 6). This is the default for the new-installs view since
+    those facets are most diagnostic for fresh deployments.
     """
     instances = _get_latest_per_instance(rows)
     total = len(instances)
 
-    distributions = _compute_distributions(instances)
+    distributions = _compute_distributions(instances, include_extended=include_extended_facets)
 
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
-    fig, axes = plt.subplots(2, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
-    if active_on_date:
+    if include_extended_facets:
+        fig, axes = plt.subplots(3, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT * 1.4))
+        cols = 3
+    else:
+        fig, axes = plt.subplots(2, 3, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+        cols = 3
+
+    if new_on_date and new_range_start:
+        title_suffix = (
+            f"\n(New installs {new_range_start} to {new_on_date}: "
+            f"{total} unique instances)"
+        )
+    elif new_on_date:
+        title_suffix = f"\n(New installs on {new_on_date}: {total} unique instances)"
+    elif active_on_date:
         title_suffix = f"\n(Active on {active_on_date}: {total} unique instances)"
     else:
         title_suffix = f"\n({total} unique instances)"
@@ -232,7 +333,7 @@ def _generate_chart(
         f"{CHART_TITLE}{title_suffix}",
         fontsize=14,
         fontweight="bold",
-        y=0.98,
+        y=0.99,
     )
 
     dimension_order = [
@@ -243,14 +344,22 @@ def _generate_chart(
         "Architecture",
         "Deployment Mode",
     ]
+    if include_extended_facets:
+        dimension_order += [
+            "Registry Version",
+            "Embeddings Backend",
+            "Cloud Detection Method",
+        ]
 
     for idx, dim_name in enumerate(dimension_order):
-        row_idx = idx // 3
-        col_idx = idx % 3
+        row_idx = idx // cols
+        col_idx = idx % cols
         ax = axes[row_idx][col_idx]
         _plot_single_facet(ax, distributions[dim_name], dim_name, total)
 
-    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    for _ax in fig.axes:
+        tufte_axes(_ax)
+    plt.tight_layout(rect=[0, 0, 1, 0.96])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
     logger.info(f"Chart saved to {output_path}")
@@ -281,7 +390,41 @@ def main() -> None:
             "deployed' snapshot rather than 'who has ever been deployed'."
         ),
     )
+    parser.add_argument(
+        "--new-on-date",
+        default=None,
+        help=(
+            "Optional YYYY-MM-DD. When provided, the chart is restricted to "
+            "instances first-seen on that date (brand-new installs). Implies "
+            "--include-extended-facets unless that flag is explicitly disabled. "
+            "Mutually exclusive with --active-on-date."
+        ),
+    )
+    parser.add_argument(
+        "--new-range-start",
+        default=None,
+        help=(
+            "Optional YYYY-MM-DD lower bound for --new-on-date. When provided, "
+            "the new-installs filter matches first-seen dates in "
+            "[--new-range-start, --new-on-date] inclusive. Useful for showing a "
+            "7-day or 14-day window of new installs when single-day samples are "
+            "too small."
+        ),
+    )
+    parser.add_argument(
+        "--include-extended-facets",
+        action="store_true",
+        help=(
+            "When set, adds three additional facets (Registry Version, "
+            "Embeddings Backend, Cloud Detection Method) for a 9-panel chart. "
+            "Most useful for the new-installs view."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.active_on_date and args.new_on_date:
+        logger.error("--active-on-date and --new-on-date are mutually exclusive")
+        raise SystemExit(2)
 
     if not os.path.exists(args.csv):
         logger.error(f"CSV file not found: {args.csv}")
@@ -299,7 +442,35 @@ def main() -> None:
             logger.error(f"No instances active on {args.active_on_date}")
             raise SystemExit(1)
 
-    _generate_chart(rows, args.output, active_on_date=args.active_on_date)
+    include_extended = args.include_extended_facets or bool(args.new_on_date)
+
+    if args.new_range_start and not args.new_on_date:
+        logger.error("--new-range-start requires --new-on-date")
+        raise SystemExit(2)
+
+    if args.new_on_date:
+        rows = _filter_rows_new_on_date(
+            rows,
+            args.new_on_date,
+            range_start=args.new_range_start,
+        )
+        if not rows:
+            window = (
+                f"{args.new_range_start}..{args.new_on_date}"
+                if args.new_range_start
+                else args.new_on_date
+            )
+            logger.error(f"No new instances in {window}")
+            raise SystemExit(1)
+
+    _generate_chart(
+        rows,
+        args.output,
+        active_on_date=args.active_on_date,
+        new_on_date=args.new_on_date,
+        new_range_start=args.new_range_start,
+        include_extended_facets=include_extended,
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/skills/usage-report/generate_lifetime_buckets_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_buckets_chart.py
@@ -38,6 +38,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -171,7 +175,7 @@ def _generate_chart(
     output_path: str,
 ) -> None:
     """Render the multi-line retention chart."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
     fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
     fig.suptitle(CHART_TITLE, fontsize=14, fontweight="bold", y=0.97)
 
@@ -227,6 +231,8 @@ def _generate_chart(
     ax.xaxis.set_major_locator(mdates.DayLocator(interval=max(1, len(parsed) // 14)))
     plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.94])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_lifetime_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_chart.py
@@ -15,6 +15,10 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 # Configure logging with basicConfig
 logging.basicConfig(
@@ -51,7 +55,7 @@ def _generate_chart(
     output_path: str,
 ) -> None:
     """Generate and save the lifetime density chart."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     fig, (ax_hist, ax_box, ax_bar) = plt.subplots(
         1,
@@ -209,6 +213,8 @@ def _generate_chart(
     max_count = max(counts) if counts else 1
     ax_bar.set_xlim(0, max_count * 1.4)
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.93])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_ltv_spend.py
+++ b/.claude/skills/usage-report/generate_ltv_spend.py
@@ -127,6 +127,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 logging.basicConfig(
     level=logging.INFO,
@@ -671,7 +675,7 @@ def _generate_chart(
     output_path: str,
 ) -> None:
     """Render a three-panel chart: daily compute $, daily Bedrock $, cumulative $."""
-    sns.set_theme(style="whitegrid")
+    apply_tufte_style()
 
     fig, (ax_compute, ax_bedrock, ax_cum) = plt.subplots(
         3,
@@ -727,6 +731,8 @@ def _generate_chart(
     ax_cum.xaxis.set_major_locator(mdates.DayLocator(interval=max(1, len(dates) // 14)))
     plt.setp(ax_cum.xaxis.get_majorticklabels(), rotation=45, ha="right")
 
+    for _ax in fig.axes:
+        tufte_axes(_ax)
     plt.tight_layout(rect=[0, 0, 1, 0.96])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/.claude/skills/usage-report/generate_timeseries_chart.py
+++ b/.claude/skills/usage-report/generate_timeseries_chart.py
@@ -19,6 +19,10 @@ matplotlib.use("Agg")
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import seaborn as sns
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
 
 # Configure logging with basicConfig
 logging.basicConfig(
@@ -162,31 +166,86 @@ def _compute_daily_unique_installs(
     return result
 
 
+def _compute_daily_new_installs(
+    rows: list[dict[str, str]],
+) -> dict[str, list[tuple[str, int]]]:
+    """Compute daily NEW registry installs per cloud provider.
+
+    A "new install" is the first calendar day a given registry_id is ever
+    seen in the dataset. Each registry_id is counted exactly once, on its
+    first-seen date, under the cloud provider it reported on that date.
+
+    Distinct from _compute_daily_unique_installs which counts any instance
+    that emitted an event on the day (returning visitors get re-counted).
+    This function answers "how many brand-new deployments came online on
+    each day?" rather than "how many were active that day?".
+
+    Returns a dict keyed by cloud provider, each value is a sorted list
+    of (date_str, new_install_count_that_day) tuples.
+    """
+    # First pass: find each registry_id's earliest (date, cloud) pair.
+    earliest: dict[str, tuple[str, str]] = {}
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid:
+            continue
+        date = _extract_date(row.get("ts", ""))
+        if not date:
+            continue
+        cloud = row.get("cloud") or "unknown"
+        prior = earliest.get(rid)
+        if prior is None or date < prior[0]:
+            earliest[rid] = (date, cloud)
+
+    # Second pass: bucket by (cloud, date).
+    cloud_date_counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for _rid, (date, cloud) in earliest.items():
+        cloud_date_counts[cloud][date] += 1
+
+    result = {}
+    for cloud, date_counts in cloud_date_counts.items():
+        sorted_dates = sorted(date_counts.keys())
+        result[cloud] = [(d, date_counts[d]) for d in sorted_dates]
+
+    return result
+
+
 def _generate_chart(
     cumulative_data: dict[str, list[tuple[str, int]]],
     daily_data: dict[str, list[tuple[str, int]]],
+    new_data: dict[str, list[tuple[str, int]]],
     output_path: str,
 ) -> None:
-    """Generate and save the timeseries chart with two subplots."""
-    sns.set_theme(style="whitegrid")
+    """Generate and save the timeseries chart with three subplots.
 
-    fig, (ax_cumulative, ax_daily) = plt.subplots(
-        2,
+    Top panel: cumulative unique installs per cloud (ever-seen running total).
+    Middle panel: daily unique active installs per cloud (any event that day).
+    Bottom panel: daily NEW installs per cloud (first-seen on that day only).
+    """
+    apply_tufte_style()
+
+    fig, (ax_cumulative, ax_daily, ax_new) = plt.subplots(
+        3,
         1,
-        figsize=(FIGURE_WIDTH, FIGURE_HEIGHT),
+        figsize=(FIGURE_WIDTH, FIGURE_HEIGHT * 1.4),
         sharex=True,
     )
     fig.suptitle(
         CHART_TITLE,
         fontsize=14,
         fontweight="bold",
-        y=0.98,
+        y=0.99,
     )
 
-    colors = sns.color_palette(LINE_PALETTE, len(cumulative_data))
+    # Use a stable colour map keyed on cloud provider so the same cloud
+    # gets the same colour in all three panels even if a panel's dict
+    # iteration order differs.
+    all_clouds = sorted(set(cumulative_data) | set(daily_data) | set(new_data))
+    palette = sns.color_palette(LINE_PALETTE, len(all_clouds))
+    cloud_color = {cloud: palette[i] for i, cloud in enumerate(all_clouds)}
 
     # Plot cumulative installs
-    for idx, (cloud, series) in enumerate(sorted(cumulative_data.items())):
+    for cloud, series in sorted(cumulative_data.items()):
         dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
         counts = [c for _, c in series]
         ax_cumulative.plot(
@@ -196,16 +255,17 @@ def _generate_chart(
             markersize=5,
             linewidth=2,
             label=cloud,
-            color=colors[idx],
+            color=cloud_color[cloud],
         )
 
     ax_cumulative.set_ylabel("Cumulative Unique Installs")
-    ax_cumulative.set_title("Cumulative Unique Registry Installs", fontsize=11)
+    ax_cumulative.set_title("Cumulative Unique Registry Installs", loc="left", fontsize=11)
     ax_cumulative.legend(title="Cloud Provider", loc="upper left")
     ax_cumulative.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+    tufte_axes(ax_cumulative)
 
     # Plot daily active installs
-    for idx, (cloud, series) in enumerate(sorted(daily_data.items())):
+    for cloud, series in sorted(daily_data.items()):
         dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
         counts = [c for _, c in series]
         ax_daily.plot(
@@ -215,20 +275,41 @@ def _generate_chart(
             markersize=4,
             linewidth=2,
             label=cloud,
-            color=colors[idx],
+            color=cloud_color[cloud],
         )
 
-    ax_daily.set_ylabel("Daily Unique Installs")
-    ax_daily.set_title("Daily Active Registry Installs", fontsize=11)
+    ax_daily.set_ylabel("Daily Active Installs")
+    ax_daily.set_title("Daily Active Registry Installs", loc="left", fontsize=11)
     ax_daily.legend(title="Cloud Provider", loc="upper left")
     ax_daily.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+    tufte_axes(ax_daily)
 
-    # Format x-axis dates
-    ax_daily.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
-    ax_daily.xaxis.set_major_locator(mdates.DayLocator(interval=1))
-    plt.setp(ax_daily.xaxis.get_majorticklabels(), rotation=45, ha="right")
+    # Plot daily NEW installs (first-seen per day)
+    for cloud, series in sorted(new_data.items()):
+        dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
+        counts = [c for _, c in series]
+        ax_new.plot(
+            dates,
+            counts,
+            marker="^",
+            markersize=4,
+            linewidth=2,
+            label=cloud,
+            color=cloud_color[cloud],
+        )
 
-    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    ax_new.set_ylabel("New Installs (first-seen)")
+    ax_new.set_title("Daily NEW Registry Installs (first-seen on that day)", loc="left", fontsize=11)
+    ax_new.legend(title="Cloud Provider", loc="upper left")
+    ax_new.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+    tufte_axes(ax_new)
+
+    # Format x-axis dates on the bottom panel
+    ax_new.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax_new.xaxis.set_major_locator(mdates.DayLocator(interval=1))
+    plt.setp(ax_new.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    plt.tight_layout(rect=[0, 0, 1, 0.97])
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
     logger.info(f"Timeseries chart saved to {output_path}")
@@ -284,12 +365,13 @@ def main() -> None:
 
     cumulative_data = _compute_cumulative_installs(unique_rows)
     daily_data = _compute_daily_unique_installs(unique_rows)
+    new_data = _compute_daily_new_installs(unique_rows)
 
     if not cumulative_data:
         logger.error("No identified registry instances found in data")
         raise SystemExit(1)
 
-    _generate_chart(cumulative_data, daily_data, args.output)
+    _generate_chart(cumulative_data, daily_data, new_data, args.output)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/usage-report/tufte-viz-guidelines.md
+++ b/.claude/skills/usage-report/tufte-viz-guidelines.md
@@ -1,0 +1,75 @@
+---
+name: tufte-viz
+description: |
+  Ideate and critique data visualizations using Edward Tufte's principles from "The Visual Display of Quantitative Information." Use this skill when:
+  (1) Designing new data visualizations or charts
+  (2) Critiquing or improving existing visualizations
+  (3) Reviewing dashboards or reports for graphical integrity
+  (4) Deciding between visualization approaches
+  (5) Reducing chartjunk or improving data-ink ratio
+  (6) Planning small multiples or high-density displays
+  Applies principles: data-ink ratio, chartjunk elimination, graphical integrity, lie factor, small multiples, and data density.
+---
+
+# Tufte Visualization Ideation
+
+Apply Edward Tufte's principles to design clear, honest, high-density data visualizations.
+
+## Workflow
+
+### For new visualizations:
+
+1. **Clarify the data story**
+   - What comparisons matter?
+   - What's the key insight to communicate?
+   - Who's the audience?
+
+2. **Select approach** using Tufte principles:
+   - High comparison need → Small multiples
+   - Dense data → Consider data tables, sparklines
+   - Time-series → Line charts with minimal grid
+   - Part-to-whole → Avoid pie charts; prefer bar/table
+
+3. **Design with data-ink in mind**
+   - Start minimal, add only what's necessary
+   - Every element must earn its ink
+   - Default to grayscale; use color purposefully
+
+4. **Apply the Tufte test** (see references/tufte-principles.md)
+
+### For critiquing visualizations:
+
+1. **Check graphical integrity**
+   - Calculate lie factor if proportions seem off
+   - Verify baselines and scales
+   - Look for 3D distortion
+
+2. **Identify chartjunk**
+   - Decorative elements
+   - Heavy grids
+   - Unnecessary 3D effects
+   - Moiré patterns
+
+3. **Evaluate data-ink ratio**
+   - What can be erased?
+   - What's redundant?
+
+4. **Suggest improvements** with specific before/after recommendations
+
+## Key Principles Reference
+
+- `references/tufte-principles.md` — core principles from *Visual Display of Quantitative Information*: lie factor, data-ink, chartjunk, small multiples, integrity.
+- `references/analytical-design.md` — extensions from *Envisioning Information*, *Visual Explanations*, and *Beautiful Evidence*: the 6 principles of analytical design, sparklines, layering & separation, micro/macro, range-frames, causality, confections. Load when designing dashboards, dense displays, sparklines, or explanatory graphics.
+
+**Quick checklist:**
+- [ ] Lie Factor ≈ 1.0 (no visual distortion)
+- [ ] Maximum data-ink ratio
+- [ ] Zero chartjunk
+- [ ] Clear labeling
+- [ ] Answers "compared to what?"
+- [ ] Shows causality or mechanism where relevant
+- [ ] Multivariate (not over-reduced)
+- [ ] Words, numbers, images integrated — not segregated
+- [ ] Reveals multiple levels of detail (micro + macro)
+- [ ] Layering: primary data dominates, secondary recedes
+- [ ] Appropriate data density

--- a/.claude/skills/usage-report/tufte_style.py
+++ b/.claude/skills/usage-report/tufte_style.py
@@ -1,0 +1,141 @@
+"""Shared Tufte-inspired styling for usage-report charts.
+
+Applies Edward Tufte's principles from "The Visual Display of Quantitative
+Information" to matplotlib/seaborn charts:
+
+- Data-ink ratio: maximize ink that conveys data, minimize decorative ink
+- Chartjunk: remove top/right spines, heavy grids, redundant labels
+- Layering: primary data in dark/saturated tones, secondary in muted greys
+- Honest scales: integer y-ticks, minimal decoration
+
+Every chart generator should import and call `apply_tufte_style()` once at
+module load, then `tufte_axes(ax)` per axes after plotting.
+
+See tufte-viz-guidelines.md for the principles this implements.
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+PRIMARY_COLOR: str = "#2b2b2b"
+SECONDARY_COLOR: str = "#6b6b6b"
+ACCENT_COLOR: str = "#1f77b4"
+GRID_COLOR: str = "#e8e8e8"
+TEXT_COLOR: str = "#333333"
+
+CATEGORICAL_PALETTE: list[str] = [
+    "#1f77b4",
+    "#ff7f0e",
+    "#2ca02c",
+    "#d62728",
+    "#9467bd",
+    "#8c564b",
+    "#e377c2",
+    "#7f7f7f",
+]
+
+SEQUENTIAL_PALETTE_NAME: str = "Greys"
+
+
+def apply_tufte_style() -> None:
+    """Apply Tufte rcParams once per process.
+
+    Sets a clean base: minimal spines, light grid, muted text, sans-serif font.
+    Call once at the top of each chart generator before any plotting.
+    """
+    sns.set_theme(style="white")
+    plt.rcParams.update(
+        {
+            "axes.spines.top": False,
+            "axes.spines.right": False,
+            "axes.spines.left": True,
+            "axes.spines.bottom": True,
+            "axes.edgecolor": SECONDARY_COLOR,
+            "axes.linewidth": 0.8,
+            "axes.labelcolor": TEXT_COLOR,
+            "axes.labelsize": 10,
+            "axes.titlesize": 11,
+            "axes.titleweight": "normal",
+            "axes.titlecolor": PRIMARY_COLOR,
+            "axes.titlepad": 8,
+            "xtick.color": SECONDARY_COLOR,
+            "ytick.color": SECONDARY_COLOR,
+            "xtick.labelsize": 9,
+            "ytick.labelsize": 9,
+            "xtick.major.size": 3,
+            "ytick.major.size": 3,
+            "xtick.major.width": 0.6,
+            "ytick.major.width": 0.6,
+            "grid.color": GRID_COLOR,
+            "grid.linewidth": 0.5,
+            "grid.alpha": 0.7,
+            "legend.frameon": False,
+            "legend.fontsize": 9,
+            "legend.title_fontsize": 9,
+            "figure.facecolor": "white",
+            "axes.facecolor": "white",
+            "savefig.facecolor": "white",
+            "savefig.dpi": 150,
+            "font.family": "sans-serif",
+            "font.size": 10,
+        }
+    )
+
+
+def tufte_axes(
+    ax: plt.Axes,
+    grid: str = "y",
+) -> None:
+    """Apply per-axes Tufte cleanup.
+
+    Args:
+        ax: The matplotlib Axes to clean up.
+        grid: "y" (default), "x", "both", or "none" for which gridlines to keep.
+              Tufte preferred minimal or no grid; "y" gives readers a quiet
+              horizontal reference for value comparisons without competing with
+              the data line.
+    """
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    if grid == "y":
+        ax.grid(axis="y", linestyle="-", linewidth=0.5, color=GRID_COLOR, alpha=0.7)
+        ax.grid(axis="x", visible=False)
+    elif grid == "x":
+        ax.grid(axis="x", linestyle="-", linewidth=0.5, color=GRID_COLOR, alpha=0.7)
+        ax.grid(axis="y", visible=False)
+    elif grid == "both":
+        ax.grid(linestyle="-", linewidth=0.5, color=GRID_COLOR, alpha=0.7)
+    else:
+        ax.grid(visible=False)
+
+    ax.set_axisbelow(True)
+    ax.tick_params(colors=SECONDARY_COLOR)
+
+
+def tufte_title(
+    ax: plt.Axes,
+    title: str,
+    subtitle: str | None = None,
+) -> None:
+    """Set a Tufte-style title (left-aligned, normal weight, optional subtitle).
+
+    Tufte preferred informative titles integrated with the chart, not the bold
+    centered headlines that come by default. Subtitle, when given, sits below
+    the title in lighter grey and is best used for units, scope, or methodology.
+    """
+    ax.set_title(title, loc="left", fontsize=11, fontweight="normal", color=PRIMARY_COLOR)
+    if subtitle:
+        ax.text(
+            0,
+            1.02,
+            subtitle,
+            transform=ax.transAxes,
+            ha="left",
+            va="bottom",
+            fontsize=9,
+            color=SECONDARY_COLOR,
+        )


### PR DESCRIPTION
## Summary

- Adds a shared `tufte_style.py` module (`apply_tufte_style()` + `tufte_axes(ax)`) and a `tufte-viz-guidelines.md` doc describing the principles (high data-ink ratio, no chartjunk, layered information, honest scales)
- Every existing chart generator switches from seaborn `whitegrid` to the shared style. Future chart generators are expected to follow suit, per a new note in `SKILL.md`
- Adds a new `generate_detection_by_version_chart.py` so the usage report can validate whether the cloud-detection fix in 1.24.2 (issue #1093 / PR #1106) actually moved the `unknown` cloud rate down on instances that adopted it
- Splits the timeseries chart into three subplots (cumulative installs, daily active, daily NEW first-seen) so acquisition velocity is visible separately from re-engagement
- Bumps SKILL.md to v1.3 and documents the new step 5f plus the visualization-guidelines reference

## Test plan

- [x] `python3 -m py_compile` passes on the new files
- [ ] Run the skill end-to-end against the live telemetry export and inspect the rendered PNGs for the Tufte style and the new detection-by-version chart
- [ ] Verify the new "Daily NEW" series in the timeseries chart shows non-zero values on first-seen days