### PR TITLE
feat(nginx): optional IPv6 listeners for IPv6-only clusters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ REGISTRY_URL=http://localhost
 # BIND_HOST=0.0.0.0
 # BIND_HOST=::
 
+# In-pod nginx reverse proxy IPv6 listeners. Default "false" keeps the
+# IPv4-only listen directives that work on every host. Set to "true" on
+# IPv6-only or dual-stack Kubernetes clusters so the entrypoint adds
+# `listen [::]:8080;` (and `[::]:8443 ssl;`) — required for the load balancer
+# and kubelet readiness probe to reach the pod over IPv6. This is the nginx
+# counterpart to BIND_HOST=:: (uvicorn).
+# NGINX_ENABLE_IPV6=false
+
 # =============================================================================
 # REGISTRY CARD CONFIGURATION
 # =============================================================================

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -222,6 +222,18 @@ else
     echo "HTTP + HTTPS Nginx configuration installed."
 fi
 
+# Optionally add IPv6 listeners for IPv6-only / dual-stack clusters (opt-in).
+# The conf templates ship IPv4-only listen directives so they keep working on
+# IPv4-only hosts where binding [::] would fail. Operators on IPv6-only or
+# dual-stack Kubernetes clusters set NGINX_ENABLE_IPV6=true so the load
+# balancer and kubelet readiness probe can reach the pod over IPv6. This is
+# the nginx counterpart to the app's BIND_HOST=:: support.
+if [ "${NGINX_ENABLE_IPV6:-false}" = "true" ]; then
+    echo "NGINX_ENABLE_IPV6=true: adding IPv6 listen directives to nginx config..."
+    sed -i 's|listen 8080;|listen 8080;\n    listen [::]:8080;|' "$NGINX_CONFIG_PATH"
+    sed -i 's|listen 8443 ssl;|listen 8443 ssl;\n    listen [::]:8443 ssl;|' "$NGINX_CONFIG_PATH"
+fi
+
 # --- Embeddings Configuration ---
 # Get embeddings configuration from environment or use defaults
 EMBEDDINGS_PROVIDER="${EMBEDDINGS_PROVIDER:-sentence-transformers}"

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -134,6 +134,7 @@ Affects only `with-gateway` deployments (nginx reverse proxy).
 |-----------|-----------------|-----------------------|----------------------|---------|
 | Extra nginx `server_name` entries | `GATEWAY_ADDITIONAL_SERVER_NAMES` | — | — (ingress annotations handle this) | Space-separated list of additional hostnames / IPs to accept. |
 | Server bind address (IPv6 opt-in) | `BIND_HOST` (and `HOST` for currenttime/mcpgw) | `bind_host` | `mcpgw.app.bindHost` | Default `0.0.0.0` (IPv4) works everywhere. Set to `::` only for IPv6-only deployments — requires `net.ipv6.bindv6only=0` on the host AND an IPv6 loopback in the container. Issue #863 / PR #864. Local-dev `uvicorn` direct invocation and `servers/currenttime` keep the safer `127.0.0.1` default. |
+| Nginx IPv6 listeners (opt-in) | `NGINX_ENABLE_IPV6` | — | via `extraEnv` | Default `false` keeps the in-pod nginx reverse proxy's IPv4-only `listen` directives, which work on every host (binding `[::]` fails where IPv6 is unavailable). Set to `true` on IPv6-only / dual-stack clusters so the entrypoint adds `listen [::]:8080;` (and `[::]:8443 ssl;`), letting the load balancer and kubelet readiness probe reach the pod over IPv6. Nginx counterpart to `BIND_HOST=::`. |
 
 ---
 


### PR DESCRIPTION
## Problem

The registry image runs an in-pod nginx reverse proxy whose config templates (`docker/nginx_rev_proxy_http_only.conf`, `docker/nginx_rev_proxy_http_and_https.conf`) use IPv4-only listen directives: `listen 8080;` and `listen 8443 ssl;`.

An IPv4 socket never accepts IPv6 connections. On **IPv6-only Kubernetes clusters**, the load balancer and the kubelet readiness probe reach the pod over its IPv6 address on `:8080` — but nginx is only bound to IPv4, so the connection is refused and the pod never becomes `Ready`.

The application's uvicorn already supports IPv6 via the existing `BIND_HOST=::` env var (Issue #863 / PR #864), but nginx had no equivalent, leaving the pod unreachable on IPv6-only clusters.

## Fix (backward-compatible, opt-in)

Adding `listen [::]` directly to the conf templates would break existing IPv4-only hosts (nginx fails to start when binding `[::]` where IPv6 is unavailable). Instead this follows the same opt-in pattern as `BIND_HOST`:

A new env var `NGINX_ENABLE_IPV6` (default `false`) is handled in `docker/registry-entrypoint.sh`. After the chosen template is copied to the generated config and **before** nginx starts, when set to `true` the entrypoint appends IPv6 listeners:

```sh
if [ "${NGINX_ENABLE_IPV6:-false}" = "true" ]; then
    sed -i 's|listen 8080;|listen 8080;\n    listen [::]:8080;|' "$NGINX_CONFIG_PATH"
    sed -i 's|listen 8443 ssl;|listen 8443 ssl;\n    listen [::]:8443 ssl;|' "$NGINX_CONFIG_PATH"
fi
```

**Default `false` = no behavior change**: existing IPv4-only deployments are untouched. Operators on IPv6-only / dual-stack clusters set `NGINX_ENABLE_IPV6=true` to add `[::]` listeners so the LB and readiness probe can connect over IPv6. The `sed` only touches `listen` lines, so it is independent of the FastAPI `{{...}}` placeholder substitution.

## Changes

- `docker/registry-entrypoint.sh` — opt-in `NGINX_ENABLE_IPV6` block that injects `[::]` listeners.
- `.env.example` — document `NGINX_ENABLE_IPV6` next to `BIND_HOST`.
- `docs/unified-parameter-reference.md` — add `NGINX_ENABLE_IPV6` to the Group 4 (Gateway Host Configuration) table.

## Test notes

- `sh -n docker/registry-entrypoint.sh` passes (POSIX syntax check).
- Verified the `sed` transforms produce the expected `listen [::]:8080;` / `listen [::]:8443 ssl;` lines against both conf templates.
- Default-off path leaves the generated config byte-for-byte identical to current behavior.

## Helm note (follow-up)

The `charts/registry` chart already supports arbitrary env via `extraEnv`, so operators can set `NGINX_ENABLE_IPV6: "true"` there today without chart changes. First-class `values.yaml` wiring can be added as a follow-up if desired; it was left out here to keep the diff minimal and focused.
