### PR TITLE
fix(auth-server): configurable listen port and nginx_service hardcode removal

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -604,7 +604,7 @@ else
 fi
 
 # Check auth service
-if curl -f http://localhost:18888/health &>/dev/null; then
+if curl -f http://localhost:8888/health &>/dev/null; then
     log "Auth service is healthy"
 else
     log "WARNING: Auth service may still be starting up..."

--- a/docker/Dockerfile.auth
+++ b/docker/Dockerfile.auth
@@ -76,7 +76,7 @@ EXPOSE 8888
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD curl -f http://localhost:8888/health || exit 1
+    CMD curl -f http://localhost:${AUTH_LISTEN_PORT:-8888}/health || exit 1
 
 # Create non-root user for security (CIS Docker Benchmark 4.1)
 RUN groupadd -g 1000 appuser && useradd -u 1000 -g appuser appuser

--- a/docker/auth-entrypoint.sh
+++ b/docker/auth-entrypoint.sh
@@ -114,14 +114,19 @@ fi
 # the net.ipv6.bindv6only=0 host-side requirement.
 BIND_HOST="${BIND_HOST:-0.0.0.0}"
 
-echo "Starting Auth Server (host=$BIND_HOST)..."
+# Internal listen port. Defaults to 8888 (Docker Compose, Helm). On ECS with
+# Service Connect, set AUTH_LISTEN_PORT=18888 to avoid conflict with Envoy's
+# outbound interceptor which binds 127.0.0.1:8888.
+AUTH_LISTEN_PORT="${AUTH_LISTEN_PORT:-8888}"
+
+echo "Starting Auth Server (host=$BIND_HOST, port=$AUTH_LISTEN_PORT)..."
 cd /app
 source .venv/bin/activate
 if [ -n "${OTEL_EXPORTER_OTLP_ENDPOINT}" ] && command -v opentelemetry-instrument >/dev/null 2>&1; then
     echo "Using OTEL_EXPORTER_OTLP_ENDPOINT at ${OTEL_EXPORTER_OTLP_ENDPOINT}"
-    UVICORN_CMD="opentelemetry-instrument uvicorn server:app --host $BIND_HOST --port 8888 --proxy-headers --forwarded-allow-ips=*"
+    UVICORN_CMD="opentelemetry-instrument uvicorn server:app --host $BIND_HOST --port $AUTH_LISTEN_PORT --proxy-headers --forwarded-allow-ips=*"
 else
     echo "OTEL_EXPORTER_OTLP_ENDPOINT not found, not using OTEL"
-    UVICORN_CMD="uvicorn server:app --host $BIND_HOST --port 8888 --proxy-headers --forwarded-allow-ips=*"
+    UVICORN_CMD="uvicorn server:app --host $BIND_HOST --port $AUTH_LISTEN_PORT --proxy-headers --forwarded-allow-ips=*"
 fi
 exec $UVICORN_CMD

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1300,7 +1300,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         # impact is the extra hop. Nginx never inspects the body or flag; auth_server decides.
         # We use the header strategy (X-Upstream-Url) so auth_server does not need a separate
         # MongoDB lookup per request, and version-aware upstream selection stays in nginx.
-        mcp_proxy_target = "http://auth-server:8888/mcp-proxy/" + path.strip("/") + "/"
+        mcp_proxy_target = f"{settings.auth_server_url}/mcp-proxy/" + path.strip("/") + "/"
         if has_versions:
             # Multi-version server: use map variable with fallback, then proxy the selected
             # upstream URL to auth_server via X-Upstream-Url so it knows where to forward.

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -53,10 +53,15 @@ module "ecs_service_auth" {
     EcsExecTaskExecution = aws_iam_policy.ecs_exec_task_execution.arn
   }
   create_tasks_iam_role = true
