### PR TITLE
cap gitlab pagination

### DIFF
--- a/.github/workflows/registry-test.yml
+++ b/.github/workflows/registry-test.yml
@@ -80,27 +80,7 @@ jobs:
 
     - name: Run all tests with coverage
       run: |
-        # Stream memory usage to the live step log every 2s. An OOM kill
-        # cancels the job (post-run artifact uploads never fire), so the log
-        # is the only place the pre-kill memory curve survives.
-        ( while true; do
-            mem=$(free -m | awk '/^Mem:/{printf "used=%sMB free=%sMB avail=%sMB", $3, $4, $7}')
-            top=$(ps -eo rss,comm --sort=-rss | awk 'NR>1 && NR<=4{printf " %s=%.0fMB", $2, $1/1024}')
-            echo "[MEM] $(date +%T) $mem | top:$top"
-            sleep 2
-          done ) &
-        MON_PID=$!
-
-        # -v streams each worker's test start/result so the last in-flight
-        # test per worker is visible if the runner dies. faulthandler dumps a
-        # traceback for any test that hangs longer than 120s.
-        set +e
-        PYTEST_ADDOPTS="-v -o faulthandler_timeout=120" \
-          uv run python scripts/test.py coverage -n 8
-        rc=$?
-        set -e
-        kill "$MON_PID" 2>/dev/null || true
-        exit $rc
+        uv run python scripts/test.py coverage -n 8
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/registry-test.yml
+++ b/.github/workflows/registry-test.yml
@@ -80,7 +80,27 @@ jobs:
 
     - name: Run all tests with coverage
       run: |
-        uv run python scripts/test.py coverage -n 8
+        # Stream memory usage to the live step log every 2s. An OOM kill
+        # cancels the job (post-run artifact uploads never fire), so the log
+        # is the only place the pre-kill memory curve survives.
+        ( while true; do
+            mem=$(free -m | awk '/^Mem:/{printf "used=%sMB free=%sMB avail=%sMB", $3, $4, $7}')
+            top=$(ps -eo rss,comm --sort=-rss | awk 'NR>1 && NR<=4{printf " %s=%.0fMB", $2, $1/1024}')
+            echo "[MEM] $(date +%T) $mem | top:$top"
+            sleep 2
+          done ) &
+        MON_PID=$!
+
+        # -v streams each worker's test start/result so the last in-flight
+        # test per worker is visible if the runner dies. faulthandler dumps a
+        # traceback for any test that hangs longer than 120s.
+        set +e
+        PYTEST_ADDOPTS="-v -o faulthandler_timeout=120" \
+          uv run python scripts/test.py coverage -n 8
+        rc=$?
+        set -e
+        kill "$MON_PID" 2>/dev/null || true
+        exit $rc
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -60,6 +60,10 @@ logger = logging.getLogger(__name__)
 # Constants
 URL_VALIDATION_TIMEOUT: int = 10
 
+# Upper bound on GitLab tree-API pages fetched during resource discovery, so a
+# server that keeps echoing the x-next-page header cannot loop indefinitely.
+MAX_GITLAB_TREE_PAGES: int = 100
+
 # Built-in trusted domains that skip IP validation (SSRF protection allowlist).
 # Enterprise GitHub hosts are merged in at runtime from settings.github_extra_hosts
 # via _trusted_domains() so GHES instances on private IPs are reachable for
