### PR TITLE
fix(api): persist visibility="public" on /servers/register and normalize absent on GET (#1181)

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -689,6 +689,11 @@ async def get_servers_json(
                     "auth_scheme": server_info.get("auth_scheme", "none"),
                     "auth_header_name": server_info.get("auth_header_name"),
                     "tool_list": _filtered_tools,
+                    # Access control. Default absent to "public" for servers
+                    # stored before the write-side fix always persisted the
+                    # field (#1181). Matches the convention used by agents,
+                    # search, and federation responses.
+                    "visibility": server_info.get("visibility") or "public",
                     # Federation and lifecycle metadata
                     "status": server_info.get("status", "active"),
                     "provider_organization": (
@@ -3606,13 +3611,15 @@ async def register_service_api(
         if sse_endpoint:
             server_entry["sse_endpoint"] = sse_endpoint
 
-    # Visibility and access control
-    if visibility and visibility != "public":
-        server_entry["visibility"] = visibility
-    if allowed_groups:
-        groups_list = [g.strip() for g in allowed_groups.split(",") if g.strip()]
-        if groups_list:
-            server_entry["allowed_groups"] = groups_list
+    # Visibility and access control. Mirror the legacy POST /register
+    # handler: normalize and validate the value (rejecting unknown values
+    # and enforcing 'group-restricted' carries at least one group), then
+    # always persist it so GET responses don't surface a misleading null
+    # when the caller chose the default "public".
+    visibility, allowed_groups_list = _validate_visibility_and_groups(visibility, allowed_groups)
+    server_entry["visibility"] = visibility
+    if allowed_groups_list:
+        server_entry["allowed_groups"] = allowed_groups_list
 
     if version:
         server_entry["version"] = version
@@ -5667,6 +5674,11 @@ async def get_server(
     if not user_context.get("is_admin"):
         if settings.deployment_mode != DeploymentMode.REGISTRY_ONLY:
             server_info.pop("proxy_pass_url", None)
+
+    # Normalize visibility for servers stored before the write-side fix
+    # always persisted the field (#1181). Matches the default-on-read
+    # pattern already used by agents, search, and federation responses.
+    server_info.setdefault("visibility", "public")
 
     return JSONResponse(
         status_code=200,

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -154,6 +154,11 @@ def mock_faiss_service():
     mock_service = MagicMock()
     mock_service.add_or_update_service = AsyncMock()
     mock_service.remove_service = AsyncMock()
+    # POST /api/servers/register schedules `asyncio.create_task(save_data())`
+    # after a successful registration; if save_data is a plain MagicMock the
+    # call returns a non-coroutine and create_task() raises, turning a 201
+    # into a 500.
+    mock_service.save_data = AsyncMock()
     return mock_service
 
 
@@ -2001,3 +2006,129 @@ class TestClearSecurityPendingLocal:
         assert response.status_code == 200
         # update_server NOT called — we short-circuit.
         mock_server_service.update_server.assert_not_called()
+
+
+# =============================================================================
+# TESTS — POST /api/servers/register visibility round-trip (Issue #1181)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerRegisterVisibility:
+    """Regression coverage for #1181.
+
+    The newer POST /api/servers/register handler previously dropped
+    visibility="public" entirely (never persisted), skipped validation,
+    and the matching GET responses surfaced absent visibility as null.
+    These tests pin the corrected behaviour.
+    """
+
+    _BASE_FORM = {
+        "name": "Vis Server",
+        "description": "Visibility round-trip test",
+        "path": "/vis-server",
+        "proxy_pass_url": "http://localhost:9000",
+    }
+
+    def test_register_persists_visibility_public(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "visibility": "public"},
+        )
+        assert response.status_code == 201
+        # The handler builds a server_entry dict and passes it to register_server.
+        # That dict must carry visibility="public" — never omitted.
+        call_args = mock_server_service.register_server.call_args
+        server_entry = call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
+        assert server_entry["visibility"] == "public"
+
+    def test_register_rejects_invalid_visibility(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "visibility": "garbage"},
+        )
+        assert response.status_code == 400
+        assert "visibility" in response.json()["detail"].lower()
+        mock_server_service.register_server.assert_not_called()
+
+    def test_register_rejects_group_restricted_without_groups(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "visibility": "group-restricted"},
+        )
+        assert response.status_code == 400
+        assert "allowed_group" in response.json()["detail"].lower()
+        mock_server_service.register_server.assert_not_called()
+
+    def test_register_persists_group_restricted_with_groups(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={
+                **self._BASE_FORM,
+                "visibility": "group-restricted",
+                "allowed_groups": "engineering,platform-team",
+            },
+        )
+        assert response.status_code == 201
+        call_args = mock_server_service.register_server.call_args
+        server_entry = call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
+        assert server_entry["visibility"] == "group-restricted"
+        assert server_entry["allowed_groups"] == ["engineering", "platform-team"]
+
+
+# =============================================================================
+# TESTS — GET endpoints normalize absent visibility to "public" (Issue #1181)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerGetVisibilityNormalization:
+    """Servers stored before #1181's write-side fix have no visibility key.
+
+    GET responses must default the field to "public" so clients never see
+    a misleading null. The list endpoint historically did not include the
+    field at all; #1181 adds it.
+    """
+
+    _LEGACY_DOC = {
+        "server_name": "Legacy Server",
+        "description": "Pre-#1181 row with no visibility key",
+        "path": "/legacy",
+        "proxy_pass_url": "http://localhost:9000",
+        "is_enabled": True,
+        # Note: no 'visibility' key — this is the legacy shape under test.
+    }
+
+    def test_get_server_defaults_absent_visibility_to_public(
+        self, test_client_admin, mock_server_service
+    ):
+        mock_server_service.get_server_info.return_value = {**self._LEGACY_DOC}
+
+        response = test_client_admin.get("/api/servers/legacy")
+        assert response.status_code == 200
+        assert response.json()["visibility"] == "public"
+
+    def test_list_servers_defaults_absent_visibility_to_public(
+        self, test_client_admin, mock_server_service
+    ):
+        mock_server_service.get_servers_paginated = AsyncMock(
+            return_value=({"/legacy": {**self._LEGACY_DOC}}, 1)
+        )
+
+        response = test_client_admin.get("/api/servers")
+        assert response.status_code == 200
+        servers = response.json()["servers"]
+        assert len(servers) == 1
+        assert servers[0]["visibility"] == "public"


### PR DESCRIPTION
## Summary

`POST /api/servers/register` had two related defects in how it handled the `visibility` form field. Both are fixed here.

- **Write side.** When the caller sent `visibility=public` (the form default and the most common value), the handler omitted the field from the persisted document, and GET responses then surfaced `"visibility": null`. The handler also skipped `_validate_visibility_and_groups()` entirely, so `visibility=garbage` was stored verbatim and `visibility=group-restricted` with no `allowed_groups` was accepted silently. Both behaviours are corrected: the value is now validated, normalized, and always persisted. The `allowed_groups` parsing and storage rule (only store when non-empty) is unchanged; the variable is just renamed to match the legacy `POST /register` handler.
- **Read side.** `GET /api/servers/{path}` and `GET /api/servers` now default absent `visibility` to `"public"`. This mirrors the existing pattern already in place for agents, search, and federation responses, and corrects the response for any server registered before the write-side fix landed — no data migration needed.

Closes #1181.

## Test plan

- [x] `uv run pytest tests/unit/api/test_server_routes.py --no-cov -q` → 60 passed, 5 skipped (pre-existing skips, unrelated).
- [x] New `TestServerRegisterVisibility` covers all four write-side acceptance criteria from #1181 (persist `public`, reject `garbage`, reject `group-restricted` without groups, persist `group-restricted` with groups).
- [x] New `TestServerGetVisibilityNormalization` covers both read-side endpoints with a legacy doc that lacks the field.
- [ ] Manual: `POST /api/servers/register -F "visibility=public" -F "name=… ..."` → MongoDB doc has `visibility: "public"`, `GET /api/servers/{path}` returns `"visibility": "public"`.
- [ ] Manual: `POST /api/servers/register -F "visibility=garbage" ...` → HTTP 400 with `"visibility"` in the detail.
- [ ] Manual: `POST /api/servers/register -F "visibility=group-restricted"` with no `allowed_groups` → HTTP 400 with `"allowed_group"` in the detail.
- [ ] Manual: hit `GET /api/servers/{path}` for a server registered *before* this PR (e.g. one already in production with no `visibility` key in Mongo) → response returns `"visibility": "public"` instead of `null`.

## Fixture note

`mock_faiss_service.save_data` is now `AsyncMock()`. `/api/servers/register` schedules `asyncio.create_task(faiss_service.save_data())` after a successful registration; with a plain `MagicMock` that call returned a non-coroutine and turned the 201 into a 500 under test. No production code change.