### PR TITLE
feat(api): add PUT/PATCH endpoints for server metadata updates

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -183,6 +183,21 @@ class ServerDetailResponse(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class ServerUpdateResponse(BaseModel):
+    """Response from PUT/PATCH /api/servers/{path}.
+
+    Returns the updated server document. Extra fields are allowed so
+    callers tolerate added server-side fields without breaking.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    path: str | None = None
+    server_name: str | None = None
+    description: str | None = None
+    updated_at: str | None = None
+
+
 class ServerListResponse(BaseModel):
     """Server list response model."""
 
@@ -1600,6 +1615,7 @@ class RegistryClient:
 
         # Determine content type based on endpoint
         # Agent, Management, Search, Federation, Skills, Virtual Servers, Registry Card, version, and group import endpoints use JSON
+        # PUT/PATCH on /api/servers/{path} (issue #1164) also use JSON
         # Server registration uses form data
         if (
             endpoint.startswith("/api/agents")
@@ -1616,6 +1632,7 @@ class RegistryClient:
             or endpoint == "/api/servers/groups/import"
             or "/auth-credential" in endpoint
             or "/versions" in endpoint
+            or (method in ("PUT", "PATCH") and endpoint.startswith("/api/servers/"))
         ):
             # Send as JSON for agent, management, search, federation, and import endpoints
             response = requests.request(
@@ -1809,6 +1826,97 @@ class RegistryClient:
         )
 
         return response.json()
+
+    def update_server(
+        self,
+        path: str,
+        body: dict[str, Any],
+        if_match: str | None = None,
+    ) -> ServerUpdateResponse:
+        """Full-replacement update via PUT /api/servers/{path}.
+
+        Replaces the server's mutable metadata. Identity anchors and
+        server-managed fields (timestamps, deployment, credentials) are
+        preserved by the server even if absent or supplied. Auth/credential
+        mutation must go through PATCH /api/servers/{path}/auth-credential.
+
+        Args:
+            path: Server path with or without leading slash (e.g.
+                "/my-server" or "my-server").
+            body: Full ServerUpdateRequest body as a dict. Required keys
+                include server_name and description.
+            if_match: Optional weak ETag (e.g. ``W/"<epoch_ms>"``) from a
+                prior GET/PUT/PATCH for optimistic concurrency. When
+                supplied and stale, the server returns 412.
+
+        Returns:
+            ServerUpdateResponse with the updated server document.
+
+        Raises:
+            requests.HTTPError: 400 empty/malformed body, 403 unauthorized
+                or federated, 404 not found, 412 precondition failed,
+                422 validation error.
+        """
+        normalized = path if path.startswith("/") else f"/{path}"
+        logger.info(f"Updating server: {normalized}")
+        logger.debug(f"Update body: {json.dumps(body, indent=2, default=str)}")
+
+        extra_headers = {"If-Match": if_match} if if_match else None
+        response = self._make_request(
+            method="PUT",
+            endpoint=f"/api/servers{normalized}",
+            data=body,
+            extra_headers=extra_headers,
+        )
+
+        result = ServerUpdateResponse(**response.json())
+        logger.info(f"Server updated successfully: {normalized}")
+        return result
+
+    def patch_server(
+        self,
+        path: str,
+        patch: dict[str, Any],
+        if_match: str | None = None,
+    ) -> ServerUpdateResponse:
+        """Partial update via PATCH /api/servers/{path} (RFC 7396 JSON Merge Patch).
+
+        Only the keys present in ``patch`` are changed; everything else is
+        left untouched. Registrant-only fields (timestamps, identity
+        anchors, deployment, credentials) are rejected by the server with
+        a 422.
+
+        Args:
+            path: Server path with or without leading slash.
+            patch: Mapping of fields to change. A JSON null clears an
+                optional field.
+            if_match: Optional weak ETag from a prior GET/PUT/PATCH for
+                optimistic concurrency. When supplied and stale, the
+                server returns 412.
+
+        Returns:
+            ServerUpdateResponse with the updated server document.
+
+        Raises:
+            requests.HTTPError: 400 empty/malformed patch, 403 unauthorized
+                or federated, 404 not found, 412 precondition failed,
+                422 validation error.
+        """
+        normalized = path if path.startswith("/") else f"/{path}"
+        logger.info(f"Patching server: {normalized}")
+        logger.debug(f"Patch body: {json.dumps(patch, indent=2, default=str)}")
+
+        extra_headers = {"If-Match": if_match} if if_match else None
+        response = self._make_request(
+            method="PATCH",
+            endpoint=f"/api/servers{normalized}",
+            data=patch,
+            extra_headers=extra_headers,
+        )
+
+        result = ServerUpdateResponse(**response.json())
+        logger.info(f"Server patched successfully: {normalized}")
+        return result
 
     def list_services(
         self,

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -253,6 +253,7 @@ from registry_client import (
     RatingInfoResponse,
     RatingResponse,
     RegistryClient,
+    ServerUpdateResponse,
     Skill,
     SkillRegistrationRequest,
     ToolMapping,
@@ -595,8 +596,7 @@ def _transform_mcp_registry_to_internal(data: dict[str, Any]) -> dict[str, Any]:
         result["proxy_pass_url"] = None
 
     logger.info(
-        f"Transformed MCP Registry server.json: "
-        f"name={name} -> path={path}, deployment={deployment}"
+        f"Transformed MCP Registry server.json: name={name} -> path={path}, deployment={deployment}"
     )
     return result
 
@@ -1298,6 +1298,129 @@ def cmd_server_get(args: argparse.Namespace) -> int:
 
     except Exception as e:
         logger.error(f"Get server failed: {e}")
+        return 1
+
+
+def _build_update_server_body(args: argparse.Namespace) -> dict[str, Any]:
+    """Build the PUT body from --body or from individual field flags.
+
+    If ``--body`` is supplied, it is parsed as JSON and used verbatim.
+    Otherwise, only the supplied field flags are added to the body so
+    the user does not have to repeat unchanged fields.
+
+    Args:
+        args: Parsed CLI arguments for the update-server command.
+
+    Returns:
+        Dict to send as the JSON body of PUT /api/servers/{path}.
+
+    Raises:
+        ValueError: If ``--body`` is not valid JSON or not a JSON object.
+    """
+    if args.body:
+        parsed = json.loads(args.body)
+        if not isinstance(parsed, dict):
+            raise ValueError("--body must be a JSON object")
+        return parsed
+
+    body: dict[str, Any] = {}
+    if args.server_name is not None:
+        body["server_name"] = args.server_name
+    if args.description is not None:
+        body["description"] = args.description
+    if args.proxy_pass_url is not None:
+        body["proxy_pass_url"] = args.proxy_pass_url
+    if args.tags is not None:
+        body["tags"] = [t.strip() for t in args.tags.split(",") if t.strip()]
+    if args.license is not None:
+        body["license"] = args.license
+    if args.num_tools is not None:
+        body["num_tools"] = args.num_tools
+    if args.metadata is not None:
+        body["metadata"] = json.loads(args.metadata)
+    if args.visibility is not None:
+        body["visibility"] = args.visibility
+    if args.allowed_groups is not None:
+        body["allowed_groups"] = [g.strip() for g in args.allowed_groups.split(",") if g.strip()]
+    return body
+
+
+def cmd_update_server(args: argparse.Namespace) -> int:
+    """
+    Replace a server's mutable metadata via PUT /api/servers/{path}.
+
+    Either provide a full JSON body via --body, or supply individual
+    field flags (--server-name, --description, ...). When --body is
+    supplied, all field flags are ignored.
+
+    Args:
+        args: Command arguments with path, body or field flags, and
+            optional if-match.
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        body = _build_update_server_body(args)
+        if not body:
+            logger.error("No update fields provided. Pass --body or at least one field flag.")
+            return 1
+
+        client = _create_client(args)
+        result: ServerUpdateResponse = client.update_server(
+            path=args.path,
+            body=body,
+            if_match=args.if_match,
+        )
+
+        print(json.dumps(result.model_dump(), indent=2, default=str))
+        return 0
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Update server failed: {e}")
+        logger.debug("Full error details:", exc_info=True)
+        return 1
+
+
+def cmd_patch_server(args: argparse.Namespace) -> int:
+    """
+    Partially update a server via PATCH /api/servers/{path}.
+
+    The patch body must be a JSON object (RFC 7396 JSON Merge Patch).
+    Only fields present in the patch are changed.
+
+    Args:
+        args: Command arguments with path, patch JSON string, and
+            optional if-match.
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        patch = json.loads(args.patch)
+        if not isinstance(patch, dict):
+            logger.error("--patch must be a JSON object")
+            return 1
+
+        client = _create_client(args)
+        result: ServerUpdateResponse = client.patch_server(
+            path=args.path,
+            patch=patch,
+            if_match=args.if_match,
+        )
+
+        print(json.dumps(result.model_dump(), indent=2, default=str))
+        return 0
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON in --patch: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Patch server failed: {e}")
+        logger.debug("Full error details:", exc_info=True)
         return 1
 
 
@@ -2233,8 +2356,7 @@ def cmd_agent_batch_submit(args: argparse.Namespace) -> int:
             print(json.dumps(response.model_dump(), indent=2, default=str))
         else:
             logger.info(
-                f"Batch submitted: job_id={response.job_id} "
-                f"(replay={response.idempotent_replay})"
+                f"Batch submitted: job_id={response.job_id} (replay={response.idempotent_replay})"
             )
             logger.info(f"Poll status with: agent-batch-status --job-id {response.job_id}")
         return 0
@@ -4954,7 +5076,7 @@ def cmd_embeddings_missing(args: argparse.Namespace) -> int:
             print(json.dumps(data, indent=2))
             return 0
 
-        print(f"\nEmbeddings Index Status:")
+        print("\nEmbeddings Index Status:")
         print(f"  Source documents:  {total_source}")
         print(f"  Indexed:           {total_indexed}")
         print(f"  Missing:           {total_missing}")
@@ -4965,11 +5087,9 @@ def cmd_embeddings_missing(args: argparse.Namespace) -> int:
 
         print(f"\nMissing documents ({total_missing}):\n")
         print(f"  {'Path':<50} {'Type':<15} {'Name'}")
-        print(f"  {'-'*50} {'-'*15} {'-'*30}")
+        print(f"  {'-' * 50} {'-' * 15} {'-' * 30}")
         for entry in data.get("missing", []):
-            print(
-                f"  {entry['path']:<50} {entry['entity_type']:<15} {entry['name']}"
-            )
+            print(f"  {entry['path']:<50} {entry['entity_type']:<15} {entry['name']}")
 
         return 0
 
@@ -5035,9 +5155,7 @@ def cmd_embeddings_reindex(args: argparse.Namespace) -> int:
 
                 for detail in result.get("details", []):
                     if detail.get("status") == "failed":
-                        print(
-                            f"    FAILED: {detail['path']} - {detail.get('error', 'unknown')}"
-                        )
+                        print(f"    FAILED: {detail['path']} - {detail.get('error', 'unknown')}")
 
         print(f"\nReindex complete: {total_success} success, {total_failed} failed")
         return 0 if total_failed == 0 else 1
@@ -5211,6 +5329,73 @@ Examples:
     # Server get command
     server_get_parser = subparsers.add_parser("server-get", help="Get details of a specific server")
     server_get_parser.add_argument("--path", required=True, help="Server path (e.g., /my-server)")
+
+    # Server full-replacement update (PUT /api/servers/{path})
+    update_server_parser = subparsers.add_parser(
+        "update-server",
+        help="Replace a server's mutable metadata (PUT /api/servers/{path})",
+    )
+    update_server_parser.add_argument(
+        "--path", required=True, help="Server path (e.g., /my-server)"
+    )
+    update_server_parser.add_argument(
+        "--body",
+        default=None,
+        help=(
+            "Full JSON body for ServerUpdateRequest. When supplied, "
+            "individual field flags are ignored."
+        ),
+    )
+    update_server_parser.add_argument("--server-name", default=None, help="New server display name")
+    update_server_parser.add_argument("--description", default=None, help="New server description")
+    update_server_parser.add_argument(
+        "--proxy-pass-url", default=None, help="Backend URL for remote-deployment servers"
+    )
+    update_server_parser.add_argument("--tags", default=None, help="Comma-separated list of tags")
+    update_server_parser.add_argument("--license", default=None, help="License identifier")
+    update_server_parser.add_argument(
+        "--num-tools", type=int, default=None, help="Number of tools exposed by the server"
+    )
+    update_server_parser.add_argument(
+        "--metadata",
+        default=None,
+        help="JSON object string for the metadata field",
+    )
+    update_server_parser.add_argument(
+        "--visibility",
+        default=None,
+        choices=["public", "private", "group-restricted"],
+        help="Visibility level",
+    )
+    update_server_parser.add_argument(
+        "--allowed-groups",
+        default=None,
+        help="Comma-separated groups for group-restricted visibility",
+    )
+    update_server_parser.add_argument(
+        "--if-match",
+        dest="if_match",
+        default=None,
+        help="Weak ETag for optimistic concurrency (e.g. 'W/\"<epoch_ms>\"')",
+    )
+
+    # Server partial update (PATCH /api/servers/{path}) - RFC 7396 JSON Merge Patch
+    patch_server_parser = subparsers.add_parser(
+        "patch-server",
+        help="Partially update a server (PATCH /api/servers/{path}, RFC 7396 JSON Merge Patch)",
+    )
+    patch_server_parser.add_argument("--path", required=True, help="Server path (e.g., /my-server)")
+    patch_server_parser.add_argument(
+        "--patch",
+        required=True,
+        help="JSON object string with fields to change (RFC 7396 JSON Merge Patch)",
+    )
+    patch_server_parser.add_argument(
+        "--if-match",
+        dest="if_match",
+        default=None,
+        help="Weak ETag for optimistic concurrency (e.g. 'W/\"<epoch_ms>\"')",
+    )
 
     # Server rate command
     server_rate_parser = subparsers.add_parser("server-rate", help="Rate a server (1-5 stars)")
@@ -6135,9 +6320,7 @@ Examples:
         "embeddings-missing",
         help="Find documents missing from the search embeddings index (admin only)",
     )
-    embeddings_missing_parser.add_argument(
-        "--json", action="store_true", help="Output raw JSON"
-    )
+    embeddings_missing_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
     embeddings_reindex_parser = subparsers.add_parser(
         "embeddings-reindex",
@@ -6203,6 +6386,8 @@ Examples:
         "list-groups": cmd_list_groups,
         "describe-group": cmd_describe_group,
         "server-get": cmd_server_get,
+        "update-server": cmd_update_server,
+        "patch-server": cmd_patch_server,
         "server-rate": cmd_server_rate,
         "server-rating": cmd_server_rating,
         "security-scan": cmd_security_scan,

--- a/registry/api/_etag_utils.py
+++ b/registry/api/_etag_utils.py
@@ -1,0 +1,85 @@
+"""
+Shared weak-ETag helpers for resources that expose optimistic concurrency
+via If-Match headers.
+
+These helpers are timestamp-based (epoch milliseconds derived from an
+``updated_at`` field, with optional fallback to a ``registered_at`` /
+``created_at`` timestamp) so they are reusable across resource types
+(agents, servers, etc.) without coupling to a specific Pydantic model.
+
+Weak validators (``W/"..."``) are used because JSON serialization is not
+byte-stable, but the ``updated_at`` timestamp reliably changes on every
+persisted mutation.
+"""
+
+import re
+from datetime import datetime
+
+from fastapi import HTTPException
+
+_WEAK_ETAG_PATTERN = re.compile(r'W/"(\d+)"')
+
+
+def weak_etag_for_timestamp(
+    updated_at: datetime | None,
+    registered_at_fallback: datetime | None = None,
+) -> str:
+    """Build a weak ETag from a timestamp (epoch milliseconds).
+
+    Args:
+        updated_at: Primary timestamp to derive the ETag from.
+        registered_at_fallback: Fallback timestamp if updated_at is None.
+
+    Returns:
+        Weak ETag string of the form ``W/"<epoch_ms>"``. Returns
+        ``W/"0"`` if both timestamps are None.
+    """
+    ts = updated_at or registered_at_fallback
+    epoch_ms = int(ts.timestamp() * 1000) if ts else 0
+    return f'W/"{epoch_ms}"'
+
+
+def parse_if_match(if_match: str | None) -> int | None:
+    """Parse a weak ETag of the form ``W/"<epoch_ms>"`` into its int value.
+
+    Args:
+        if_match: Raw If-Match header value.
+
+    Returns:
+        The epoch-ms integer, or None if if_match is None.
+
+    Raises:
+        HTTPException: 400 on malformed input, including the strong-ETag
+            form. Strong form is explicitly rejected rather than silently
+            ignored so clients that think they set a precondition see the
+            error rather than getting last-write-wins.
+    """
+    if if_match is None:
+        return None
+    s = if_match.strip()
+    if s.startswith('"') and s.endswith('"'):
+        raise HTTPException(
+            status_code=400,
+            detail='Strong ETag not supported; use weak form W/"<epoch_ms>"',
+        )
+    m = _WEAK_ETAG_PATTERN.fullmatch(s)
+    if not m:
+        raise HTTPException(status_code=400, detail="Malformed If-Match header")
+    return int(m.group(1))
+
+
+def updated_ms(
+    updated_at: datetime | None,
+    registered_at_fallback: datetime | None = None,
+) -> int:
+    """Return epoch-ms of the timestamp (or fallback, else 0).
+
+    Args:
+        updated_at: Primary timestamp.
+        registered_at_fallback: Fallback timestamp if updated_at is None.
+
+    Returns:
+        Epoch milliseconds, or 0 if both timestamps are None.
+    """
+    ts = updated_at or registered_at_fallback
+    return int(ts.timestamp() * 1000) if ts else 0

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -11,7 +11,6 @@ import asyncio
 import hashlib
 import json
 import logging
-import re
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
@@ -59,6 +58,11 @@ from ..services.registration_gate_service import check_registration_gate
 from ..services.webhook_service import send_registration_webhook
 from ..utils.metadata import flatten_metadata_to_text
 from ..utils.request_utils import get_client_ip
+from ._etag_utils import (
+    parse_if_match,
+    updated_ms,
+    weak_etag_for_timestamp,
+)
 
 
 def get_search_repo() -> SearchRepositoryBase:
@@ -238,40 +242,22 @@ def _normalize_path(
 def _weak_etag_for(agent_card: AgentCard) -> str:
     """Weak ETag derived from updated_at epoch milliseconds.
 
-    Weak validator because JSON serialization is not byte-stable, but
-    updated_at reliably changes on every persisted mutation.
+    Thin wrapper over the shared helper to preserve agent-specific call sites.
     """
-    ts = agent_card.updated_at or agent_card.registered_at
-    epoch_ms = int(ts.timestamp() * 1000) if ts else 0
-    return f'W/"{epoch_ms}"'
+    return weak_etag_for_timestamp(agent_card.updated_at, agent_card.registered_at)
 
 
 def _parse_if_match(if_match: str | None) -> int | None:
-    """Parse a weak ETag of the form W/"<epoch_ms>" into its int.
-
-    Returns None if if_match is None. Raises HTTPException(400) on malformed
-    input, including the strong-ETag form. Strong form is explicitly rejected
-    rather than silently ignored so clients that think they set a precondition
-    see the error rather than getting last-write-wins.
-    """
-    if if_match is None:
-        return None
-    s = if_match.strip()
-    if s.startswith('"') and s.endswith('"'):
-        raise HTTPException(
-            status_code=400,
-            detail='Strong ETag not supported; use weak form W/"<epoch_ms>"',
-        )
-    m = re.fullmatch(r'W/"(\d+)"', s)
-    if not m:
-        raise HTTPException(status_code=400, detail="Malformed If-Match header")
-    return int(m.group(1))
+    """Parse a weak If-Match header. Thin wrapper over the shared helper."""
+    return parse_if_match(if_match)
 
 
 def _agent_updated_ms(agent_card: AgentCard) -> int:
-    """Epoch-ms of the card's updated_at (or registered_at fallback, else 0)."""
-    ts = agent_card.updated_at or agent_card.registered_at
-    return int(ts.timestamp() * 1000) if ts else 0
+    """Epoch-ms of the card's updated_at (or registered_at fallback, else 0).
+
+    Thin wrapper over the shared helper to preserve agent-specific call sites.
+    """
+    return updated_ms(agent_card.updated_at, agent_card.registered_at)
 
 
 def _hash_items(items: list[AgentBatchItem]) -> str:

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -2,10 +2,22 @@ import asyncio
 import json
 import logging
 import os
+from datetime import UTC, datetime
 from typing import Annotated, Any
 
 import httpx
-from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, Query, Request, status
+from fastapi import (
+    APIRouter,
+    Cookie,
+    Depends,
+    Form,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
@@ -22,12 +34,21 @@ from ..auth.tool_filter import filter_tools_for_user
 from ..constants import VALID_AUTH_SCHEMES, DeploymentType, HealthStatus
 from ..core.config import DeploymentMode, settings
 from ..core.schemas import AuthCredentialUpdateRequest
+from ..schemas.server_update_models import (
+    SERVER_REGISTRANT_ONLY_FIELDS,
+    ServerCardPatch,
+    ServerUpdateRequest,
+)
 from ..services.registration_gate_service import check_registration_gate
 from ..services.security_scanner import security_scanner_service
 from ..services.server_service import server_service
 from ..services.webhook_service import send_registration_webhook
-from ..utils.credential_encryption import encrypt_credential_in_server_dict
+from ..utils.credential_encryption import (
+    encrypt_credential_in_server_dict,
+    strip_credentials_from_dict,
+)
 from ..utils.metadata import flatten_metadata_to_text
+from ._etag_utils import parse_if_match, updated_ms, weak_etag_for_timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -838,6 +859,124 @@ from ..schemas.duplicate_check_models import (
     ServerDuplicateCheckRequest,
 )
 from ..services.duplicate_check_service import get_duplicate_check_service
+
+
+def _normalize_server_path(path: str) -> str:
+    """Normalize a server path to canonical form.
+
+    Ensures leading slash and strips a trailing slash unless the path is
+    just "/". Used by PUT/PATCH server endpoints so callers can pass
+    path with or without slashes.
+
+    Args:
+        path: Raw path from the URL.
+
+    Returns:
+        Canonical path string.
+    """
+    if not path.startswith("/"):
+        path = "/" + path
+    if len(path) > 1 and path.endswith("/"):
+        path = path.rstrip("/")
+    return path
+
+
+def _to_dt(value: Any) -> datetime | None:
+    """Coerce a stored timestamp value into a datetime.
+
+    Server documents may carry timestamps as either ISO-8601 strings
+    (with optional trailing 'Z') or pre-parsed datetime instances,
+    depending on the storage backend. ETag/If-Match comparisons need a
+    datetime, so this helper normalises both forms.
+
+    Args:
+        value: The stored timestamp value (string, datetime, or None).
+
+    Returns:
+        A datetime, or None if the input is None or unparseable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _check_server_permission(
+    permission: str,
+    server_name: str,
+    user_context: dict[str, Any],
+) -> None:
+    """Check whether the user has the requested UI permission for a server.
+
+    Mirrors `_check_agent_permission` in agent_routes.py so PUT/PATCH on
+    servers behaves the same way as PUT/PATCH on agents.
+
+    Args:
+        permission: UI permission name (e.g., "modify_service").
+        server_name: Display name of the server, used for the 403 detail.
+        user_context: Authenticated user context.
+
+    Raises:
+        HTTPException: 403 if the user lacks the permission.
+    """
+    from ..auth.dependencies import user_has_ui_permission_for_service
+
+    if not user_has_ui_permission_for_service(
+        permission,
+        server_name,
+        user_context.get("ui_permissions", {}),
+    ):
+        logger.warning(
+            f"User {user_context.get('username')} attempted to perform {permission} "
+            f"on server {server_name} without permission"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"You do not have permission to {permission} for {server_name}",
+        )
+
+
+def _merge_server_update(
+    existing: dict[str, Any],
+    incoming: dict[str, Any],
+) -> dict[str, Any]:
+    """Layer an incoming update over an existing server, re-pinning read-only fields.
+
+    Used by both PUT and PATCH handlers. Defence-in-depth: even if the
+    Pydantic models accept a registrant-only field, this helper restores
+    the stored value before persistence. Tag-shaped CSV strings are
+    normalised to lists so downstream search/index code stays simple.
+
+    Args:
+        existing: Server dict fetched from storage (with credentials).
+        incoming: Incoming update dict (already validated).
+
+    Returns:
+        A new merged dict; ``existing`` and ``incoming`` are not mutated.
+    """
+    merged: dict[str, Any] = {**existing, **incoming}
+
+    # Re-pin every registrant-only field from the existing record.
+    for field in SERVER_REGISTRANT_ONLY_FIELDS:
+        if field in existing:
+            merged[field] = existing[field]
+        else:
+            merged.pop(field, None)
+
+    # Normalise CSV-shaped tag fields to lists for downstream consistency.
+    for tag_field in ("tags", "external_tags"):
+        value = merged.get(tag_field)
+        if isinstance(value, str):
+            merged[tag_field] = [t.strip() for t in value.split(",") if t.strip()]
+
+    merged["updated_at"] = datetime.now(UTC).isoformat()
+    return merged
 
 
 def _check_register_permission(
@@ -3662,6 +3801,338 @@ async def register_service_api(
     except Exception as e:
         logger.error(f"Service registration failed for {path}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Service registration failed")
+
+
+@router.put("/servers/{path:path}")
+async def update_server_endpoint(
+    http_request: Request,
+    path: str,
+    body: ServerUpdateRequest,
+    response: Response,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
+):
+    """Replace a registered server's mutable metadata.
+
+    Registrant-only fields (timestamps, identity anchors, deployment,
+    credential blobs) are preserved from storage even if a client sends
+    them. Auth/credential mutation goes through
+    PATCH /api/servers/{path}/auth-credential.
+
+    Concurrency: when ``If-Match`` is supplied the request is rejected
+    with 412 if the stored ``updated_at`` no longer matches.
+    """
+    path = _normalize_server_path(path)
+
+    existing = await server_service.get_server_info(path, include_credentials=True)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}'",
+        )
+
+    set_audit_action(
+        http_request,
+        "update",
+        "server",
+        resource_id=path,
+        description=f"Update server {existing.get('server_name', path)}",
+        metadata={"had_if_match": if_match is not None},
+    )
+
+    sync_metadata = existing.get("sync_metadata") or {}
+    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
+        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
+        logger.warning(
+            f"User {user_context['username']} attempted to update federated server {path} "
+            f"from {source_peer}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Server '{path}' is synced from {source_peer} and cannot be "
+                f"updated locally. Update at the source registry, or remove "
+                f"the peer federation."
+            ),
+        )
+
+    _check_server_permission(
+        "modify_service",
+        existing.get("server_name", path),
+        user_context,
+    )
+
+    if (
+        not user_context.get("is_admin")
+        and existing.get("registered_by") != user_context["username"]
+    ):
+        logger.warning(
+            f"User {user_context['username']} attempted to update server {path} "
+            f"owned by {existing.get('registered_by')}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only update servers you registered",
+        )
+
+    client_ts = parse_if_match(if_match)
+    if client_ts is not None:
+        server_ts = updated_ms(
+            _to_dt(existing.get("updated_at")),
+            _to_dt(existing.get("registered_at")),
+        )
+        if client_ts != server_ts:
+            logger.warning(
+                "update_server_endpoint if_match_mismatch path=%s user=%s "
+                "client_ts=%d server_ts=%d",
+                path,
+                user_context["username"],
+                client_ts,
+                server_ts,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
+
+    incoming = body.model_dump(exclude_unset=False, mode="json")
+    if body.provider is not None:
+        incoming["provider"] = body.provider.model_dump()
+
+    merged = _merge_server_update(existing, incoming)
+
+    gate_result = await check_registration_gate(
+        asset_type="server",
+        operation="update",
+        source_api=f"/api/servers/{path}",
+        registration_payload=merged,
+        raw_headers=http_request.scope.get("headers", []),
+    )
+    if not gate_result.allowed:
+        logger.warning(
+            f"Registration gate denied server update '{path}': {gate_result.error_message}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Registration denied by policy gate: {gate_result.error_message}",
+        )
+
+    success = await server_service.update_server(path, merged)
+    if not success:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": "Failed to save server"},
+        )
+
+    if existing.get("deployment") != "local" and existing.get("proxy_pass_url") != merged.get(
+        "proxy_pass_url"
+    ):
+        asyncio.create_task(
+            _perform_security_scan_on_registration(
+                path,
+                merged.get("proxy_pass_url"),
+                merged,
+                merged.get("headers") or [],
+            )
+        )
+
+    asyncio.create_task(
+        send_registration_webhook(
+            event_type="update",
+            registration_type="server",
+            card_data=strip_credentials_from_dict(dict(merged)),
+            performed_by=user_context.get("username"),
+        )
+    )
+
+    fresh = await server_service.get_server_info(path)
+    if fresh is None:
+        # Concurrent delete is unlikely but defensible.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}' after update",
+        )
+
+    response.headers["ETag"] = weak_etag_for_timestamp(
+        _to_dt(fresh.get("updated_at")),
+        _to_dt(fresh.get("registered_at")),
+    )
+
+    logger.info(
+        "update_server_endpoint success path=%s user=%s if_match_supplied=%s",
+        path,
+        user_context["username"],
+        if_match is not None,
+    )
+
+    return fresh
+
+
+@router.patch("/servers/{path:path}")
+async def patch_server_endpoint(
+    http_request: Request,
+    path: str,
+    patch_body: ServerCardPatch,
+    response: Response,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
+):
+    """Apply an RFC 7396 JSON Merge Patch to a server's metadata.
+
+    Only fields explicitly supplied are changed. Registrant-only fields
+    are rejected by the ServerCardPatch validator before this handler
+    runs; this handler additionally re-pins them defensively.
+
+    Auth/credential mutation goes through
+    PATCH /api/servers/{path}/auth-credential.
+    """
+    path = _normalize_server_path(path)
+
+    existing = await server_service.get_server_info(path, include_credentials=True)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}'",
+        )
+
+    set_audit_action(
+        http_request,
+        "update",
+        "server",
+        resource_id=path,
+        description=f"Patch server {existing.get('server_name', path)}",
+        metadata={"had_if_match": if_match is not None},
+    )
+
+    sync_metadata = existing.get("sync_metadata") or {}
+    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
+        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
+        logger.warning(
+            f"User {user_context['username']} attempted to patch federated server {path} "
+            f"from {source_peer}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Server '{path}' is synced from {source_peer} and cannot be "
+                f"patched locally. Patch at the source registry, or remove "
+                f"the peer federation."
+            ),
+        )
+
+    _check_server_permission(
+        "modify_service",
+        existing.get("server_name", path),
+        user_context,
+    )
+
+    if (
+        not user_context.get("is_admin")
+        and existing.get("registered_by") != user_context["username"]
+    ):
+        logger.warning(
+            f"User {user_context['username']} attempted to patch server {path} "
+            f"owned by {existing.get('registered_by')}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only patch servers you registered",
+        )
+
+    client_ts = parse_if_match(if_match)
+    if client_ts is not None:
+        server_ts = updated_ms(
+            _to_dt(existing.get("updated_at")),
+            _to_dt(existing.get("registered_at")),
+        )
+        if client_ts != server_ts:
+            logger.warning(
+                "patch_server_endpoint if_match_mismatch path=%s user=%s client_ts=%d server_ts=%d",
+                path,
+                user_context["username"],
+                client_ts,
+                server_ts,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
+
+    patch_dict = patch_body.model_dump(exclude_unset=True, by_alias=False, mode="json")
+    if not patch_dict:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty patch body",
+        )
+
+    merged = _merge_server_update(existing, patch_dict)
+
+    gate_result = await check_registration_gate(
+        asset_type="server",
+        operation="update",
+        source_api=f"/api/servers/{path}",
+        registration_payload=merged,
+        raw_headers=http_request.scope.get("headers", []),
+    )
+    if not gate_result.allowed:
+        logger.warning(
+            f"Registration gate denied server patch '{path}': {gate_result.error_message}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Registration denied by policy gate: {gate_result.error_message}",
+        )
+
+    success = await server_service.update_server(path, merged)
+    if not success:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": "Failed to save server"},
+        )
+
+    if (
+        "proxy_pass_url" in patch_dict
+        and existing.get("deployment") != "local"
+        and existing.get("proxy_pass_url") != merged.get("proxy_pass_url")
+    ):
+        asyncio.create_task(
+            _perform_security_scan_on_registration(
+                path,
+                merged.get("proxy_pass_url"),
+                merged,
+                merged.get("headers") or [],
+            )
+        )
+
+    asyncio.create_task(
+        send_registration_webhook(
+            event_type="update",
+            registration_type="server",
+            card_data=strip_credentials_from_dict(dict(merged)),
+            performed_by=user_context.get("username"),
+        )
+    )
+
+    fresh = await server_service.get_server_info(path)
+    if fresh is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}' after patch",
+        )
+
+    response.headers["ETag"] = weak_etag_for_timestamp(
+        _to_dt(fresh.get("updated_at")),
+        _to_dt(fresh.get("registered_at")),
+    )
+
+    logger.info(
+        "patch_server_endpoint success path=%s user=%s if_match_supplied=%s",
+        path,
+        user_context["username"],
+        if_match is not None,
+    )
+
+    return fresh
 
 
 @router.patch("/servers/{server_path:path}/auth-credential")

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -3803,338 +3803,6 @@ async def register_service_api(
         raise HTTPException(status_code=500, detail="Service registration failed")
 
 
-@router.put("/servers/{path:path}")
-async def update_server_endpoint(
-    http_request: Request,
-    path: str,
-    body: ServerUpdateRequest,
-    response: Response,
-    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
-    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
-):
-    """Replace a registered server's mutable metadata.
-
-    Registrant-only fields (timestamps, identity anchors, deployment,
-    credential blobs) are preserved from storage even if a client sends
-    them. Auth/credential mutation goes through
-    PATCH /api/servers/{path}/auth-credential.
-
-    Concurrency: when ``If-Match`` is supplied the request is rejected
-    with 412 if the stored ``updated_at`` no longer matches.
-    """
-    path = _normalize_server_path(path)
-
-    existing = await server_service.get_server_info(path, include_credentials=True)
-    if not existing:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Server not found at path '{path}'",
-        )
-
-    set_audit_action(
-        http_request,
-        "update",
-        "server",
-        resource_id=path,
-        description=f"Update server {existing.get('server_name', path)}",
-        metadata={"had_if_match": if_match is not None},
-    )
-
-    sync_metadata = existing.get("sync_metadata") or {}
-    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
-        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
-        logger.warning(
-            f"User {user_context['username']} attempted to update federated server {path} "
-            f"from {source_peer}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                f"Server '{path}' is synced from {source_peer} and cannot be "
-                f"updated locally. Update at the source registry, or remove "
-                f"the peer federation."
-            ),
-        )
-
-    _check_server_permission(
-        "modify_service",
-        existing.get("server_name", path),
-        user_context,
-    )
-
-    if (
-        not user_context.get("is_admin")
-        and existing.get("registered_by") != user_context["username"]
-    ):
-        logger.warning(
-            f"User {user_context['username']} attempted to update server {path} "
-            f"owned by {existing.get('registered_by')}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only update servers you registered",
-        )
-
-    client_ts = parse_if_match(if_match)
-    if client_ts is not None:
-        server_ts = updated_ms(
-            _to_dt(existing.get("updated_at")),
-            _to_dt(existing.get("registered_at")),
-        )
-        if client_ts != server_ts:
-            logger.warning(
-                "update_server_endpoint if_match_mismatch path=%s user=%s "
-                "client_ts=%d server_ts=%d",
-                path,
-                user_context["username"],
-                client_ts,
-                server_ts,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_412_PRECONDITION_FAILED,
-                detail="If-Match does not match current server version",
-            )
-
-    incoming = body.model_dump(exclude_unset=False, mode="json")
-    if body.provider is not None:
-        incoming["provider"] = body.provider.model_dump()
-
-    merged = _merge_server_update(existing, incoming)
-
-    gate_result = await check_registration_gate(
-        asset_type="server",
-        operation="update",
-        source_api=f"/api/servers/{path}",
-        registration_payload=merged,
-        raw_headers=http_request.scope.get("headers", []),
-    )
-    if not gate_result.allowed:
-        logger.warning(
-            f"Registration gate denied server update '{path}': {gate_result.error_message}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Registration denied by policy gate: {gate_result.error_message}",
-        )
-
-    success = await server_service.update_server(path, merged)
-    if not success:
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"detail": "Failed to save server"},
-        )
-
-    if existing.get("deployment") != "local" and existing.get("proxy_pass_url") != merged.get(
-        "proxy_pass_url"
-    ):
-        asyncio.create_task(
-            _perform_security_scan_on_registration(
-                path,
-                merged.get("proxy_pass_url"),
-                merged,
-                merged.get("headers") or [],
-            )
-        )
-
-    asyncio.create_task(
-        send_registration_webhook(
-            event_type="update",
-            registration_type="server",
-            card_data=strip_credentials_from_dict(dict(merged)),
-            performed_by=user_context.get("username"),
-        )
-    )
-
-    fresh = await server_service.get_server_info(path)
-    if fresh is None:
-        # Concurrent delete is unlikely but defensible.
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Server not found at path '{path}' after update",
-        )
-
-    response.headers["ETag"] = weak_etag_for_timestamp(
-        _to_dt(fresh.get("updated_at")),
-        _to_dt(fresh.get("registered_at")),
-    )
-
-    logger.info(
-        "update_server_endpoint success path=%s user=%s if_match_supplied=%s",
-        path,
-        user_context["username"],
-        if_match is not None,
-    )
-
-    return fresh
-
-
-@router.patch("/servers/{path:path}")
-async def patch_server_endpoint(
-    http_request: Request,
-    path: str,
-    patch_body: ServerCardPatch,
-    response: Response,
-    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
-    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
-):
-    """Apply an RFC 7396 JSON Merge Patch to a server's metadata.
-
-    Only fields explicitly supplied are changed. Registrant-only fields
-    are rejected by the ServerCardPatch validator before this handler
-    runs; this handler additionally re-pins them defensively.
-
-    Auth/credential mutation goes through
-    PATCH /api/servers/{path}/auth-credential.
-    """
-    path = _normalize_server_path(path)
-
-    existing = await server_service.get_server_info(path, include_credentials=True)
-    if not existing:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Server not found at path '{path}'",
-        )
-
-    set_audit_action(
-        http_request,
-        "update",
-        "server",
-        resource_id=path,
-        description=f"Patch server {existing.get('server_name', path)}",
-        metadata={"had_if_match": if_match is not None},
-    )
-
-    sync_metadata = existing.get("sync_metadata") or {}
-    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
-        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
-        logger.warning(
-            f"User {user_context['username']} attempted to patch federated server {path} "
-            f"from {source_peer}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=(
-                f"Server '{path}' is synced from {source_peer} and cannot be "
-                f"patched locally. Patch at the source registry, or remove "
-                f"the peer federation."
-            ),
-        )
-
-    _check_server_permission(
-        "modify_service",
-        existing.get("server_name", path),
-        user_context,
-    )
-
-    if (
-        not user_context.get("is_admin")
-        and existing.get("registered_by") != user_context["username"]
-    ):
-        logger.warning(
-            f"User {user_context['username']} attempted to patch server {path} "
-            f"owned by {existing.get('registered_by')}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only patch servers you registered",
-        )
-
-    client_ts = parse_if_match(if_match)
-    if client_ts is not None:
-        server_ts = updated_ms(
-            _to_dt(existing.get("updated_at")),
-            _to_dt(existing.get("registered_at")),
-        )
-        if client_ts != server_ts:
-            logger.warning(
-                "patch_server_endpoint if_match_mismatch path=%s user=%s client_ts=%d server_ts=%d",
-                path,
-                user_context["username"],
-                client_ts,
-                server_ts,
-            )
-            raise HTTPException(
-                status_code=status.HTTP_412_PRECONDITION_FAILED,
-                detail="If-Match does not match current server version",
-            )
-
-    patch_dict = patch_body.model_dump(exclude_unset=True, by_alias=False, mode="json")
-    if not patch_dict:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Empty patch body",
-        )
-
-    merged = _merge_server_update(existing, patch_dict)
-
-    gate_result = await check_registration_gate(
-        asset_type="server",
-        operation="update",
-        source_api=f"/api/servers/{path}",
-        registration_payload=merged,
-        raw_headers=http_request.scope.get("headers", []),
-    )
-    if not gate_result.allowed:
-        logger.warning(
-            f"Registration gate denied server patch '{path}': {gate_result.error_message}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Registration denied by policy gate: {gate_result.error_message}",
-        )
-
-    success = await server_service.update_server(path, merged)
-    if not success:
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"detail": "Failed to save server"},
-        )
-
-    if (
-        "proxy_pass_url" in patch_dict
-        and existing.get("deployment") != "local"
-        and existing.get("proxy_pass_url") != merged.get("proxy_pass_url")
-    ):
-        asyncio.create_task(
-            _perform_security_scan_on_registration(
-                path,
-                merged.get("proxy_pass_url"),
-                merged,
-                merged.get("headers") or [],
-            )
-        )
-
-    asyncio.create_task(
-        send_registration_webhook(
-            event_type="update",
-            registration_type="server",
-            card_data=strip_credentials_from_dict(dict(merged)),
-            performed_by=user_context.get("username"),
-        )
-    )
-
-    fresh = await server_service.get_server_info(path)
-    if fresh is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Server not found at path '{path}' after patch",
-        )
-
-    response.headers["ETag"] = weak_etag_for_timestamp(
-        _to_dt(fresh.get("updated_at")),
-        _to_dt(fresh.get("registered_at")),
-    )
-
-    logger.info(
-        "patch_server_endpoint success path=%s user=%s if_match_supplied=%s",
-        path,
-        user_context["username"],
-        if_match is not None,
-    )
-
-    return fresh
-
-
 @router.patch("/servers/{server_path:path}/auth-credential")
 async def update_server_auth_credential(
     request: Request,
@@ -5602,6 +5270,340 @@ async def get_server_connect_config(
 
 
 # IMPORTANT: This catch-all route must remain AFTER all /servers/{path}/... suffixed routes
+
+
+@router.put("/servers/{path:path}")
+async def update_server_endpoint(
+    http_request: Request,
+    path: str,
+    body: ServerUpdateRequest,
+    response: Response,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
+):
+    """Replace a registered server's mutable metadata.
+
+    Registrant-only fields (timestamps, identity anchors, deployment,
+    credential blobs) are preserved from storage even if a client sends
+    them. Auth/credential mutation goes through
+    PATCH /api/servers/{path}/auth-credential.
+
+    Concurrency: when ``If-Match`` is supplied the request is rejected
+    with 412 if the stored ``updated_at`` no longer matches.
+    """
+    path = _normalize_server_path(path)
+
+    existing = await server_service.get_server_info(path, include_credentials=True)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}'",
+        )
+
+    set_audit_action(
+        http_request,
+        "update",
+        "server",
+        resource_id=path,
+        description=f"Update server {existing.get('server_name', path)}",
+        metadata={"had_if_match": if_match is not None},
+    )
+
+    sync_metadata = existing.get("sync_metadata") or {}
+    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
+        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
+        logger.warning(
+            f"User {user_context['username']} attempted to update federated server {path} "
+            f"from {source_peer}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Server '{path}' is synced from {source_peer} and cannot be "
+                f"updated locally. Update at the source registry, or remove "
+                f"the peer federation."
+            ),
+        )
+
+    _check_server_permission(
+        "modify_service",
+        existing.get("server_name", path),
+        user_context,
+    )
+
+    if (
+        not user_context.get("is_admin")
+        and existing.get("registered_by") != user_context["username"]
+    ):
+        logger.warning(
+            f"User {user_context['username']} attempted to update server {path} "
+            f"owned by {existing.get('registered_by')}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only update servers you registered",
+        )
+
+    client_ts = parse_if_match(if_match)
+    if client_ts is not None:
+        server_ts = updated_ms(
+            _to_dt(existing.get("updated_at")),
+            _to_dt(existing.get("registered_at")),
+        )
+        if client_ts != server_ts:
+            logger.warning(
+                "update_server_endpoint if_match_mismatch path=%s user=%s "
+                "client_ts=%d server_ts=%d",
+                path,
+                user_context["username"],
+                client_ts,
+                server_ts,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
+
+    incoming = body.model_dump(exclude_unset=False, mode="json")
+    if body.provider is not None:
+        incoming["provider"] = body.provider.model_dump()
+
+    merged = _merge_server_update(existing, incoming)
+
+    gate_result = await check_registration_gate(
+        asset_type="server",
+        operation="update",
+        source_api=f"/api/servers/{path}",
+        registration_payload=merged,
+        raw_headers=http_request.scope.get("headers", []),
+    )
+    if not gate_result.allowed:
+        logger.warning(
+            f"Registration gate denied server update '{path}': {gate_result.error_message}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Registration denied by policy gate: {gate_result.error_message}",
+        )
+
+    success = await server_service.update_server(path, merged)
+    if not success:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": "Failed to save server"},
+        )
+
+    if existing.get("deployment") != "local" and existing.get("proxy_pass_url") != merged.get(
+        "proxy_pass_url"
+    ):
+        asyncio.create_task(
+            _perform_security_scan_on_registration(
+                path,
+                merged.get("proxy_pass_url"),
+                merged,
+                merged.get("headers") or [],
+            )
+        )
+
+    asyncio.create_task(
+        send_registration_webhook(
+            event_type="update",
+            registration_type="server",
+            card_data=strip_credentials_from_dict(dict(merged)),
+            performed_by=user_context.get("username"),
+        )
+    )
+
+    fresh = await server_service.get_server_info(path)
+    if fresh is None:
+        # Concurrent delete is unlikely but defensible.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}' after update",
+        )
+
+    response.headers["ETag"] = weak_etag_for_timestamp(
+        _to_dt(fresh.get("updated_at")),
+        _to_dt(fresh.get("registered_at")),
+    )
+
+    logger.info(
+        "update_server_endpoint success path=%s user=%s if_match_supplied=%s",
+        path,
+        user_context["username"],
+        if_match is not None,
+    )
+
+    return fresh
+
+
+@router.patch("/servers/{path:path}")
+async def patch_server_endpoint(
+    http_request: Request,
+    path: str,
+    patch_body: ServerCardPatch,
+    response: Response,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+    if_match: Annotated[str | None, Header(alias="If-Match")] = None,
+):
+    """Apply an RFC 7396 JSON Merge Patch to a server's metadata.
+
+    Only fields explicitly supplied are changed. Registrant-only fields
+    are rejected by the ServerCardPatch validator before this handler
+    runs; this handler additionally re-pins them defensively.
+
+    Auth/credential mutation goes through
+    PATCH /api/servers/{path}/auth-credential.
+    """
+    path = _normalize_server_path(path)
+
+    existing = await server_service.get_server_info(path, include_credentials=True)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}'",
+        )
+
+    set_audit_action(
+        http_request,
+        "update",
+        "server",
+        resource_id=path,
+        description=f"Patch server {existing.get('server_name', path)}",
+        metadata={"had_if_match": if_match is not None},
+    )
+
+    sync_metadata = existing.get("sync_metadata") or {}
+    if sync_metadata.get("is_federated") or sync_metadata.get("is_read_only"):
+        source_peer = sync_metadata.get("source_peer_id", "unknown peer registry")
+        logger.warning(
+            f"User {user_context['username']} attempted to patch federated server {path} "
+            f"from {source_peer}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Server '{path}' is synced from {source_peer} and cannot be "
+                f"patched locally. Patch at the source registry, or remove "
+                f"the peer federation."
+            ),
+        )
+
+    _check_server_permission(
+        "modify_service",
+        existing.get("server_name", path),
+        user_context,
+    )
+
+    if (
+        not user_context.get("is_admin")
+        and existing.get("registered_by") != user_context["username"]
+    ):
+        logger.warning(
+            f"User {user_context['username']} attempted to patch server {path} "
+            f"owned by {existing.get('registered_by')}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only patch servers you registered",
+        )
+
+    client_ts = parse_if_match(if_match)
+    if client_ts is not None:
+        server_ts = updated_ms(
+            _to_dt(existing.get("updated_at")),
+            _to_dt(existing.get("registered_at")),
+        )
+        if client_ts != server_ts:
+            logger.warning(
+                "patch_server_endpoint if_match_mismatch path=%s user=%s client_ts=%d server_ts=%d",
+                path,
+                user_context["username"],
+                client_ts,
+                server_ts,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
+
+    patch_dict = patch_body.model_dump(exclude_unset=True, by_alias=False, mode="json")
+    if not patch_dict:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty patch body",
+        )
+
+    merged = _merge_server_update(existing, patch_dict)
+
+    gate_result = await check_registration_gate(
+        asset_type="server",
+        operation="update",
+        source_api=f"/api/servers/{path}",
+        registration_payload=merged,
+        raw_headers=http_request.scope.get("headers", []),
+    )
+    if not gate_result.allowed:
+        logger.warning(
+            f"Registration gate denied server patch '{path}': {gate_result.error_message}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Registration denied by policy gate: {gate_result.error_message}",
+        )
+
+    success = await server_service.update_server(path, merged)
+    if not success:
+        return JSONResponse(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            content={"detail": "Failed to save server"},
+        )
+
+    if (
+        "proxy_pass_url" in patch_dict
+        and existing.get("deployment") != "local"
+        and existing.get("proxy_pass_url") != merged.get("proxy_pass_url")
+    ):
+        asyncio.create_task(
+            _perform_security_scan_on_registration(
+                path,
+                merged.get("proxy_pass_url"),
+                merged,
+                merged.get("headers") or [],
+            )
+        )
+
+    asyncio.create_task(
+        send_registration_webhook(
+            event_type="update",
+            registration_type="server",
+            card_data=strip_credentials_from_dict(dict(merged)),
+            performed_by=user_context.get("username"),
+        )
+    )
+
+    fresh = await server_service.get_server_info(path)
+    if fresh is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Server not found at path '{path}' after patch",
+        )
+
+    response.headers["ETag"] = weak_etag_for_timestamp(
+        _to_dt(fresh.get("updated_at")),
+        _to_dt(fresh.get("registered_at")),
+    )
+
+    logger.info(
+        "patch_server_endpoint success path=%s user=%s if_match_supplied=%s",
+        path,
+        user_context["username"],
+        if_match is not None,
+    )
+
+    return fresh
+
+
 @router.get("/servers/{path:path}")
 async def get_server(
     request: Request,

--- a/registry/audit/context.py
+++ b/registry/audit/context.py
@@ -5,6 +5,8 @@ This module provides helper functions for setting audit action context
 in route handlers, which is then captured by the AuditMiddleware.
 """
 
+from typing import Any
+
 from fastapi import Request
 
 
@@ -15,6 +17,7 @@ def set_audit_action(
     resource_id: str | None = None,
     description: str | None = None,
     idp_skip_reason: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> None:
     """
     Set audit action context on the request for the AuditMiddleware.
@@ -31,6 +34,9 @@ def set_audit_action(
         idp_skip_reason: When an IdP admin call was intentionally skipped, the
             reason. One of: 'local_only', 'forbidden', 'not_found'.
             See issue #946.
+        metadata: Optional structured dimensions to record alongside the action
+            (e.g., `{'had_if_match': True}`). Persisted on the audit event
+            for later analysis.
 
     Example:
         @router.post("/servers")
@@ -44,6 +50,7 @@ def set_audit_action(
         "resource_id": resource_id,
         "description": description,
         "idp_skip_reason": idp_skip_reason,
+        "metadata": metadata or {},
     }
 
 

--- a/registry/audit/middleware.py
+++ b/registry/audit/middleware.py
@@ -264,6 +264,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
                 resource_id=audit_action.get("resource_id"),
                 description=audit_action.get("description"),
                 idp_skip_reason=audit_action.get("idp_skip_reason"),
+                metadata=audit_action.get("metadata") or {},
             )
 
         return None

--- a/registry/audit/models.py
+++ b/registry/audit/models.py
@@ -150,6 +150,13 @@ class Action(BaseModel):
             "'forbidden' (IdP 403), 'not_found' (IdP 404)."
         ),
     )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Optional structured dimensions recorded alongside the action "
+            "(e.g., {'had_if_match': True}). Used for later analysis."
+        ),
+    )
 
 
 class Authorization(BaseModel):

--- a/registry/schemas/server_update_models.py
+++ b/registry/schemas/server_update_models.py
@@ -1,0 +1,262 @@
+"""Pydantic models for server metadata updates (PUT and PATCH)."""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .agent_models import AgentProvider
+
+# Fields that callers must not mutate via PUT or PATCH.
+# Server-managed (timestamps, health) or identity anchors.
+SERVER_REGISTRANT_ONLY_FIELDS: frozenset[str] = frozenset(
+    {
+        "id",
+        "path",
+        "registered_by",
+        "registered_at",
+        "updated_at",
+        "is_enabled",
+        "is_active",
+        "version",
+        "deployment",
+        "local_runtime",
+        "health_status",
+        "last_health_check",
+        "auth_credential_encrypted",
+        "custom_headers_encrypted",
+        "sync_metadata",
+        # Auth/credential fields, owned by the dedicated
+        # PATCH /api/servers/{path}/auth-credential endpoint.
+        # Rejected on this endpoint to keep credential mutation
+        # behind a single, narrowly-scoped surface.
+        "auth_scheme",
+        "auth_credential",
+        "auth_header_name",
+        "custom_headers",
+        "custom_header_names",
+    }
+)
+
+
+_MAX_METADATA_BYTES: int = 64 * 1024
+_MAX_TAGS: int = 50
+_MAX_TAG_LEN: int = 64
+_MAX_DESCRIPTION_LEN: int = 4096
+_MAX_SERVER_NAME_LEN: int = 256
+
+
+def _validate_tag_list(v: list[str] | str | None) -> list[str] | None:
+    """Normalise CSV strings to lists, enforce count and per-tag length caps."""
+    if v is None:
+        return None
+    if isinstance(v, str):
+        v = [t.strip() for t in v.split(",") if t.strip()]
+    if len(v) > _MAX_TAGS:
+        raise ValueError(f"tag list must contain at most {_MAX_TAGS} entries")
+    for tag in v:
+        if len(tag) > _MAX_TAG_LEN:
+            raise ValueError(f"each tag must be at most {_MAX_TAG_LEN} chars")
+    return v
+
+
+def _validate_metadata_size(v: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Reject metadata blobs that serialise to more than _MAX_METADATA_BYTES."""
+    if v is None:
+        return None
+    import json
+
+    encoded = json.dumps(v, default=str).encode("utf-8")
+    if len(encoded) > _MAX_METADATA_BYTES:
+        raise ValueError(
+            f"metadata must serialise to at most {_MAX_METADATA_BYTES} bytes (got {len(encoded)})"
+        )
+    return v
+
+
+class ServerUpdateRequest(BaseModel):
+    """Full-replacement body for PUT /api/servers/{path}.
+
+    Only mutable metadata fields are accepted. Identity anchors and
+    server-managed fields must not appear; supplying them is a 422.
+
+    Size caps (from LLD Should-fix #3):
+        - server_name <= 256 chars
+        - description <= 4096 chars
+        - tags <= 50 entries, each <= 64 chars
+        - external_tags <= 50 entries, each <= 64 chars
+        - metadata <= 64 KB serialised JSON
+        These caps protect downstream code (DocumentDB document size,
+        embedding text budget, UI rendering). NOTE: POST /register
+        does not currently enforce these caps; a follow-up issue
+        will add them there for consistency.
+
+    Visibility & access control:
+        `visibility` and `allowed_groups` are deliberately mutable. The
+        owner of a server can change these at any time (same authority
+        they have at registration time). The handler enforces an
+        ownership check before this body is applied, so non-owners
+        cannot mutate them via this endpoint. See the LLD Threat
+        Model section for the full reasoning.
+
+    Auth/credential fields:
+        `auth_scheme`, `auth_credential`, `auth_header_name`,
+        `custom_headers`, and `custom_header_names` are intentionally
+        absent. Use PATCH /api/servers/{path}/auth-credential instead.
+
+    Local-deployment fields:
+        `deployment` and `local_runtime` are in
+        SERVER_REGISTRANT_ONLY_FIELDS and rejected with 422. To change
+        a local server's launch recipe today, re-register with
+        overwrite=true. A dedicated endpoint is planned for the future.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    server_name: str = Field(..., min_length=1, max_length=_MAX_SERVER_NAME_LEN)
+    description: str = Field(..., min_length=1, max_length=_MAX_DESCRIPTION_LEN)
+
+    # Routing: remote-deployment only; server's existing deployment is
+    # preserved by the handler. PUT cannot flip deployment type.
+    proxy_pass_url: str | None = None
+    mcp_endpoint: str | None = None
+    sse_endpoint: str | None = None
+    transport: str | None = None
+    supported_transports: list[str] | None = None
+    headers: list[dict[str, Any]] | None = None
+
+    # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
+    # auth_header_name, custom_headers) are intentionally absent.
+    # They are owned by PATCH /api/servers/{path}/auth-credential.
+    # Supplying them on this endpoint is rejected by Pydantic
+    # extra="forbid" (returns 422).
+    auth_provider: str | None = None  # provider name only; non-secret
+
+    # Metadata
+    tags: list[str] | str = Field(default_factory=list)
+    license: str = "N/A"
+    num_tools: int | None = None
+    tool_list: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] | None = None
+    visibility: str = "public"
+    allowed_groups: list[str] | None = None
+    status: str | None = None
+
+    # Provider/lineage
+    provider: AgentProvider | None = None  # structured; persisted via .model_dump()
+    source_created_at: str | None = None
+    source_updated_at: str | None = None
+    external_tags: list[str] | None = None
+
+    @field_validator("tags", mode="after")
+    @classmethod
+    def _cap_tags(
+        cls,
+        v: list[str] | str,
+    ) -> list[str]:
+        return _validate_tag_list(v) or []
+
+    @field_validator("external_tags", mode="after")
+    @classmethod
+    def _cap_external_tags(
+        cls,
+        v: list[str] | None,
+    ) -> list[str] | None:
+        return _validate_tag_list(v)
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _cap_metadata(
+        cls,
+        v: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        return _validate_metadata_size(v)
+
+
+class ServerCardPatch(BaseModel):
+    """RFC 7396 JSON Merge Patch body for PATCH /api/servers/{path}.
+
+    Every field is optional. Fields explicitly supplied override the
+    stored value; fields absent are preserved. SERVER_REGISTRANT_ONLY_FIELDS
+    are rejected with 422 if supplied.
+
+    Visibility & access control:
+        `visibility` and `allowed_groups` are mutable. The handler's
+        ownership check ensures only the server's owner (or an admin)
+        can apply this patch, so this is not a privilege-escalation
+        path. See the LLD Threat Model section.
+
+        Self-lockout: a non-admin owner can narrow `allowed_groups` in
+        a way that removes their own access. This is not prevented;
+        the audit trail makes it recoverable by an admin.
+
+    Auth/credential fields:
+        `auth_scheme`, `auth_credential`, `auth_header_name`,
+        `custom_headers`, `custom_header_names` are intentionally
+        absent and rejected by extra="forbid" with 422. Use
+        PATCH /api/servers/{path}/auth-credential to mutate auth.
+
+    Local-deployment fields:
+        `deployment` and `local_runtime` are not patchable here. To
+        change a local server's launch recipe today, re-register with
+        overwrite=true. See LLD Non-Goals for rationale.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    server_name: str | None = Field(default=None, min_length=1, max_length=_MAX_SERVER_NAME_LEN)
+    description: str | None = Field(default=None, max_length=_MAX_DESCRIPTION_LEN)
+    proxy_pass_url: str | None = None
+    mcp_endpoint: str | None = None
+    sse_endpoint: str | None = None
+    transport: str | None = None
+    supported_transports: list[str] | None = None
+    headers: list[dict[str, Any]] | None = None
+    # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
+    # auth_header_name, custom_headers, custom_header_names) are
+    # intentionally absent and rejected by extra="forbid" with 422.
+    # Use PATCH /api/servers/{path}/auth-credential to mutate auth.
+    auth_provider: str | None = None  # provider name only; non-secret
+    tags: list[str] | str | None = None
+    license: str | None = None
+    num_tools: int | None = None
+    tool_list: list[dict[str, Any]] | None = None
+    metadata: dict[str, Any] | None = None
+    visibility: str | None = None
+    allowed_groups: list[str] | None = None
+    status: str | None = None
+    provider: AgentProvider | None = None  # structured; persisted via .model_dump()
+    source_created_at: str | None = None
+    source_updated_at: str | None = None
+    external_tags: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _reject_registrant_only(self) -> "ServerCardPatch":
+        supplied = set(self.model_dump(exclude_unset=True, by_alias=False).keys())
+        bad = SERVER_REGISTRANT_ONLY_FIELDS & supplied
+        if bad:
+            raise ValueError(f"Field(s) {sorted(bad)} are read-only and cannot be patched")
+        return self
+
+    @field_validator("tags", mode="after")
+    @classmethod
+    def _cap_tags(
+        cls,
+        v: list[str] | str | None,
+    ) -> list[str] | None:
+        return _validate_tag_list(v)
+
+    @field_validator("external_tags", mode="after")
+    @classmethod
+    def _cap_external_tags(
+        cls,
+        v: list[str] | str | None,
+    ) -> list[str] | None:
+        return _validate_tag_list(v)
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _cap_metadata(
+        cls,
+        v: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        return _validate_metadata_size(v)

--- a/tests/unit/api/test_server_routes_etag.py
+++ b/tests/unit/api/test_server_routes_etag.py
@@ -1,0 +1,318 @@
+"""ETag/If-Match concurrency tests for the server PUT/PATCH endpoints (issue #1164).
+
+Mirrors ``test_agent_routes_etag.py`` style but exercises the routes via a
+TestClient so we cover the full If-Match handshake (parse + compare + emit).
+"""
+
+import re
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.api.server_routes import router
+
+_WEAK_ETAG_RE = re.compile(r'^W/"\d+"$')
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def user_context() -> dict[str, Any]:
+    return {
+        "username": "alice",
+        "groups": ["g"],
+        "scopes": ["modify_service"],
+        "auth_method": "session",
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "ui_permissions": {
+            "modify_service": ["all"],
+        },
+        "is_admin": False,
+    }
+
+
+@pytest.fixture
+def client(user_context):
+    app = FastAPI()
+    app.include_router(router)
+
+    from registry.api.server_routes import nginx_proxied_auth
+    from registry.auth.csrf import verify_csrf_token_flexible
+
+    app.dependency_overrides[nginx_proxied_auth] = lambda: user_context
+    app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _existing(updated_at: datetime, registered_by: str = "alice") -> dict[str, Any]:
+    return {
+        "server_name": "Etag Server",
+        "description": "old description",
+        "path": "/test-server",
+        "tags": [],
+        "license": "MIT",
+        "deployment": "remote",
+        "proxy_pass_url": "http://upstream:9000",
+        "registered_by": registered_by,
+        "registered_at": updated_at.isoformat(),
+        "updated_at": updated_at.isoformat(),
+        "is_enabled": True,
+        "version": "v1.0.0",
+        "auth_scheme": "none",
+    }
+
+
+def _etag_for(ts: datetime) -> str:
+    return f'W/"{int(ts.timestamp() * 1000)}"'
+
+
+def _valid_put_body(**overrides: Any) -> dict[str, Any]:
+    body = {
+        "server_name": "Etag Server",
+        "description": "new description",
+        "proxy_pass_url": "http://upstream:9000",
+        "tags": [],
+        "license": "MIT",
+        "visibility": "public",
+    }
+    body.update(overrides)
+    return body
+
+
+def _gate_allow() -> MagicMock:
+    return MagicMock(allowed=True, error_message=None)
+
+
+def _patches():
+    """Common patches used across tests."""
+    return {
+        "ui_perm": patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=True,
+        ),
+        "gate": patch(
+            "registry.api.server_routes.check_registration_gate",
+            AsyncMock(return_value=_gate_allow()),
+        ),
+        "webhook": patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+    }
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerEtag:
+    """ETag/If-Match concurrency tests for server PUT/PATCH."""
+
+    @pytest.mark.skip(
+        reason="GET /servers/{path} does not currently emit an ETag header. "
+        "PUT/PATCH responses do — see test_etag_format_is_weak below."
+    )
+    def test_get_server_returns_etag_header(self, client):
+        pass
+
+    def test_put_with_matching_if_match_succeeds(self, client):
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        fresh = {
+            **existing,
+            "updated_at": datetime(2026, 2, 2, tzinfo=UTC).isoformat(),
+        }
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": _etag_for(ts)},
+            )
+
+        assert response.status_code == 200
+
+    def test_put_with_stale_if_match_returns_412(self, client):
+        ts_current = datetime(2026, 6, 1, tzinfo=UTC)
+        ts_stale = datetime(2025, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts_current)
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": _etag_for(ts_stale)},
+            )
+
+        assert response.status_code == 412
+
+    def test_patch_with_matching_if_match_succeeds(self, client):
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        fresh = {
+            **existing,
+            "updated_at": datetime(2026, 2, 2, tzinfo=UTC).isoformat(),
+        }
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+                headers={"If-Match": _etag_for(ts)},
+            )
+
+        assert response.status_code == 200
+
+    def test_patch_with_stale_if_match_returns_412(self, client):
+        ts_current = datetime(2026, 6, 1, tzinfo=UTC)
+        ts_stale = datetime(2025, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts_current)
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+                headers={"If-Match": _etag_for(ts_stale)},
+            )
+
+        assert response.status_code == 412
+
+    def test_etag_changes_on_each_update(self, client):
+        """After PUT, the new ETag in the response differs from the prior one."""
+        ts_old = datetime(2026, 1, 1, tzinfo=UTC)
+        ts_new = datetime(2026, 6, 6, tzinfo=UTC)
+        existing = _existing(updated_at=ts_old)
+        fresh = {**existing, "updated_at": ts_new.isoformat()}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+        assert response.headers["ETag"] == _etag_for(ts_new)
+        assert response.headers["ETag"] != _etag_for(ts_old)
+
+    def test_etag_format_is_weak(self, client):
+        ts = datetime(2026, 7, 7, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        fresh = {**existing}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch("/servers/test-server", json={"description": "x"})
+
+        assert response.status_code == 200
+        etag = response.headers["ETag"]
+        assert _WEAK_ETAG_RE.match(etag), f"ETag {etag!r} is not weak form"
+
+    def test_malformed_if_match_returns_400(self, client):
+        existing = _existing(updated_at=datetime(2026, 1, 1, tzinfo=UTC))
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": "garbage"},
+            )
+
+        assert response.status_code == 400
+        assert "Malformed If-Match" in response.json()["detail"]
+
+    def test_strong_form_if_match_returns_400(self, client):
+        existing = _existing(updated_at=datetime(2026, 1, 1, tzinfo=UTC))
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+                headers={"If-Match": '"1700000000000"'},
+            )
+
+        assert response.status_code == 400
+        assert "Strong ETag" in response.json()["detail"]

