### PR TITLE
ci: bump tfvars.example examples that pin a semver tag

### DIFF
--- a/.github/workflows/helm-chart-update.yml
+++ b/.github/workflows/helm-chart-update.yml
@@ -55,12 +55,24 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Replace :latest (or any existing tag) with the release version
-          # only on UNCOMMENTED image_uri lines. Commented-out lines (starting
-          # with #) are example placeholders and must not be modified.
-          sed -i "/^[^#]*image_uri/s|\(image_uri.*:\)[^\"]*\"|\1${VERSION}\"|" \
-            terraform/aws-ecs/terraform.tfvars.example
-          echo "Updated terraform/aws-ecs/terraform.tfvars.example"
+          # Replace any pinned version tag on UNCOMMENTED image_uri lines, AND
+          # on commented `image_uri` lines that already pin a semver tag (e.g.
+          # `# foo_image_uri = "...:1.24.3"`). Commented placeholder lines that
+          # use `:latest` or symbolic tags like `:YOUR_VERSION` are deliberately
+          # left alone so they remain instructional. Skipping commented semver-
+          # pinned lines was a footgun: stale examples like `:1.24.3` would
+          # never be bumped, and the auto-PR body would over-claim updates that
+          # never actually happened.
+          FILE=terraform/aws-ecs/terraform.tfvars.example
+
+          # 1. Uncommented image_uri lines: replace any tag.
+          sed -i "/^[^#]*image_uri/s|\(image_uri.*:\)[^\"]*\"|\1${VERSION}\"|" "$FILE"
+
+          # 2. Commented image_uri lines pinned to a semver: replace tag.
+          #    Match `:1.2.3` or `:1.2.3-anything` followed by `"` only.
+          sed -i -E "/^#.*image_uri/s|(image_uri.*:)[0-9]+\\.[0-9]+\\.[0-9]+[A-Za-z0-9._-]*(\")|\\1${VERSION}\\2|" "$FILE"
+
+          echo "Updated $FILE"
 
       - name: Check for changes
         id: update


### PR DESCRIPTION
## Context

PR #1198 (the auto-generated "Update Image Tags on Release" PR for 1.24.4) listed `terraform/aws-ecs/terraform.tfvars.example` in its body as one of the updated files — but the actual diff didn't include it. Investigation found that:

1. The workflow's sed only touched **uncommented** `image_uri` lines.
2. Lines 834-835 of `terraform.tfvars.example` are commented examples that pin a real semver tag (`:1.24.3`):
   ```
   # metrics_service_image_uri = "...:1.24.3"
   # grafana_image_uri         = "...:1.24.3"
   ```
3. Because they're commented, the workflow skipped them. Result: stale `1.24.3` references after 1.24.4 was released.

## Change

Add a second sed pass to the workflow that targets **commented `image_uri` lines pinned to a semver tag** and rewrites the tag. Commented placeholder lines that use `:latest` or symbolic tags like `:YOUR_VERSION` are deliberately still left alone so they remain instructional.

| Line shape | Example | Behavior after this PR |
|------------|---------|------------------------|
| Uncommented `image_uri` | `registry_image_uri = "...:1.24.3"` | bumped (existing behavior, unchanged) |
| Commented `:latest` | `# registry_image_uri = "...:latest"` | left alone (instructional placeholder) |
| Commented `:YOUR_VERSION` | `# foo_image_uri = "...:YOUR_VERSION"` | left alone (instructional placeholder) |
| **Commented `:semver`** | `# metrics_service_image_uri = "...:1.24.3"` | **bumped (new behavior)** |

## Verification

Simulated the new sed against the current `tfvars.example` with `VERSION=1.99.0`:

- Bumps the 2 commented `metrics_service_image_uri` and `grafana_image_uri` lines from `:1.24.4` → `:1.99.0`
- Leaves all 7 `:latest` placeholder lines (lines 106-108, 118-121) untouched

## Why not just bump 834-835 manually for this release?

Considered it. The workflow fix is the correct durable fix — without it, the same drift will recur on every future release whenever a commented `image_uri` is left pinned to an old semver. PR #1198 itself can keep the stale lines and be merged as-is; the next release will pick them up.

## Test plan

- [ ] Workflow YAML still parses (verified locally: `python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Bash for the new sed parses (verified locally: `bash -n`)
- [ ] On the next release tag, the auto-PR's body and the actual `tfvars.example` diff agree, and lines 834-835 get bumped to the new version