-  tasks_iam_role_policies = {
-    SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
-    EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
-  }
+  tasks_iam_role_policies = merge(
+    {
+      SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
+      EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
+    },
+    var.enable_observability ? {
+      AMPRemoteWrite = aws_iam_policy.adot_amp_write[0].arn
+    } : {}
+  )
 
   # Enable Service Connect
   service_connect_configuration = {
@@ -72,10 +77,10 @@ module "ecs_service_auth" {
   }
 
   # Container definitions
-  container_definitions = {
+  container_definitions = merge({
     auth-server = {
-      cpu                    = tonumber(var.cpu)
-      memory                 = tonumber(var.memory)
+      cpu                    = var.enable_observability ? tonumber(var.cpu) - local.adot_sidecar_cpu : tonumber(var.cpu)
+      memory                 = var.enable_observability ? tonumber(var.memory) - local.adot_sidecar_memory : tonumber(var.memory)
       essential              = true
       image                  = var.auth_server_image_uri
       versionConsistency     = "disabled"
@@ -84,7 +89,7 @@ module "ecs_service_auth" {
       portMappings = [
         {
           name          = "auth-server"
-          containerPort = 8888
+          containerPort = 18888
           protocol      = "tcp"
         }
       ]
@@ -97,6 +102,10 @@ module "ecs_service_auth" {
         {
           name  = "BIND_HOST"
           value = var.bind_host
+        },
+        {
+          name  = "AUTH_LISTEN_PORT"
+          value = "18888"
         },
         {
           name  = "AUTH_SERVER_URL"
@@ -362,19 +371,29 @@ module "ecs_service_auth" {
           name  = "TOOL_FILTER_AUDIT_LOG_LEVEL"
           value = var.tool_filter_audit_log_level
         },
-        # Metrics pipeline (only wired when observability is enabled).
-        # Issue #1122: auth-server intentionally has no OTel sidecar on ECS
-        # because uvicorn 0.0.0.0:8888 races with Service Connect Envoy's
-        # 127.0.0.1:8888 outbound interceptor. The legacy metrics-service
-        # POST path is the only metrics surface for auth-server on ECS for
-        # this PR; registry+mcpgw still get the full OTel-native pipeline.
-        {
-          name  = "METRICS_SERVICE_URL"
-          value = var.enable_observability ? "http://metrics-service:8890" : ""
-        },
         {
           name  = "METRICS_LEGACY_HTTP_POST"
-          value = var.enable_observability ? "true" : "false"
+          value = "false"
+        },
+        {
+          name  = "OTEL_METRIC_EXPORT_INTERVAL_MS"
+          value = "15000"
+        },
+        {
+          name  = "OTEL_EXPORTER_PROMETHEUS_HOST"
+          value = "0.0.0.0"
+        },
+        {
+          name  = "OTEL_EXPORTER_PROMETHEUS_PORT"
+          value = "9464"
+        },
+        {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.enable_observability ? "http://localhost:4317" : ""
+        },
+        {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "grpc"
         }
         ],
         # PR #947: MongoDB connection string override (plain-text variant).
@@ -478,14 +497,47 @@ module "ecs_service_auth" {
       cloudwatch_log_group_retention_in_days = 30
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:8888/health || exit 1"]
+        command     = ["CMD-SHELL", "curl -f http://localhost:18888/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3
         startPeriod = 60
       }
     }
-  }
+    },
+    var.enable_observability ? {
+      adot-collector = {
+        cpu                    = local.adot_sidecar_cpu
+        memory                 = local.adot_sidecar_memory
+        essential              = false
+        image                  = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+        versionConsistency     = "disabled"
+        readonlyRootFilesystem = false
+
+        command = ["--config=env:AOT_CONFIG_CONTENT"]
+
+        environment = [
+          {
+            name  = "AOT_CONFIG_CONTENT"
+            value = local.adot_otlp_to_amp_config
+          },
+          {
+            name  = "AWS_REGION"
+            value = data.aws_region.current.id
+          }
+        ]
+
+        enable_cloudwatch_logging              = true
+        cloudwatch_log_group_name              = "/ecs/${local.name_prefix}-auth-adot"
+        cloudwatch_log_group_retention_in_days = 30
+
+        dependencies = [{
+          containerName = "auth-server"
+          condition     = "START"
+        }]
+      }
+    } : {}
+  )
 
   volume = {
     mcp-logs = {
@@ -508,16 +560,16 @@ module "ecs_service_auth" {
     service = {
       target_group_arn = module.alb.target_groups["auth"].arn
       container_name   = "auth-server"
-      container_port   = 8888
+      container_port   = 18888
     }
   }
 
   subnet_ids = var.private_subnet_ids
   security_group_ingress_rules = {
-    alb_8888 = {
+    alb_18888 = {
       description                  = "Auth server port from ALB"
-      from_port                    = 8888
-      to_port                      = 8888
+      from_port                    = 18888
+      to_port                      = 18888
       ip_protocol                  = "tcp"
       referenced_security_group_id = module.alb.security_group_id
     }
@@ -1385,12 +1437,14 @@ resource "aws_vpc_security_group_ingress_rule" "mcpgw_to_registry" {
 }
 
 
-# Allow registry to communicate with auth server on port 8888
+# Allow registry to communicate with auth server on port 18888
+# Service Connect proxy-to-proxy traffic uses containerPort (18888),
+# not client_alias.port (8888).
 resource "aws_vpc_security_group_ingress_rule" "registry_to_auth" {
   security_group_id            = module.ecs_service_auth.security_group_id
   referenced_security_group_id = module.ecs_service_registry.security_group_id
-  from_port                    = 8888
-  to_port                      = 8888
+  from_port                    = 18888
+  to_port                      = 18888
   ip_protocol                  = "tcp"
   description                  = "Allow registry to access auth server"
 

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -53,15 +53,10 @@ module "ecs_service_auth" {
     EcsExecTaskExecution = aws_iam_policy.ecs_exec_task_execution.arn
   }
   create_tasks_iam_role = true
-  tasks_iam_role_policies = merge(
-    {
-      SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
-      EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
-    },
-    var.enable_observability ? {
-      AMPRemoteWrite = aws_iam_policy.adot_amp_write[0].arn
-    } : {}
-  )
+  tasks_iam_role_policies = {
+    SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
+    EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
+  }
 
   # Enable Service Connect
   service_connect_configuration = {
@@ -77,10 +72,10 @@ module "ecs_service_auth" {
   }
 
   # Container definitions
-  container_definitions = merge({
+  container_definitions = {
     auth-server = {
-      cpu                    = var.enable_observability ? tonumber(var.cpu) - local.adot_sidecar_cpu : tonumber(var.cpu)
-      memory                 = var.enable_observability ? tonumber(var.memory) - local.adot_sidecar_memory : tonumber(var.memory)
+      cpu                    = tonumber(var.cpu)
+      memory                 = tonumber(var.memory)
       essential              = true
       image                  = var.auth_server_image_uri
       versionConsistency     = "disabled"
@@ -89,7 +84,7 @@ module "ecs_service_auth" {
       portMappings = [
         {
           name          = "auth-server"
-          containerPort = 18888
+          containerPort = 8888
           protocol      = "tcp"
         }
       ]
@@ -104,12 +99,8 @@ module "ecs_service_auth" {
           value = var.bind_host
         },
         {
-          name  = "AUTH_LISTEN_PORT"
-          value = "18888"
-        },
-        {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:18888"
+          value = "http://auth-server:8888"
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"
@@ -371,29 +362,19 @@ module "ecs_service_auth" {
           name  = "TOOL_FILTER_AUDIT_LOG_LEVEL"
           value = var.tool_filter_audit_log_level
         },
+        # Metrics pipeline (only wired when observability is enabled).
+        # Issue #1122: auth-server intentionally has no OTel sidecar on ECS
+        # because uvicorn 0.0.0.0:8888 races with Service Connect Envoy's
+        # 127.0.0.1:8888 outbound interceptor. The legacy metrics-service
+        # POST path is the only metrics surface for auth-server on ECS for
+        # this PR; registry+mcpgw still get the full OTel-native pipeline.
+        {
+          name  = "METRICS_SERVICE_URL"
+          value = var.enable_observability ? "http://metrics-service:8890" : ""
+        },
         {
           name  = "METRICS_LEGACY_HTTP_POST"
-          value = "false"
-        },
-        {
-          name  = "OTEL_METRIC_EXPORT_INTERVAL_MS"
-          value = "15000"
-        },
-        {
-          name  = "OTEL_EXPORTER_PROMETHEUS_HOST"
-          value = "0.0.0.0"
-        },
-        {
-          name  = "OTEL_EXPORTER_PROMETHEUS_PORT"
-          value = "9464"
-        },
-        {
-          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
-          value = var.enable_observability ? "http://localhost:4317" : ""
-        },
-        {
-          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
-          value = "grpc"
+          value = var.enable_observability ? "true" : "false"
         }
         ],
         # PR #947: MongoDB connection string override (plain-text variant).
@@ -497,47 +478,14 @@ module "ecs_service_auth" {
       cloudwatch_log_group_retention_in_days = 30
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:18888/health || exit 1"]
+        command     = ["CMD-SHELL", "curl -f http://localhost:8888/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3
         startPeriod = 60
       }
     }
-    },
-    var.enable_observability ? {
-      adot-collector = {
-        cpu                    = local.adot_sidecar_cpu
-        memory                 = local.adot_sidecar_memory
-        essential              = false
-        image                  = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
-        versionConsistency     = "disabled"
-        readonlyRootFilesystem = false
-
-        command = ["--config=env:AOT_CONFIG_CONTENT"]
-
-        environment = [
-          {
-            name  = "AOT_CONFIG_CONTENT"
-            value = local.adot_otlp_to_amp_config
-          },
-          {
-            name  = "AWS_REGION"
-            value = data.aws_region.current.id
-          }
-        ]
-
-        enable_cloudwatch_logging              = true
-        cloudwatch_log_group_name              = "/ecs/${local.name_prefix}-auth-adot"
-        cloudwatch_log_group_retention_in_days = 30
-
-        dependencies = [{
-          containerName = "auth-server"
-          condition     = "START"
-        }]
-      }
-    } : {}
-  )
+  }
 
   volume = {
     mcp-logs = {
@@ -560,16 +508,16 @@ module "ecs_service_auth" {
     service = {
       target_group_arn = module.alb.target_groups["auth"].arn
       container_name   = "auth-server"
-      container_port   = 18888
+      container_port   = 8888
     }
   }
 
   subnet_ids = var.private_subnet_ids
   security_group_ingress_rules = {
-    alb_18888 = {
+    alb_8888 = {
       description                  = "Auth server port from ALB"
-      from_port                    = 18888
-      to_port                      = 18888
+      from_port                    = 8888
+      to_port                      = 8888
       ip_protocol                  = "tcp"
       referenced_security_group_id = module.alb.security_group_id
     }
@@ -714,7 +662,7 @@ module "ecs_service_registry" {
         },
         {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:18888"
+          value = "http://auth-server:8888"
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -53,10 +53,15 @@ module "ecs_service_auth" {
     EcsExecTaskExecution = aws_iam_policy.ecs_exec_task_execution.arn
   }
   create_tasks_iam_role = true
-  tasks_iam_role_policies = {
-    SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
-    EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
-  }
+  tasks_iam_role_policies = merge(
+    {
+      SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
+      EcsExecTask          = aws_iam_policy.ecs_exec_task.arn
+    },
+    var.enable_observability ? {
+      AMPRemoteWrite = aws_iam_policy.adot_amp_write[0].arn
+    } : {}
+  )
 
   # Enable Service Connect
   service_connect_configuration = {
@@ -72,10 +77,10 @@ module "ecs_service_auth" {
   }
 
   # Container definitions
-  container_definitions = {
+  container_definitions = merge({
     auth-server = {
-      cpu                    = tonumber(var.cpu)
-      memory                 = tonumber(var.memory)
+      cpu                    = var.enable_observability ? tonumber(var.cpu) - local.adot_sidecar_cpu : tonumber(var.cpu)
+      memory                 = var.enable_observability ? tonumber(var.memory) - local.adot_sidecar_memory : tonumber(var.memory)
       essential              = true
       image                  = var.auth_server_image_uri
       versionConsistency     = "disabled"
@@ -84,7 +89,7 @@ module "ecs_service_auth" {
       portMappings = [
         {
           name          = "auth-server"
-          containerPort = 8888
+          containerPort = 18888
           protocol      = "tcp"
         }
       ]
@@ -99,8 +104,12 @@ module "ecs_service_auth" {
           value = var.bind_host
         },
         {
+          name  = "AUTH_LISTEN_PORT"
+          value = "18888"
+        },
+        {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:8888"
+          value = "http://auth-server:18888"
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"
@@ -362,19 +371,29 @@ module "ecs_service_auth" {
           name  = "TOOL_FILTER_AUDIT_LOG_LEVEL"
           value = var.tool_filter_audit_log_level
         },
-        # Metrics pipeline (only wired when observability is enabled).
-        # Issue #1122: auth-server intentionally has no OTel sidecar on ECS
-        # because uvicorn 0.0.0.0:8888 races with Service Connect Envoy's
-        # 127.0.0.1:8888 outbound interceptor. The legacy metrics-service
-        # POST path is the only metrics surface for auth-server on ECS for
-        # this PR; registry+mcpgw still get the full OTel-native pipeline.
-        {
-          name  = "METRICS_SERVICE_URL"
-          value = var.enable_observability ? "http://metrics-service:8890" : ""
-        },
         {
           name  = "METRICS_LEGACY_HTTP_POST"
-          value = var.enable_observability ? "true" : "false"
+          value = "false"
+        },
+        {
+          name  = "OTEL_METRIC_EXPORT_INTERVAL_MS"
+          value = "15000"
+        },
+        {
+          name  = "OTEL_EXPORTER_PROMETHEUS_HOST"
+          value = "0.0.0.0"
+        },
+        {
+          name  = "OTEL_EXPORTER_PROMETHEUS_PORT"
+          value = "9464"
+        },
+        {
+          name  = "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value = var.enable_observability ? "http://localhost:4317" : ""
+        },
+        {
+          name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
+          value = "grpc"
         }
         ],
         # PR #947: MongoDB connection string override (plain-text variant).
@@ -478,14 +497,47 @@ module "ecs_service_auth" {
       cloudwatch_log_group_retention_in_days = 30
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:8888/health || exit 1"]
+        command     = ["CMD-SHELL", "curl -f http://localhost:18888/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3
         startPeriod = 60
       }
     }
-  }
+    },
+    var.enable_observability ? {
+      adot-collector = {
+        cpu                    = local.adot_sidecar_cpu
+        memory                 = local.adot_sidecar_memory
+        essential              = false
+        image                  = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+        versionConsistency     = "disabled"
+        readonlyRootFilesystem = false
+
+        command = ["--config=env:AOT_CONFIG_CONTENT"]
+
+        environment = [
+          {
+            name  = "AOT_CONFIG_CONTENT"
+            value = local.adot_otlp_to_amp_config
+          },
+          {
+            name  = "AWS_REGION"
+            value = data.aws_region.current.id
+          }
+        ]
+
+        enable_cloudwatch_logging              = true
+        cloudwatch_log_group_name              = "/ecs/${local.name_prefix}-auth-adot"
+        cloudwatch_log_group_retention_in_days = 30
+
+        dependencies = [{
+          containerName = "auth-server"
+          condition     = "START"
+        }]
+      }
+    } : {}
+  )
 
   volume = {
     mcp-logs = {
@@ -508,16 +560,16 @@ module "ecs_service_auth" {
     service = {
       target_group_arn = module.alb.target_groups["auth"].arn
       container_name   = "auth-server"
-      container_port   = 8888
+      container_port   = 18888
     }
   }
 
   subnet_ids = var.private_subnet_ids
   security_group_ingress_rules = {
-    alb_8888 = {
+    alb_18888 = {
       description                  = "Auth server port from ALB"
-      from_port                    = 8888
-      to_port                      = 8888
+      from_port                    = 18888
+      to_port                      = 18888
       ip_protocol                  = "tcp"
       referenced_security_group_id = module.alb.security_group_id
     }
@@ -662,7 +714,7 @@ module "ecs_service_registry" {
         },
         {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:8888"
+          value = "http://auth-server:18888"
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"

--- a/terraform/aws-ecs/modules/mcp-gateway/networking.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/networking.tf
@@ -185,7 +185,7 @@ module "alb" {
     }
     auth = {
       backend_protocol                  = "HTTP"
-      backend_port                      = 8888
+      backend_port                      = 18888
       target_type                       = "ip"
       deregistration_delay              = 5
       load_balancing_cross_zone_enabled = true

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -59,6 +59,7 @@ def nginx_service():
             mock_settings.deployment_mode = MagicMock()
             mock_settings.deployment_mode.value = "with-gateway"
             mock_settings.nginx_config_path = "/etc/nginx/conf.d/nginx_rev_proxy.conf"
+            mock_settings.auth_server_url = "http://auth-server:8888"
 
             service = NginxConfigService()
             yield service


### PR DESCRIPTION
## Summary

- Make auth-server uvicorn listen port configurable via `AUTH_LISTEN_PORT` env var (defaults to 8888, no behavior change for Compose/Helm)
- Replace hardcoded `auth-server:8888` in `nginx_service.py` with `settings.auth_server_url` so the MCP proxy route respects the configured URL
- Fix pre-existing bug in `build_and_run.sh` where auth health check used port 18888 instead of the Docker Compose host port 8888

## Context

Prep work for a future PR that moves auth-server to port 18888 on ECS to avoid the Service Connect Envoy outbound interceptor conflict on `127.0.0.1:8888`. That PR will also need `ingress_port_override = 18888` in the service connect config block and the ADOT sidecar addition.

## Test plan

- [x] `bash -n docker/auth-entrypoint.sh` passes
- [x] `uv run python -m py_compile registry/core/nginx_service.py` passes
- [ ] `./build_and_run.sh` locally (auth still on 8888, login works)
- [ ] ECS: no terraform changes, no deployment impact