### PR TITLE
fix: bump terraform variables.tf public-ECR image defaults to 1.24.4

### DIFF
--- a/.github/workflows/helm-chart-update.yml
+++ b/.github/workflows/helm-chart-update.yml
@@ -51,28 +51,28 @@ jobs:
             echo "Updated $VALUES_FILE"
           done
 
-      - name: Update image tags in terraform.tfvars.example
+      - name: Update public ECR image defaults in Terraform variables.tf
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Replace any pinned version tag on UNCOMMENTED image_uri lines, AND
-          # on commented `image_uri` lines that already pin a semver tag (e.g.
-          # `# foo_image_uri = "...:1.24.3"`). Commented placeholder lines that
-          # use `:latest` or symbolic tags like `:YOUR_VERSION` are deliberately
-          # left alone so they remain instructional. Skipping commented semver-
-          # pinned lines was a footgun: stale examples like `:1.24.3` would
-          # never be bumped, and the auto-PR body would over-claim updates that
-          # never actually happened.
-          FILE=terraform/aws-ecs/terraform.tfvars.example
-
-          # 1. Uncommented image_uri lines: replace any tag.
-          sed -i "/^[^#]*image_uri/s|\(image_uri.*:\)[^\"]*\"|\1${VERSION}\"|" "$FILE"
-
-          # 2. Commented image_uri lines pinned to a semver: replace tag.
-          #    Match `:1.2.3` or `:1.2.3-anything` followed by `"` only.
-          sed -i -E "/^#.*image_uri/s|(image_uri.*:)[0-9]+\\.[0-9]+\\.[0-9]+[A-Za-z0-9._-]*(\")|\\1${VERSION}\\2|" "$FILE"
-
-          echo "Updated $FILE"
+          # Bump the `default = "public.ecr.aws/p3v1o3c6/<service>:<version>"`
+          # lines in the Terraform variable declarations. These defaults are
+          # what `terraform apply` uses when the operator does not set the
+          # corresponding variable in their `terraform.tfvars`, so they
+          # decide what image a fresh ECS deployment pulls. They MUST track
+          # the latest released version.
+          #
+          # `terraform.tfvars.example` is intentionally NOT touched here.
+          # That file is documentation only (Terraform never reads it). Its
+          # commented-out lines stay as `:latest` placeholders that operators
+          # uncomment and edit in their own `terraform.tfvars` if they want
+          # to override the default with a custom-built image.
+          for VARS_FILE in \
+            terraform/aws-ecs/variables.tf \
+            terraform/aws-ecs/modules/mcp-gateway/variables.tf; do
+            sed -i -E "s|(public\\.ecr\\.aws/p3v1o3c6/[a-zA-Z0-9._-]+:)[0-9]+\\.[0-9]+\\.[0-9]+[A-Za-z0-9._-]*|\\1${VERSION}|g" "$VARS_FILE"
+            echo "Updated $VARS_FILE"
+          done
 
       - name: Check for changes
         id: update
@@ -172,7 +172,8 @@ jobs:
             - `charts/auth-server/values.yaml`
             - `charts/registry/values.yaml`
             - `charts/mcpgw/values.yaml`