--- a/tests/unit/api/test_server_routes_patch.py
+++ b/tests/unit/api/test_server_routes_patch.py
@@ -1,0 +1,493 @@
+"""Route-level unit tests for PATCH /servers/{path:path} (issue #1164).
+
+Exercises ``patch_server_endpoint`` via a FastAPI TestClient with the auth
+dependency overridden. Service-layer collaborators are mocked so these stay
+unit-level. Only fields explicitly supplied in the patch body are changed.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.api.server_routes import router
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def user_context() -> dict[str, Any]:
+    return {
+        "username": "alice",
+        "groups": ["g"],
+        "scopes": ["modify_service"],
+        "auth_method": "session",
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "ui_permissions": {
+            "modify_service": ["all"],
+        },
+        "is_admin": False,
+    }
+
+
+@pytest.fixture
+def client(user_context):
+    app = FastAPI()
+    app.include_router(router)
+
+    from registry.api.server_routes import nginx_proxied_auth
+    from registry.auth.csrf import verify_csrf_token_flexible
+
+    app.dependency_overrides[nginx_proxied_auth] = lambda: user_context
+    app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _existing(
+    registered_by: str = "alice",
+    updated_at: datetime | None = None,
+    sync_metadata: dict[str, Any] | None = None,
+    deployment: str = "remote",
+    proxy_pass_url: str = "http://upstream:9000",
+    auth_credential_encrypted: str | None = None,
+    description: str = "old description",
+    tags: list[str] | None = None,
+    license: str = "MIT",
+) -> dict[str, Any]:
+    ts = updated_at or datetime(2026, 1, 1, tzinfo=UTC)
+    info: dict[str, Any] = {
+        "server_name": "Existing Server",
+        "description": description,
+        "path": "/test-server",
+        "tags": list(tags) if tags is not None else ["old"],
+        "license": license,
+        "deployment": deployment,
+        "registered_by": registered_by,
+        "registered_at": ts.isoformat(),
+        "updated_at": ts.isoformat(),
+        "is_enabled": True,
+        "version": "v1.0.0",
+        "auth_scheme": "none",
+    }
+    if deployment == "remote":
+        info["proxy_pass_url"] = proxy_pass_url
+    if sync_metadata is not None:
+        info["sync_metadata"] = sync_metadata
+    if auth_credential_encrypted is not None:
+        info["auth_credential_encrypted"] = auth_credential_encrypted
+    return info
+
+
+def _gate_allow() -> MagicMock:
+    return MagicMock(allowed=True, error_message=None)
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerPatch:
+    """Tests for PATCH /servers/{path:path}."""
+
+    def test_patch_partial_update_happy_path(self, client):
+        existing = _existing(
+            description="old description",
+            tags=["preserve-me"],
+            license="Apache-2.0",
+            proxy_pass_url="http://keep:9000",
+        )
+        # Fresh reflects only the description change.
+        fresh = {**existing, "description": "patched"}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["description"] == "patched"
+        assert data["tags"] == ["preserve-me"]
+        assert data["license"] == "Apache-2.0"
+        assert data["proxy_pass_url"] == "http://keep:9000"
+
+    def test_patch_audit_action_set_with_existing_server_name(self, client):
+        existing = _existing()
+        existing["server_name"] = "Original Name"
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.patch(
+                "/servers/test-server",
+                json={"server_name": "Different Name"},
+            )
+
+        mock_audit.assert_called_once()
+        assert "Original Name" in mock_audit.call_args.kwargs["description"]
+        assert "Different Name" not in mock_audit.call_args.kwargs["description"]
+
+    def test_patch_audit_metadata_had_if_match_false_when_absent(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.patch("/servers/test-server", json={"description": "x"})
+
+        assert mock_audit.call_args.kwargs["metadata"] == {"had_if_match": False}
+
+    def test_patch_audit_metadata_had_if_match_true_when_present(self, client):
+        ts_ms = int(datetime(2026, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        if_match = f'W/"{ts_ms}"'
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+                headers={"If-Match": if_match},
+            )
+
+        assert mock_audit.call_args.kwargs["metadata"] == {"had_if_match": True}
+
+    def test_patch_400_empty_body(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch("/servers/test-server", json={})
+
+        assert response.status_code == 400
+        assert "Empty patch body" in response.json()["detail"]
+
+    def test_patch_404_when_server_not_found(self, client):
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=None)
+            response = client.patch("/servers/nope", json={"description": "x"})
+
+        assert response.status_code == 404
+
+    def test_patch_403_when_not_owner(self, client):
+        existing = _existing(registered_by="bob")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+            )
+
+        assert response.status_code == 403
+        assert "only patch servers you registered" in response.json()["detail"]
+
+    def test_patch_403_when_missing_modify_service(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=False,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+            )
+
+        assert response.status_code == 403
+        assert "permission" in response.json()["detail"].lower()
+
+    def test_patch_federated_guard_blocks(self, client):
+        existing = _existing(
+            sync_metadata={"is_federated": True, "source_peer_id": "peer-1"},
+        )
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+            )
+
+        assert response.status_code == 403
+        assert "peer-1" in response.json()["detail"]
+
+    def test_patch_422_credential_fields_rejected(self, client):
+        existing = _existing()
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"auth_credential": "Bearer leaked"},
+            )
+
+        assert response.status_code == 422
+
+    def test_patch_422_registrant_only_field_rejected(self, client):
+        existing = _existing()
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.patch(
+                "/servers/test-server",
+                json={"registered_by": "not-allowed"},
+            )
+
+        # ServerCardPatch has extra="forbid", so registrant-only fields are
+        # rejected at parse time before the model_validator runs. The error
+        # body still mentions the offending field name.
+        assert response.status_code == 422
+        body = response.json()
+        assert "registered_by" in str(body)
+
+    def test_patch_credentials_preserved(self, client):
+        existing = _existing(auth_credential_encrypted="ENC::keepme")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+            )
+
+        assert response.status_code == 200
+        merged = svc.update_server.call_args[0][1]
+        assert merged["auth_credential_encrypted"] == "ENC::keepme"
+
+    def test_patch_proxy_url_change_triggers_scan(self, client):
+        existing = _existing(proxy_pass_url="http://old:9000")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch(
+                "registry.api.server_routes._perform_security_scan_on_registration",
+                new_callable=AsyncMock,
+            ) as mock_scan,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"proxy_pass_url": "http://new:9000"},
+            )
+
+        assert response.status_code == 200
+        mock_scan.assert_called_once()
+        scan_args = mock_scan.call_args[0]
+        assert scan_args[0] == "/test-server"
+        assert scan_args[1] == "http://new:9000"
+
+    def test_patch_no_proxy_url_change_no_scan(self, client):
+        existing = _existing(proxy_pass_url="http://upstream:9000")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch(
+                "registry.api.server_routes._perform_security_scan_on_registration",
+                new_callable=AsyncMock,
+            ) as mock_scan,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "just text"},
+            )
+
+        assert response.status_code == 200
+        mock_scan.assert_not_called()
+
+    def test_patch_etag_header_set_on_response(self, client):
+        existing = _existing(updated_at=datetime(2026, 1, 1, tzinfo=UTC))
+        fresh = {
+            **existing,
+            "updated_at": datetime(2026, 2, 2, tzinfo=UTC).isoformat(),
+        }
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "x"},
+            )
+
+        assert response.status_code == 200
+        etag = response.headers.get("ETag")
+        assert etag is not None
+        assert etag.startswith('W/"')
+        assert etag.endswith('"')
+
+    def test_patch_visibility_change_allowed_for_owner(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"visibility": "public"},
+            )
+
+        assert response.status_code == 200
+        merged = svc.update_server.call_args[0][1]
+        assert merged["visibility"] == "public"
+
+    def test_patch_calls_server_service_update_server(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+            )
+
+        svc.update_server.assert_called_once()
+        called_path, called_dict = svc.update_server.call_args[0]
+        assert called_path == "/test-server"
+        assert called_dict["description"] == "patched"

--- a/tests/unit/api/test_server_routes_put.py
+++ b/tests/unit/api/test_server_routes_put.py
@@ -1,0 +1,663 @@
+"""Route-level unit tests for PUT /servers/{path:path} (issue #1164).
+
+Exercises ``update_server_endpoint`` via a FastAPI TestClient with the auth
+dependency overridden. Service-layer collaborators (server_service,
+registration_gate, security scanner, webhook) are mocked so these stay
+unit-level.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from registry.api.server_routes import router
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def user_context() -> dict[str, Any]:
+    """Owner of /test-server (matches sample_existing.registered_by)."""
+    return {
+        "username": "alice",
+        "groups": ["g"],
+        "scopes": ["modify_service"],
+        "auth_method": "session",
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "ui_permissions": {
+            "modify_service": ["all"],
+            "publish_agent": ["all"],
+        },
+        "is_admin": False,
+    }
+
+
+@pytest.fixture
+def admin_context() -> dict[str, Any]:
+    return {
+        "username": "admin",
+        "groups": ["mcp-registry-admin"],
+        "scopes": ["admin"],
+        "auth_method": "session",
+        "accessible_servers": ["all"],
+        "accessible_services": ["all"],
+        "ui_permissions": {
+            "modify_service": ["all"],
+        },
+        "is_admin": True,
+    }
+
+
+@pytest.fixture
+def client(user_context):
+    """TestClient with owner ``alice`` as the authenticated user."""
+    app = FastAPI()
+    app.include_router(router)
+
+    from registry.api.server_routes import nginx_proxied_auth
+    from registry.auth.csrf import verify_csrf_token_flexible
+
+    app.dependency_overrides[nginx_proxied_auth] = lambda: user_context
+    app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_admin(admin_context):
+    """TestClient with an admin user."""
+    app = FastAPI()
+    app.include_router(router)
+
+    from registry.api.server_routes import nginx_proxied_auth
+    from registry.auth.csrf import verify_csrf_token_flexible
+
+    app.dependency_overrides[nginx_proxied_auth] = lambda: admin_context
+    app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _existing(
+    registered_by: str = "alice",
+    updated_at: datetime | None = None,
+    sync_metadata: dict[str, Any] | None = None,
+    deployment: str = "remote",
+    proxy_pass_url: str = "http://upstream:9000",
+    auth_credential_encrypted: str | None = None,
+) -> dict[str, Any]:
+    """Build a stored server dict (as returned by server_service.get_server_info)."""
+    ts = updated_at or datetime(2026, 1, 1, tzinfo=UTC)
+    info: dict[str, Any] = {
+        "server_name": "Existing Server",
+        "description": "old description",
+        "path": "/test-server",
+        "tags": ["old"],
+        "license": "MIT",
+        "deployment": deployment,
+        "registered_by": registered_by,
+        "registered_at": ts.isoformat(),
+        "updated_at": ts.isoformat(),
+        "is_enabled": True,
+        "version": "v1.0.0",
+        "auth_scheme": "none",
+    }
+    if deployment == "remote":
+        info["proxy_pass_url"] = proxy_pass_url
+    if sync_metadata is not None:
+        info["sync_metadata"] = sync_metadata
+    if auth_credential_encrypted is not None:
+        info["auth_credential_encrypted"] = auth_credential_encrypted
+    return info
+
+
+def _valid_put_body(**overrides: Any) -> dict[str, Any]:
+    """Minimal valid PUT body."""
+    body = {
+        "server_name": "Existing Server",
+        "description": "new description",
+        "proxy_pass_url": "http://upstream:9000",
+        "tags": ["new"],
+        "license": "MIT",
+        "visibility": "public",
+    }
+    body.update(overrides)
+    return body
+
+
+def _gate_allow() -> MagicMock:
+    return MagicMock(allowed=True, error_message=None)
+
+
+def _gate_deny(message: str = "blocked by policy") -> MagicMock:
+    return MagicMock(allowed=False, error_message=message)
+
+
+def _patch_gate_and_webhook():
+    """Patch the registration gate and webhook so they don't run real I/O."""
+    return [
+        patch(
+            "registry.api.server_routes.check_registration_gate",
+            AsyncMock(return_value=_gate_allow()),
+        ),
+        patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+    ]
+
+
+# =============================================================================
+# Happy path + audit
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerPut:
+    """Tests for PUT /servers/{path:path}."""
+
+    def test_put_full_replacement_happy_path(self, client):
+        existing = _existing()
+        fresh = {**existing, "description": "new description"}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["description"] == "new description"
+        assert data["server_name"] == "Existing Server"
+
+    def test_put_audit_action_set_with_existing_server_name(self, client):
+        existing = _existing()
+        existing["server_name"] = "Original Name"
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.put(
+                "/servers/test-server",
+                json=_valid_put_body(server_name="Brand New Name"),
+            )
+
+        mock_audit.assert_called_once()
+        # description includes EXISTING server_name, not new one
+        assert "Original Name" in mock_audit.call_args.kwargs["description"]
+        assert "Brand New Name" not in mock_audit.call_args.kwargs["description"]
+
+    def test_put_audit_metadata_had_if_match_false_when_absent(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.put("/servers/test-server", json=_valid_put_body())
+
+        assert mock_audit.call_args.kwargs["metadata"] == {"had_if_match": False}
+
+    def test_put_audit_metadata_had_if_match_true_when_present(self, client):
+        existing = _existing()
+        # Use the matching ETag so we don't 412 first.
+        ts_ms = int(datetime(2026, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        if_match = f'W/"{ts_ms}"'
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch("registry.api.server_routes.set_audit_action") as mock_audit,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": if_match},
+            )
+
+        assert mock_audit.call_args.kwargs["metadata"] == {"had_if_match": True}
+
+    def test_put_404_when_server_not_found(self, client):
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=None)
+            response = client.put("/servers/nope", json=_valid_put_body())
+
+        assert response.status_code == 404
+        assert "/nope" in response.json()["detail"]
+
+    def test_put_403_when_not_owner_and_not_admin(self, client):
+        existing = _existing(registered_by="bob")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 403
+        assert "only update servers you registered" in response.json()["detail"]
+
+    def test_put_403_when_missing_modify_service_permission(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=False,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 403
+        assert "permission" in response.json()["detail"].lower()
+
+    def test_put_admin_can_update_any_server(self, client_admin):
+        existing = _existing(registered_by="bob")  # admin is not the owner
+        fresh = {**existing, "description": "new description"}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client_admin.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+
+    def test_put_federated_guard_blocks(self, client):
+        existing = _existing(
+            sync_metadata={"is_federated": True, "source_peer_id": "peer-99"},
+        )
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 403
+        assert "peer-99" in response.json()["detail"]
+
+    def test_put_422_extra_field(self, client):
+        existing = _existing()
+        body = _valid_put_body()
+        body["totally_unknown_field"] = "boom"
+
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=body)
+
+        assert response.status_code == 422
+
+    def test_put_422_credential_fields_rejected(self, client):
+        existing = _existing()
+        body = _valid_put_body()
+        body["auth_credential"] = "Bearer leaked-secret"
+
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=body)
+
+        assert response.status_code == 422
+
+    def test_put_422_registrant_only_fields_rejected(self, client):
+        existing = _existing()
+        body = _valid_put_body()
+        body["registered_by"] = "not-allowed"
+
+        with patch("registry.api.server_routes.server_service") as svc:
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put("/servers/test-server", json=body)
+
+        assert response.status_code == 422
+
+    def test_put_412_if_match_mismatch(self, client):
+        existing = _existing(updated_at=datetime(2026, 1, 1, tzinfo=UTC))
+        stale_ms = int(datetime(2025, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        stale_etag = f'W/"{stale_ms}"'
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": stale_etag},
+            )
+
+        assert response.status_code == 412
+        assert "If-Match" in response.json()["detail"]
+
+    def test_put_400_if_match_malformed(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": "not-an-etag"},
+            )
+
+        assert response.status_code == 400
+        assert "Malformed If-Match" in response.json()["detail"]
+
+    def test_put_400_if_match_strong_form(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            response = client.put(
+                "/servers/test-server",
+                json=_valid_put_body(),
+                headers={"If-Match": '"1234567890"'},
+            )
+
+        assert response.status_code == 400
+        assert "Strong ETag" in response.json()["detail"]
+
+    def test_put_etag_header_set_on_response(self, client):
+        ts = datetime(2026, 5, 5, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        # Fresh has a newer updated_at the handler will read.
+        fresh = {**existing, "updated_at": datetime(2026, 6, 6, tzinfo=UTC).isoformat()}
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, fresh])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+        etag = response.headers.get("ETag")
+        assert etag is not None
+        assert etag.startswith('W/"')
+        # The ETag value is digits only inside the quotes.
+        inner = etag[3:-1]
+        assert inner.isdigit()
+
+    def test_put_credentials_preserved_when_not_supplied(self, client):
+        """Stored ``auth_credential_encrypted`` survives a PUT without that
+        field in the body. Defence-in-depth: PUT body has no credential
+        fields, but the stored encrypted blob must still be present in the
+        merged dict the service receives."""
+        existing = _existing(auth_credential_encrypted="ENC::abc123")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+        merged = svc.update_server.call_args[0][1]
+        assert merged["auth_credential_encrypted"] == "ENC::abc123"
+
+    def test_put_calls_server_service_update_server(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            client.put("/servers/test-server", json=_valid_put_body())
+
+        svc.update_server.assert_called_once()
+        called_path, called_dict = svc.update_server.call_args[0]
+        assert called_path == "/test-server"
+        assert isinstance(called_dict, dict)
+        assert called_dict["description"] == "new description"
+
+    def test_put_returns_500_when_update_fails(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            svc.update_server = AsyncMock(return_value=False)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 500
+        assert "Failed to save" in response.json()["detail"]
+
+    def test_put_registration_gate_denial_403(self, client):
+        existing = _existing()
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_deny("policy says no")),
+            ),
+        ):
+            svc.get_server_info = AsyncMock(return_value=existing)
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 403
+        assert "policy says no" in response.json()["detail"]
+
+    def test_put_security_scan_triggered_when_proxy_url_changes(self, client):
+        existing = _existing(proxy_pass_url="http://old:9000")
+        # Body has a different proxy_pass_url — should trigger scan.
+        body = _valid_put_body(proxy_pass_url="http://new:9000")
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch(
+                "registry.api.server_routes._perform_security_scan_on_registration",
+                new_callable=AsyncMock,
+            ) as mock_scan,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=body)
+
+        assert response.status_code == 200
+        # The scan coroutine was scheduled (asyncio.create_task wraps it).
+        mock_scan.assert_called_once()
+        scan_args = mock_scan.call_args[0]
+        assert scan_args[0] == "/test-server"
+        assert scan_args[1] == "http://new:9000"
+
+    def test_put_security_scan_not_triggered_for_local_deployment(self, client):
+        """For local deployment, the scan must NOT run regardless of body
+        contents. proxy_pass_url is ignored for local servers."""
+        existing = _existing(deployment="local", proxy_pass_url="http://anything")
+        # Even if body carries a proxy URL, local existing skips scan.
+        body = _valid_put_body(proxy_pass_url="http://different:9000")
+
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+            patch(
+                "registry.api.server_routes._perform_security_scan_on_registration",
+                new_callable=AsyncMock,
+            ) as mock_scan,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=body)
+
+        assert response.status_code == 200
+        mock_scan.assert_not_called()
+
+    def test_put_webhook_scheduled_on_success(self, client):
+        existing = _existing(auth_credential_encrypted="ENC::secret")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch(
+                "registry.api.server_routes.send_registration_webhook",
+                new_callable=AsyncMock,
+            ) as mock_webhook,
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.put("/servers/test-server", json=_valid_put_body())
+
+        assert response.status_code == 200
+        mock_webhook.assert_called_once()
+        kwargs = mock_webhook.call_args.kwargs
+        assert kwargs["event_type"] == "update"
+        assert kwargs["registration_type"] == "server"
+        assert kwargs["performed_by"] == "alice"
+        # Credentials are stripped from the webhook payload.
+        card_data = kwargs["card_data"]
+        assert "auth_credential_encrypted" not in card_data

