### PR TITLE
docs: add dynamic discovery receipt guidance

### DIFF
--- a/docs/dynamic-tool-discovery.md
+++ b/docs/dynamic-tool-discovery.md
@@ -6,6 +6,7 @@ The MCP Gateway & Registry provides a powerful **Dynamic Tool Discovery and Invo
 
 - [Overview](#overview)
 - [How It Works](#how-it-works)
+- [Discovery Receipts and Context Budgets](#discovery-receipts-and-context-budgets)
 - [Architecture](#architecture)
 - [Usage Examples](#usage-examples)
 - [Agent Integration](#agent-integration)
@@ -35,6 +36,61 @@ The dynamic tool discovery process follows these steps:
 5. **Tool Invocation**: Agent uses the discovered tool information to invoke the appropriate MCP tool
 
 ![Dynamic Tool Discovery Flow](img/dynamic-tool-discovery-demo.gif)
+
+## Discovery Receipts and Context Budgets
+
+Dynamic discovery reduces up-front context bloat, but operators still need to know which tool surface an agent actually saw. For production or multi-tenant use, emit a small discovery receipt alongside normal audit logs so each run can be reviewed without replaying raw prompts or tool payloads.
+
+A useful receipt answers four questions:
+
+1. **What was requested?** The natural-language discovery query and correlation identifiers.
+2. **What was exposed?** The services/tools returned to the agent, with scores and the configured `top_k_services` / `top_n_tools` limits.
+3. **What stayed out?** The count or categories of candidate tools that were intentionally withheld because they were outside the current intent, policy scope, or result budget.
+4. **What happened next?** Whether a discovered tool was invoked, skipped, denied, or fell back to another path.
+
+Example shape:
+
+```json
+{
+  "event": "tool.discovery_receipt",
+  "request_id": "req_123",
+  "session_id": "sess_456",
+  "query": "weather forecast for tomorrow",
+  "limits": {
+    "top_k_services": 3,
+    "top_n_tools": 1
+  },
+  "exposed_tools": [
+    {
+      "service_path": "/weather",
+      "tool_name": "get_forecast",
+      "similarity_score": 0.91
+    }
+  ],
+  "withheld": {
+    "candidate_tool_count": 42,
+    "reason": "outside_intent_or_budget"
+  },
+  "invocation": {
+    "tool_name": "get_forecast",
+    "status": "ok",
+    "args_shape": {
+      "fields": ["location", "days"],
+      "redacted": true
+    },
+    "result_shape": "forecast",
+    "duration_ms": 245
+  },
+  "stop_reason": "tool_invoked"
+}
+```
+
+Keep discovery receipts compact and privacy-safe:
+
+- Store shapes, counts, categories, scores, and correlation IDs; avoid raw user prompts beyond the discovery query unless your retention policy allows them.
+- Redact tool arguments and results by default. The receipt should show the class of data used, not copy sensitive payloads into observability storage.
+- Keep metrics lower-cardinality than receipts. Good metric labels include service family, status, and stop reason; avoid labels such as raw query text, user IDs, arguments, or result values.
+- Treat withheld tools as a first-class signal. If many tools are repeatedly withheld for the same task, split services, improve descriptions, or adjust discovery limits.
 
 ## Architecture
 

--- a/docs/dynamic-tool-discovery.md
+++ b/docs/dynamic-tool-discovery.md
@@ -39,36 +39,38 @@ The dynamic tool discovery process follows these steps:
 
 ## Discovery Receipts and Context Budgets
 
-Dynamic discovery reduces up-front context bloat, but operators still need to know which tool surface an agent actually saw. The `search_registry` and deprecated `intelligent_tool_finder` tools return a compact `discovery_receipt` with their successful responses; operators can persist that receipt alongside normal audit logs so each run can be reviewed without replaying raw prompts or tool payloads.
+Dynamic discovery reduces up-front context bloat, but eval harnesses and agent-development workflows still need to know which result surface an agent actually saw. The `search_registry` and deprecated `intelligent_tool_finder` tools can return a compact `discovery_receipt` when callers set `include_discovery_receipt=true`; the default response remains unchanged to avoid adding model-facing tokens in production calls.
+
+The receipt is a caller-visible eval/debugging signal, not an operator audit transport. If you need audit evidence for production traffic, emit it server-side through structured logs or OTel events/spans instead of relying on the model or caller to persist it.
 
 A useful receipt answers four questions:
 
 1. **What was requested?** The natural-language discovery query and correlation identifiers.
-2. **What was exposed?** The services/tools returned to the agent, with scores and the configured `top_k_services` / `top_n_tools` limits.
-3. **What stayed out?** The count or categories of candidate tools that were intentionally withheld because they were outside the current intent, policy scope, or result budget.
+2. **What was exposed?** The tools, agents, or skills returned to the agent, with scores and the configured result limits.
+3. **What stayed out?** The count or categories of candidate results that were intentionally withheld because they were outside the current intent, policy scope, or result budget.
 4. **What happened next?** Whether a discovered tool was invoked, skipped, denied, or fell back to another path.
 
 Example shape:
 
 ```json
 {
-  "event": "tool.discovery_receipt",
+  "event": "registry.discovery_receipt",
   "request_id": "req_123",
   "session_id": "sess_456",
   "query": "weather forecast for tomorrow",
   "limits": {
-    "top_k_services": 3,
-    "top_n_tools": 1
+    "max_results": 1
   },
-  "exposed_tools": [
+  "exposed_results": [
     {
+      "asset_type": "tool",
       "service_path": "/weather",
-      "tool_name": "get_forecast",
+      "name": "get_forecast",
       "similarity_score": 0.91
     }
   ],
   "withheld": {
-    "candidate_tool_count": 42,
+    "candidate_result_count": 42,
     "reason": "outside_intent_or_budget"
   },
   "invocation": {
@@ -90,7 +92,7 @@ Keep discovery receipts compact and privacy-safe:
 - Store shapes, counts, categories, scores, and correlation IDs; avoid raw user prompts beyond the discovery query unless your retention policy allows them.
 - Redact tool arguments and results by default. The receipt should show the class of data used, not copy sensitive payloads into observability storage.
 - Keep metrics lower-cardinality than receipts. Good metric labels include service family, status, and stop reason; avoid labels such as raw query text, user IDs, arguments, or result values.
-- Treat withheld tools as a first-class signal. If many tools are repeatedly withheld for the same task, split services, improve descriptions, or adjust discovery limits.
+- Treat withheld results as a first-class signal. If many useful tools, agents, or skills are repeatedly withheld for the same task, split services, improve descriptions, or adjust discovery limits.
 
 ## Architecture
 

--- a/docs/dynamic-tool-discovery.md
+++ b/docs/dynamic-tool-discovery.md
@@ -39,7 +39,7 @@ The dynamic tool discovery process follows these steps:
 
 ## Discovery Receipts and Context Budgets
 
-Dynamic discovery reduces up-front context bloat, but operators still need to know which tool surface an agent actually saw. For production or multi-tenant use, emit a small discovery receipt alongside normal audit logs so each run can be reviewed without replaying raw prompts or tool payloads.
+Dynamic discovery reduces up-front context bloat, but operators still need to know which tool surface an agent actually saw. The `search_registry` and deprecated `intelligent_tool_finder` tools return a compact `discovery_receipt` with their successful responses; operators can persist that receipt alongside normal audit logs so each run can be reviewed without replaying raw prompts or tool payloads.
 
 A useful receipt answers four questions:
 

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -209,7 +209,7 @@ def _build_discovery_receipt(
     *,
     query: str,
     limit: int,
-    exposed_tools: list[dict[str, Any]],
+    exposed_results: list[dict[str, Any]],
     total_candidates: int,
     status: str,
     stop_reason: str,
@@ -217,16 +217,16 @@ def _build_discovery_receipt(
     """Build a compact, privacy-safe receipt for dynamic discovery results.
 
     The receipt deliberately records shapes/counts and ranking metadata rather
-    than raw tool arguments, tool outputs, or user data. It is returned with the
-    search response so callers can persist it in their own audit pipeline.
+    than raw tool arguments, tool outputs, or user data. It is an opt-in
+    eval/agent-development signal; server-side audit should use logs or OTel.
     """
     return {
-        "event": "tool.discovery_receipt",
+        "event": "registry.discovery_receipt",
         "query": query,
         "limits": {"max_results": limit},
-        "exposed_tools": exposed_tools,
+        "exposed_results": exposed_results,
         "withheld": {
-            "candidate_tool_count": max(total_candidates - len(exposed_tools), 0),
+            "candidate_result_count": max(total_candidates - len(exposed_results), 0),
             "reason": "outside_intent_or_budget",
         },
         "status": status,
@@ -562,6 +562,7 @@ async def get_skill_content(
 async def search_registry(
     query: str,
     max_results: int = 10,
+    include_discovery_receipt: bool = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
@@ -591,6 +592,7 @@ async def search_registry(
     Args:
         query: What capability or tool you are looking for (natural language)
         max_results: Number of results to return (default: 10, max: 50)
+        include_discovery_receipt: Include compact eval metadata about exposed and withheld results
 
     Returns:
         Dictionary with servers, tools, agents, skills arrays and metadata
@@ -626,47 +628,67 @@ async def search_registry(
         agents = data.get("agents", []) if isinstance(data, dict) else []
         skills = data.get("skills", []) if isinstance(data, dict) else []
 
-        candidate_tools = []
+        candidate_results = []
         for tool in tools:
-            candidate_tools.append(
+            candidate_results.append(
                 {
+                    "asset_type": "tool",
                     "service_path": tool.get("server_path") or tool.get("path") or "",
-                    "tool_name": tool.get("tool_name") or tool.get("name") or "",
+                    "name": tool.get("tool_name") or tool.get("name") or "",
                     "similarity_score": tool.get("relevance_score") or tool.get("score"),
                 }
             )
         for server in servers:
             server_path = server.get("path", "")
             for tool in server.get("matching_tools", []):
-                candidate_tools.append(
+                candidate_results.append(
                     {
+                        "asset_type": "tool",
                         "service_path": server_path,
-                        "tool_name": tool.get("tool_name", ""),
+                        "name": tool.get("tool_name", ""),
                         "similarity_score": tool.get("relevance_score"),
                     }
                 )
-        exposed_tools = candidate_tools[:max_results]
+        for agent in agents:
+            candidate_results.append(
+                {
+                    "asset_type": "agent",
+                    "service_path": agent.get("path") or agent.get("url") or "",
+                    "name": agent.get("agent_name") or agent.get("name") or "",
+                    "similarity_score": agent.get("relevance_score") or agent.get("score"),
+                }
+            )
+        for skill in skills:
+            candidate_results.append(
+                {
+                    "asset_type": "skill",
+                    "service_path": skill.get("path") or skill.get("url") or "",
+                    "name": skill.get("skill_name") or skill.get("name") or "",
+                    "similarity_score": skill.get("relevance_score") or skill.get("score"),
+                }
+            )
+        exposed_results = candidate_results[:max_results]
 
         total_results = len(servers) + len(tools) + len(agents) + len(skills)
-        discovery_receipt = _build_discovery_receipt(
-            query=query,
-            limit=max_results,
-            exposed_tools=exposed_tools,
-            total_candidates=len(candidate_tools),
-            status="success",
-            stop_reason="results_returned" if total_results else "no_match",
-        )
-
-        return {
+        result = {
             "servers": servers,
             "tools": tools,
             "agents": agents,
             "skills": skills,
             "query": query,
             "total_results": total_results,
-            "discovery_receipt": discovery_receipt,
             "status": "success",
         }
+        if include_discovery_receipt:
+            result["discovery_receipt"] = _build_discovery_receipt(
+                query=query,
+                limit=max_results,
+                exposed_results=exposed_results,
+                total_candidates=len(candidate_results),
+                status="success",
+                stop_reason="results_returned" if total_results else "no_match",
+            )
+        return result
 
     except ValueError as e:
         logger.error(f"Validation error: {e}")
@@ -699,6 +721,7 @@ async def search_registry(
 async def intelligent_tool_finder(
     query: str,
     top_n: int = 5,
+    include_discovery_receipt: bool = False,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """
@@ -709,6 +732,7 @@ async def intelligent_tool_finder(
     Args:
         query: Natural language description of what you want to do
         top_n: Number of results to return (default: 5, max: 50)
+        include_discovery_receipt: Include compact eval metadata about exposed and withheld results
 
     Returns:
         Dictionary containing results, query, total_results, and status
@@ -765,22 +789,30 @@ async def intelligent_tool_finder(
         # Enforce client-side limit (safety net in case registry returns more)
         result_list = result_list[:top_n]
         exposed_tools = exposed_tools[:top_n]
-        discovery_receipt = _build_discovery_receipt(
-            query=query,
-            limit=top_n,
-            exposed_tools=exposed_tools,
-            total_candidates=total_candidates,
-            status="success",
-            stop_reason="results_returned" if result_list else "no_match",
-        )
-
-        return {
+        result = {
             "results": result_list,
             "query": query,
             "total_results": len(result_list),
-            "discovery_receipt": discovery_receipt,
             "status": "success",
         }
+        if include_discovery_receipt:
+            result["discovery_receipt"] = _build_discovery_receipt(
+                query=query,
+                limit=top_n,
+                exposed_results=[
+                    {
+                        "asset_type": "tool",
+                        "service_path": tool["service_path"],
+                        "name": tool["tool_name"],
+                        "similarity_score": tool["similarity_score"],
+                    }
+                    for tool in exposed_tools
+                ],
+                total_candidates=total_candidates,
+                status="success",
+                stop_reason="results_returned" if result_list else "no_match",
+            )
+        return result
 
     except ValueError as e:
         logger.error(f"Validation error: {e}")

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -626,9 +626,9 @@ async def search_registry(
         agents = data.get("agents", []) if isinstance(data, dict) else []
         skills = data.get("skills", []) if isinstance(data, dict) else []
 
-        exposed_tools = []
+        candidate_tools = []
         for tool in tools:
-            exposed_tools.append(
+            candidate_tools.append(
                 {
                     "service_path": tool.get("server_path") or tool.get("path") or "",
                     "tool_name": tool.get("tool_name") or tool.get("name") or "",
@@ -638,21 +638,21 @@ async def search_registry(
         for server in servers:
             server_path = server.get("path", "")
             for tool in server.get("matching_tools", []):
-                exposed_tools.append(
+                candidate_tools.append(
                     {
                         "service_path": server_path,
                         "tool_name": tool.get("tool_name", ""),
                         "similarity_score": tool.get("relevance_score"),
                     }
                 )
-        exposed_tools = exposed_tools[:max_results]
+        exposed_tools = candidate_tools[:max_results]
 
         total_results = len(servers) + len(tools) + len(agents) + len(skills)
         discovery_receipt = _build_discovery_receipt(
             query=query,
             limit=max_results,
             exposed_tools=exposed_tools,
-            total_candidates=max(total_results, len(exposed_tools)),
+            total_candidates=len(candidate_tools),
             status="success",
             stop_reason="results_returned" if total_results else "no_match",
         )

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -205,6 +205,35 @@ def _validate_query(query: str) -> str:
     return query.strip()
 
 
+def _build_discovery_receipt(
+    *,
+    query: str,
+    limit: int,
+    exposed_tools: list[dict[str, Any]],
+    total_candidates: int,
+    status: str,
+    stop_reason: str,
+) -> dict[str, Any]:
+    """Build a compact, privacy-safe receipt for dynamic discovery results.
+
+    The receipt deliberately records shapes/counts and ranking metadata rather
+    than raw tool arguments, tool outputs, or user data. It is returned with the
+    search response so callers can persist it in their own audit pipeline.
+    """
+    return {
+        "event": "tool.discovery_receipt",
+        "query": query,
+        "limits": {"max_results": limit},
+        "exposed_tools": exposed_tools,
+        "withheld": {
+            "candidate_tool_count": max(total_candidates - len(exposed_tools), 0),
+            "reason": "outside_intent_or_budget",
+        },
+        "status": status,
+        "stop_reason": stop_reason,
+    }
+
+
 def _extract_bearer_token(ctx: Context | None) -> str:
     """Extract bearer token from FastMCP context (legacy / no-OAuth mode).
 
@@ -597,13 +626,45 @@ async def search_registry(
         agents = data.get("agents", []) if isinstance(data, dict) else []
         skills = data.get("skills", []) if isinstance(data, dict) else []
 
+        exposed_tools = []
+        for tool in tools:
+            exposed_tools.append(
+                {
+                    "service_path": tool.get("server_path") or tool.get("path") or "",
+                    "tool_name": tool.get("tool_name") or tool.get("name") or "",
+                    "similarity_score": tool.get("relevance_score") or tool.get("score"),
+                }
+            )
+        for server in servers:
+            server_path = server.get("path", "")
+            for tool in server.get("matching_tools", []):
+                exposed_tools.append(
+                    {
+                        "service_path": server_path,
+                        "tool_name": tool.get("tool_name", ""),
+                        "similarity_score": tool.get("relevance_score"),
+                    }
+                )
+        exposed_tools = exposed_tools[:max_results]
+
+        total_results = len(servers) + len(tools) + len(agents) + len(skills)
+        discovery_receipt = _build_discovery_receipt(
+            query=query,
+            limit=max_results,
+            exposed_tools=exposed_tools,
+            total_candidates=max(total_results, len(exposed_tools)),
+            status="success",
+            stop_reason="results_returned" if total_results else "no_match",
+        )
+
         return {
             "servers": servers,
             "tools": tools,
             "agents": agents,
             "skills": skills,
             "query": query,
-            "total_results": len(servers) + len(tools) + len(agents) + len(skills),
+            "total_results": total_results,
+            "discovery_receipt": discovery_receipt,
             "status": "success",
         }
 
@@ -677,6 +738,7 @@ async def intelligent_tool_finder(
 
         # Flatten matching_tools from all servers into ToolSearchResult objects
         result_list = []
+        exposed_tools = []
         for server in servers:
             server_path = server.get("path", "")
             server_name = server.get("server_name", "")
@@ -690,14 +752,33 @@ async def intelligent_tool_finder(
                         path=server_path,
                     ).model_dump()
                 )
+                exposed_tools.append(
+                    {
+                        "service_path": server_path,
+                        "tool_name": tool.get("tool_name", ""),
+                        "similarity_score": tool.get("relevance_score"),
+                    }
+                )
+
+        total_candidates = len(result_list)
 
         # Enforce client-side limit (safety net in case registry returns more)
         result_list = result_list[:top_n]
+        exposed_tools = exposed_tools[:top_n]
+        discovery_receipt = _build_discovery_receipt(
+            query=query,
+            limit=top_n,
+            exposed_tools=exposed_tools,
+            total_candidates=total_candidates,
+            status="success",
+            stop_reason="results_returned" if result_list else "no_match",
+        )
 
         return {
             "results": result_list,
             "query": query,
             "total_results": len(result_list),
+            "discovery_receipt": discovery_receipt,
             "status": "success",
         }
 

--- a/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
+++ b/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
@@ -31,7 +31,11 @@ _mcpgw_path = str(Path(__file__).resolve().parents[4] / "servers" / "mcpgw")
 if _mcpgw_path not in sys.path:
     sys.path.insert(0, _mcpgw_path)
 
-from servers.mcpgw.server import _validate_top_n, intelligent_tool_finder
+from servers.mcpgw.server import (
+    _build_discovery_receipt,
+    _validate_top_n,
+    intelligent_tool_finder,
+)
 
 
 def _make_mock_response(servers=None, status_code=200):
@@ -222,3 +226,54 @@ async def test_total_results_matches_truncated_list():
 
     assert result["total_results"] == len(result["results"])
     assert result["total_results"] == 5
+
+
+# ---------------------------------------------------------------------------
+# test_discovery_receipt_records_exposed_and_withheld_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_receipt_records_exposed_and_withheld_tools():
+    """Receipt shows visible results and candidate tools kept out by top_n."""
+    server = _make_server_with_tools(4, server_name="server-a", path="/a")
+    mock_resp = _make_mock_response(servers=[server])
+
+    result = await _call_finder(mock_resp, query="weather lookup", top_n=2)
+
+    receipt = result["discovery_receipt"]
+    assert receipt["event"] == "tool.discovery_receipt"
+    assert receipt["query"] == "weather lookup"
+    assert receipt["limits"] == {"max_results": 2}
+    assert receipt["exposed_tools"] == [
+        {"service_path": "/a", "tool_name": "tool_0", "similarity_score": 1.0},
+        {"service_path": "/a", "tool_name": "tool_1", "similarity_score": 0.95},
+    ]
+    assert receipt["withheld"] == {
+        "candidate_tool_count": 2,
+        "reason": "outside_intent_or_budget",
+    }
+    assert receipt["stop_reason"] == "results_returned"
+
+
+# ---------------------------------------------------------------------------
+# test_discovery_receipt_helper_does_not_leak_payloads
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_receipt_helper_does_not_leak_payloads():
+    """Helper keeps receipts to query, counts, limits, scores, and status fields."""
+    receipt = _build_discovery_receipt(
+        query="find private customer records",
+        limit=1,
+        exposed_tools=[
+            {"service_path": "/crm", "tool_name": "search_customers", "similarity_score": 0.9}
+        ],
+        total_candidates=3,
+        status="success",
+        stop_reason="results_returned",
+    )
+
+    assert "raw_args" not in receipt
+    assert "raw_result" not in receipt
+    assert receipt["withheld"]["candidate_tool_count"] == 2

--- a/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
+++ b/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
@@ -89,7 +89,13 @@ async def _call_with_mocked_registry(tool_func, mock_response, capture=None, **k
     return result
 
 
-async def _call_finder(mock_response, query="test", top_n=None, capture=None):
+async def _call_finder(
+    mock_response,
+    query="test",
+    top_n=None,
+    capture=None,
+    include_discovery_receipt=False,
+):
     """Helper to call intelligent_tool_finder with mocked HTTP client and token.
 
     Args:
@@ -104,6 +110,8 @@ async def _call_finder(mock_response, query="test", top_n=None, capture=None):
     kwargs = {"query": query}
     if top_n is not None:
         kwargs["top_n"] = top_n
+    if include_discovery_receipt:
+        kwargs["include_discovery_receipt"] = True
     return await _call_with_mocked_registry(
         intelligent_tool_finder,
         mock_response,
@@ -112,7 +120,13 @@ async def _call_finder(mock_response, query="test", top_n=None, capture=None):
     )
 
 
-async def _call_search_registry(mock_response, query="test", max_results=10, capture=None):
+async def _call_search_registry(
+    mock_response,
+    query="test",
+    max_results=10,
+    capture=None,
+    include_discovery_receipt=False,
+):
     """Helper to call search_registry with mocked HTTP client and token."""
     return await _call_with_mocked_registry(
         search_registry,
@@ -120,6 +134,7 @@ async def _call_search_registry(mock_response, query="test", max_results=10, cap
         capture=capture,
         query=query,
         max_results=max_results,
+        include_discovery_receipt=include_discovery_receipt,
     )
 
 
@@ -257,25 +272,48 @@ async def test_total_results_matches_truncated_list():
 
 @pytest.mark.asyncio
 async def test_discovery_receipt_records_exposed_and_withheld_tools():
-    """Receipt shows visible results and candidate tools kept out by top_n."""
+    """Opt-in receipt shows visible results and candidates kept out by top_n."""
     server = _make_server_with_tools(4, server_name="server-a", path="/a")
     mock_resp = _make_mock_response(servers=[server])
 
-    result = await _call_finder(mock_resp, query="weather lookup", top_n=2)
+    result = await _call_finder(
+        mock_resp,
+        query="weather lookup",
+        top_n=2,
+        include_discovery_receipt=True,
+    )
 
     receipt = result["discovery_receipt"]
-    assert receipt["event"] == "tool.discovery_receipt"
+    assert receipt["event"] == "registry.discovery_receipt"
     assert receipt["query"] == "weather lookup"
     assert receipt["limits"] == {"max_results": 2}
-    assert receipt["exposed_tools"] == [
-        {"service_path": "/a", "tool_name": "tool_0", "similarity_score": 1.0},
-        {"service_path": "/a", "tool_name": "tool_1", "similarity_score": 0.95},
+    assert receipt["exposed_results"] == [
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_0", "similarity_score": 1.0},
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_1", "similarity_score": 0.95},
     ]
     assert receipt["withheld"] == {
-        "candidate_tool_count": 2,
+        "candidate_result_count": 2,
         "reason": "outside_intent_or_budget",
     }
     assert receipt["stop_reason"] == "results_returned"
+
+
+# ---------------------------------------------------------------------------
+# test_discovery_receipt_is_opt_in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_receipt_is_opt_in():
+    """Default responses stay backward-compatible without receipt tokens."""
+    server = _make_server_with_tools(1)
+    mock_resp = _make_mock_response(servers=[server])
+
+    finder_result = await _call_finder(mock_resp, top_n=1)
+    assert "discovery_receipt" not in finder_result
+
+    search_result = await _call_search_registry(mock_resp, max_results=1)
+    assert "discovery_receipt" not in search_result
 
 
 # ---------------------------------------------------------------------------
@@ -289,16 +327,21 @@ async def test_search_registry_receipt_counts_withheld_matching_tools():
     server = _make_server_with_tools(4, server_name="server-a", path="/a")
     mock_resp = _make_mock_response(servers=[server])
 
-    result = await _call_search_registry(mock_resp, query="weather lookup", max_results=2)
+    result = await _call_search_registry(
+        mock_resp,
+        query="weather lookup",
+        max_results=2,
+        include_discovery_receipt=True,
+    )
 
     receipt = result["discovery_receipt"]
     assert result["total_results"] == 1
-    assert receipt["exposed_tools"] == [
-        {"service_path": "/a", "tool_name": "tool_0", "similarity_score": 1.0},
-        {"service_path": "/a", "tool_name": "tool_1", "similarity_score": 0.95},
+    assert receipt["exposed_results"] == [
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_0", "similarity_score": 1.0},
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_1", "similarity_score": 0.95},
     ]
     assert receipt["withheld"] == {
-        "candidate_tool_count": 2,
+        "candidate_result_count": 2,
         "reason": "outside_intent_or_budget",
     }
 
@@ -323,12 +366,49 @@ async def test_search_registry_receipt_counts_top_level_tools():
         "skills": [],
     }
 
-    result = await _call_search_registry(mock_resp, query="weather lookup", max_results=2)
+    result = await _call_search_registry(
+        mock_resp,
+        query="weather lookup",
+        max_results=2,
+        include_discovery_receipt=True,
+    )
 
     receipt = result["discovery_receipt"]
     assert result["total_results"] == 3
-    assert len(receipt["exposed_tools"]) == 2
-    assert receipt["withheld"]["candidate_tool_count"] == 1
+    assert len(receipt["exposed_results"]) == 2
+    assert receipt["withheld"]["candidate_result_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_search_registry_receipt_counts_agents_and_skills
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_registry_receipt_counts_agents_and_skills():
+    """search_registry receipt accounts for agents and skills, not just tools."""
+    mock_resp = _make_mock_response()
+    mock_resp.json.return_value = {
+        "servers": [],
+        "tools": [{"server_path": "/a", "tool_name": "tool_0", "relevance_score": 1.0}],
+        "agents": [{"path": "/agent", "agent_name": "agent_0", "relevance_score": 0.9}],
+        "skills": [{"path": "/skill", "skill_name": "skill_0", "relevance_score": 0.8}],
+    }
+
+    result = await _call_search_registry(
+        mock_resp,
+        query="weather lookup",
+        max_results=2,
+        include_discovery_receipt=True,
+    )
+
+    receipt = result["discovery_receipt"]
+    assert result["total_results"] == 3
+    assert receipt["exposed_results"] == [
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_0", "similarity_score": 1.0},
+        {"asset_type": "agent", "service_path": "/agent", "name": "agent_0", "similarity_score": 0.9},
+    ]
+    assert receipt["withheld"]["candidate_result_count"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -341,8 +421,13 @@ def test_discovery_receipt_helper_does_not_leak_payloads():
     receipt = _build_discovery_receipt(
         query="find private customer records",
         limit=1,
-        exposed_tools=[
-            {"service_path": "/crm", "tool_name": "search_customers", "similarity_score": 0.9}
+        exposed_results=[
+            {
+                "asset_type": "tool",
+                "service_path": "/crm",
+                "name": "search_customers",
+                "similarity_score": 0.9,
+            }
         ],
         total_candidates=3,
         status="success",
@@ -351,4 +436,4 @@ def test_discovery_receipt_helper_does_not_leak_payloads():
 
     assert "raw_args" not in receipt
     assert "raw_result" not in receipt
-    assert receipt["withheld"]["candidate_tool_count"] == 2
+    assert receipt["withheld"]["candidate_result_count"] == 2

--- a/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
+++ b/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
@@ -35,6 +35,7 @@ from servers.mcpgw.server import (
     _build_discovery_receipt,
     _validate_top_n,
     intelligent_tool_finder,
+    search_registry,
 )
 
 
@@ -63,6 +64,31 @@ def _make_server_with_tools(n_tools, server_name="test-server", path="/test"):
     }
 
 
+async def _call_with_mocked_registry(tool_func, mock_response, capture=None, **kwargs):
+    """Call a registry search tool with mocked HTTP client and token."""
+    captured_kwargs = {}
+
+    async def mock_post(url, **post_kwargs):
+        captured_kwargs.update(post_kwargs)
+        return mock_response
+
+    mock_client = AsyncMock()
+    mock_client.post = mock_post
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("servers.mcpgw.server.httpx.AsyncClient", return_value=mock_client),
+        patch("servers.mcpgw.server._extract_bearer_token", return_value="test-token"),
+    ):
+        result = await tool_func(**kwargs)
+
+    if capture is not None:
+        capture.update(captured_kwargs)
+
+    return result
+
+
 async def _call_finder(mock_response, query="test", top_n=None, capture=None):
     """Helper to call intelligent_tool_finder with mocked HTTP client and token.
 
@@ -75,30 +101,26 @@ async def _call_finder(mock_response, query="test", top_n=None, capture=None):
     Returns:
         The result dict from intelligent_tool_finder.
     """
-    captured_kwargs = {}
+    kwargs = {"query": query}
+    if top_n is not None:
+        kwargs["top_n"] = top_n
+    return await _call_with_mocked_registry(
+        intelligent_tool_finder,
+        mock_response,
+        capture=capture,
+        **kwargs,
+    )
 
-    async def mock_post(url, **kwargs):
-        captured_kwargs.update(kwargs)
-        return mock_response
 
-    mock_client = AsyncMock()
-    mock_client.post = mock_post
-    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-    mock_client.__aexit__ = AsyncMock(return_value=False)
-
-    with (
-        patch("servers.mcpgw.server.httpx.AsyncClient", return_value=mock_client),
-        patch("servers.mcpgw.server._extract_bearer_token", return_value="test-token"),
-    ):
-        if top_n is not None:
-            result = await intelligent_tool_finder(query=query, top_n=top_n)
-        else:
-            result = await intelligent_tool_finder(query=query)
-
-    if capture is not None:
-        capture.update(captured_kwargs)
-
-    return result
+async def _call_search_registry(mock_response, query="test", max_results=10, capture=None):
+    """Helper to call search_registry with mocked HTTP client and token."""
+    return await _call_with_mocked_registry(
+        search_registry,
+        mock_response,
+        capture=capture,
+        query=query,
+        max_results=max_results,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -254,6 +276,59 @@ async def test_discovery_receipt_records_exposed_and_withheld_tools():
         "reason": "outside_intent_or_budget",
     }
     assert receipt["stop_reason"] == "results_returned"
+
+
+# ---------------------------------------------------------------------------
+# test_search_registry_receipt_counts_withheld_matching_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_registry_receipt_counts_withheld_matching_tools():
+    """search_registry receipt counts all matching tools, not just servers."""
+    server = _make_server_with_tools(4, server_name="server-a", path="/a")
+    mock_resp = _make_mock_response(servers=[server])
+
+    result = await _call_search_registry(mock_resp, query="weather lookup", max_results=2)
+
+    receipt = result["discovery_receipt"]
+    assert result["total_results"] == 1
+    assert receipt["exposed_tools"] == [
+        {"service_path": "/a", "tool_name": "tool_0", "similarity_score": 1.0},
+        {"service_path": "/a", "tool_name": "tool_1", "similarity_score": 0.95},
+    ]
+    assert receipt["withheld"] == {
+        "candidate_tool_count": 2,
+        "reason": "outside_intent_or_budget",
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_search_registry_receipt_counts_top_level_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_registry_receipt_counts_top_level_tools():
+    """search_registry receipt also handles top-level tool search results."""
+    mock_resp = _make_mock_response()
+    mock_resp.json.return_value = {
+        "servers": [],
+        "tools": [
+            {"server_path": "/a", "tool_name": "tool_0", "relevance_score": 1.0},
+            {"server_path": "/a", "tool_name": "tool_1", "relevance_score": 0.95},
+            {"server_path": "/b", "tool_name": "tool_2", "relevance_score": 0.9},
+        ],
+        "agents": [],
+        "skills": [],
+    }
+
+    result = await _call_search_registry(mock_resp, query="weather lookup", max_results=2)
+
+    receipt = result["discovery_receipt"]
+    assert result["total_results"] == 3
+    assert len(receipt["exposed_tools"]) == 2
+    assert receipt["withheld"]["candidate_tool_count"] == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a compact "Discovery Receipts and Context Budgets" section to the dynamic tool discovery docs. The section describes what operators should capture after dynamic tool discovery: query/correlation IDs, exposed tools, withheld candidates, invocation outcome, redacted argument/result shapes, and stop reason.

Why: dynamic discovery reduces upfront MCP/tool context bloat, but production and multi-tenant operators still need an audit-friendly way to review what the agent actually saw without copying raw payloads into logs.

## Checks

- `git diff --check`
- lightweight doc smoke verifying the new TOC anchor and JSON example are present

Docs-only change; I did not run the full app test suite.