### PR TITLE
fix(nginx): make NGINX_ENABLE_IPV6 patch templates so IPv6 listeners survive config re-render

### DIFF
--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -211,6 +211,33 @@ NGINX_TEMPLATE_HTTP_ONLY="/app/docker/nginx_rev_proxy_http_only.conf"
 NGINX_TEMPLATE_HTTP_AND_HTTPS="/app/docker/nginx_rev_proxy_http_and_https.conf"
 NGINX_CONFIG_PATH="/etc/nginx/conf.d/nginx_rev_proxy.conf"
 
+# Optionally add IPv6 listeners for IPv6-only / dual-stack clusters (opt-in).
+# The conf templates ship IPv4-only listen directives so they keep working on
+# IPv4-only hosts where binding [::] would fail. Operators on IPv6-only or
+# dual-stack Kubernetes clusters set NGINX_ENABLE_IPV6=true so the load
+# balancer and kubelet readiness probe can reach the pod over IPv6. This is
+# the nginx counterpart to the app's BIND_HOST=:: support.
+#
+# Patch the *templates*, not the rendered $NGINX_CONFIG_PATH: the registry
+# re-renders the active config from these templates at startup and on every
+# server change (see registry/core/nginx_service.py::_render_config_impl).
+# Patching the rendered file is overwritten by the first render, dropping the
+# IPv6 listeners. The grep guards keep this idempotent across restarts.
+if [ "${NGINX_ENABLE_IPV6:-false}" = "true" ]; then
+    echo "NGINX_ENABLE_IPV6=true: adding IPv6 listen directives to nginx templates..."
+    for nginx_template in "$NGINX_TEMPLATE_HTTP_ONLY" "$NGINX_TEMPLATE_HTTP_AND_HTTPS"; do
+        [ -f "$nginx_template" ] || continue
+        if ! grep -q 'listen \[::\]:8080;' "$nginx_template"; then
+            sed -i 's|listen 8080;|listen 8080;\
+    listen [::]:8080;|' "$nginx_template"
+        fi
+        if grep -q 'listen 8443 ssl;' "$nginx_template" && ! grep -q 'listen \[::\]:8443 ssl;' "$nginx_template"; then
+            sed -i 's|listen 8443 ssl;|listen 8443 ssl;\
+    listen [::]:8443 ssl;|' "$nginx_template"
+        fi
+    done
+fi
+
 # Check if SSL certificates exist and use appropriate config
 if [ ! -f "$SSL_CERT_PATH" ] || [ ! -f "$SSL_KEY_PATH" ]; then
     echo "Using HTTP-only Nginx configuration (no SSL certificates)..."
@@ -220,20 +247,6 @@ else
     echo "Using HTTP + HTTPS Nginx configuration (SSL certificates found)..."
     cp "$NGINX_TEMPLATE_HTTP_AND_HTTPS" "$NGINX_CONFIG_PATH"
     echo "HTTP + HTTPS Nginx configuration installed."
-fi
-
-# Optionally add IPv6 listeners for IPv6-only / dual-stack clusters (opt-in).
-# The conf templates ship IPv4-only listen directives so they keep working on
-# IPv4-only hosts where binding [::] would fail. Operators on IPv6-only or
-# dual-stack Kubernetes clusters set NGINX_ENABLE_IPV6=true so the load
-# balancer and kubelet readiness probe can reach the pod over IPv6. This is
-# the nginx counterpart to the app's BIND_HOST=:: support.
-if [ "${NGINX_ENABLE_IPV6:-false}" = "true" ]; then
-    echo "NGINX_ENABLE_IPV6=true: adding IPv6 listen directives to nginx config..."
-    sed -i 's|listen 8080;|listen 8080;\
-    listen [::]:8080;|' "$NGINX_CONFIG_PATH"
-    sed -i 's|listen 8443 ssl;|listen 8443 ssl;\
-    listen [::]:8443 ssl;|' "$NGINX_CONFIG_PATH"
 fi
 
 # --- Embeddings Configuration ---


### PR DESCRIPTION
## Description

`NGINX_ENABLE_IPV6=true` currently has no effect when the registry generates its own nginx config (default `with-gateway` / `REGISTRY_MODE=full`, and registry-only at startup). The entrypoint patches the **rendered** config file, but the app immediately re-renders that file from the nginx **templates**, wiping the IPv6 `listen [::]` directives. On IPv6-only / dual-stack Kubernetes clusters the ALB and kubelet probes then get `connection refused` and the pod CrashLoops.

Fixes #1204.

## Root cause

`docker/registry-entrypoint.sh` ran the IPv6 `sed` against `$NGINX_CONFIG_PATH` (`/etc/nginx/conf.d/nginx_rev_proxy.conf`). But `registry/core/nginx_service.py::_render_config_impl()` reads the template (`nginx_rev_proxy_http_only.conf` / `..._http_and_https.conf`) and `_atomic_write_text()` overwrites `$NGINX_CONFIG_PATH` at startup (`generate_config_async(force_base_config=True)`) and on every server change. The `listen` directives only ever originate from the templates, so patching the rendered file is always discarded.

## Fix

Patch the **template** files instead of the rendered config, so the IPv6 listeners are part of every subsequent render. Also:

- Run the patch before the template→config copy, so the first install already carries the listeners.
- `grep` guards make it idempotent across restarts.
- The `:8443 ssl` listener is only added to the template that actually has an SSL listener (HTTP+HTTPS), matching the previous behavior.

The `sed` substitution strings are unchanged from the existing implementation; only the target (templates vs rendered file) and the idempotency guards changed.

## Testing

- `sh -n docker/registry-entrypoint.sh` — passes.
- Ran the patch block under GNU sed against both real templates:
  - `nginx_rev_proxy_http_only.conf` → `listen [::]:8080;` added after `listen 8080;`; no `:8443` line (correct, no ssl listener).
  - `nginx_rev_proxy_http_and_https.conf` → both `listen [::]:8080;` and `listen [::]:8443 ssl;` added.
  - Idempotent: running twice yields exactly one of each directive.
- Verified the failure mode and fix on a live dual-stack EKS cluster: before, `/etc/nginx/conf.d/nginx_rev_proxy.conf` had only `listen 8080;` after the app's render (probes failing over IPv6); patching the templates makes the rendered config retain `listen [::]:8080;`.

Note: I couldn't run the full `./tests/run_all_tests.sh` suite locally (it needs a running stack with Keycloak/DocumentDB + generated credentials). Happy to iterate on any CI findings.

## Checklist

- [x] Working against the latest `main`
- [x] Change is focused on the specific fix
- [x] Opened an issue first (#1204)
- [x] Clear commit message
- [ ] ~~Full integration test suite run locally~~ (requires a live deployment; validated the mechanism on a dual-stack cluster + GNU-sed unit check)