--- a/tests/unit/schemas/test_server_update_models.py
+++ b/tests/unit/schemas/test_server_update_models.py
@@ -1,0 +1,366 @@
+"""Tests for issue #1164 server update schemas in registry.schemas.server_update_models.
+
+Covers:
+- ServerUpdateRequest: PUT body with required fields, size caps, registrant-only rejection,
+  extra="forbid", credential-field rejection, deployment/local_runtime rejection.
+- ServerCardPatch: optional fields, RFC 7396 merge-patch semantics, registrant-only
+  rejection (with explicit error message), size caps, extra="forbid".
+- SERVER_REGISTRANT_ONLY_FIELDS constant shape.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from registry.schemas.server_update_models import (
+    SERVER_REGISTRANT_ONLY_FIELDS,
+    ServerCardPatch,
+    ServerUpdateRequest,
+)
+
+# Credential-shaped fields are rejected by extra="forbid" since they are
+# absent from both models. Non-credential registrant-only fields hit
+# either extra="forbid" (PUT) or the model_validator (PATCH).
+_CREDENTIAL_FIELDS = [
+    "auth_credential",
+    "auth_scheme",
+    "auth_header_name",
+    "custom_headers",
+    "custom_header_names",
+]
+
+# Subset of SERVER_REGISTRANT_ONLY_FIELDS minus credential-shaped fields.
+# These are anchors and server-managed fields explicitly forbidden.
+_NON_CREDENTIAL_REGISTRANT_FIELDS = [
+    "id",
+    "path",
+    "registered_by",
+    "registered_at",
+    "updated_at",
+    "is_enabled",
+    "is_active",
+    "version",
+    "deployment",
+    "local_runtime",
+    "health_status",
+    "last_health_check",
+    "auth_credential_encrypted",
+    "custom_headers_encrypted",
+    "sync_metadata",
+]
+
+
+@pytest.mark.unit
+class TestServerUpdateRequest:
+    """Tests for the PUT /api/servers/{path} body model."""
+
+    def test_minimal_valid_body(self):
+        """Only required fields (server_name, description) accepted; defaults applied."""
+        body = ServerUpdateRequest(server_name="srv", description="d")
+        assert body.server_name == "srv"
+        assert body.description == "d"
+        assert body.tags == []
+        assert body.license == "N/A"
+        assert body.visibility == "public"
+
+    def test_full_valid_body(self):
+        """Every mutable field provided, parses cleanly and round-trips via model_dump()."""
+        payload = {
+            "server_name": "srv",
+            "description": "full body",
+            "proxy_pass_url": "https://x.example.com",
+            "mcp_endpoint": "/mcp",
+            "sse_endpoint": "/sse",
+            "transport": "sse",
+            "supported_transports": ["sse", "streamable-http"],
+            "headers": [{"name": "X-Trace", "value": "1"}],
+            "auth_provider": "github",
+            "tags": ["a", "b"],
+            "license": "Apache-2.0",
+            "num_tools": 3,
+            "tool_list": [{"name": "t1"}],
+            "metadata": {"k": "v"},
+            "visibility": "private",
+            "allowed_groups": ["g1"],
+            "status": "ACTIVE",
+            "provider": {"organization": "acme", "url": "https://acme.com"},
+            "source_created_at": "2026-01-01T00:00:00Z",
+            "source_updated_at": "2026-02-01T00:00:00Z",
+            "external_tags": ["ext1", "ext2"],
+        }
+        body = ServerUpdateRequest(**payload)
+        round_trip = body.model_dump()
+        assert round_trip["server_name"] == "srv"
+        assert round_trip["provider"] == {"organization": "acme", "url": "https://acme.com"}
+        assert round_trip["tags"] == ["a", "b"]
+
+    def test_extra_field_rejected(self):
+        """Unknown fields raise (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(server_name="srv", description="d", foo="bar")
+
+    @pytest.mark.parametrize("field", _CREDENTIAL_FIELDS)
+    def test_credential_fields_rejected(self, field):
+        """Credential-shaped fields are never accepted on PUT (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(**{"server_name": "srv", "description": "d", field: "x"})
+
+    def test_deployment_field_rejected(self):
+        """Supplying `deployment` raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(server_name="srv", description="d", deployment={"type": "remote"})
+
+    def test_local_runtime_field_rejected(self):
+        """Supplying `local_runtime` raises ValidationError."""
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(server_name="srv", description="d", local_runtime={"cmd": "node"})
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "id",
+            "path",
+            "registered_by",
+            "registered_at",
+            "updated_at",
+            "is_enabled",
+            "version",
+            "health_status",
+            "last_health_check",
+            "sync_metadata",
+        ],
+    )
+    def test_registrant_only_fields_rejected(self, field):
+        """Each registrant-only field raises ValidationError on PUT (extra='forbid')."""
+        assert field in SERVER_REGISTRANT_ONLY_FIELDS
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(**{"server_name": "srv", "description": "d", field: "x"})
+
+    def test_server_name_max_length(self):
+        """server_name over 256 chars rejected; exactly 256 accepted."""
+        ServerUpdateRequest(server_name="s" * 256, description="d")
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(server_name="s" * 257, description="d")
+
+    def test_description_max_length(self):
+        """description over 4096 chars rejected; exactly 4096 accepted."""
+        ServerUpdateRequest(server_name="srv", description="d" * 4096)
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(server_name="srv", description="d" * 4097)
+
+    def test_tags_csv_normalised_to_list(self):
+        """A CSV `tags` string parses to a stripped list, skipping empties."""
+        body = ServerUpdateRequest(server_name="srv", description="d", tags="a, b ,c, ,")
+        assert body.tags == ["a", "b", "c"]
+
+    def test_tags_max_count(self):
+        """Over 50 tags rejected; exactly 50 accepted."""
+        ServerUpdateRequest(
+            server_name="srv",
+            description="d",
+            tags=[f"t{i}" for i in range(50)],
+        )
+        with pytest.raises(ValidationError, match="at most 50"):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                tags=[f"t{i}" for i in range(51)],
+            )
+
+    def test_tag_length_cap(self):
+        """A single tag over 64 chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="at most 64 chars"):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                tags=["x" * 65],
+            )
+
+    def test_external_tags_max_count(self):
+        """external_tags also enforces the 50-entry cap."""
+        ServerUpdateRequest(
+            server_name="srv",
+            description="d",
+            external_tags=[f"e{i}" for i in range(50)],
+        )
+        with pytest.raises(ValidationError, match="at most 50"):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                external_tags=[f"e{i}" for i in range(51)],
+            )
+
+    def test_external_tag_length_cap(self):
+        """external_tags also enforces the 64-char-per-tag cap."""
+        with pytest.raises(ValidationError, match="at most 64 chars"):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                external_tags=["x" * 65],
+            )
+
+    def test_metadata_size_cap(self):
+        """metadata over 64 KB serialised JSON rejected; just-under accepted."""
+        # Just under cap (the JSON envelope adds a few bytes; subtract margin).
+        ServerUpdateRequest(
+            server_name="srv",
+            description="d",
+            metadata={"k": "x" * (64 * 1024 - 16)},
+        )
+        with pytest.raises(ValidationError, match="at most 65536 bytes"):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                metadata={"k": "x" * (64 * 1024 + 1)},
+            )
+
+    def test_provider_structured(self):
+        """provider parses to AgentProvider; bad structure raises ValidationError."""
+        body = ServerUpdateRequest(
+            server_name="srv",
+            description="d",
+            provider={"organization": "acme", "url": "https://acme.com"},
+        )
+        assert body.provider is not None
+        assert body.provider.organization == "acme"
+
+        with pytest.raises(ValidationError):
+            ServerUpdateRequest(
+                server_name="srv",
+                description="d",
+                provider={"hacker": "x"},
+            )
+
+
+@pytest.mark.unit
+class TestServerCardPatch:
+    """Tests for the PATCH /api/servers/{path} body model."""
+
+    def test_empty_body_valid_at_model_layer(self):
+        """No fields supplied parses cleanly. Empty-body 400 is the handler's job."""
+        patch = ServerCardPatch()
+        assert patch.model_dump(exclude_unset=True) == {}
+
+    def test_extra_field_rejected(self):
+        """Unknown fields raise (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            ServerCardPatch(foo="bar")
+
+    @pytest.mark.parametrize("field", _CREDENTIAL_FIELDS)
+    def test_credential_fields_rejected(self, field):
+        """Credential-shaped fields are never accepted on PATCH (extra='forbid')."""
+        with pytest.raises(ValidationError):
+            ServerCardPatch(**{field: "x"})
+
+    def test_deployment_local_runtime_rejected(self):
+        """Both `deployment` and `local_runtime` are rejected on PATCH."""
+        with pytest.raises(ValidationError):
+            ServerCardPatch(deployment={"type": "remote"})
+        with pytest.raises(ValidationError):
+            ServerCardPatch(local_runtime={"cmd": "node"})
+
+    @pytest.mark.parametrize("field", _NON_CREDENTIAL_REGISTRANT_FIELDS)
+    def test_registrant_only_fields_rejected(self, field):
+        """Each non-credential registrant-only field raises ValidationError.
+
+        For these fields, extra='forbid' fires first because none are declared
+        on the model. The dedicated message comes from the model_validator and
+        only fires for fields actually declared on the model. For now, we just
+        assert ValidationError is raised.
+        """
+        assert field in SERVER_REGISTRANT_ONLY_FIELDS
+        with pytest.raises(ValidationError):
+            ServerCardPatch(**{field: "x"})
+
+    def test_partial_fields_only(self):
+        """Only explicitly supplied fields appear in exclude_unset output."""
+        patch = ServerCardPatch(description="x")
+        assert patch.model_dump(exclude_unset=True) == {"description": "x"}
+
+    def test_server_name_max_length(self):
+        """server_name over 256 chars rejected; exactly 256 accepted."""
+        ServerCardPatch(server_name="s" * 256)
+        with pytest.raises(ValidationError):
+            ServerCardPatch(server_name="s" * 257)
+
+    def test_description_max_length(self):
+        """description over 4096 chars rejected; exactly 4096 accepted."""
+        ServerCardPatch(description="d" * 4096)
+        with pytest.raises(ValidationError):
+            ServerCardPatch(description="d" * 4097)
+
+    def test_tags_max_count(self):
+        """Over 50 tags rejected; exactly 50 accepted."""
+        ServerCardPatch(tags=[f"t{i}" for i in range(50)])
+        with pytest.raises(ValidationError, match="at most 50"):
+            ServerCardPatch(tags=[f"t{i}" for i in range(51)])
+
+    def test_tag_length_cap(self):
+        """A single tag over 64 chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="at most 64 chars"):
+            ServerCardPatch(tags=["x" * 65])
+
+    def test_tags_csv_normalised_to_list(self):
+        """A CSV `tags` string parses to a stripped list, skipping empties."""
+        patch = ServerCardPatch(tags="a, b ,c, ,")
+        assert patch.tags == ["a", "b", "c"]
+
+    def test_external_tags_max_count(self):
+        """external_tags also enforces the 50-entry cap."""
+        ServerCardPatch(external_tags=[f"e{i}" for i in range(50)])
+        with pytest.raises(ValidationError, match="at most 50"):
+            ServerCardPatch(external_tags=[f"e{i}" for i in range(51)])
+
+    def test_external_tag_length_cap(self):
+        """external_tags also enforces the 64-char-per-tag cap."""
+        with pytest.raises(ValidationError, match="at most 64 chars"):
+            ServerCardPatch(external_tags=["x" * 65])
+
+    def test_metadata_size_cap(self):
+        """metadata over 64 KB serialised JSON rejected; just-under accepted."""
+        ServerCardPatch(metadata={"k": "x" * (64 * 1024 - 16)})
+        with pytest.raises(ValidationError, match="at most 65536 bytes"):
+            ServerCardPatch(metadata={"k": "x" * (64 * 1024 + 1)})
+
+    def test_provider_structured(self):
+        """provider parses to AgentProvider; bad structure raises ValidationError."""
+        patch = ServerCardPatch(provider={"organization": "acme", "url": "https://acme.com"})
+        assert patch.provider is not None
+        assert patch.provider.organization == "acme"
+
+        with pytest.raises(ValidationError):
+            ServerCardPatch(provider={"hacker": "x"})
+
+
+@pytest.mark.unit
+class TestSizeCapsAndConstants:
+    """Sanity checks on the module-level constants."""
+
+    def test_registrant_only_fields_is_frozenset(self):
+        """The shared constant is an immutable frozenset."""
+        assert isinstance(SERVER_REGISTRANT_ONLY_FIELDS, frozenset)
+
+    def test_registrant_only_fields_contents(self):
+        """The constant contains the expected 20 names from the LLD."""
+        expected = {
+            "id",
+            "path",
+            "registered_by",
+            "registered_at",
+            "updated_at",
+            "is_enabled",
+            "is_active",
+            "version",
+            "deployment",
+            "local_runtime",
+            "health_status",
+            "last_health_check",
+            "auth_credential_encrypted",
+            "custom_headers_encrypted",
+            "sync_metadata",
+            "auth_scheme",
+            "auth_credential",
+            "auth_header_name",
+            "custom_headers",
+            "custom_header_names",
+        }
+        assert SERVER_REGISTRANT_ONLY_FIELDS == frozenset(expected)


