### PR TITLE
fix(nginx): use POSIX-compatible newlines in sed for IPv6 listener injection

### DIFF
--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -230,8 +230,10 @@ fi
 # the nginx counterpart to the app's BIND_HOST=:: support.
 if [ "${NGINX_ENABLE_IPV6:-false}" = "true" ]; then
     echo "NGINX_ENABLE_IPV6=true: adding IPv6 listen directives to nginx config..."
-    sed -i 's|listen 8080;|listen 8080;\n    listen [::]:8080;|' "$NGINX_CONFIG_PATH"
-    sed -i 's|listen 8443 ssl;|listen 8443 ssl;\n    listen [::]:8443 ssl;|' "$NGINX_CONFIG_PATH"
+    sed -i 's|listen 8080;|listen 8080;\
+    listen [::]:8080;|' "$NGINX_CONFIG_PATH"
+    sed -i 's|listen 8443 ssl;|listen 8443 ssl;\
+    listen [::]:8443 ssl;|' "$NGINX_CONFIG_PATH"
 fi
 
 # --- Embeddings Configuration ---


### PR DESCRIPTION
## Summary

- Replace `\n` escape sequences with literal backslash-newlines in the sed commands that inject IPv6 listen directives
- GNU sed handles `\n` in replacement strings, but BSD sed (macOS) and POSIX sed treat it as literal `\n` text
- Using a real newline after the backslash is portable across all sed implementations

Follow-up to PR #1162.

## Test plan

- [ ] `bash -n docker/registry-entrypoint.sh` passes
- [ ] On Linux container with `NGINX_ENABLE_IPV6=true`, verify the generated nginx config contains `listen [::]:8080;` on its own line