-            - `terraform/aws-ecs/terraform.tfvars.example`
+            - `terraform/aws-ecs/variables.tf`
+            - `terraform/aws-ecs/modules/mcp-gateway/variables.tf`
           labels: release
 
       - name: Comment on PR with missing env vars

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -41,19 +41,19 @@ variable "task_execution_role_arn" {
 variable "registry_image_uri" {
   description = "Container image URI for registry service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.4"
 }
 
 variable "auth_server_image_uri" {
   description = "Container image URI for auth server service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.4"
 }
 
 variable "mcpgw_image_uri" {
   description = "Container image URI for mcpgw service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.4"
 }
 
 variable "enable_demo_servers" {

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -127,19 +127,19 @@ variable "keycloak_log_level" {
 variable "registry_image_uri" {
   description = "Container image URI for registry service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.4"
 }
 
 variable "auth_server_image_uri" {
   description = "Container image URI for auth server service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.4"
 }
 
 variable "mcpgw_image_uri" {
   description = "Container image URI for mcpgw service (defaults to pre-built image from public ECR)"
   type        = string
-  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.4"
 }
 
 variable "keycloak_image_uri" {


### PR DESCRIPTION
## Context

Follow-up to PR #1198 (the auto-generated release-update PR for 1.24.4). While reviewing #1198 we noticed that:

1. The release auto-update workflow was rewriting `terraform.tfvars.example` but never touching the actual deployment defaults that live in the Terraform variable declarations.
2. As a result, the public-ECR image defaults in `terraform/aws-ecs/variables.tf` were stuck at `:1.24.3` after 1.24.4 shipped.
3. The module-level copies in `terraform/aws-ecs/modules/mcp-gateway/variables.tf` were even more stale, still pinned at `:1.24.2`.

Anyone running `terraform apply` without explicitly setting `registry_image_uri` / `auth_server_image_uri` / `mcpgw_image_uri` in their `terraform.tfvars` was deploying an old version on a fresh stack — and those vars are usually unset because the whole point of the `default` is so operators don't have to set them.

## Why variables.tf, not tfvars.example

| File | Role |
|------|------|
| `variables.tf` | Variable declaration + default. **Terraform reads this at plan/apply time. The default is what gets deployed when the operator doesn't override.** |
| `terraform.tfvars.example` | Documentation only. Terraform never reads it. Operators copy lines into their own (gitignored) `terraform.tfvars` to override. |

So bumping `variables.tf` is the actual deployment fix; `tfvars.example` is purely instructional.

## Changes

### 1. Bump 6 public-ECR defaults to 1.24.4

`terraform/aws-ecs/variables.tf` — root vars (operator-facing, the path used by `terraform apply` from `terraform/aws-ecs/`):

```diff
-  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.4"
-  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.4"
-  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.3"
+  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.4"
```

`terraform/aws-ecs/modules/mcp-gateway/variables.tf` — module-level fallbacks (used only if someone calls the `mcp-gateway` module standalone from another root config):

```diff
-  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/registry:1.24.4"
-  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/auth-server:1.24.4"
-  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.2"
+  default     = "public.ecr.aws/p3v1o3c6/mcpgw:1.24.4"
```

The module-level defaults are usually shadowed by the root vars passed via `module "mcp-gateway" { registry_image_uri = var.registry_image_uri ... }` in `main.tf`, but kept here so the module remains self-contained for any future standalone caller.

### 2. Update the release auto-PR workflow

`.github/workflows/helm-chart-update.yml`:

- **Removed** the `Update image tags in terraform.tfvars.example` step. tfvars.example commented examples are pedagogical (`:latest` placeholders + `YOUR_ACCOUNT_ID` substitutions). Bumping their tags would be misleading.
- **Added** an `Update public ECR image defaults in Terraform variables.tf` step that sed-bumps the 6 `default = "public.ecr.aws/p3v1o3c6/<svc>:<ver>"` lines across both variables.tf files.
- **Updated** the auto-PR body's "Updated files" list to reference the new files.

Net result: every future release tag will correctly propagate into the actual ECS deployment defaults, the way 1.24.3 → 1.24.4 should have but didn't.

## Verification

- YAML parses (verified with `python3 -c "import yaml; yaml.safe_load(...)"`)
- Simulated the new sed locally with `VERSION=1.99.0`: matches exactly the 6 public-ECR `default = "..."` lines across both files, bumps them, leaves all other content untouched.
- Confirmed `terraform.tfvars.example` is no longer in the workflow's path.

## Test plan

- [ ] Workflow YAML parses
- [ ] On the next release tag, the auto-PR includes both `variables.tf` files in its diff and the body
- [ ] Operators running `terraform apply` after merging this PR get 1.24.4 by default (no need to set image_uri vars manually)

## Notes

- This obsoletes the workflow change in PR #1199 (which was a generic catch-all for commented semver-pinned `image_uri` lines in tfvars.example — no longer needed since we're not touching tfvars.example at all). PR #1199 is harmless to keep, but its sed will be a no-op against tfvars.example whose commented lines all use `:latest`.