### PR DESCRIPTION
Closes #1164.

## Summary

Adds two new REST endpoints that mirror the agent update surface:

- `PUT  /api/servers/{path}` - full-replacement metadata update
- `PATCH /api/servers/{path}` - RFC 7396 JSON Merge Patch update

Customer-reported requirement: there was no way to update an MCP Server's metadata (tags, description, custom metadata fields) without re-registering the entire server via `POST /api/servers/register?overwrite=true`. Servers now have parity with agents (`PUT /api/agents/{path}` and `PATCH /api/agents/{path}`).

## Acceptance Criteria

- [x] `PUT /api/servers/{path}` for full server update
- [x] `PATCH /api/servers/{path}` for partial server update (RFC 7396)
- [x] Requires `modify_service` UI permission
- [x] Owner-or-admin authorization check
- [x] Audit trail for updates (with new `had_if_match` dimension)
- [x] OpenAPI spec updated (auto-regenerated by FastAPI)
- [x] Tests covering both endpoints

## Design

Full design with multi-persona expert review at `.scratchpad/issue-1164/lld.md` (see review verdicts: 4 blockers + 5 should-fixes resolved before implementation).

Key safety properties enforced at the model layer (`extra=\"forbid\"`):

- **Credential fields rejected** (`auth_scheme`, `auth_credential`, `auth_header_name`, `custom_headers`, `custom_header_names`) - mutation goes through the existing `PATCH /api/servers/{path}/auth-credential` endpoint
- **Deployment immutability** (`deployment`, `local_runtime` rejected) - flipping deployment type would orphan one runtime config
- **Registrant-only fields rejected** (`id`, `path`, `registered_by`, `registered_at`, `updated_at`, `is_enabled`, `version`, `health_status`, `last_health_check`, `sync_metadata`, etc.)
- **Defence-in-depth re-pin** in `_merge_server_update`: even if a field slips past the model, the existing storage value wins
- **Size caps**: server_name ≤ 256, description ≤ 4096, tags ≤ 50 entries × 64 chars, metadata ≤ 64 KB serialized JSON

