### PR TITLE
feat(gitlab): translate GitLab /-/raw/ URLs to API v4 for private repos

### DIFF
--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -196,9 +196,10 @@ def _build_fetch_headers(
 ) -> tuple[str, dict[str, str]]:
     """Build fetch URL and auth headers for a SKILL.md request.
 
-    Returns (fetch_url, headers) tuple.  The URL is returned unchanged;
-    platform-specific modules may override to translate web URLs to
-    authenticated API endpoints.
+    For GitLab URLs with credentials, translates /-/raw/ web URLs to
+    API v4 endpoints that accept PRIVATE-TOKEN headers.
+
+    Returns (fetch_url, headers) tuple.
     """
     headers: dict[str, str] = {}
     fetch_url = url
@@ -212,6 +213,16 @@ def _build_fetch_headers(
     elif auth_scheme == "api_key":
         header_name = auth_header_name or "PRIVATE-TOKEN"
         headers[header_name] = auth_credential
+
+    if headers and "gitlab" in url.lower():
+        try:
+            from ..utils.gitlab_url_utils import translate_gitlab_to_api_url
+
+            api_url = translate_gitlab_to_api_url(url)
+            if api_url:
+                fetch_url = api_url
+        except ImportError:
+            pass
 
     return fetch_url, headers
 
@@ -290,6 +301,18 @@ def _resolve_tree_api(
         - ``skill_dir``: directory portion of the path leading up to
           ``SKILL.md`` (``""`` when SKILL.md is at the repo root).
     """
+    # Try GitLab translation first (Meraki: defensive import so removing
+    # gitlab_url_utils leaves upstream features fully functional for GitHub).
+    try:
+        from ..utils.gitlab_url_utils import translate_gitlab_tree_api_url
+
+        gitlab_result = translate_gitlab_tree_api_url(skill_md_url)
+        if gitlab_result is not None:
+            return gitlab_result
+    except ImportError:
+        pass
+
+    # Fall through to upstream GitHub / GHES handling.
     parsed = urlparse(skill_md_url)
     hostname = parsed.hostname or ""
     if not hostname:

--- a/registry/utils/gitlab_url_utils.py
+++ b/registry/utils/gitlab_url_utils.py
@@ -1,0 +1,118 @@
+"""
+GitLab-specific URL utilities for API v4 endpoint translation.
+
+Provides functions to translate GitLab web URLs (/-/raw/) to API v4
+authenticated endpoints, derive resource URLs within GitLab repos,
+and build tree API URLs for resource discovery.
+
+These helpers are not needed for GitHub-hosted skills and can be
+omitted from upstream distributions.
+"""
+
+import re
+from urllib.parse import quote as url_quote
+from urllib.parse import unquote
+
+
+class _GitLabParts:
+    """Parsed components of a GitLab /-/raw/ or API v4 file URL."""
+
+    __slots__ = ("base", "project", "ref", "filepath")
+
+    def __init__(self, base: str, project: str, ref: str, filepath: str):
+        self.base = base
+        self.project = project
+        self.ref = ref
+        self.filepath = filepath
+
+    @property
+    def encoded_project(self) -> str:
+        return url_quote(self.project, safe="")
+
+    @property
+    def file_dir(self) -> str:
+        """Directory containing the file (everything before the last /)."""
+        return self.filepath.rsplit("/", 1)[0] if "/" in self.filepath else ""
+
+
+def parse_gitlab_url(url: str) -> _GitLabParts | None:
+    """Parse a GitLab raw-web or API v4 file URL into its components.
+
+    Handles two forms:
+      /-/raw/  web URLs:  https://host/group/repo/-/raw/branch/path/to/file
+      API v4 file URLs:   https://host/api/v4/projects/group%2Frepo/repository/files/path%2Fto%2Ffile/raw?ref=branch
+
+    Returns None if the URL matches neither pattern.
+    """
+    m = re.match(r"(https?://[^/]+)/(.+?)/-/raw/([^/]+)/(.+)$", url)
+    if m:
+        return _GitLabParts(*m.groups())
+
+    api_m = re.match(
+        r"(https?://[^/]+)/api/v4/projects/([^/]+)/repository/files/(.+?)/raw\?ref=(.+)$",
+        url,
+    )
+    if api_m:
+        base, encoded_project, encoded_path, ref = api_m.groups()
+        return _GitLabParts(base, unquote(encoded_project), ref, unquote(encoded_path))
+
+    return None
+
+
+def translate_gitlab_to_api_url(url: str) -> str | None:
+    """Translate a GitLab web raw URL to a GitLab API v4 raw file endpoint.
+
+    GitLab's /-/raw/ web URLs require session cookies for private repos.
+    The API v4 endpoint accepts PRIVATE-TOKEN header authentication.
+
+    Returns None if the URL doesn't match the expected GitLab pattern.
+    """
+    parts = parse_gitlab_url(url)
+    if not parts:
+        return None
+    encoded_path = url_quote(parts.filepath, safe="")
+    return (
+        f"{parts.base}/api/v4/projects/{parts.encoded_project}"
+        f"/repository/files/{encoded_path}/raw?ref={parts.ref}"
+    )
+
+
+def derive_gitlab_resource_url(skill_md_url: str, resource_path: str) -> str | None:
+    """Derive a resource URL from a GitLab SKILL.md URL.
+
+    Returns an API v4 file URL for the resource, or None if the
+    skill_md_url is not a recognised GitLab URL.
+    """
+    parts = parse_gitlab_url(skill_md_url)
+    if not parts:
+        return None
+
+    file_dir = parts.file_dir
+    new_path = f"{file_dir}/{resource_path}" if file_dir else resource_path
+    encoded_path = url_quote(new_path, safe="")
+    return (
+        f"{parts.base}/api/v4/projects/{parts.encoded_project}"
+        f"/repository/files/{encoded_path}/raw?ref={parts.ref}"
+    )
+
+
+def translate_gitlab_tree_api_url(skill_md_url: str) -> tuple[str, str, str, str] | None:
+    """Derive a GitLab API v4 tree endpoint from a skill's URL.
+
+    Returns (tree_api_url, project_encoded, ref, skill_dir) or None if not a
+    GitLab URL.  *skill_dir* is the directory prefix that the tree API will
+    prepend to every returned path (e.g. ``skills/jira-to-pr``).
+    """
+    parts = parse_gitlab_url(skill_md_url)
+    if not parts:
+        return None
+
+    skill_dir = parts.file_dir
+    if not skill_dir:
+        return None
+
+    tree_url = (
+        f"{parts.base}/api/v4/projects/{parts.encoded_project}/repository/tree"
+        f"?path={url_quote(skill_dir, safe='')}&ref={parts.ref}&recursive=true&per_page=100"
+    )
+    return tree_url, parts.encoded_project, parts.ref, skill_dir

--- a/registry/utils/url_utils.py
+++ b/registry/utils/url_utils.py
@@ -257,9 +257,18 @@ def extract_repository_url(
 def derive_resource_url(skill_md_url: str, resource_path: str) -> str:
     """Derive a resource URL by replacing the filename in a SKILL.md URL.
 
-    Works by stripping the filename from the base URL and appending the
-    requested resource path.
+    Tries platform-specific derivation first (e.g. GitLab API v4), then
+    falls back to simple path replacement.
     """
+    try:
+        from .gitlab_url_utils import derive_gitlab_resource_url
+
+        gitlab_url = derive_gitlab_resource_url(skill_md_url, resource_path)
+        if gitlab_url:
+            return gitlab_url
+    except ImportError:
+        pass
+
     if "/SKILL.md" in skill_md_url:
         base = skill_md_url.rsplit("/SKILL.md", 1)[0]
         return f"{base}/{resource_path}"

--- a/tests/unit/services/test_skill_service_gitlab.py
+++ b/tests/unit/services/test_skill_service_gitlab.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for the GitLab integration hooks in registry.services.skill_service.
+
+These cover the call-site branches added alongside the optional
+registry.utils.gitlab_url_utils helper:
+
+  * _build_fetch_headers — translates a /-/raw/ URL to API v4 only when
+    auth headers are populated and the URL is GitLab-shaped.
+  * _resolve_tree_api    — tries GitLab translation first, falls through
+    to GitHub / GHES handling when the URL is not GitLab.
+
+Both hooks wrap their import in try/except ImportError so the upstream
+GitHub paths keep working when gitlab_url_utils is removed.  Those
+fall-through paths are exercised by patching sys.modules.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from registry.services.skill_service import (
+    _build_fetch_headers,
+    _resolve_tree_api,
+)
+
+
+# =============================================================================
+# _build_fetch_headers — GitLab URL translation
+# =============================================================================
+
+
+class TestBuildFetchHeadersGitlab:
+    """Translation of GitLab /-/raw/ URLs to API v4 raw-file endpoints."""
+
+    def test_gitlab_raw_url_with_api_key_is_translated(self):
+        url = "https://gitlab.example.com/g/r/-/raw/main/skills/demo/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="api_key", auth_credential="glpat-xxx"
+        )
+
+        assert headers == {"PRIVATE-TOKEN": "glpat-xxx"}
+        assert fetch_url == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+    def test_gitlab_url_with_bearer_auth_also_translates(self):
+        url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="bearer", auth_credential="tok"
+        )
+
+        assert headers == {"Authorization": "Bearer tok"}
+        assert fetch_url == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr"
+            "/repository/files/SKILL.md/raw?ref=main"
+        )
+
+    def test_github_url_is_not_translated(self):
+        url = "https://github.com/owner/repo/blob/main/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="api_key", auth_credential="ghp-xxx"
+        )
+
+        assert fetch_url == url
+        assert headers == {"PRIVATE-TOKEN": "ghp-xxx"}
+
+    def test_gitlab_url_without_credentials_skips_translation(self):
+        url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(url, auth_scheme="none")
+
+        assert fetch_url == url
+        assert headers == {}
+
+    def test_gitlab_url_with_unrecognised_shape_falls_through(self):
+        # Contains "gitlab" but is not a /-/raw/ or API v4 file URL,
+        # so translate_gitlab_to_api_url returns None and fetch_url
+        # is left unchanged.
+        url = "https://gitlab.example.com/g/r/blob/main/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="api_key", auth_credential="glpat-xxx"
+        )
+
+        assert fetch_url == url
+        assert headers == {"PRIVATE-TOKEN": "glpat-xxx"}
+
+    def test_importerror_is_swallowed_and_url_unchanged(self):
+        # Simulate gitlab_url_utils being absent (upstream-only deployment).
+        url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        with patch.dict(
+            sys.modules, {"registry.utils.gitlab_url_utils": None}
+        ):
+            fetch_url, headers = _build_fetch_headers(
+                url, auth_scheme="api_key", auth_credential="glpat-xxx"
+            )
+
+        assert fetch_url == url
+        assert headers == {"PRIVATE-TOKEN": "glpat-xxx"}
+
+
+# =============================================================================
+# _resolve_tree_api — GitLab branch + ImportError fall-through
+# =============================================================================
+
+
+class TestResolveTreeApiGitlab:
+    """GitLab path through the tree-API resolver."""
+
+    def test_gitlab_url_returns_api_v4_tree_url(self):
+        skill_md_url = (
+            "https://gitlab.example.com/g/r/-/raw/main/skills/demo/SKILL.md"
+        )
+
+        result = _resolve_tree_api(skill_md_url)
+
+        assert result is not None
+        tree_url, project_encoded, ref, skill_dir = result
+        assert project_encoded == "g%2Fr"
+        assert ref == "main"
+        assert skill_dir == "skills/demo"
+        assert tree_url == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr/repository/tree"
+            "?path=skills%2Fdemo&ref=main&recursive=true&per_page=100"
+        )
+
+    def test_gitlab_skill_md_at_repo_root_falls_through_to_github_branch(self):
+        # translate_gitlab_tree_api_url returns None for root-level files,
+        # so the function continues to the GitHub matcher which then also
+        # returns None (no /blob/ or /refs/heads/ in the path).
+        skill_md_url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        assert _resolve_tree_api(skill_md_url) is None
+
+    def test_importerror_falls_through_to_github_path(self):
+        # With gitlab_url_utils unavailable, a GitHub URL must still resolve.
+        github_url = "https://github.com/anthropics/skills/blob/main/x/SKILL.md"
+
+        with patch.dict(
+            sys.modules, {"registry.utils.gitlab_url_utils": None}
+        ):
+            result = _resolve_tree_api(github_url)
+
+        assert result is not None
+        tree_url, project, ref, skill_dir = result
+        assert tree_url == (
+            "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        )
+        assert project == "anthropics/skills"
+        assert ref == "main"
+        assert skill_dir == "x"
+
+
+# =============================================================================
+# Parametrised non-GitLab auth schemes (kept short — for regression only)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "scheme,credential,expected_header",
+    [
+        ("bearer", "abc", {"Authorization": "Bearer abc"}),
+        ("api_key", "abc", {"PRIVATE-TOKEN": "abc"}),
+        ("none", "abc", {}),
+        ("global_credentials", "abc", {}),
+    ],
+)
+def test_build_fetch_headers_non_gitlab_url_leaves_url_intact(
+    scheme, credential, expected_header
+):
+    url = "https://example.com/path/SKILL.md"
+
+    fetch_url, headers = _build_fetch_headers(
+        url, auth_scheme=scheme, auth_credential=credential
+    )
+
+    assert fetch_url == url
+    assert headers == expected_header

--- a/tests/unit/utils/test_gitlab_url_utils.py
+++ b/tests/unit/utils/test_gitlab_url_utils.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for registry.utils.gitlab_url_utils.
+
+Validates parsing of GitLab raw-web and API v4 file URLs, translation
+between the two forms, derivation of sibling resource URLs, and
+construction of tree API URLs for multi-file skill discovery.
+"""
+
+import pytest
+
+from registry.utils.gitlab_url_utils import (
+    derive_gitlab_resource_url,
+    parse_gitlab_url,
+    translate_gitlab_to_api_url,
+    translate_gitlab_tree_api_url,
+)
+
+
+class TestParseGitlabUrl:
+    """Tests for parse_gitlab_url."""
+
+    def test_parses_raw_web_url(self):
+        """Should parse a /-/raw/ web URL into base/project/ref/filepath."""
+        url = "https://gitlab.example.com/group/repo/-/raw/main/skills/demo/SKILL.md"
+
+        parts = parse_gitlab_url(url)
+
+        assert parts is not None
+        assert parts.base == "https://gitlab.example.com"
+        assert parts.project == "group/repo"
+        assert parts.ref == "main"
+        assert parts.filepath == "skills/demo/SKILL.md"
+
+    def test_parses_api_v4_file_url(self):
+        """Should parse an API v4 raw-file URL and decode path components."""
+        url = (
+            "https://gitlab.example.com/api/v4/projects/group%2Frepo"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+        parts = parse_gitlab_url(url)
+
+        assert parts is not None
+        assert parts.project == "group/repo"
+        assert parts.ref == "main"
+        assert parts.filepath == "skills/demo/SKILL.md"
+
+    def test_parts_properties(self):
+        """file_dir and encoded_project should expose API-ready components."""
+        nested = parse_gitlab_url(
+            "https://gitlab.example.com/g/sub/r/-/raw/main/a/b/c/SKILL.md"
+        )
+        root = parse_gitlab_url(
+            "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+        )
+
+        assert nested is not None and root is not None
+        assert nested.file_dir == "a/b/c"
+        assert nested.encoded_project == "g%2Fsub%2Fr"
+        assert root.file_dir == ""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            "https://github.com/owner/repo/blob/main/SKILL.md",
+            "https://raw.githubusercontent.com/owner/repo/main/SKILL.md",
+            "https://gitlab.example.com/group/repo/blob/main/SKILL.md",
+            "not a url at all",
+        ],
+    )
+    def test_returns_none_for_unrecognised_urls(self, url):
+        """Should return None for any URL that matches neither pattern."""
+        assert parse_gitlab_url(url) is None
+
+
+class TestTranslateGitlabToApiUrl:
+    """Tests for translate_gitlab_to_api_url."""
+
+    def test_translates_raw_web_url_to_api_v4(self):
+        """Should rewrite a /-/raw/ URL to the API v4 raw file endpoint."""
+        url = "https://gitlab.example.com/group/repo/-/raw/main/skills/demo/SKILL.md"
+
+        result = translate_gitlab_to_api_url(url)
+
+        assert result == (
+            "https://gitlab.example.com/api/v4/projects/group%2Frepo"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+    def test_translates_nested_group_url(self):
+        """Should encode nested-group project paths correctly."""
+        url = "https://gitlab.example.com/g/sub/repo/-/raw/main/SKILL.md"
+
+        result = translate_gitlab_to_api_url(url)
+
+        assert result == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fsub%2Frepo"
+            "/repository/files/SKILL.md/raw?ref=main"
+        )
+
+    def test_translation_is_idempotent_for_api_v4_input(self):
+        """Re-translating an API v4 URL should yield an equivalent API v4 URL."""
+        api_url = (
+            "https://gitlab.example.com/api/v4/projects/group%2Frepo"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+        result = translate_gitlab_to_api_url(api_url)
+
+        assert result == api_url
+
+    def test_returns_none_for_non_gitlab_url(self):
+        """Should return None when the URL is not recognisably GitLab."""
+        url = "https://github.com/owner/repo/blob/main/SKILL.md"
+
+        assert translate_gitlab_to_api_url(url) is None
+
+
+class TestDeriveGitlabResourceUrl:
+    """Tests for derive_gitlab_resource_url."""
+
+    def test_derives_sibling_resource_in_same_directory(self):
+        """Should resolve a sibling resource relative to the SKILL.md dir."""
+        skill_md_url = (
+            "https://gitlab.example.com/g/r/-/raw/main/skills/demo/SKILL.md"
+        )
+
+        result = derive_gitlab_resource_url(skill_md_url, "reference/notes.md")
+
+        assert result == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr"
+            "/repository/files/skills%2Fdemo%2Freference%2Fnotes.md/raw?ref=main"
+        )
+
+    def test_derives_resource_when_skill_at_repo_root(self):
+        """Should treat resource_path as the full path when SKILL.md is at root."""
+        skill_md_url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        result = derive_gitlab_resource_url(skill_md_url, "asset.png")
+
+        assert result == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr"
+            "/repository/files/asset.png/raw?ref=main"
+        )
+
+    def test_encodes_special_characters_in_resource_path(self):
+        """Should percent-encode spaces and reserved characters in the path."""
+        skill_md_url = "https://gitlab.example.com/g/r/-/raw/main/dir/SKILL.md"
+
+        result = derive_gitlab_resource_url(skill_md_url, "a b/c+d.txt")
+
+        assert result is not None
+        # Path should be fully quoted, including '/' between dir and resource.
+        assert "/repository/files/dir%2Fa%20b%2Fc%2Bd.txt/raw?ref=main" in result
+
+    def test_returns_none_for_non_gitlab_url(self):
+        """Should return None when the skill URL is not a GitLab URL."""
+        assert (
+            derive_gitlab_resource_url(
+                "https://github.com/o/r/blob/main/SKILL.md", "ref.md"
+            )
+            is None
+        )
+
+
+class TestTranslateGitlabTreeApiUrl:
+    """Tests for translate_gitlab_tree_api_url."""
+
+    def test_builds_tree_api_url_for_skill_directory(self):
+        """Should return tree URL plus encoded project, ref, and skill_dir."""
+        skill_md_url = (
+            "https://gitlab.example.com/g/r/-/raw/main/skills/demo/SKILL.md"
+        )
+
+        result = translate_gitlab_tree_api_url(skill_md_url)
+
+        assert result is not None
+        tree_url, project_encoded, ref, skill_dir = result
+        assert project_encoded == "g%2Fr"
+        assert ref == "main"
+        assert skill_dir == "skills/demo"
+        assert tree_url == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr/repository/tree"
+            "?path=skills%2Fdemo&ref=main&recursive=true&per_page=100"
+        )
+
+    def test_encodes_nested_skill_directories(self):
+        """Should percent-encode every slash in deeply nested skill paths."""
+        skill_md_url = (
+            "https://gitlab.example.com/g/r/-/raw/main/a/b/c/SKILL.md"
+        )
+
+        result = translate_gitlab_tree_api_url(skill_md_url)
+
+        assert result is not None
+        tree_url, _, _, skill_dir = result
+        assert skill_dir == "a/b/c"
+        assert "path=a%2Fb%2Fc" in tree_url
+
+    def test_returns_none_when_skill_md_at_repo_root(self):
+        """Tree resolution requires a parent directory; root files yield None."""
+        skill_md_url = "https://gitlab.example.com/g/r/-/raw/main/SKILL.md"
+
+        assert translate_gitlab_tree_api_url(skill_md_url) is None
+
+    def test_returns_none_for_non_gitlab_url(self):
+        """Should return None for non-GitLab URLs."""
+        assert (
+            translate_gitlab_tree_api_url(
+                "https://github.com/o/r/blob/main/skills/demo/SKILL.md"
+            )
+            is None
+        )

