### PR TITLE
fix(gitlab): address review feedback from PR #1128

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -610,13 +610,17 @@ GITHUB_ENABLED=false
 # GITHUB_APP_INSTALLATION_ID=78901234
 # GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 
-# Extra GitHub hosts for enterprise instances (comma-separated)
+# Extra GitHub/GitLab hosts for enterprise or self-hosted instances (comma-separated)
 # Hosts listed here are trusted for two purposes:
 #   1. GitHub auth headers are injected ONLY for github.com, raw.githubusercontent.com,
 #      and hosts in this list.
 #   2. SKILL.md SSRF allowlist: hosts in this list bypass the private-IP check
-#      so GHES instances on internal networks can be reached. Keep the list tight.
-# GITHUB_EXTRA_HOSTS=github.mycompany.com,raw.github.mycompany.com
+#      so GHES or self-hosted GitLab instances on internal networks can be reached.
+#      Keep the list tight.
+# Include self-hosted GitLab hostnames here so the registry can fetch private
+# skills via the GitLab API v4 translation (even when the hostname does not
+# contain "gitlab" in its name).
+# GITHUB_EXTRA_HOSTS=github.mycompany.com,raw.github.mycompany.com,gitlab.mycompany.com
 
 # GitHub API base URL (default: https://api.github.com)
 # For GitHub Enterprise Server, use: https://github.mycompany.com/api/v3

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -188,6 +188,17 @@ def _is_safe_url(
         return False
 
 
+def _append_page_param(
+    url: str,
+    page: str,
+) -> str:
+    """Append or replace the page query parameter on a URL."""
+    if re.search(r"(?<![a-z_])page=\d+", url):
+        return re.sub(r"(?<![a-z_])page=\d+", f"page={page}", url)
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}page={page}"
+
+
 def _build_fetch_headers(
     url: str,
     auth_scheme: str = "none",
@@ -214,13 +225,17 @@ def _build_fetch_headers(
         header_name = auth_header_name or "PRIVATE-TOKEN"
         headers[header_name] = auth_credential
 
-    if headers and "gitlab" in url.lower():
+    if headers:
         try:
-            from ..utils.gitlab_url_utils import translate_gitlab_to_api_url
+            from ..utils.gitlab_url_utils import (
+                parse_gitlab_url,
+                translate_gitlab_to_api_url,
+            )
 
-            api_url = translate_gitlab_to_api_url(url)
-            if api_url:
-                fetch_url = api_url
+            if parse_gitlab_url(url):
+                api_url = translate_gitlab_to_api_url(url)
+                if api_url:
+                    fetch_url = api_url
         except ImportError:
             pass
 
@@ -440,6 +455,21 @@ async def _discover_skill_resources(
                 logger.warning("Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url)
                 return None
             payload = resp.json()
+
+            # GitLab tree API returns a bare JSON array and paginates via
+            # the x-next-page response header. Fetch remaining pages.
+            if isinstance(payload, list):
+                next_page = resp.headers.get("x-next-page", "")
+                while next_page:
+                    page_url = _append_page_param(tree_url, next_page)
+                    resp = await client.get(page_url, headers=merged_headers)
+                    if resp.status_code >= 400:
+                        break
+                    page_payload = resp.json()
+                    if not isinstance(page_payload, list):
+                        break
+                    payload.extend(page_payload)
+                    next_page = resp.headers.get("x-next-page", "")
     except Exception as e:
         logger.warning("Resource discovery error for %s: %s", tree_url, e)
         return None

--- a/tests/unit/services/test_skill_service_gitlab.py
+++ b/tests/unit/services/test_skill_service_gitlab.py
@@ -77,6 +77,34 @@ class TestBuildFetchHeadersGitlab:
         assert fetch_url == url
         assert headers == {}
 
+    def test_self_hosted_gitlab_without_gitlab_in_hostname(self):
+        """Self-hosted GitLab with no 'gitlab' in hostname still translates."""
+        url = "https://code.internal.corp/team/project/-/raw/main/skills/demo/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="api_key", auth_credential="glpat-xxx"
+        )
+
+        assert headers == {"PRIVATE-TOKEN": "glpat-xxx"}
+        assert fetch_url == (
+            "https://code.internal.corp/api/v4/projects/team%2Fproject"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+    def test_self_hosted_gitlab_bearer_without_gitlab_in_hostname(self):
+        """Self-hosted GitLab with bearer auth and no 'gitlab' in hostname."""
+        url = "https://scm.mycompany.io/ops/infra/-/raw/develop/SKILL.md"
+
+        fetch_url, headers = _build_fetch_headers(
+            url, auth_scheme="bearer", auth_credential="token123"
+        )
+
+        assert headers == {"Authorization": "Bearer token123"}
+        assert fetch_url == (
+            "https://scm.mycompany.io/api/v4/projects/ops%2Finfra"
+            "/repository/files/SKILL.md/raw?ref=develop"
+        )
+
     def test_gitlab_url_with_unrecognised_shape_falls_through(self):
         # Contains "gitlab" but is not a /-/raw/ or API v4 file URL,
         # so translate_gitlab_to_api_url returns None and fetch_url
@@ -130,6 +158,24 @@ class TestResolveTreeApiGitlab:
             "?path=skills%2Fdemo&ref=main&recursive=true&per_page=100"
         )
 
+    def test_self_hosted_gitlab_without_gitlab_in_hostname(self):
+        """Self-hosted GitLab without 'gitlab' in hostname resolves tree URL."""
+        skill_md_url = (
+            "https://code.internal.corp/team/project/-/raw/main/skills/demo/SKILL.md"
+        )
+
+        result = _resolve_tree_api(skill_md_url)
+
+        assert result is not None
+        tree_url, project_encoded, ref, skill_dir = result
+        assert project_encoded == "team%2Fproject"
+        assert ref == "main"
+        assert skill_dir == "skills/demo"
+        assert tree_url == (
+            "https://code.internal.corp/api/v4/projects/team%2Fproject/repository/tree"
+            "?path=skills%2Fdemo&ref=main&recursive=true&per_page=100"
+        )
+
     def test_gitlab_skill_md_at_repo_root_falls_through_to_github_branch(self):
         # translate_gitlab_tree_api_url returns None for root-level files,
         # so the function continues to the GitHub matcher which then also
@@ -159,6 +205,48 @@ class TestResolveTreeApiGitlab:
 
 # =============================================================================
 # Parametrised non-GitLab auth schemes (kept short — for regression only)
+# =============================================================================
+
+
+# =============================================================================
+# _append_page_param helper
+# =============================================================================
+
+
+class TestAppendPageParam:
+    """Tests for the _append_page_param URL helper."""
+
+    def test_appends_page_to_url_with_existing_params(self):
+        from registry.services.skill_service import _append_page_param
+
+        url = "https://host/api/v4/projects/x/repository/tree?path=a&ref=main&recursive=true&per_page=100"
+
+        result = _append_page_param(url, "2")
+
+        assert result == url + "&page=2"
+
+    def test_replaces_existing_page_param(self):
+        from registry.services.skill_service import _append_page_param
+
+        url = "https://host/api/tree?path=a&ref=main&page=2&per_page=100"
+
+        result = _append_page_param(url, "3")
+
+        assert "page=3" in result
+        assert "page=2" not in result
+
+    def test_appends_page_to_url_without_query_string(self):
+        from registry.services.skill_service import _append_page_param
+
+        url = "https://host/api/tree"
+
+        result = _append_page_param(url, "1")
+
+        assert result == "https://host/api/tree?page=1"
+
+
+# =============================================================================
+# Parametrised non-GitLab auth schemes (kept short - for regression only)
 # =============================================================================
 
 

--- a/tests/unit/utils/test_gitlab_url_utils.py
+++ b/tests/unit/utils/test_gitlab_url_utils.py
@@ -59,6 +59,33 @@ class TestParseGitlabUrl:
         assert nested.encoded_project == "g%2Fsub%2Fr"
         assert root.file_dir == ""
 
+    def test_parses_self_hosted_without_gitlab_in_hostname(self):
+        """Should parse a /-/raw/ URL from a self-hosted instance without 'gitlab' in name."""
+        url = "https://code.internal.corp/team/project/-/raw/develop/skills/jira/SKILL.md"
+
+        parts = parse_gitlab_url(url)
+
+        assert parts is not None
+        assert parts.base == "https://code.internal.corp"
+        assert parts.project == "team/project"
+        assert parts.ref == "develop"
+        assert parts.filepath == "skills/jira/SKILL.md"
+
+    def test_parses_api_v4_url_from_self_hosted_without_gitlab_in_hostname(self):
+        """Should parse an API v4 URL from a self-hosted instance without 'gitlab' in name."""
+        url = (
+            "https://scm.mycompany.io/api/v4/projects/ops%2Finfra"
+            "/repository/files/skills%2Fdemo%2FSKILL.md/raw?ref=main"
+        )
+
+        parts = parse_gitlab_url(url)
+
+        assert parts is not None
+        assert parts.base == "https://scm.mycompany.io"
+        assert parts.project == "ops/infra"
+        assert parts.ref == "main"
+        assert parts.filepath == "skills/demo/SKILL.md"
+
     @pytest.mark.parametrize(
         "url",
         [


### PR DESCRIPTION
## Summary

Follow-up to PR #1128 addressing @omrishiv's review feedback:

- **Detection logic**: Replace `"gitlab" in url` string check with `parse_gitlab_url(url)` so self-hosted GitLab instances without "gitlab" in the hostname are properly detected and translated to API v4 endpoints
- **Pagination**: Add support for GitLab tree API pagination via `x-next-page` response header, so repos with 100+ skill files are fully discovered (previously capped at first page of 100)
- **Documentation**: Update `GITHUB_EXTRA_HOSTS` in `.env.example` to mention that self-hosted GitLab hostnames should be included
- **Tests**: Add tests for self-hosted domains without "gitlab" in hostname, and tests for the page-param helper

## Test plan

- [x] All 41 GitLab-related unit tests pass
- [x] New tests cover self-hosted hostnames (e.g. `code.internal.corp`, `scm.mycompany.io`)
- [x] `_append_page_param` helper tested for append, replace, and no-query-string cases
- [x] Existing GitHub paths unaffected (regression tests pass)