### PR TITLE
feat(mcpgw): add Claude Code server connection instructions to search tool

### DIFF
--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -142,6 +142,10 @@ mcp = FastMCP(
         "Start with search_registry to find relevant AI assets by describing "
         "what you need in natural language. Once you find a useful MCP server, "
         "you can connect to it directly via its endpoint URL. "
+        "For Claude Code, add the server with: "
+        "claude mcp add --transport http --scope user <name> <endpoint_url>. "
+        "Adding a server usually requires restarting the AI assistant session "
+        "for the new tools to take effect. "
         "For skills, use get_skill_content to retrieve the full instructions."
     ),
     auth=_auth_provider,
@@ -542,6 +546,13 @@ async def search_registry(
     - Tools: individual capabilities within servers, with inputSchema
     - Agents: autonomous agents with a URL you can delegate tasks to
     - Skills: workflow instructions (use get_skill_content to fetch the full markdown)
+
+    When a useful MCP server is found, use the endpoint_url to add it to
+    the AI assistant's MCP configuration so its tools become available.
+    For Claude Code, run:
+      claude mcp add --transport http --scope user <server-name> <endpoint_url>
+    Note: adding a server usually requires restarting the AI assistant
+    session for the new tools to take effect.
 
     Examples:
         "search documentation" -> finds doc search servers


### PR DESCRIPTION
## Summary
- Adds Claude Code `claude mcp add` instructions to the FastMCP server description so the AI assistant sees them in the system prompt
- Adds the same guidance to the `search_registry` tool docstring so search results include actionable next steps
- Notes that a session restart is typically required after adding a new server

## Test plan
- [ ] Verify `uv run python -m py_compile servers/mcpgw/server.py` passes
- [ ] Confirm the search_registry tool docstring renders correctly when calling the tool
- [ ] End-to-end: search for a server and verify the Claude Code add command appears in the response