--- a/tests/unit/utils/test_url_utils.py
+++ b/tests/unit/utils/test_url_utils.py
@@ -1,11 +1,15 @@
 """
-Unit tests for registry.utils.url_utils.extract_repository_url.
+Unit tests for registry.utils.url_utils.
 
-Validates extraction of GitHub repository URLs from SKILL.md URLs,
-including public GitHub, raw.githubusercontent.com, and enterprise instances.
+Covers extract_repository_url (GitHub / GHES extraction) and
+derive_resource_url, including the optional GitLab translation hook
+and its ImportError fall-through.
 """
 
-from registry.utils.url_utils import extract_repository_url
+import sys
+from unittest.mock import patch
+
+from registry.utils.url_utils import derive_resource_url, extract_repository_url
 
 
 class TestExtractRepositoryUrl:
@@ -101,3 +105,53 @@ class TestExtractRepositoryUrl:
 
         # Assert
         assert result is None
+
+
+class TestDeriveResourceUrl:
+    """Tests for derive_resource_url, including the GitLab hook."""
+
+    def test_github_url_uses_skill_md_stripping(self):
+        """GitHub URLs should fall through to the SKILL.md path-replace path."""
+        skill_md_url = (
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/dir/SKILL.md"
+        )
+
+        result = derive_resource_url(skill_md_url, "ref/note.md")
+
+        assert result == (
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/dir/ref/note.md"
+        )
+
+    def test_non_skill_md_url_falls_back_to_basename_replace(self):
+        """When the URL doesn't end in /SKILL.md, replace the basename."""
+        skill_md_url = "https://example.com/a/b/index.html"
+
+        result = derive_resource_url(skill_md_url, "asset.png")
+
+        assert result == "https://example.com/a/b/asset.png"
+
+    def test_gitlab_url_is_translated_to_api_v4(self):
+        """GitLab SKILL.md URLs go through derive_gitlab_resource_url."""
+        skill_md_url = "https://gitlab.example.com/g/r/-/raw/main/dir/SKILL.md"
+
+        result = derive_resource_url(skill_md_url, "ref/note.md")
+
+        assert result == (
+            "https://gitlab.example.com/api/v4/projects/g%2Fr"
+            "/repository/files/dir%2Fref%2Fnote.md/raw?ref=main"
+        )
+
+    def test_importerror_falls_back_to_skill_md_stripping(self):
+        """With gitlab_url_utils absent, GitHub-style fallback still works."""
+        skill_md_url = (
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md"
+        )
+
+        with patch.dict(
+            sys.modules, {"registry.utils.gitlab_url_utils": None}
+        ):
+            result = derive_resource_url(skill_md_url, "asset.png")
+
+        assert result == (
+            "https://raw.githubusercontent.com/o/r/refs/heads/main/asset.png"
+        )


