### PR TITLE
refactor(metrics): rename all custom metrics to mcpgw_registry_ prefix

### DIFF
--- a/auth_server/observability/meters.py
+++ b/auth_server/observability/meters.py
@@ -87,13 +87,13 @@ _meter = metrics.get_meter("mcp-auth-server")
 # =============================================================================
 
 auth_request_total = _meter.create_counter(
-    name="auth_request_total",
+    name="mcpgw_registry_auth_request_total",
     description="Authentication request count, labeled by outcome and method",
     unit="1",
 )
 
 auth_request_duration_ms = _meter.create_histogram(
-    name="auth_request_duration",
+    name="mcpgw_registry_auth_request_duration",
     description="Authentication request duration",
     unit="ms",
 )
@@ -104,7 +104,7 @@ auth_request_duration_ms = _meter.create_histogram(
 # =============================================================================
 
 tool_execution_total = _meter.create_counter(
-    name="tool_execution_total",
+    name="mcpgw_registry_tool_execution_total",
     description="Tool execution count detected at the auth layer",
     unit="1",
 )
@@ -121,7 +121,7 @@ tool_execution_duration_ms = _meter.create_histogram(
 # =============================================================================
 
 protocol_latency_ms = _meter.create_histogram(
-    name="protocol_latency",
+    name="mcpgw_registry_protocol_latency",
     description=(
         "Time between MCP protocol stages: initialize -> tools/list, "
         "tools/list -> tools/call, initialize -> tools/call"
@@ -135,7 +135,7 @@ protocol_latency_ms = _meter.create_histogram(
 # =============================================================================
 
 _metrics_emission_path_counter = _meter.create_counter(
-    name="metrics_emission_path_total",
+    name="mcpgw_registry_metrics_emission_path_total",
     description=(
         "Counts which emission path produced a metric. Helps operators verify "
         "the OTel migration: when METRICS_LEGACY_HTTP_POST=false the legacy "

--- a/config/grafana/dashboards/mcp-analytics-comprehensive.json
+++ b/config/grafana/dashboards/mcp-analytics-comprehensive.json
@@ -21,19 +21,19 @@
       "targets": [
         {
           "legendFormat": "Initialize Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Tools List Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Tool Call Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Auth Success Rate",
-          "expr": "sum(increase(auth_request_total{success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"true\"}[1m]))"
         }
       ],
       "gridPos": {
@@ -64,11 +64,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(auth_request_total{success=\"true\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"true\"}[5m]))",
           "legendFormat": "Successful Auth"
         },
         {
-          "expr": "sum(rate(auth_request_total{success=\"false\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"false\"}[5m]))",
           "legendFormat": "Failed Auth"
         }
       ],
@@ -100,7 +100,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(auth_request_total{success=\"true\"}) / sum(auth_request_total) * 100",
+          "expr": "sum(mcpgw_registry_auth_request_total{success=\"true\"}) / sum(mcpgw_registry_auth_request_total) * 100",
           "legendFormat": "Success Rate %"
         }
       ],
@@ -142,7 +142,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (server_name)(tool_execution_total))",
+          "expr": "count(count by (server_name)(mcpgw_registry_tool_execution_total))",
           "legendFormat": "Active Servers"
         }
       ],
@@ -187,7 +187,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(increase(tool_execution_total[1h]))",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total[1h]))",
           "legendFormat": "Tools/Hour"
         }
       ],
@@ -232,7 +232,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "topk(1, sum(tool_execution_total{method=\"tools/call\"}) by (tool_name))",
+          "expr": "topk(1, sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name))",
           "legendFormat": "{{tool_name}}"
         }
       ],
@@ -304,7 +304,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(tool_execution_total[5m])) by (method)",
+          "expr": "sum(rate(mcpgw_registry_tool_execution_total[5m])) by (method)",
           "legendFormat": "{{method}}"
         }
       ],
@@ -337,11 +337,11 @@
       "targets": [
         {
           "legendFormat": "Auth Error Rate",
-          "expr": "sum(increase(auth_request_total{success=\"false\"}[5m])) / sum(increase(auth_request_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
         },
         {
           "legendFormat": "Tool Execution Error Rate",
-          "expr": "sum(increase(tool_execution_total{success=\"false\"}[5m])) / sum(increase(tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -388,7 +388,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "avg(rate(auth_request_duration_milliseconds_sum[5m])) / avg(rate(auth_request_duration_milliseconds_count[5m]))",
+          "expr": "avg(rate(mcpgw_registry_auth_request_duration_milliseconds_sum[5m])) / avg(rate(mcpgw_registry_auth_request_duration_milliseconds_count[5m]))",
           "legendFormat": "Auth Avg Response Time"
         },
         {
@@ -424,19 +424,19 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total) by (server_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total) by (server_name)",
           "legendFormat": "{{server_name}}_total_calls",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(increase(tool_execution_total[1h])) by (server_name)",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total[1h])) by (server_name)",
           "legendFormat": "{{server_name}}_calls_per_hour",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "count(count by (server_name, tool_name)(tool_execution_total)) by (server_name)",
+          "expr": "count(count by (server_name, tool_name)(mcpgw_registry_tool_execution_total)) by (server_name)",
           "legendFormat": "{{server_name}}_unique_tools",
           "format": "table",
           "instant": true
@@ -475,13 +475,13 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total{method=\"tools/call\"}) by (tool_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name)",
           "legendFormat": "{{tool_name}}",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(increase(tool_execution_total{method=\"tools/call\"}[1h])) by (tool_name)",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\"}[1h])) by (tool_name)",
           "legendFormat": "{{tool_name}}_rate",
           "format": "table",
           "instant": true
@@ -527,7 +527,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total{method!=\"tools/call\"}) by (method))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total{method!=\"tools/call\"}) by (method))",
           "legendFormat": "{{method}}"
         }
       ],
@@ -559,7 +559,7 @@
       "type": "barchart",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total{method=\"tools/call\"}) by (tool_name))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name))",
           "legendFormat": "{{tool_name}}",
           "instant": true,
           "format": "table"
@@ -597,7 +597,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total) by (client_name))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total) by (client_name))",
           "legendFormat": "{{client_name}}"
         }
       ],