Optimistic concurrency:
- Both endpoints accept optional `If-Match: W/\"<epoch_ms>\"` (412 on mismatch, 400 on malformed/strong-form)
- Both endpoints set `ETag: W/\"<epoch_ms>\"` on success

## Test plan

### Unit (running in CI)

- `tests/unit/schemas/test_server_update_models.py` - 64 tests
- `tests/unit/api/test_server_routes_put.py` - 23 tests
- `tests/unit/api/test_server_routes_patch.py` - 16 tests
- `tests/unit/api/test_server_routes_etag.py` - 9 tests

Total new tests: **112 added**, all passing. Full suite: 3976 passed (2 unrelated flaky failures, neither file touched by this branch).

### Integration (manual, against live Keycloak stack)

Followed `.scratchpad/issue-1164/testing.md`:

- §1.1 curl tests: 14 cases - **PASS** (PUT/PATCH happy paths, 403 not-owner, 404 missing path, 422 credential/registrant-only/deployment, 412 ETag mismatch, 400 malformed/strong-form If-Match, 200 If-Match success)
- §1.2 CLI tests: 4 cases - **PASS** (`update-server`, `patch-server`, `--if-match` non-zero on stale, `list --json` shows updates)
- §2.1 backwards-compat: 4 cases - **PASS** (legacy `/register?overwrite=true` still 201, listing shape unchanged, dedicated `/auth-credential` still 200, `/versions/default` still 200)
- §5.1 E2E lifecycle - **PASS** (register → PATCH → ETag → PUT → 412 on stale)