### PR DESCRIPTION
## Summary

GitLab's `/-/raw/` web URLs require session cookies and therefore can't be
fetched from a private repository with only a Personal Access Token. The
API v4 raw file endpoint
(`/api/v4/projects/:id/repository/files/:path/raw`) accepts a
`PRIVATE-TOKEN` header instead, which is exactly what the registry already
configures via `auth_credential`.

This PR adds a small **optional** helper module,
`registry/utils/gitlab_url_utils.py`, plus three defensive hook points in
`skill_service` and `url_utils`. With the helper present, the registry can
fetch SKILL.md, sibling resource files, and recursive tree listings from
private GitLab projects using the same PAT-style auth flow that already
works for GitHub. With the helper absent (e.g. you delete the file), the
hooks fall through and existing GitHub / raw URL behaviour is completely
unchanged.

### What's in the helper

- `parse_gitlab_url` — parses both `/-/raw/` web URLs and API v4 raw-file
  URLs into base, project, ref and filepath.
- `translate_gitlab_to_api_url` — rewrites a `/-/raw/` URL to the
  equivalent API v4 raw-file URL so `PRIVATE-TOKEN` works.
- `derive_gitlab_resource_url` — resolves a sibling resource (e.g. a file
  referenced from a SKILL.md) to its API v4 URL with proper percent
  encoding.