@@ -629,19 +629,19 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total{method=\"initialize\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"initialize\"}) by (client_name)",
           "legendFormat": "{{client_name}}_init",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(tool_execution_total{method=\"tools/list\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/list\"}) by (client_name)",
           "legendFormat": "{{client_name}}_list",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(tool_execution_total{method=\"tools/call\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (client_name)",
           "legendFormat": "{{client_name}}_call",
           "format": "table",
           "instant": true
@@ -680,7 +680,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "sum(auth_request_total) by (method)",
+          "expr": "sum(mcpgw_registry_auth_request_total) by (method)",
           "legendFormat": "{{method}}"
         }
       ],
@@ -713,7 +713,7 @@
       "targets": [
         {
           "legendFormat": "Success Rate",
-          "expr": "sum(increase(tool_execution_total{success=\"true\"}[5m])) / sum(increase(tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"true\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -763,7 +763,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(15, sum(rate(tool_execution_total[5m])) by (client_name))",
+          "expr": "topk(15, sum(rate(mcpgw_registry_tool_execution_total[5m])) by (client_name))",
           "legendFormat": "{{client_name}}"
         }
       ],
@@ -795,7 +795,7 @@
       {
         "name": "server",
         "type": "query",
-        "query": "label_values(auth_request_total, server)",
+        "query": "label_values(mcpgw_registry_auth_request_total, server)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"
@@ -803,7 +803,7 @@
       {
         "name": "client",
         "type": "query",
-        "query": "label_values(tool_execution_total, client_name)",
+        "query": "label_values(mcpgw_registry_tool_execution_total, client_name)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"
@@ -811,7 +811,7 @@
       {
         "name": "method",
         "type": "query",
-        "query": "label_values(tool_execution_total, method)",
+        "query": "label_values(mcpgw_registry_tool_execution_total, method)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -25,13 +25,13 @@ investigations operators most often need to run.
 │                Registry / Auth-Server / Mcpgw                      │
 │                                                                    │
 │  In-process OTel SDK with:                                         │
-│   • Path-2 events (registry_operation_total, auth_request_total,   │
-│     tool_execution_total, tool_discovery_total, protocol_latency)  │
-│   • Path-3 in-process counters (nginx_config_writes_total,         │
+│   • Path-2 events (mcpgw_registry_operation_total, mcpgw_registry_auth_request_total,   │
+│     mcpgw_registry_tool_execution_total, tool_discovery_total, protocol_latency)  │
+│   • Path-3 in-process counters (mcpgw_registry_nginx_config_writes_total,         │
 │     peer_sync_failures_total, m2m_orphan_cleanups_total, ...)      │
 │   • HTTP auto-instrumentation (http_server_duration_milliseconds_*)│
-│   • Mcpgw per-tool metrics (mcpgw_tool_invocations_total,          │
-│     mcpgw_tool_duration)                                           │
+│   • Mcpgw per-tool metrics (mcpgw_registry_tool_invocations_total,          │
+│     mcpgw_registry_tool_duration)                                           │
 └────────────────────────┬───────────────────────────────────────────┘
                          │
    ┌─────────────────────┴─────────────────────┐
@@ -190,7 +190,7 @@ Quick AMP query from the CLI:
 
 ```bash
 AMP_ENDPOINT=$(terraform -chdir=terraform/aws-ecs output -raw amp_endpoint)
-awscurl --service aps --region <region> "${AMP_ENDPOINT}api/v1/query?query=auth_request_total"
+awscurl --service aps --region <region> "${AMP_ENDPOINT}api/v1/query?query=mcpgw_registry_auth_request_total"
 ```
 
 To verify metrics are flowing into AMP after a deploy:
@@ -283,42 +283,42 @@ exposition form** (after the OTel exporter appends the unit suffix).
 
 | Metric | Source | Labels | What it counts |
 |---|---|---|---|
-| `auth_request_total` | auth-server | `success`, `method`, `server` | Authenticated /validate calls |
-| `tool_execution_total` | auth-server | `tool_name`, `server_name`, `success`, `method`, `client_name`, `client_version` | MCP tool calls detected at the auth layer |
-| `registry_operation_total` | registry middleware | `operation`, `resource_type`, `success` | Registry API operations (list/create/update/delete/search) |
+| `mcpgw_registry_auth_request_total` | auth-server | `success`, `method`, `server` | Authenticated /validate calls |
+| `mcpgw_registry_tool_execution_total` | auth-server | `tool_name`, `server_name`, `success`, `method`, `client_name`, `client_version` | MCP tool calls detected at the auth layer |
+| `mcpgw_registry_operation_total` | registry middleware | `operation`, `resource_type`, `success` | Registry API operations (list/create/update/delete/search) |
 | `tool_discovery_total` | registry middleware | `results_count_bucket` | Semantic search calls |
 | `health_check_total` | registry | `endpoint`, `status_code`, `healthy` | Health check probe count |
-| `mcpgw_tool_invocations_total` | mcpgw | `tool`, `success` | FastMCP tool invocations |
-| `nginx_config_writes_total` | registry | `status` | Nginx config file writes by outcome |
-| `registry_nginx_updates_skipped_total` | registry | `operation` | Nginx updates skipped due to mode |
-| `registry_mode_blocked_requests_total` | registry | `path_category`, `mode` | Requests blocked by registry mode |
+| `mcpgw_registry_tool_invocations_total` | mcpgw | `tool`, `success` | FastMCP tool invocations |
+| `mcpgw_registry_nginx_config_writes_total` | registry | `status` | Nginx config file writes by outcome |
+| `mcpgw_registry_nginx_updates_skipped_total` | registry | `operation` | Nginx updates skipped due to mode |
+| `mcpgw_registry_mode_blocked_requests_total` | registry | `path_category`, `mode` | Requests blocked by registry mode |
 | `peer_sync_failures_total` | registry | `peer_id`, `failure_type` | Federation peer sync failures |
 | `app_log_mongodb_flush_failures_total` | registry | `service` | MongoDB log handler failures |
 | `telemetry_sends_total` | registry | `event`, `status` | Telemetry events sent |
 | `m2m_orphan_cleanups_total` | registry | `idp_had_record` | M2M orphan cleanup deletions |
-| `mcp_registry_cloud_detection_total` | registry | `cloud`, `method` | Cloud-detection outcomes |
-| `mcp_config_view_requests_total` | registry | `user_type` | Configuration view requests |
-| `mcp_config_export_requests_total` | registry | `format`, `includes_sensitive` | Configuration export requests |
-| `registry_logout_id_token_hint_present_total` | registry | — | Logouts with id_token hint present |
-| `registry_logout_id_token_hint_missing_total` | registry | — | Logouts without id_token hint |
-| `registry_logout_jwt_validation_failed_total` | registry | — | Logout JWT validation failures |
-| `registry_logout_url_length_warning_total` | registry | — | Logout URLs over recommended length |
-| `registry_session_store_resolve_total` | registry | `result` | Session store lookups |
+| `mcpgw_registry_cloud_detection_total` | registry | `cloud`, `method` | Cloud-detection outcomes |
+| `mcpgw_registry_config_view_requests_total` | registry | `user_type` | Configuration view requests |
+| `mcpgw_registry_config_export_requests_total` | registry | `format`, `includes_sensitive` | Configuration export requests |
+| `mcpgw_registry_logout_id_token_hint_present_total` | registry | — | Logouts with id_token hint present |
+| `mcpgw_registry_logout_id_token_hint_missing_total` | registry | — | Logouts without id_token hint |
+| `mcpgw_registry_logout_jwt_validation_failed_total` | registry | — | Logout JWT validation failures |
+| `mcpgw_registry_logout_url_length_warning_total` | registry | — | Logout URLs over recommended length |
+| `mcpgw_registry_session_store_resolve_total` | registry | `result` | Session store lookups |
 | `m2m_management_requests_total` | registry | `operation`, `outcome` | Direct M2M client API calls |
-| `metrics_emission_path_total` | registry, auth-server, mcpgw | `path` (`otel`/`legacy`) | Migration self-observability |
-| `registry_deployment_mode_info` (Gauge) | registry | `deployment_mode`, `registry_mode` | Current deployment mode (always 1, observed each cycle) |
+| `mcpgw_registry_metrics_emission_path_total` | registry, auth-server, mcpgw | `path` (`otel`/`legacy`) | Migration self-observability |
+| `mcpgw_registry_deployment_mode_info` (Gauge) | registry | `deployment_mode`, `registry_mode` | Current deployment mode (always 1, observed each cycle) |
 
 ### Histograms
 
 | Metric | Source | Labels | What it measures |
 |---|---|---|---|
-| `auth_request_duration_milliseconds` (`_count`, `_sum`, `_bucket`) | auth-server | `success`, `method`, `server` | Auth /validate latency |
-| `tool_execution_duration_milliseconds` | auth-server | same as `tool_execution_total` | Tool call latency at auth layer |
-| `protocol_latency_milliseconds` | auth-server | `flow_step`, `server_name` | Time between MCP protocol stages (init → tools/list, etc.) |
-| `registry_operation_duration_milliseconds` | registry middleware | same as `registry_operation_total` | Registry API operation latency |
-| `tool_discovery_duration_milliseconds` | registry middleware | same as `tool_discovery_total` | Semantic search latency |
+| `mcpgw_registry_auth_request_duration_milliseconds` (`_count`, `_sum`, `_bucket`) | auth-server | `success`, `method`, `server` | Auth /validate latency |
+| `tool_execution_duration_milliseconds` | auth-server | same as `mcpgw_registry_tool_execution_total` | Tool call latency at auth layer |
+| `mcpgw_registry_protocol_latency_milliseconds` | auth-server | `flow_step`, `server_name` | Time between MCP protocol stages (init → tools/list, etc.) |
+| `mcpgw_registry_operation_duration_milliseconds` | registry middleware | same as `mcpgw_registry_operation_total` | Registry API operation latency |
+| `mcpgw_registry_tool_discovery_duration_milliseconds` | registry middleware | same as `tool_discovery_total` | Semantic search latency |
 | `peer_sync_duration_seconds` | registry | `peer_id`, `success` | Peer sync operation duration |
-| `mcpgw_tool_duration_milliseconds` | mcpgw | `tool`, `success` | Per-tool invocation latency |
+| `mcpgw_registry_tool_duration_milliseconds` | mcpgw | `tool`, `success` | Per-tool invocation latency |
 
 ### HTTP auto-instrumentation (when OTel auto-instrument is active)
 
@@ -347,19 +347,19 @@ minutes.
 | p95 latency | `histogram_quantile(0.95, sum by (le)(rate(http_server_duration_milliseconds_bucket{http_target="/api/search/semantic"}[5m])))` |
 | Average latency | `rate(http_server_duration_milliseconds_sum{http_target="/api/search/semantic"}[5m]) / rate(http_server_duration_milliseconds_count{http_target="/api/search/semantic"}[5m])` |
 | Application-level view (results-bucket dimension) | `sum by (results_count_bucket)(rate(tool_discovery_total[5m]))` |
-| Search latency from middleware (alternative source) | `histogram_quantile(0.95, sum by (le)(rate(tool_discovery_duration_milliseconds_bucket[5m])))` |
+| Search latency from middleware (alternative source) | `histogram_quantile(0.95, sum by (le)(rate(mcpgw_registry_tool_discovery_duration_milliseconds_bucket[5m])))` |
 
 ### Mcpgw — per-tool stats
 
 | Goal | Query |
 |---|---|
-| Total invocations per tool | `sum by (tool)(mcpgw_tool_invocations_total)` |
-| Tool QPS | `sum by (tool)(rate(mcpgw_tool_invocations_total[5m]))` |
-| Per-tool error rate | `sum by (tool)(rate(mcpgw_tool_invocations_total{success="False"}[5m])) / sum by (tool)(rate(mcpgw_tool_invocations_total[5m]))` |
-| Most-called tool right now | `topk(3, sum by (tool)(rate(mcpgw_tool_invocations_total[5m])))` |
-| p95 latency per tool | `histogram_quantile(0.95, sum by (le, tool)(rate(mcpgw_tool_duration_milliseconds_bucket[5m])))` |
-| Average duration per tool | `sum by (tool)(rate(mcpgw_tool_duration_milliseconds_sum[5m])) / sum by (tool)(rate(mcpgw_tool_duration_milliseconds_count[5m]))` |
-| Slowest tool right now | `topk(1, histogram_quantile(0.95, sum by (le, tool)(rate(mcpgw_tool_duration_milliseconds_bucket[5m]))))` |
+| Total invocations per tool | `sum by (tool)(mcpgw_registry_tool_invocations_total)` |
+| Tool QPS | `sum by (tool)(rate(mcpgw_registry_tool_invocations_total[5m]))` |
+| Per-tool error rate | `sum by (tool)(rate(mcpgw_registry_tool_invocations_total{success="False"}[5m])) / sum by (tool)(rate(mcpgw_registry_tool_invocations_total[5m]))` |
+| Most-called tool right now | `topk(3, sum by (tool)(rate(mcpgw_registry_tool_invocations_total[5m])))` |
+| p95 latency per tool | `histogram_quantile(0.95, sum by (le, tool)(rate(mcpgw_registry_tool_duration_milliseconds_bucket[5m])))` |
+| Average duration per tool | `sum by (tool)(rate(mcpgw_registry_tool_duration_milliseconds_sum[5m])) / sum by (tool)(rate(mcpgw_registry_tool_duration_milliseconds_count[5m]))` |
+| Slowest tool right now | `topk(1, histogram_quantile(0.95, sum by (le, tool)(rate(mcpgw_registry_tool_duration_milliseconds_bucket[5m]))))` |
 
 ### Any API endpoint — invocations + success/failure
 
@@ -382,21 +382,21 @@ Replace `<TARGET>` with the path you care about (e.g. `/api/servers`,
 
 | Goal | Query |
 |---|---|
-| Auth requests per second by outcome | `sum by (success)(rate(auth_request_total[5m]))` |
-| Auth p95 latency | `histogram_quantile(0.95, sum by (le)(rate(auth_request_duration_milliseconds_bucket[5m])))` |
-| Session-store hit rate | `sum(rate(registry_session_store_resolve_total{result="hit"}[5m])) / sum(rate(registry_session_store_resolve_total[5m]))` |
+| Auth requests per second by outcome | `sum by (success)(rate(mcpgw_registry_auth_request_total[5m]))` |
+| Auth p95 latency | `histogram_quantile(0.95, sum by (le)(rate(mcpgw_registry_auth_request_duration_milliseconds_bucket[5m])))` |
+| Session-store hit rate | `sum(rate(mcpgw_registry_session_store_resolve_total{result="hit"}[5m])) / sum(rate(mcpgw_registry_session_store_resolve_total[5m]))` |
 | Federation peer sync failures by type | `sum by (peer_id, failure_type)(rate(peer_sync_failures_total[5m]))` |
-| Logout JWT validation failure rate | `rate(registry_logout_jwt_validation_failed_total[5m])` |
+| Logout JWT validation failure rate | `rate(mcpgw_registry_logout_jwt_validation_failed_total[5m])` |
 
 ### Registry health and operations
 
 | Goal | Query |
 |---|---|
-| Registry API operations per second by type | `sum by (operation, resource_type)(rate(registry_operation_total[5m]))` |
-| Operations p95 latency | `histogram_quantile(0.95, sum by (le, operation)(rate(registry_operation_duration_milliseconds_bucket[5m])))` |
-| Nginx config write outcomes | `sum by (status)(rate(nginx_config_writes_total[5m]))` |
+| Registry API operations per second by type | `sum by (operation, resource_type)(rate(mcpgw_registry_operation_total[5m]))` |
+| Operations p95 latency | `histogram_quantile(0.95, sum by (le, operation)(rate(mcpgw_registry_operation_duration_milliseconds_bucket[5m])))` |
+| Nginx config write outcomes | `sum by (status)(rate(mcpgw_registry_nginx_config_writes_total[5m]))` |
 | M2M orphan cleanups | `sum by (idp_had_record)(rate(m2m_orphan_cleanups_total[5m]))` |
-| Cloud detection method distribution | `sum by (cloud, method)(mcp_registry_cloud_detection_total)` |
+| Cloud detection method distribution | `sum by (cloud, method)(mcpgw_registry_cloud_detection_total)` |
 | Telemetry pings success rate | `sum(rate(telemetry_sends_total{status="success"}[5m])) / sum(rate(telemetry_sends_total[5m]))` |
 
 ## Verifying the migration is working
@@ -415,7 +415,7 @@ You should see `mcp-registry`, `mcp-auth-server`, `mcp-mcpgw`, and (until
 **2. Migration self-observability**
 
 ```
-metrics_emission_path_total
+mcpgw_registry_metrics_emission_path_total
 ```
 
 Should show `path="otel"` rows incrementing on every request.
@@ -425,7 +425,7 @@ If both are incrementing, you have the dual-write transition flag enabled.
 **3. Previously-invisible counters are now visible**
 
 ```
-nginx_config_writes_total
+mcpgw_registry_nginx_config_writes_total
 peer_sync_failures_total
 m2m_orphan_cleanups_total
 ```

--- a/metrics-service/app/otel/instruments.py
+++ b/metrics-service/app/otel/instruments.py
@@ -33,13 +33,13 @@ class MetricsInstruments:
 
         # Histogram instruments for duration tracking
         self.auth_histogram = self.meter.create_histogram(
-            name="mcp_auth_request_duration_seconds",
+            name="mcpgw_registry_auth_request_duration_seconds",
             description="Duration of authentication requests in seconds",
             unit="s",
         )
 
         self.discovery_histogram = self.meter.create_histogram(
-            name="mcp_tool_discovery_duration_seconds",
+            name="mcpgw_registry_tool_discovery_duration_seconds",
             description="Duration of tool discovery requests in seconds",
             unit="s",
         )
@@ -51,7 +51,7 @@ class MetricsInstruments:
         )
 
         self.latency_histogram = self.meter.create_histogram(
-            name="mcp_protocol_latency_seconds",
+            name="mcpgw_registry_protocol_latency_seconds",
             description="Latency between MCP protocol steps in seconds",
             unit="s",
         )

--- a/registry/observability/meters.py
+++ b/registry/observability/meters.py
@@ -142,31 +142,31 @@ _meter = metrics.get_meter("mcp-gateway-registry")
 # =============================================================================
 
 registry_operation_total = _meter.create_counter(
-    name="registry_operation_total",
+    name="mcpgw_registry_operation_total",
     description="Registry API operations (read/create/update/delete/list/search)",
     unit="1",
 )
 
 registry_operation_duration_ms = _meter.create_histogram(
-    name="registry_operation_duration",
+    name="mcpgw_registry_operation_duration",
     description="Registry API operation duration",
     unit="ms",
 )
 
 tool_discovery_total = _meter.create_counter(
-    name="tool_discovery_total",
+    name="mcpgw_registry_tool_discovery_total",
     description="Semantic search calls",
     unit="1",
 )
 
 tool_discovery_duration_ms = _meter.create_histogram(
-    name="tool_discovery_duration",
+    name="mcpgw_registry_tool_discovery_duration",
     description="Semantic search duration",
     unit="ms",
 )
 
 tool_execution_total = _meter.create_counter(
-    name="tool_execution_total",
+    name="mcpgw_registry_tool_execution_total",
     description="Tool execution count (registry side)",
     unit="1",
 )
@@ -192,14 +192,14 @@ health_check_total = _meter.create_counter(
 
 # Configuration viewer metrics (registry/core/metrics.py:6,12)
 _config_view_requests_counter = _meter.create_counter(
-    name="mcp_config_view_requests_total",
+    name="mcpgw_registry_config_view_requests_total",
     description="Configuration view requests",
     unit="1",
 )
 config_view_requests_total = _CounterAdapter(_config_view_requests_counter)
 
 _config_export_requests_counter = _meter.create_counter(
-    name="mcp_config_export_requests_total",
+    name="mcpgw_registry_config_export_requests_total",
     description="Configuration export requests",
     unit="1",
 )
@@ -234,7 +234,7 @@ def _deployment_mode_callback(options: Any) -> Any:
 
 
 _meter.create_observable_gauge(
-    name="registry_deployment_mode_info",
+    name="mcpgw_registry_deployment_mode_info",
     callbacks=[_deployment_mode_callback],
     description="Current deployment mode configuration (observed each export cycle)",
     unit="1",
@@ -243,14 +243,14 @@ _meter.create_observable_gauge(
 
 # Nginx-related counters (registry/core/metrics.py:26,36)
 _nginx_updates_skipped_counter = _meter.create_counter(
-    name="registry_nginx_updates_skipped_total",
+    name="mcpgw_registry_nginx_updates_skipped_total",
     description="Number of nginx updates skipped due to registry-only mode",
     unit="1",
 )
 nginx_updates_skipped_total = _CounterAdapter(_nginx_updates_skipped_counter)
 
 _nginx_config_writes_counter = _meter.create_counter(
-    name="nginx_config_writes_total",
+    name="mcpgw_registry_nginx_config_writes_total",
     description="Total nginx config file writes performed by the registry, by outcome",
     unit="1",
 )
@@ -259,7 +259,7 @@ nginx_config_writes_total = _CounterAdapter(_nginx_config_writes_counter)
 
 # Mode-blocked requests (registry/core/metrics.py:43)
 _mode_blocked_requests_counter = _meter.create_counter(
-    name="registry_mode_blocked_requests_total",
+    name="mcpgw_registry_mode_blocked_requests_total",
     description="Requests blocked due to registry mode restrictions",
     unit="1",
 )
@@ -319,7 +319,7 @@ m2m_orphan_cleanups_total = _CounterAdapter(_m2m_orphan_cleanups_counter)
 
 # Cloud detection (registry/core/metrics.py:87)
 _cloud_detection_counter = _meter.create_counter(
-    name="mcp_registry_cloud_detection_total",
+    name="mcpgw_registry_cloud_detection_total",
     description="Cloud-detection outcomes labeled by cloud and detection method",
     unit="1",
 )
@@ -328,28 +328,28 @@ cloud_detection_total = _CounterAdapter(_cloud_detection_counter)
 
 # Logout-related counters (registry/auth/routes.py:59-77)
 _logout_id_token_hint_present_counter = _meter.create_counter(
-    name="registry_logout_id_token_hint_present_total",
+    name="mcpgw_registry_logout_id_token_hint_present_total",
     description="Logouts where id_token hint was present",
     unit="1",
 )
 logout_id_token_hint_present_total = _CounterAdapter(_logout_id_token_hint_present_counter)
 
 _logout_id_token_hint_missing_counter = _meter.create_counter(
-    name="registry_logout_id_token_hint_missing_total",
+    name="mcpgw_registry_logout_id_token_hint_missing_total",
     description="Logouts where id_token hint was missing",
     unit="1",
 )
 logout_id_token_hint_missing_total = _CounterAdapter(_logout_id_token_hint_missing_counter)
 
 _logout_jwt_validation_failed_counter = _meter.create_counter(
-    name="registry_logout_jwt_validation_failed_total",
+    name="mcpgw_registry_logout_jwt_validation_failed_total",
     description="Logout JWT validation failures",
     unit="1",
 )
 logout_jwt_validation_failed_total = _CounterAdapter(_logout_jwt_validation_failed_counter)
 
 _logout_url_length_warning_counter = _meter.create_counter(
-    name="registry_logout_url_length_warning_total",
+    name="mcpgw_registry_logout_url_length_warning_total",
     description="Logout URLs exceeding recommended length",
     unit="1",
 )
@@ -358,7 +358,7 @@ logout_url_length_warning_total = _CounterAdapter(_logout_url_length_warning_cou
 
 # Session store (registry/auth/session_store.py:32)
 _session_store_resolve_counter = _meter.create_counter(
-    name="registry_session_store_resolve_total",
+    name="mcpgw_registry_session_store_resolve_total",
     description="Session store resolve outcomes (hit/miss/expired/store_error)",
     unit="1",
 )
@@ -367,7 +367,7 @@ session_store_resolve_total = _CounterAdapter(_session_store_resolve_counter)
 
 # M2M management API (registry/api/m2m_management_routes.py:42)
 _m2m_management_requests_counter = _meter.create_counter(
-    name="m2m_management_requests_total",
+    name="mcpgw_registry_m2m_management_requests_total",
     description="Direct M2M client management API calls",
     unit="1",
 )
@@ -379,7 +379,7 @@ m2m_management_requests_total = _CounterAdapter(_m2m_management_requests_counter
 # =============================================================================
 
 _metrics_emission_path_counter = _meter.create_counter(
-    name="metrics_emission_path_total",
+    name="mcpgw_registry_metrics_emission_path_total",
     description=(
         "Counts which emission path produced a metric. Helps operators verify "
         "the OTel migration: when METRICS_LEGACY_HTTP_POST=false the legacy "

--- a/servers/mcpgw/observability_bootstrap.py
+++ b/servers/mcpgw/observability_bootstrap.py
@@ -44,12 +44,12 @@ def _get_tool_instruments() -> tuple[Any, Any] | tuple[None, None]:
 
     meter = metrics.get_meter("mcp-gateway-mcpgw")
     _tool_invocations_counter = meter.create_counter(
-        name="mcpgw_tool_invocations_total",
+        name="mcpgw_registry_tool_invocations_total",
         description="FastMCP tool invocation count, labeled by tool and outcome",
         unit="1",
     )
     _tool_duration_histogram = meter.create_histogram(
-        name="mcpgw_tool_duration",
+        name="mcpgw_registry_tool_duration",
         description="FastMCP tool invocation duration",
         unit="ms",
     )
@@ -63,10 +63,10 @@ def track_tool(
 
     Apply directly underneath ``@mcp.tool()``. Records:
 
-    - ``mcpgw_tool_invocations_total{tool, success}`` Counter
+    - ``mcpgw_registry_tool_invocations_total{tool, success}`` Counter
       (``success="True"`` on a normal return, ``"False"`` on any raised
       exception).
-    - ``mcpgw_tool_duration_ms{tool, success}`` Histogram (per-call
+    - ``mcpgw_registry_tool_duration_ms{tool, success}`` Histogram (per-call
       duration in milliseconds).
 
     Args:

--- a/terraform/aws-ecs/grafana/dashboards/mcp-analytics-comprehensive.json
+++ b/terraform/aws-ecs/grafana/dashboards/mcp-analytics-comprehensive.json
@@ -21,19 +21,19 @@
       "targets": [
         {
           "legendFormat": "Initialize Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Tools List Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Tool Call Rate",
-          "expr": "sum(increase(tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
         },
         {
           "legendFormat": "Auth Success Rate",
-          "expr": "sum(increase(auth_request_total{success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"true\"}[1m]))"
         }
       ],
       "gridPos": {
@@ -64,11 +64,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(auth_request_total{success=\"true\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"true\"}[5m]))",
           "legendFormat": "Successful Auth"
         },
         {
-          "expr": "sum(rate(auth_request_total{success=\"false\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"false\"}[5m]))",
           "legendFormat": "Failed Auth"
         }
       ],
@@ -100,7 +100,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(auth_request_total{success=\"true\"}) / sum(auth_request_total) * 100",
+          "expr": "sum(mcpgw_registry_auth_request_total{success=\"true\"}) / sum(mcpgw_registry_auth_request_total) * 100",
           "legendFormat": "Success Rate %"
         }
       ],
@@ -142,7 +142,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count(count by (server_name)(tool_execution_total))",
+          "expr": "count(count by (server_name)(mcpgw_registry_tool_execution_total))",
           "legendFormat": "Active Servers"
         }
       ],
@@ -187,7 +187,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(increase(tool_execution_total[1h]))",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total[1h]))",
           "legendFormat": "Tools/Hour"
         }
       ],
@@ -232,7 +232,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "topk(1, sum(tool_execution_total{method=\"tools/call\"}) by (tool_name))",
+          "expr": "topk(1, sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name))",
           "legendFormat": "{{tool_name}}"
         }
       ],
@@ -304,7 +304,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(tool_execution_total[5m])) by (method)",
+          "expr": "sum(rate(mcpgw_registry_tool_execution_total[5m])) by (method)",
           "legendFormat": "{{method}}"
         }
       ],
@@ -337,11 +337,11 @@
       "targets": [
         {
           "legendFormat": "Auth Error Rate",
-          "expr": "sum(increase(auth_request_total{success=\"false\"}[5m])) / sum(increase(auth_request_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
         },
         {
           "legendFormat": "Tool Execution Error Rate",
-          "expr": "sum(increase(tool_execution_total{success=\"false\"}[5m])) / sum(increase(tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -388,7 +388,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "avg(rate(auth_request_duration_milliseconds_sum[5m])) / avg(rate(auth_request_duration_milliseconds_count[5m]))",
+          "expr": "avg(rate(mcpgw_registry_auth_request_duration_milliseconds_sum[5m])) / avg(rate(mcpgw_registry_auth_request_duration_milliseconds_count[5m]))",
           "legendFormat": "Auth Avg Response Time"
         },
         {
@@ -424,19 +424,19 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total) by (server_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total) by (server_name)",
           "legendFormat": "{{server_name}}_total_calls",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(increase(tool_execution_total[1h])) by (server_name)",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total[1h])) by (server_name)",
           "legendFormat": "{{server_name}}_calls_per_hour",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "count(count by (server_name, tool_name)(tool_execution_total)) by (server_name)",
+          "expr": "count(count by (server_name, tool_name)(mcpgw_registry_tool_execution_total)) by (server_name)",
           "legendFormat": "{{server_name}}_unique_tools",
           "format": "table",
           "instant": true
@@ -475,13 +475,13 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total{method=\"tools/call\"}) by (tool_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name)",
           "legendFormat": "{{tool_name}}",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(increase(tool_execution_total{method=\"tools/call\"}[1h])) by (tool_name)",
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\"}[1h])) by (tool_name)",
           "legendFormat": "{{tool_name}}_rate",
           "format": "table",
           "instant": true
@@ -527,7 +527,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total{method!=\"tools/call\"}) by (method))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total{method!=\"tools/call\"}) by (method))",
           "legendFormat": "{{method}}"
         }
       ],
@@ -559,7 +559,7 @@
       "type": "barchart",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total{method=\"tools/call\"}) by (tool_name))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (tool_name))",
           "legendFormat": "{{tool_name}}",
           "instant": true,
           "format": "table"
@@ -597,7 +597,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(10, sum(tool_execution_total) by (client_name))",
+          "expr": "topk(10, sum(mcpgw_registry_tool_execution_total) by (client_name))",
           "legendFormat": "{{client_name}}"
         }
       ],
@@ -629,19 +629,19 @@
       "type": "table",
       "targets": [
         {
-          "expr": "sum(tool_execution_total{method=\"initialize\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"initialize\"}) by (client_name)",
           "legendFormat": "{{client_name}}_init",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(tool_execution_total{method=\"tools/list\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/list\"}) by (client_name)",
           "legendFormat": "{{client_name}}_list",
           "format": "table",
           "instant": true
         },
         {
-          "expr": "sum(tool_execution_total{method=\"tools/call\"}) by (client_name)",
+          "expr": "sum(mcpgw_registry_tool_execution_total{method=\"tools/call\"}) by (client_name)",
           "legendFormat": "{{client_name}}_call",
           "format": "table",
           "instant": true
@@ -680,7 +680,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "sum(auth_request_total) by (method)",
+          "expr": "sum(mcpgw_registry_auth_request_total) by (method)",
           "legendFormat": "{{method}}"
         }
       ],
@@ -713,7 +713,7 @@
       "targets": [
         {
           "legendFormat": "Success Rate",
-          "expr": "sum(increase(tool_execution_total{success=\"true\"}[5m])) / sum(increase(tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"true\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -763,7 +763,7 @@
       "type": "bargauge",
       "targets": [
         {
-          "expr": "topk(15, sum(rate(tool_execution_total[5m])) by (client_name))",
+          "expr": "topk(15, sum(rate(mcpgw_registry_tool_execution_total[5m])) by (client_name))",
           "legendFormat": "{{client_name}}"
         }
       ],
@@ -795,7 +795,7 @@
       {
         "name": "server",
         "type": "query",
-        "query": "label_values(auth_request_total, server)",
+        "query": "label_values(mcpgw_registry_auth_request_total, server)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"
@@ -803,7 +803,7 @@
       {
         "name": "client",
         "type": "query",
-        "query": "label_values(tool_execution_total, client_name)",
+        "query": "label_values(mcpgw_registry_tool_execution_total, client_name)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"
@@ -811,7 +811,7 @@
       {
         "name": "method",
         "type": "query",
-        "query": "label_values(tool_execution_total, method)",
+        "query": "label_values(mcpgw_registry_tool_execution_total, method)",
         "refresh": 1,
         "includeAll": true,
         "allValue": ".*"


### PR DESCRIPTION
## Summary

- Rename all custom metrics to use a consistent `mcpgw_registry_` namespace prefix
- In a large enterprise Prometheus/AMP workspace, operators can now filter all MCP Gateway Registry metrics with `{__name__=~"mcpgw_registry_.*"}`
- OTel auto-instrumented `http_server_*` metrics are standard and unchanged

## Breaking Change

All custom metric names have changed. Existing Grafana dashboards, alerts, and PromQL queries referencing the old names will need updating. The Grafana dashboard JSONs in this repo are already updated.

## Files Modified

- `registry/observability/meters.py` - registry metric definitions
- `auth_server/observability/meters.py` - auth-server metric definitions
- `servers/mcpgw/observability_bootstrap.py` - mcpgw metric definitions
- `metrics-service/app/otel/instruments.py` - legacy metrics-service
- `config/grafana/dashboards/mcp-analytics-comprehensive.json` - Docker Compose dashboard
- `terraform/aws-ecs/grafana/dashboards/mcp-analytics-comprehensive.json` - ECS dashboard
- `docs/OBSERVABILITY.md` - metric inventory and PromQL cookbook

## Test plan

- [x] All Python files compile
- [x] 26/26 observability unit tests pass
- [x] Grafana dashboard JSON updated
- [ ] Docker Compose stack emits metrics with new prefix on `:9464/metrics`

Closes #1141