### PR TITLE
feat(ui): add "All Agents" wildcard option to IAM group Agent Access (#1189)

### DIFF
--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -892,6 +892,9 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
             placeholder="Search and add agents..."
             isLoading={agentsLoading}
             maxDescriptionWords={8}
+            specialOptions={[
+              { value: '*', label: '* (All agents)', description: 'Grant access to all agents' },
+            ]}
           />
         </div>
 
@@ -1207,6 +1210,9 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                 placeholder="Search and add agents..."
                 isLoading={agentsLoading}
                 maxDescriptionWords={8}
+                specialOptions={[
+                  { value: '*', label: '* (All agents)', description: 'Grant access to all agents' },
+                ]}
               />
             </div>
 

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -893,7 +893,7 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
             isLoading={agentsLoading}
             maxDescriptionWords={8}
             specialOptions={[
-              { value: '*', label: '* (All agents)', description: 'Grant access to all agents' },
+              { value: 'all', label: '* (All agents)', description: 'Grant access to all agents' },
             ]}
           />
         </div>
@@ -1211,7 +1211,7 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                 isLoading={agentsLoading}
                 maxDescriptionWords={8}
                 specialOptions={[
-                  { value: '*', label: '* (All agents)', description: 'Grant access to all agents' },
+                  { value: 'all', label: '* (All agents)', description: 'Grant access to all agents' },
                 ]}
               />
             </div>

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -79,6 +79,38 @@ def _normalize_agent_path(path: str) -> str:
     return path
 
 
+# Spellings of the "all agents" wildcard that clients may submit. They all
+# coerce to the canonical "all" before storage so the resolver / filter at
+# registry/api/agent_routes.py and registry/services/visibility.py (both of
+# which only check for the literal "all") work uniformly. Without this
+# coercion, "*" passed through `_normalize_agent_path` becomes "/*" - a
+# literal path no agent has, so the group grants access to nothing.
+_AGENT_WILDCARDS: frozenset[str] = frozenset({"all", "*", "/*"})
+
+
+def _coerce_agent_wildcard(value: str) -> str | None:
+    """Return canonical "all" if value is a known agent wildcard, else None."""
+    if isinstance(value, str) and value.strip() in _AGENT_WILDCARDS:
+        return "all"
+    return None
+
+
+def _normalize_agent_entries(values: list) -> list:
+    """Normalize a list of agent identifiers. Wildcards collapse to "all",
+    literal paths get a leading slash via `_normalize_agent_path`. Duplicate
+    canonical values are dropped so ["*", "all"] becomes ["all"]."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in values:
+        if not raw:
+            continue
+        canonical = _coerce_agent_wildcard(raw) or _normalize_agent_path(raw)
+        if canonical not in seen:
+            seen.add(canonical)
+            out.append(canonical)
+    return out
+
+
 def _normalize_agent_paths_in_scope_config(
     agent_access: list | None,
     ui_permissions: dict | None,
@@ -86,7 +118,10 @@ def _normalize_agent_paths_in_scope_config(
     """
     Normalize agent paths in agent_access and ui_permissions.
 
-    Ensures all agent paths have leading slashes for consistent matching.
+    Ensures all agent paths have leading slashes for consistent matching,
+    and that every spelling of the "all agents" wildcard collapses to the
+    canonical "all" string the downstream filter and visibility checks
+    look for.
 
     Args:
         agent_access: List of agent paths
@@ -97,16 +132,13 @@ def _normalize_agent_paths_in_scope_config(
     """
     # Normalize agent_access
     if agent_access:
-        agent_access = [_normalize_agent_path(p) for p in agent_access if p]
+        agent_access = _normalize_agent_entries(agent_access)
 
     # Normalize agent-related ui_permissions
     if ui_permissions:
         for key in ["list_agents", "get_agent", "publish_agent", "modify_agent", "delete_agent"]:
             if key in ui_permissions and isinstance(ui_permissions[key], list):
-                # Don't normalize "all" - it's a special value
-                ui_permissions[key] = [
-                    p if p == "all" else _normalize_agent_path(p) for p in ui_permissions[key] if p
-                ]
+                ui_permissions[key] = _normalize_agent_entries(ui_permissions[key])
 
     return agent_access, ui_permissions
 

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -1178,3 +1178,115 @@ class TestManagementHelpers:
 
         assert exc_info.value.status_code == 403
         assert "Administrator permissions" in exc_info.value.detail
+
+
+# =============================================================================
+# TESTS - agent_access / ui_permissions wildcard normalization (#1189 follow-up)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestAgentWildcardNormalization:
+    """The agent-access wildcard convention is the literal string "all".
+    Clients may submit "*" (from the PR #1191 dropdown's prior shape),
+    "all" (admin scope convention), or "/*" (pre-fix UI artifact). All
+    three must collapse to "all" before storage so the downstream filter
+    at agent_routes.py and visibility.py (both of which only match
+    "all") grant access correctly.
+
+    Pre-fix, "_normalize_agent_path" prepended a slash to "*" -> "/*",
+    which the resolver treated as a literal path. The group then
+    silently filtered every agent.
+    """
+
+    def test_coerce_wildcard_recognizes_all(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard("all") == "all"
+
+    def test_coerce_wildcard_recognizes_star(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard("*") == "all"
+
+    def test_coerce_wildcard_recognizes_slash_star(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard("/*") == "all"
+
+    def test_coerce_wildcard_strips_whitespace(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard("  *  ") == "all"
+
+    def test_coerce_wildcard_rejects_literal_paths(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard("/flight-booking") is None
+        assert _coerce_agent_wildcard("agents/foo") is None
+
+    def test_coerce_wildcard_rejects_non_strings(self):
+        from registry.api.management_routes import _coerce_agent_wildcard
+        assert _coerce_agent_wildcard(None) is None
+        assert _coerce_agent_wildcard(42) is None
+        assert _coerce_agent_wildcard([]) is None
+
+    def test_normalize_agent_access_star_collapses_to_all(self):
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config(["*"], None)
+        assert agent_access == ["all"]
+
+    def test_normalize_agent_access_slash_star_collapses_to_all(self):
+        """Existing broken scopes have '/*' stored. Saving the group
+        again must auto-repair to 'all'."""
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config(["/*"], None)
+        assert agent_access == ["all"]
+
+    def test_normalize_agent_access_preserves_literal_paths(self):
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config(
+            ["flight-booking", "/jewel-homes-support"], None
+        )
+        assert agent_access == ["/flight-booking", "/jewel-homes-support"]
+
+    def test_normalize_agent_access_dedupes_wildcards(self):
+        """A caller passing both 'all' and '*' must not produce ['all', 'all']."""
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config(["*", "all"], None)
+        assert agent_access == ["all"]
+
+    def test_normalize_agent_access_mixed_wildcard_and_paths(self):
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config(
+            ["*", "flight-booking"], None
+        )
+        assert agent_access == ["all", "/flight-booking"]
+
+    def test_normalize_ui_permissions_collapses_wildcards(self):
+        """ui_permissions previously only special-cased 'all'. After the
+        fix, '*' and '/*' there must collapse the same way."""
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        _, ui_permissions = _normalize_agent_paths_in_scope_config(
+            None,
+            {
+                "list_agents": ["*"],
+                "get_agent": ["/*"],
+                "modify_agent": ["all", "/foo"],
+            },
+        )
+        assert ui_permissions["list_agents"] == ["all"]
+        assert ui_permissions["get_agent"] == ["all"]
+        assert ui_permissions["modify_agent"] == ["all", "/foo"]
+
+    def test_normalize_handles_none_and_empty(self):
+        from registry.api.management_routes import _normalize_agent_paths_in_scope_config
+
+        agent_access, ui_permissions = _normalize_agent_paths_in_scope_config(None, None)
+        assert agent_access is None
+        assert ui_permissions is None
+
+        agent_access, _ = _normalize_agent_paths_in_scope_config([], None)
+        assert agent_access == []


### PR DESCRIPTION
## Summary

Adds a "* (All agents)" wildcard option to the IAM group Agent Access picker, mirroring the existing Server Access pattern. Fixes the underlying server-side normalizer that silently broke the wildcard before reaching storage, so the option actually grants access instead of producing an empty filter.

Two commits:

- `ea09cf6c` — frontend: add `specialOptions` to both Agent Access `SearchableSelect` instances (create and edit forms).
- `7c94a629` — backend + tests: canonicalize agent wildcards in `_normalize_agent_paths_in_scope_config` and switch the dropdown value to `"all"` (the form the downstream filter actually accepts).

Closes #1189.

## Why the second commit was needed

The first commit alone would have shipped a broken option. Trace:

1. User picks the dropdown entry. Frontend sends `agent_access: ["*"]`.
2. Server-side normalizer in `_normalize_agent_paths_in_scope_config` runs `_normalize_agent_path` on every entry, which prepends `/` to anything not starting with one. `"*"` → `"/*"`.
3. Mongo stores `agent_access: ["/*"]` and `ui_permissions.list_agents: ["/*"]`.
4. Auth resolver builds `accessible_agents: ["/*"]` from the scope.
5. Filter at `registry/api/agent_routes.py:374` (`if "all" not in accessible_agent_list and agent.path not in accessible_agent_list: continue`) and visibility check at `registry/services/visibility.py:76` only recognize the literal string `"all"`. `/*` is treated as a literal path that no agent has, so every agent gets filtered out.

This reproduced live: the `test-all-agents` group used in testing stored `agent_access: ["/*"]` and the registry logs showed `User <user> listed 0 agents (total: 0)`.

The fix collapses every wildcard spelling (`"all"`, `"*"`, `"/*"`) to the canonical `"all"` before storage, in both `agent_access` and the agent-related `ui_permissions` keys. The dropdown's `value` is now `"all"` so the canonical form is on the wire from the first hop. The label and description are unchanged.

Backend behaviour changes only on the write path (registering or editing a group via the management API). Existing broken scopes self-repair on the next save through that path; an operator can also patch them in place with a one-shot Mongo update.

## Test plan

- [x] `uv run pytest tests/unit/api/test_management_routes.py --no-cov -q` → 49 passed (13 new + 36 pre-existing). No regressions.
- [x] `TestAgentWildcardNormalization` covers:
  - `_coerce_agent_wildcard` recognizes `"all"`, `"*"`, `"/*"`, strips whitespace, rejects literal paths and non-strings.
  - `_normalize_agent_paths_in_scope_config` collapses `"*"` and `"/*"` to `"all"` in both `agent_access` and `ui_permissions`.
  - Mixed inputs (`["*", "/flight-booking"]`) produce `["all", "/flight-booking"]`.
  - Dedup (`["*", "all"]` → `["all"]`).
  - `None` / `[]` round-trip cleanly.
- [ ] Manual: open **Settings > IAM > Groups > Create**. Open the Agent Access dropdown. `* (All agents)` appears at the top with the description "Grant access to all agents".
- [ ] Manual: pick it, name the group, save. The Mongo scope record stores `agent_access: ["all"]` and `ui_permissions.list_agents: ["all"]` (not `["*"]`, not `["/*"]`).
- [ ] Manual: log in as a user in that group, hit `GET /api/agents`. All agents are visible.
- [ ] Manual: open the same group in the Edit view. `* (All agents)` is still selectable and the wildcard is still applied.
- [ ] Manual: existing groups without the wildcard (specific agent paths) are unaffected — sanity check by editing one and confirming the saved paths are unchanged.

## Out of scope

- Renaming or reworking the Server Access wildcard (servers use `"*"` as canonical, agents use `"all"`; both are existing conventions documented in the admin scope records).
- Group edit page UI redesign.
- Auto-migrating already-broken scopes in production. The path forward is either the next save through this endpoint (which now canonicalizes) or an operator-run Mongo `updateMany({agent_access: "/*"}, {$set: {agent_access: ["all"]}})` style patch.