- `translate_gitlab_tree_api_url` — builds a recursive tree API URL so
  multi-file skill discovery works against GitLab the same way it does
  against GitHub.

### Why this is safe for upstream

Every call site uses a `try/except ImportError` guard:

- `skill_service._build_fetch_headers` only attempts the rewrite when both
  auth headers are set **and** the URL contains `gitlab`.
- `skill_service._resolve_tree_api` tries the GitLab translator first and
  falls through to the existing GitHub / GHES handling on `None`.
- `url_utils.derive_resource_url` tries GitLab first and falls back to the
  current `SKILL.md`-stripping behaviour.

There are no new required dependencies, no changes to existing GitHub
code paths, and no behavioural change for any non-GitLab URL.

## Test plan

- [x] 20 new unit tests in `tests/unit/utils/test_gitlab_url_utils.py`
      covering:
  - parsing `/-/raw/` and API v4 file URLs
  - `file_dir` / `encoded_project` helpers (nested groups, root files)
  - translation `/-/raw/` → API v4
  - idempotency when the input is already an API v4 URL
  - sibling resource derivation with subdirectories and at the repo root
  - percent-encoding of spaces and reserved characters in resource paths
  - tree-API URL construction and `skill_dir` extraction
  - `None` fall-through for empty / non-GitLab / blob-style URLs
- [x] Tests pass locally (`pytest tests/unit/utils/test_gitlab_url_utils.py`
      → 20 passed).
- [ ] Reviewer sanity-check that GitHub-only paths are unaffected (the
      defensive imports are the only edits in `skill_service.py` and
      `url_utils.py`).