@@ -350,13 +354,15 @@ def _resolve_tree_api(
 
 # Files that live in the skill folder but should never be classified as
 # resources (the SKILL.md itself, plus standard repo metadata).
-_SKILL_DIR_EXCLUDED_FILENAMES: frozenset[str] = frozenset({
-    "SKILL.MD",
-    "README.MD",
-    "LICENSE",
-    "LICENSE.TXT",
-    "LICENSE.MD",
-})
+_SKILL_DIR_EXCLUDED_FILENAMES: frozenset[str] = frozenset(
+    {
+        "SKILL.MD",
+        "README.MD",
+        "LICENSE",
+        "LICENSE.TXT",
+        "LICENSE.MD",
+    }
+)
 
 
 def _classify_resource(
@@ -437,7 +443,9 @@ async def _discover_skill_resources(
 
     tree_info = _resolve_tree_api(skill_md_url)
     if not tree_info:
-        logger.debug("Cannot derive tree API URL from %s — skipping resource discovery", skill_md_url)
+        logger.debug(
+            "Cannot derive tree API URL from %s — skipping resource discovery", skill_md_url
+        )
         return None
 
     tree_url, _encoded_project, _ref, skill_dir = tree_info
@@ -452,7 +460,9 @@ async def _discover_skill_resources(
             merged_headers = {**github_headers, **headers}
             resp = await client.get(tree_url, headers=merged_headers)
             if resp.status_code >= 400:
-                logger.warning("Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url)
+                logger.warning(
+                    "Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url
+                )
                 return None
             payload = resp.json()
 
@@ -460,7 +470,8 @@ async def _discover_skill_resources(
             # the x-next-page response header. Fetch remaining pages.
             if isinstance(payload, list):
                 next_page = resp.headers.get("x-next-page", "")
-                while next_page:
+                pages_fetched = 0
+                while next_page and pages_fetched < MAX_GITLAB_TREE_PAGES:
                     page_url = _append_page_param(tree_url, next_page)
                     resp = await client.get(page_url, headers=merged_headers)
                     if resp.status_code >= 400:
@@ -469,7 +480,15 @@ async def _discover_skill_resources(
                     if not isinstance(page_payload, list):
                         break
                     payload.extend(page_payload)
+                    pages_fetched += 1
                     next_page = resp.headers.get("x-next-page", "")
+                if next_page:
+                    logger.warning(
+                        "GitLab tree pagination hit %s-page cap for %s; "
+                        "results may be incomplete",
+                        MAX_GITLAB_TREE_PAGES,
+                        tree_url,
+                    )
     except Exception as e:
         logger.warning("Resource discovery error for %s: %s", tree_url, e)
         return None
@@ -512,7 +531,7 @@ async def _discover_skill_resources(
         # WITHIN the skill folder. Don't reject parts of the path that
         # appear in skill_dir itself (e.g. ".claude/skills/usage-report"
         # is a perfectly valid skill location).
-        relative_path = path[len(skill_dir_prefix):] if path.startswith(skill_dir_prefix) else path
+        relative_path = path[len(skill_dir_prefix) :] if path.startswith(skill_dir_prefix) else path
         if any(part.startswith(".") or part.startswith("__") for part in relative_path.split("/")):
             continue
 
@@ -533,14 +552,22 @@ async def _discover_skill_resources(
         if bucket is not None:
             bucket.append(resource)
 
-    total = len(manifest.references) + len(manifest.scripts) + len(manifest.agents) + len(manifest.assets)
+    total = (
+        len(manifest.references)
+        + len(manifest.scripts)
+        + len(manifest.agents)
+        + len(manifest.assets)
+    )
     if total == 0:
         return None
 
     logger.info(
         "Discovered %d resources: %d references, %d scripts, %d agents, %d assets",
-        total, len(manifest.references), len(manifest.scripts),
-        len(manifest.agents), len(manifest.assets),
+        total,
+        len(manifest.references),
+        len(manifest.scripts),
+        len(manifest.agents),
+        len(manifest.assets),
     )
     return manifest
 
@@ -579,7 +606,9 @@ async def _validate_skill_md_url(
             github_headers = await _github_auth.get_auth_headers(str(url))
             merged_headers = {**fetch_headers, **github_headers}
             response = await client.get(
-                fetch_url, headers=merged_headers, follow_redirects=True,
+                fetch_url,
+                headers=merged_headers,
+                follow_redirects=True,
                 timeout=URL_VALIDATION_TIMEOUT,
             )
 
@@ -657,7 +686,10 @@ async def _parse_skill_md_content(
     try:
         async with httpx.AsyncClient() as client:
             fetch_url, fetch_headers = _build_fetch_headers(
-                raw_url_str, auth_scheme, auth_credential, auth_header_name,
+                raw_url_str,
+                auth_scheme,
+                auth_credential,
+                auth_header_name,
             )
             if auth_scheme == "none":
                 headers = fetch_headers
@@ -846,17 +878,17 @@ async def _check_skill_health(
 
         credential = decrypt_credential(auth_credential_encrypted)
 
-    fetch_url, fetch_headers = _build_fetch_headers(
-        url, auth_scheme, credential, auth_header_name
-    )
+    fetch_url, fetch_headers = _build_fetch_headers(url, auth_scheme, credential, auth_header_name)
 
     try:
         async with httpx.AsyncClient() as client:
             github_headers = await _github_auth.get_auth_headers(str(url))
             merged_headers = {**github_headers, **fetch_headers}
             response = await client.head(
-                fetch_url, headers=merged_headers,
-                follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
+                fetch_url,
+                headers=merged_headers,
+                follow_redirects=True,
+                timeout=URL_VALIDATION_TIMEOUT,
             )
 
             # SSRF protection: validate final URL after redirects
@@ -914,12 +946,17 @@ async def _compute_content_integrity(
         rel_path: str,
     ) -> FileHash | None:
         fetch_url, fetch_headers = _build_fetch_headers(
-            url, auth_scheme, auth_credential, auth_header_name,
+            url,
+            auth_scheme,
+            auth_credential,
+            auth_header_name,
         )
         try:
             resp = await client.get(
-                fetch_url, headers=fetch_headers,
-                follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT,
+                fetch_url,
+                headers=fetch_headers,
+                follow_redirects=True,
+                timeout=URL_VALIDATION_TIMEOUT,
             )
             if resp.status_code >= 400:
                 logger.warning("Integrity fetch failed for %s: HTTP %s", rel_path, resp.status_code)
@@ -1007,7 +1044,10 @@ async def _fetch_authenticated_content(
 
     auth_scheme, credential, auth_header_name = _decrypt_skill_auth(skill)
     fetch_url, fetch_headers = _build_fetch_headers(
-        url, auth_scheme, credential, auth_header_name,
+        url,
+        auth_scheme,
+        credential,
+        auth_header_name,
     )
 
     if auth_scheme == "none":
@@ -1033,7 +1073,8 @@ async def _fetch_authenticated_content(
 
             if response.status_code >= 400:
                 raise SkillContentFetchError(
-                    url, f"HTTP {response.status_code}",
+                    url,
+                    f"HTTP {response.status_code}",
                 )
 
             if max_size and len(response.content) > max_size:
@@ -1106,7 +1147,8 @@ async def _check_drift_inline(
             await service.toggle_skill(skill_path, enabled=False)
             logger.warning(
                 "Drift detected for %s in skill %s, skill disabled",
-                file_path, skill_path,
+                file_path,
+                skill_path,
             )
         else:
             await service.toggle_skill(skill_path, enabled=True)
@@ -1158,10 +1200,9 @@ def _build_skill_card(
     # Encrypt credential if provided
     auth_credential_encrypted = None
     credential_updated_at = None
-    if (
-        getattr(request, "auth_credential", None)
-        and getattr(request, "auth_scheme", "none") not in ("none", "global_credentials")
-    ):
+    if getattr(request, "auth_credential", None) and getattr(
+        request, "auth_scheme", "none"
+    ) not in ("none", "global_credentials"):
         from ..utils.credential_encryption import encrypt_credential
 
         auth_credential_encrypted = encrypt_credential(request.auth_credential)

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -380,8 +380,14 @@ class TestDiscoverSkillResources:
 
         response = MagicMock()
         response.status_code = 200
-        response.json = MagicMock(return_value=[{"type": "blob", "path": "x/r.py", "size": 100}])
-        response.headers = {"x-next-page": "9"}  # never empty -> would loop
+        # Fresh list per call: real httpx parses a new list each response, so
+        # the loop's payload.extend(page_payload) appends distinct objects. A
+        # shared return_value list would make payload.extend(payload) double the
+        # list every iteration (exponential blow-up) and OOM before the cap.
+        response.json = MagicMock(
+            side_effect=lambda: [{"type": "blob", "path": "x/r.py", "size": 100}]
+        )
+        response.headers = {"x-next-page": "9"}  # never empty -> would loop forever without the cap
 
         client_instance = MagicMock()
         client_instance.get = AsyncMock(return_value=response)

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -37,7 +37,9 @@ class TestResolveTreeApi:
         result = _resolve_tree_api(url)
         assert result is not None
         tree_url, project, ref, skill_dir = result
-        assert tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        assert (
+            tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        )
         assert project == "anthropics/skills"
         assert ref == "main"
         assert skill_dir == "example"
@@ -47,7 +49,9 @@ class TestResolveTreeApi:
         result = _resolve_tree_api(url)
         assert result is not None
         tree_url, _, ref, skill_dir = result
-        assert tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        assert (
+            tree_url == "https://api.github.com/repos/anthropics/skills/git/trees/main?recursive=1"
+        )
         assert ref == "main"
         assert skill_dir == "example"
 
@@ -208,6 +212,10 @@ class TestDiscoverSkillResources:
             response = MagicMock()
             response.status_code = 200
             response.json = MagicMock()
+            # Real dict so the GitLab pagination loop sees no x-next-page header
+            # and terminates; a bare MagicMock would return a truthy sentinel
+            # and loop forever.
+            response.headers = {}
 
             client_instance = MagicMock()
             client_instance.get = AsyncMock(return_value=response)
@@ -226,16 +234,18 @@ class TestDiscoverSkillResources:
         mock_github_auth,
         mock_async_client,
     ):
-        mock_async_client.json.return_value = _trees_payload([
-            {"type": "blob", "path": "example/SKILL.md", "size": 1000},
-            {"type": "blob", "path": "example/references/arch.md", "size": 200},
-            {"type": "blob", "path": "example/scripts/run.sh", "size": 300},
-            {"type": "blob", "path": "example/agents/coder.md", "size": 400},
-            {"type": "blob", "path": "example/assets/diagram.png", "size": 500},
-            # Tree entries other than the skill folder must be ignored.
-            {"type": "blob", "path": "other-skill/SKILL.md", "size": 999},
-            {"type": "tree", "path": "example/references", "size": 0},
-        ])
+        mock_async_client.json.return_value = _trees_payload(
+            [
+                {"type": "blob", "path": "example/SKILL.md", "size": 1000},
+                {"type": "blob", "path": "example/references/arch.md", "size": 200},
+                {"type": "blob", "path": "example/scripts/run.sh", "size": 300},
+                {"type": "blob", "path": "example/agents/coder.md", "size": 400},
+                {"type": "blob", "path": "example/assets/diagram.png", "size": 500},
+                # Tree entries other than the skill folder must be ignored.
+                {"type": "blob", "path": "other-skill/SKILL.md", "size": 999},
+                {"type": "tree", "path": "example/references", "size": 0},
+            ]
+        )
 
         manifest = await _discover_skill_resources(
             "https://github.com/foo/bar/blob/main/example/SKILL.md",
@@ -252,16 +262,22 @@ class TestDiscoverSkillResources:
         mock_async_client,
     ):
         # Mirrors the agentic-community/mcp-gateway-registry usage-report layout.
-        mock_async_client.json.return_value = _trees_payload([
-            {"type": "blob", "path": ".claude/skills/usage-report/SKILL.md", "size": 1000},
-            {"type": "blob", "path": ".claude/skills/usage-report/analyze.py", "size": 200},
-            {"type": "blob", "path": ".claude/skills/usage-report/install.sh", "size": 50},
-            {"type": "blob", "path": ".claude/skills/usage-report/notes.md", "size": 80},
-            {"type": "blob", "path": ".claude/skills/usage-report/style.css", "size": 60},
-            # Hidden / pycache content should be filtered.
-            {"type": "blob", "path": ".claude/skills/usage-report/__pycache__/x.pyc", "size": 90},
-            {"type": "blob", "path": ".claude/skills/usage-report/.DS_Store", "size": 5},
-        ])
+        mock_async_client.json.return_value = _trees_payload(
+            [
+                {"type": "blob", "path": ".claude/skills/usage-report/SKILL.md", "size": 1000},
+                {"type": "blob", "path": ".claude/skills/usage-report/analyze.py", "size": 200},
+                {"type": "blob", "path": ".claude/skills/usage-report/install.sh", "size": 50},
+                {"type": "blob", "path": ".claude/skills/usage-report/notes.md", "size": 80},
+                {"type": "blob", "path": ".claude/skills/usage-report/style.css", "size": 60},
+                # Hidden / pycache content should be filtered.
+                {
+                    "type": "blob",
+                    "path": ".claude/skills/usage-report/__pycache__/x.pyc",
+                    "size": 90,
+                },
+                {"type": "blob", "path": ".claude/skills/usage-report/.DS_Store", "size": 5},
+            ]
+        )
 
         manifest = await _discover_skill_resources(
             "https://raw.githubusercontent.com/agentic-community/mcp-gateway-registry/"
@@ -278,12 +294,14 @@ class TestDiscoverSkillResources:
         mock_github_auth,
         mock_async_client,
     ):
-        mock_async_client.json.return_value = _trees_payload([
-            {"type": "blob", "path": "x/SKILL.md", "size": 100},
-            {"type": "blob", "path": "x/README.md", "size": 100},
-            {"type": "blob", "path": "x/LICENSE", "size": 100},
-            {"type": "blob", "path": "x/run.py", "size": 100},
-        ])
+        mock_async_client.json.return_value = _trees_payload(
+            [
+                {"type": "blob", "path": "x/SKILL.md", "size": 100},
+                {"type": "blob", "path": "x/README.md", "size": 100},
+                {"type": "blob", "path": "x/LICENSE", "size": 100},
+                {"type": "blob", "path": "x/run.py", "size": 100},
+            ]
+        )
         manifest = await _discover_skill_resources(
             "https://github.com/foo/bar/blob/main/x/SKILL.md",
         )
@@ -296,10 +314,12 @@ class TestDiscoverSkillResources:
         mock_github_auth,
         mock_async_client,
     ):
-        mock_async_client.json.return_value = _trees_payload([
-            {"type": "blob", "path": "x/SKILL.md", "size": 100},
-            {"type": "blob", "path": "x/Makefile", "size": 100},  # no extension
-        ])
+        mock_async_client.json.return_value = _trees_payload(
+            [
+                {"type": "blob", "path": "x/SKILL.md", "size": 100},
+                {"type": "blob", "path": "x/Makefile", "size": 100},  # no extension
+            ]
+        )
         result = await _discover_skill_resources(
             "https://github.com/foo/bar/blob/main/x/SKILL.md",
         )
@@ -350,16 +370,47 @@ class TestDiscoverSkillResources:
         assert manifest is not None
         assert {r.path for r in manifest.scripts} == {"r.py"}
 
+    async def test_gitlab_pagination_is_bounded_by_page_cap(
+        self,
+        mock_github_auth,
+    ):
+        # A GitLab server that always echoes x-next-page must not loop forever:
+        # discovery stops after MAX_GITLAB_TREE_PAGES fetches.
+        from registry.services.skill_service import MAX_GITLAB_TREE_PAGES
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json = MagicMock(return_value=[{"type": "blob", "path": "x/r.py", "size": 100}])
+        response.headers = {"x-next-page": "9"}  # never empty -> would loop
+
+        client_instance = MagicMock()
+        client_instance.get = AsyncMock(return_value=response)
+        client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+        client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "registry.services.skill_service.httpx.AsyncClient",
+            return_value=client_instance,
+        ):
+            await _discover_skill_resources(
+                "https://gitlab.example.com/g/r/-/raw/main/skills/demo/SKILL.md",
+            )
+
+        # 1 initial fetch + MAX_GITLAB_TREE_PAGES paginated fetches, no more.
+        assert client_instance.get.await_count == MAX_GITLAB_TREE_PAGES + 1
+
     async def test_github_auth_headers_merged_into_request(
         self,
         mock_github_auth,
         mock_async_client,
     ):
         mock_github_auth.get_auth_headers.return_value = {"Authorization": "Bearer ghs_xxx"}
-        mock_async_client.json.return_value = _trees_payload([
-            {"type": "blob", "path": "x/SKILL.md", "size": 100},
-            {"type": "blob", "path": "x/r.py", "size": 100},
-        ])
+        mock_async_client.json.return_value = _trees_payload(
+            [
+                {"type": "blob", "path": "x/SKILL.md", "size": 100},
+                {"type": "blob", "path": "x/r.py", "size": 100},
+            ]
+        )
 
         await _discover_skill_resources(
             "https://github.com/foo/bar/blob/main/x/SKILL.md",

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -212,9 +212,11 @@ class TestDiscoverSkillResources:
             response = MagicMock()
             response.status_code = 200
             response.json = MagicMock()
-            # Real dict so the GitLab pagination loop sees no x-next-page header
-            # and terminates; a bare MagicMock would return a truthy sentinel
-            # and loop forever.
+            # Empty dict so the GitLab pagination loop never starts: a bare
+            # MagicMock would make .get("x-next-page", "") return a truthy
+            # sentinel, and because json() returns one shared list the loop's
+            # payload.extend(payload) would double the list every iteration and
+            # OOM the worker.
             response.headers = {}
 
             client_instance = MagicMock()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#1128 and #1170 introduced gitlab tree support, but an unbounded pagination condition created test failures. This PR fixes that by capping the `x-next-page` header to 100 pages and updates the tests to not create an unbounded loop

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
