### PR TITLE
fix(api): metadata round-trip follow-ups to PR #1175 (#1165)

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -171,6 +171,25 @@ def _validate_visibility_and_groups(
     return normalized, allowed_groups_list
 
 
+def _coerce_metadata_to_dict(parsed_metadata: Any, path: str) -> dict[str, Any]:
+    """Coerce parsed JSON metadata to a dict, with a warning on non-dict input.
+
+    ServerInfo.metadata is declared dict[str, Any]; arrays / scalars / None
+    all violate that invariant. PR #1175 fixed the None case for #1165; this
+    helper extends it to every non-dict shape so storage stays consistent
+    regardless of input. Non-dict input is silently coerced to {} (lenient,
+    matching the PR's intent) and logged so the coercion is observable.
+    """
+    if isinstance(parsed_metadata, dict):
+        return parsed_metadata
+    logger.warning(
+        "metadata for %s coerced to {}: expected JSON object, got %s",
+        path,
+        type(parsed_metadata).__name__,
+    )
+    return {}
+
+
 async def _build_versions_list(
     server_info: dict,
     current_version: str,
@@ -1198,7 +1217,7 @@ async def register_service(
             import json
 
             parsed_metadata = json.loads(metadata)
-            server_entry["metadata"] = parsed_metadata if parsed_metadata is not None else {}
+            server_entry["metadata"] = _coerce_metadata_to_dict(parsed_metadata, path)
         except json.JSONDecodeError:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1497,7 +1516,7 @@ async def internal_register_service(
     if metadata:
         try:
             parsed_metadata = json.loads(metadata) if isinstance(metadata, str) else metadata
-            server_entry["metadata"] = parsed_metadata if parsed_metadata is not None else {}
+            server_entry["metadata"] = _coerce_metadata_to_dict(parsed_metadata, path)
         except json.JSONDecodeError:
             return JSONResponse(
                 status_code=400,
@@ -3711,7 +3730,7 @@ async def register_service_api(
     if metadata:
         try:
             parsed_metadata = json.loads(metadata) if isinstance(metadata, str) else metadata
-            server_entry["metadata"] = parsed_metadata if parsed_metadata is not None else {}
+            server_entry["metadata"] = _coerce_metadata_to_dict(parsed_metadata, path)
         except json.JSONDecodeError:
             return JSONResponse(
                 status_code=400,
@@ -5681,6 +5700,14 @@ async def get_server(
     # always persisted the field (#1181). Matches the default-on-read
     # pattern already used by agents, search, and federation responses.
     server_info.setdefault("visibility", "public")
+
+    # Normalize metadata for servers stored before the write-side fix
+    # always persisted the field (#1165). The list endpoint already does
+    # this via server_info.get("metadata", {}); mirror it here so the
+    # single-GET contract matches and clients never have to special-case
+    # absent vs empty.
+    if not isinstance(server_info.get("metadata"), dict):
+        server_info["metadata"] = {}
 
     return JSONResponse(
         status_code=200,

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -2279,3 +2279,215 @@ class TestServerGetVisibilityNormalization:
         servers = response.json()["servers"]
         assert len(servers) == 1
         assert servers[0]["visibility"] == "public"
+
+
+# =============================================================================
+# TESTS — Metadata round-trip on POST /api/servers/register (Issue #1165 follow-up)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServersRegisterAPIMetadata:
+    """Mirrors the metadata matrix that PR #1175 added for POST /api/register
+    onto the newer POST /api/servers/register. The fix in #1175 lands in
+    three handlers but only the legacy one was covered; this class closes
+    that gap and also pins the non-dict guard added as a #1165 follow-up.
+    """
+
+    _BASE_FORM = {
+        "name": "Meta Server",
+        "description": "Metadata round-trip test",
+        "path": "/meta-server",
+        "proxy_pass_url": "http://localhost:9000",
+    }
+
+    @staticmethod
+    def _stored(mock_server_service):
+        call_args = mock_server_service.register_server.call_args
+        return call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
+
+    def test_register_metadata_omitted_defaults_to_empty_dict(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post("/api/servers/register", data=self._BASE_FORM)
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+
+    def test_register_metadata_empty_json_object_defaults_to_empty_dict(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "metadata": "{}"},
+        )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+
+    def test_register_metadata_preserved_when_provided(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "metadata": '{"team": "platform", "tier": "gold"}'},
+        )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {
+            "team": "platform",
+            "tier": "gold",
+        }
+
+    def test_register_metadata_json_null_defaults_to_empty_dict(
+        self, test_client_admin, mock_server_service
+    ):
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={**self._BASE_FORM, "metadata": "null"},
+        )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+
+    def test_register_metadata_array_coerced_to_empty_dict(
+        self, test_client_admin, mock_server_service, caplog
+    ):
+        with caplog.at_level("WARNING", logger="registry.api.server_routes"):
+            response = test_client_admin.post(
+                "/api/servers/register",
+                data={**self._BASE_FORM, "metadata": "[]"},
+            )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+        assert any("coerced to {}" in rec.message for rec in caplog.records)
+
+    def test_register_metadata_scalar_coerced_to_empty_dict(
+        self, test_client_admin, mock_server_service, caplog
+    ):
+        with caplog.at_level("WARNING", logger="registry.api.server_routes"):
+            response = test_client_admin.post(
+                "/api/servers/register",
+                data={**self._BASE_FORM, "metadata": "42"},
+            )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+        assert any("coerced to {}" in rec.message for rec in caplog.records)
+
+
+# =============================================================================
+# TESTS — Metadata round-trip on POST /api/internal/register (#1165 follow-up)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestInternalRegisterMetadata:
+    """Same metadata matrix for the internal register endpoint."""
+
+    _BASE_FORM = {
+        "name": "Internal Meta Server",
+        "description": "Internal metadata test",
+        "path": "/internal-meta-server",
+        "proxy_pass_url": "http://localhost:9000",
+    }
+
+    @staticmethod
+    def _stored(mock_server_service):
+        call_args = mock_server_service.register_server.call_args
+        return call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
+
+    def _post(self, client, payload):
+        with (
+            patch.dict("os.environ", {"SECRET_KEY": "testpass"}),
+            patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
+        ):
+            token = generate_internal_token(subject="test-service", purpose="test")
+            return client.post(
+                "/api/internal/register",
+                data=payload,
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+    def test_internal_register_metadata_omitted_defaults_to_empty_dict(
+        self, test_client_no_auth, mock_server_service
+    ):
+        response = self._post(test_client_no_auth, self._BASE_FORM)
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+
+    def test_internal_register_metadata_preserved_when_provided(
+        self, test_client_no_auth, mock_server_service
+    ):
+        response = self._post(
+            test_client_no_auth,
+            {**self._BASE_FORM, "metadata": '{"owner": "ops"}'},
+        )
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {"owner": "ops"}
+
+    def test_internal_register_metadata_json_null_defaults_to_empty_dict(
+        self, test_client_no_auth, mock_server_service
+    ):
+        response = self._post(test_client_no_auth, {**self._BASE_FORM, "metadata": "null"})
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+
+    def test_internal_register_metadata_array_coerced_to_empty_dict(
+        self, test_client_no_auth, mock_server_service, caplog
+    ):
+        with caplog.at_level("WARNING", logger="registry.api.server_routes"):
+            response = self._post(test_client_no_auth, {**self._BASE_FORM, "metadata": "[]"})
+        assert response.status_code == 201
+        assert self._stored(mock_server_service)["metadata"] == {}
+        assert any("coerced to {}" in rec.message for rec in caplog.records)
+
+
+# =============================================================================
+# TESTS — Read-side metadata normalization on GET /api/servers/{path} (#1165 follow-up)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+@pytest.mark.servers
+class TestServerGetMetadataNormalization:
+    """Single-GET on a legacy doc with no metadata key historically omitted
+    the field entirely, while the list endpoint emitted metadata: {}. The
+    read-side default closes that contract gap. Mirrors the visibility
+    normalization pattern from #1181/#1186.
+    """
+
+    _LEGACY_DOC = {
+        "server_name": "Legacy Server",
+        "description": "Pre-#1165 row with no metadata key",
+        "path": "/legacy-meta",
+        "proxy_pass_url": "http://localhost:9000",
+        "is_enabled": True,
+        # No 'metadata' key — this is the legacy shape under test.
+    }
+
+    def test_get_server_defaults_absent_metadata_to_empty_dict(
+        self, test_client_admin, mock_server_service
+    ):
+        mock_server_service.get_server_info.return_value = {**self._LEGACY_DOC}
+
+        response = test_client_admin.get("/api/servers/legacy-meta")
+        assert response.status_code == 200
+        body = response.json()
+        assert "metadata" in body
+        assert body["metadata"] == {}
+
+    def test_get_server_coerces_non_dict_metadata_to_empty_dict(
+        self, test_client_admin, mock_server_service
+    ):
+        """A stored row with metadata=[] or metadata=42 must not leak the bad
+        shape into the response — the read path coerces to {} to match the
+        ServerInfo type invariant."""
+        mock_server_service.get_server_info.return_value = {
+            **self._LEGACY_DOC,
+            "metadata": [],
+        }
+
+        response = test_client_admin.get("/api/servers/legacy-meta")
+        assert response.status_code == 200
+        assert response.json()["metadata"] == {}


### PR DESCRIPTION
## Summary

Follow-up to PR #1175 (fixes #1165). That PR fixed the headline crash where omitting the `metadata` form field, or sending it as JSON `null`, caused registration to fail. Three gaps remained, each reproduced against the running stack before this PR was written. All three are closed here in a single small patch.

### Gap 1 — test coverage for the other two register handlers
PR #1175 patched three handlers (`/api/register`, `/api/internal/register`, `/api/servers/register`) but added regression tests only for the legacy `/api/register`. The other two had identical logic and zero regression coverage.

This PR mirrors the four-case matrix (omitted / `{}` / populated / `"null"`) onto `/api/servers/register` (new `TestServersRegisterAPIMetadata`) and `/api/internal/register` (new `TestInternalRegisterMetadata`).

### Gap 2 — non-dict JSON values still bypass the type invariant
PR #1175's guard was `parsed_metadata if parsed_metadata is not None else {}`. That only catches `None`. Arrays, ints, and other non-dict JSON shapes still passed through. Reproduced against `POST /api/servers/register`:

```
metadata=[]   -> HTTP 201, Mongo: { "metadata": [] }
metadata=42   -> HTTP 201, Mongo: { "metadata": 42 }
```

Both violate `ServerInfo.metadata: dict[str, Any]` and trip downstream Pydantic re-hydration paths.

Fix: extract a `_coerce_metadata_to_dict()` helper and call it from all three register handlers. Lenient stance (matches PR #1175's intent): non-dict input is coerced to `{}` and a `logger.warning(...)` is emitted so the silent coercion is visible in operations.

### Gap 3 — read-side inconsistency on legacy rows
PR #1175 only normalized the write path. The list endpoint already defaults absent metadata to `{}` via `server_info.get("metadata", {})` ([server_routes.py:679](registry/api/server_routes.py#L679)), but the single-GET handler returned the raw stored doc. Reproduced against `/context7`, a real legacy row with no `metadata` key in Mongo:

```
Mongo:                       { "_id": "/context7" }                  (no metadata key)
GET /api/servers/context7:   { ... no "metadata" field at all ... }
GET /api/servers (list):     { ..., "metadata": {} }
```

Same row, two different response shapes — clients must special-case absent vs empty.

Fix: in the single-GET handler, after the existing `setdefault("visibility", "public")` (from #1181/#1186), coerce metadata too:

```python
if not isinstance(server_info.get("metadata"), dict):
    server_info["metadata"] = {}
```

This also handles legacy rows whose stored metadata is itself non-dict (e.g. a row registered via `metadata="[]"` before Gap 2 was fixed).

Closes #1165 follow-up work. PR #1175 already covered the headline bug.

## Test plan

- [x] `uv run pytest tests/unit/api/test_server_routes.py --no-cov -q` → 76 passed, 5 skipped (pre-existing skips, unrelated).
- [x] 12 new tests across 3 classes:
  - `TestServersRegisterAPIMetadata` — 6 cases against `/api/servers/register` (omitted, `{}`, populated, `"null"`, `"[]"`, `"42"`).
  - `TestInternalRegisterMetadata` — 4 cases against `/api/internal/register` (omitted, populated, `"null"`, `"[]"`).
  - `TestServerGetMetadataNormalization` — 2 cases (absent key in storage; non-dict stored value).
- [x] The two coercion tests use `caplog` to assert the warning fires.
- [ ] Manual: `POST /api/servers/register -F "metadata=[]" -F "name=… ..."` → HTTP 201, Mongo doc has `metadata: {}`, registry logs show a `metadata for /… coerced to {}` warning.
- [ ] Manual: `GET /api/servers/context7` (legacy row with no `metadata` key) → response now includes `"metadata": {}` instead of omitting the field.