## Caught and fixed during integration testing

Initial implementation registered `PATCH /servers/{path:path}` BEFORE the dedicated `PATCH /servers/{path:path}/auth-credential` (and similarly for PUT vs `/versions/default`). FastAPI matches in registration order, so the broad routes captured every request and returned 422. Fixed by moving both new handlers to immediately before the catch-all `GET /servers/{path:path}` so all specific subpath routes match first. Second commit on this branch.

## Files changed

- New: `registry/api/_etag_utils.py` (shared weak-ETag helpers)
- New: `registry/schemas/server_update_models.py` (`ServerUpdateRequest`, `ServerCardPatch`, `SERVER_REGISTRANT_ONLY_FIELDS`)
- Modified: `registry/api/server_routes.py` (new handlers + private helpers)
- Modified: `registry/api/agent_routes.py` (refactored to use shared ETag helpers; behaviour unchanged)
- Modified: `registry/audit/{context,middleware,models}.py` (`set_audit_action` gains `metadata` kwarg)
- Modified: `api/registry_client.py` (`update_server`, `patch_server` SDK)
- Modified: `api/registry_management.py` (`update-server`, `patch-server` CLI)

## Out of scope

- Bulk/batch server updates (the agent batch surface is broader; deferred)
- Replacing the HTML-driven `POST /api/servers/edit/{path}` UI form
- Editing `local_runtime` for local-deployment servers (re-register with `overwrite=true` for now)
- Deprecating `POST /api/servers/register?overwrite=true` (signposted as future work)

## Test plan checklist (for reviewers)

- [x] All 4 LLD blockers resolved (credential rejection, status.HTTP_*, threat model, redaction verification)
- [x] All 5 LLD should-fixes resolved (local_runtime out-of-scope note, audit description, size caps, AgentProvider typing, had_if_match dimension)
- [x] Pre-merge verification checklist for credential redaction (LLD §Pre-Merge Verification Checklist) - to be walked through pre-merge