### PR TITLE
feat: Amazon Cognito support (Terraform/ECS, IAM manager, docs)

### DIFF
--- a/docs/cognito.md
+++ b/docs/cognito.md
@@ -2,6 +2,8 @@
 
 This comprehensive guide covers setting up Amazon Cognito for both user identity and agent identity authentication modes with the MCP Gateway Registry system.
 
+> **Looking for deployment wiring?** For how to point each deployment surface (Docker Compose, Terraform/ECS, Helm) at a Cognito User Pool, see [Amazon Cognito (Deployment Surfaces)](idp/cognito.md). This guide focuses on the Cognito console setup and the two agent authentication modes.
+
 ## Table of Contents
 
 1. [Overview](#overview)
@@ -18,7 +20,7 @@ The MCP Gateway Registry supports two distinct authentication modes:
 - **Agent Uses User Identity Mode**: Agents act on behalf of users using OAuth 2.0 PKCE flow with session cookies
 - **Agent Uses Its Own Identity Mode**: Agents have their own identity using Machine-to-Machine (M2M) authentication with JWT tokens
 
-Both modes integrate with Amazon Cognito as the Identity Provider (IdP) and use the same scope-based authorization system defined in [`auth_server/scopes.yml`](../auth_server/scopes.yml).
+Both modes integrate with Amazon Cognito as the Identity Provider (IdP) and use the same scope-based authorization system. Group-to-scope mappings and permissions are stored in DocumentDB and managed through the registry's IAM > Groups / Scopes UI; the auth server resolves a user's or agent's groups to scopes at validation time by querying DocumentDB.
 
 ## Amazon Cognito Setup
 
@@ -130,7 +132,7 @@ This setup is for agents that have their own identity and authenticate using cli
      - `read`: "Read access to all MCP servers"
      - `execute`: "Execute access to all MCP servers"
    - This group gives your agent access to all MCP servers and tools accessible via the MCP Gateway
-   - See [`auth_server/scopes.yml`](../auth_server/scopes.yml) file for more details on scope configuration
+   - The matching `mcp-servers-unrestricted` scope and its read/execute permissions are defined in the registry (DocumentDB), managed via the IAM > Groups / Scopes UI
 
 #### Step 3: Assign Scopes to Agent App Client
 
@@ -157,7 +159,7 @@ This mode enables agents to act on behalf of users, using their Cognito identity
 Ensure your Cognito User Pool is configured with:
 - **PKCE-enabled app client** (public client without secret)
 - **Hosted UI enabled** with appropriate callback URLs
-- **User groups** mapped to MCP scopes via [`scopes.yml`](../auth_server/scopes.yml)
+- **User groups** mapped to MCP scopes in the registry (DocumentDB), managed via the IAM > Groups / Scopes UI
 
 #### 2. OAuth 2.0 PKCE Flow Setup
 
@@ -339,8 +341,8 @@ python -c 'import secrets; print(secrets.token_hex(32))'
 
 **Problem**: Access denied errors despite valid authentication
 
-**Solution**: Verify scope mappings in [`scopes.yml`](../auth_server/scopes.yml):
-- Check group mappings match Cognito groups
+**Solution**: Verify the group-to-scope mappings in the registry (DocumentDB), via the IAM > Groups / Scopes UI:
+- Check group mappings match the Cognito group names exactly
 - Ensure server/tool permissions are correctly defined
 - Verify M2M client has required custom scopes
 
@@ -429,7 +431,7 @@ python cli_user_auth.py
 
 **Solution**:
 1. Check user's group membership in Cognito
-2. Verify group mappings in [`scopes.yml`](../auth_server/scopes.yml)
+2. Verify the group mappings in the registry (DocumentDB), via the IAM > Groups / Scopes UI
 3. For M2M, check client's assigned scopes in Cognito
 
 #### Error: `JWT token validation failed`
@@ -484,7 +486,7 @@ python agent.py --message "test" --mcp-registry-url http://localhost/mcpgw/sse
 
 ```bash
 # View auth server logs for validation details
-docker-compose logs -f auth-server
+docker compose logs -f auth-server
 
 # Look for:
 # - Token validation attempts
@@ -494,29 +496,20 @@ docker-compose logs -f auth-server
 
 #### Verify Scope Mappings
 
+Group-to-scope mappings live in DocumentDB, not in a local file. Inspect or edit them through the registry's **IAM > Groups / Scopes** UI, which shows each group, the scopes it maps to, and the resulting permissions.
+
+To confirm what scopes a login actually resolved to, check the auth server logs after a login or token validation; `map_groups_to_scopes()` logs the final mapped scopes:
+
 ```bash
-# Test scope mapping logic
-cd auth_server/
-python -c "
-import yaml
-from server import map_cognito_groups_to_scopes
-
-# Load scopes config
-with open('scopes.yml', 'r') as f:
-    config = yaml.safe_load(f)
-
-# Test group mapping
-groups = ['mcp-registry-user']
-scopes = map_cognito_groups_to_scopes(groups)
-print(f'Groups {groups} mapped to scopes: {scopes}')
-"
+docker compose logs -f auth-server | grep -i "mapped scopes"
 ```
 
 ## Related Documentation
 
 - [Main Authentication Guide](auth.md) - Overview of the authentication architecture
-- [Scopes Configuration](../auth_server/scopes.yml) - Detailed scope and permission definitions
-- [Environment Template](../.env.template) - Complete environment configuration template
+- [Amazon Cognito (Deployment Surfaces)](idp/cognito.md) - Wiring Cognito into Docker Compose, Terraform/ECS, and Helm
+- [Access Control & Scopes](scopes.md) - How group-to-scope mappings and permissions work (stored in DocumentDB)
+- [Environment Template](../.env.example) - Complete environment configuration template
 - [Agent Implementation](../agents/agent.py) - Reference agent implementation
 - [CLI Authentication Tool](../agents/cli_user_auth.py) - User authentication utility
 
@@ -535,13 +528,13 @@ This guide provides comprehensive coverage of Amazon Cognito setup for both auth
 
 After completing the Cognito setup and obtaining your client ID and secret, you need to configure the agent environment files to use these credentials.
 
-### Step 1: Copy Template to Environment File
+### Step 1: Create the Environment File
 
-Navigate to the `agents/` directory and copy the template file:
+The CLI authentication tool (`cli_user_auth.py`) loads its configuration from `agents/.env.user`. Create that file in the `agents/` directory:
 
 ```bash
 cd agents/
-cp .env.template .env.user
+touch .env.user
 ```
 
 ### Step 2: Configure Client Credentials

--- a/docs/idp/cognito.md
+++ b/docs/idp/cognito.md
@@ -112,13 +112,58 @@ terraform apply
 
 One Secrets Manager entry is created (`cognito_client_secret`) and the registry/auth-server tasks read it via `valueFrom` at boot. The plain (non-secret) values are wired as regular environment variables.
 
-### Step 4: Configure the App Client redirect URI
+### Step 4: Register the callback and sign-out URLs on the App Client (post-deployment)
 
-In the Cognito App Client, add the registry's callback URL as an allowed callback URL:
+Two separate URL lists on the App Client must be configured, and Cognito rejects any value not present in the matching list:
 
-- `https://<your-registry-domain>/oauth2/callback/cognito`
+- **Allowed callback URLs** — the auth-server sends `redirect_uri = <registry-external-url>/oauth2/callback/cognito` during login.
+- **Allowed sign-out URLs** — the auth-server sends `logout_uri = <registry-external-url>/login` during logout. This is easy to miss; if only the callback is registered, login works but logout fails with a Cognito error page (`Required String parameter 'redirect_uri' is not present` or a sign-out URL mismatch).
 
-This must match the auth-server's external URL, which Terraform sets from your `domain_name`.
+The registry does NOT configure Cognito for you (it is bring-your-own), so this is a manual step.
+
+When you use a custom domain (`enable_route53_dns = true`), you know the registry URL up front and can register both URLs before deploying. When you use CloudFront-only mode (`enable_cloudfront = true`, no custom domain), the registry domain is the CloudFront distribution domain, which is not known until after `terraform apply` — so this step must happen AFTER the first apply.
+
+1. Get the registry's external URL from the Terraform output:
+
+   ```bash
+   terraform output cloudfront_mcp_gateway_url
+   # e.g. https://d2xl2zfuhgc4l0.cloudfront.net
+   ```
+
+   For a custom-domain deployment it is `https://<your-registry-domain>` instead.
+
+2. On the App Client, set:
+   - **Allowed callback URLs:** `<that URL>/oauth2/callback/cognito`
+   - **Allowed sign-out URLs:** `<that URL>/login`
+
+   **From the AWS console:**
+   - Open the Cognito console, select your User Pool.
+   - Go to **App integration** -> **App clients** -> select your app client.
+   - Under **Hosted UI** (or **Login pages**), click **Edit**.
+   - Add the callback URL to **Allowed callback URLs** and the `/login` URL to **Allowed sign-out URLs** (keep any existing entries, e.g. the localhost ones for local testing), then **Save changes**.
+
+   **From the CLI** (note: `update-user-pool-client` replaces the full lists, so include every URL you want to keep):
+
+   ```bash
+   aws cognito-idp update-user-pool-client \
+     --user-pool-id "<your-user-pool-id>" \
+     --client-id "<your-app-client-id>" \
+     --region "<your-region>" \
+     --callback-urls \
+       "https://<your-registry-domain>/oauth2/callback/cognito" \
+       "http://localhost:8888/oauth2/callback/cognito" \
+     --logout-urls \
+       "https://<your-registry-domain>/login" \
+       "http://localhost:8888/login" \
+     --allowed-o-auth-flows code \
+     --allowed-o-auth-scopes openid email profile aws.cognito.signin.user.admin \
+     --allowed-o-auth-flows-user-pool-client \
+     --supported-identity-providers COGNITO
+   ```
+
+   Updating these URLs is a Cognito-side change only; it takes effect immediately and does NOT require redeploying the stack.
+
+> **CloudFront domain changes on recreate.** The callback and sign-out URLs you register here are fixed strings stored on the App Client; nothing in Terraform manages them. If a later `terraform apply` recreates the CloudFront distribution, its domain changes, the auth-server starts sending the new domain in `redirect_uri` / `logout_uri`, and login or logout fails until you re-register the new URLs (repeat this step). For a stable configuration that never drifts, use a custom domain (`enable_route53_dns = true`) instead of CloudFront-only mode.
 
 ## Mode 3: Helm / Kubernetes (BYO Cognito)
 
@@ -161,9 +206,9 @@ helm install mcp-gateway-registry charts/mcp-gateway-registry-stack \
   -f values.yaml
 ```
 
-### Step 5: Configure the App Client redirect URI
+### Step 5: Register the registry callback URL on the App Client
 
-Add `https://<your-registry-domain>/oauth2/callback/cognito` as an allowed callback URL on the Cognito App Client.
+Add `https://<your-registry-domain>/oauth2/callback/cognito` to the App Client's allowed callback URLs (console or `aws cognito-idp update-user-pool-client`, exactly as in [Mode 2, Step 4](#step-4-register-the-registry-callback-url-on-the-app-client-post-deployment)). On Helm the registry domain is your ingress host, so it is known up front; register it before or right after install. It must match what the auth-server sends (`<registry-external-url>/oauth2/callback/cognito`).
 
 ## Console Configuration
 
@@ -189,9 +234,51 @@ These are the one-time steps you must perform in the AWS Cognito console. They a
 
 You do NOT configure OAuth scopes or a resource server in Cognito for this. The only thing Cognito contributes is group membership; the actual permissions are defined in the registry. See [How groups map to access](#how-groups-map-to-access) below for the full model.
 
-1. In the User Pool, create the **groups** your users will belong to. Use the same names the registry expects, e.g. `mcp-registry-admin` (built-in admin) and a non-admin group such as `public-mcp-users`.
+1. In the User Pool, create the **groups** your users will belong to. Use the same names the registry expects, e.g. `registry-admins` (admin) and a non-admin group such as `public-mcp-users`.
 2. Assign users to those groups. Cognito places group memberships in the `cognito:groups` claim of the ID token.
 3. Make sure a matching group mapping exists in the registry (next section). The group name in Cognito is the contract: it must match a group mapping in the registry exactly.
+
+**From the AWS console:** User Pool -> **Groups** -> **Create group** for each name; then User Pool -> **Users** -> select a user -> **Add to group**.
+
+**From the CLI** (replace `<pool-id>` and `<region>`):
+
+```bash
+POOL=<pool-id>
+REGION=<region>
+
+# Create the groups
+aws cognito-idp create-group --group-name registry-admins \
+  --user-pool-id "$POOL" --region "$REGION" \
+  --description "Registry admins"
+aws cognito-idp create-group --group-name public-mcp-users \
+  --user-pool-id "$POOL" --region "$REGION" \
+  --description "General read-only users"
+
+# Create an admin user and a test user (email as username; no invite email)
+aws cognito-idp admin-create-user --user-pool-id "$POOL" --region "$REGION" \
+  --username admin@example.com \
+  --user-attributes Name=email,Value=admin@example.com Name=email_verified,Value=true \
+  --message-action SUPPRESS
+aws cognito-idp admin-create-user --user-pool-id "$POOL" --region "$REGION" \
+  --username testuser@example.com \
+  --user-attributes Name=email,Value=testuser@example.com Name=email_verified,Value=true \
+  --message-action SUPPRESS
+
+# Set permanent passwords so the users can log in immediately
+# (requires the cognito-idp:AdminSetUserPassword permission)
+aws cognito-idp admin-set-user-password --user-pool-id "$POOL" --region "$REGION" \
+  --username admin@example.com --password '<admin-password>' --permanent
+aws cognito-idp admin-set-user-password --user-pool-id "$POOL" --region "$REGION" \
+  --username testuser@example.com --password '<test-password>' --permanent
+
+# Assign each user to its group
+aws cognito-idp admin-add-user-to-group --user-pool-id "$POOL" --region "$REGION" \
+  --username admin@example.com --group-name registry-admins
+aws cognito-idp admin-add-user-to-group --user-pool-id "$POOL" --region "$REGION" \
+  --username testuser@example.com --group-name public-mcp-users
+```
+
+> A freshly created user without `admin-set-user-password --permanent` stays in `FORCE_CHANGE_PASSWORD` status and cannot sign in through the hosted UI sign-in form. If your principal lacks `cognito-idp:AdminSetUserPassword`, set the password from the console instead (Users -> select user -> **Actions -> Set password**, mark as Permanent), or have the user complete the forgot-password flow.
 
 ### 4. (Optional) Custom hosted UI domain
 
@@ -214,13 +301,34 @@ This is the same groups-to-scopes path used by every other IdP (Keycloak, Entra,
 
 So to set up, for example, an admin group and a general-user group:
 
-1. In Cognito, create groups `mcp-registry-admin` and `public-mcp-users`, and assign users.
-2. In the registry's IAM > Groups / Scopes UI (backed by DocumentDB), make sure a group mapping exists for each of those exact names with the scopes you want. `mcp-registry-admin` is the built-in admin scope; `public-mcp-users` (or any name you choose) is whatever read-only/limited scope set you define.
+1. In Cognito, create groups `registry-admins` and `public-mcp-users`, and assign users (see the CLI/console commands in [Create groups](#3-create-groups-not-scopes) above).
+2. In the registry's IAM > Groups / Scopes UI (backed by DocumentDB), make sure a group mapping exists for each of those exact names with the scopes you want. `registry-admins` maps to the admin scope; `public-mcp-users` (or any name you choose) is whatever read-only/limited scope set you define.
 3. Nothing else is configured in Cognito: no resource server, no custom OAuth scopes, no scope-to-group rules.
 
 If a Cognito group name has no matching mapping in DocumentDB, that group simply contributes no scopes (the user may end up with no access). The group names must match exactly.
 
 For agents that authenticate with their own identity (M2M / client credentials), see the agent-identity section in [docs/cognito.md](../cognito.md).
+
+## Seeding the group-to-scope mappings in DocumentDB
+
+The registry reads group-to-scope mappings from DocumentDB at validation time; it does NOT auto-seed them from `scopes.yml` on startup. So a fresh DocumentDB has no mappings, with one exception: the deployment's database-init step seeds a single bootstrap admin group named **`registry-admins`** (mapped to full admin: all servers, all tools, all agent actions). This is what lets the first admin log in and then manage everything else from the UI.
+
+How the bootstrap admin group gets seeded per surface:
+
+- **Terraform / ECS:** run the DocumentDB init task once after the stack is up. It runs `init-documentdb-indexes.py` inside an ECS task (which has VPC access to the cluster) and loads the default `registry-admins` admin scope:
+
+  ```bash
+  ./terraform/aws-ecs/scripts/run-documentdb-init.sh
+  ```
+
+- **Helm:** the `mongodb-configure` Job seeds `registry-admins` automatically on install.
+- **Docker Compose:** the database-init step seeds `registry-admins` as part of `build_and_run.sh`.
+
+This is why the admin group in the examples above is named `registry-admins`: it matches the seeded DocumentDB mapping. Point your Cognito admin group at that exact name and the first admin gets full access with no extra DocumentDB work.
+
+Every OTHER group (for example `public-mcp-users`) is NOT seeded. After the admin logs in, create those mappings through the registry's **IAM > Groups / Scopes** UI, using the same names as the Cognito groups. There is no separate init script to write — the bootstrap task plus the UI cover it. The model is: seed `registry-admins` via the init step, then create all other groups in the UI.
+
+> **Cognito IAM management in the UI is read-only.** The registry's IAM > Groups / Users pages can *list* Cognito groups and users, but cannot create or delete Cognito groups/users from the UI yet (the registry task role is granted only `cognito-idp:ListGroups`, `ListUsers`, and `AdminListGroupsForUser`). Create the Cognito groups and assign users via the AWS console or `aws cognito-idp ...` (see [Create groups](#3-create-groups-not-scopes)). The registry IAM UI is still where you define each group's **scopes/permissions** in DocumentDB — that part works normally. In short: define the group's membership in Cognito, define the group's scopes in the registry UI.
 
 ## Troubleshooting
 
@@ -230,11 +338,30 @@ For agents that authenticate with their own identity (M2M / client credentials),
 
 **Fix:** The callback URL registered on the App Client must exactly match `<protocol>://<auth-server-host>/oauth2/callback/cognito`. Confirm the protocol (http vs https), the host, and the path. On Terraform/ECS and Helm the host is your registry domain; on local Docker Compose it is `http://localhost:8888`.
 
+A common cause on Terraform/ECS CloudFront-only deployments: a `terraform apply` recreated the CloudFront distribution, so the registry domain changed but the App Client's callback URL still points at the old domain. Re-run `terraform output cloudfront_mcp_gateway_url` and re-register the new callback URL on the App Client (see [Mode 2, Step 4](#step-4-register-the-callback-and-sign-out-urls-on-the-app-client-post-deployment)).
+
+### Logout fails with a Cognito error page
+
+**Symptom:** Login works, but clicking logout lands on a Cognito error page (e.g. `Required String parameter 'redirect_uri' is not present`), with a URL like `.../error?...&logout_uri=https%3A%2F%2F<domain>%2Flogin`.
+
+**Fix:** The App Client's **Allowed sign-out URLs** must include `<registry-external-url>/login` — this is a separate list from the callback URLs, and is easy to miss. The auth-server sends `logout_uri = <registry-external-url>/login` on logout; Cognito rejects it if it is not registered. Add it (see [Mode 2, Step 4](#step-4-register-the-callback-and-sign-out-urls-on-the-app-client-post-deployment)). The `logout_uri` echoed in the error page URL is the value Cognito rejected, not a separate problem.
+
 ### Empty groups after login
 
 **Symptom:** The user logs in but has no permissions.
 
 **Fix:** Confirm the user is assigned to at least one Cognito group, and that a group mapping with that exact name exists in the registry's DocumentDB (IAM > Groups / Scopes UI). Cognito only emits `cognito:groups` for groups the user actually belongs to, and a group with no DocumentDB mapping contributes no scopes.
+
+If even your admin user has no permissions, the bootstrap admin mapping was likely never seeded into DocumentDB. Run the database-init step for your surface (see [Seeding the group-to-scope mappings in DocumentDB](#seeding-the-group-to-scope-mappings-in-documentdb)) — on Terraform/ECS that is `./terraform/aws-ecs/scripts/run-documentdb-init.sh` — and make sure your Cognito admin group is named `registry-admins` to match the seeded mapping.
+
+### "Unable to list IAM groups" on the IAM pages
+
+**Symptom:** Login works, but the **Settings -> IAM -> Groups** (or Users) page shows `Unable to list IAM groups` (HTTP 502).
+
+**Fix:** This is a server-side failure listing groups from Cognito. Check two things:
+
+1. **Registry version** must include the Cognito IAM manager. Older builds had no Cognito case in the IAM manager factory and silently fell back to the Keycloak manager, which fails against a Cognito deployment. Confirm the registry image is recent enough to support `AUTH_PROVIDER=cognito` for IAM listing.
+2. **Task role permissions.** The registry task role must allow `cognito-idp:ListGroups`, `cognito-idp:ListUsers`, and `cognito-idp:AdminListGroupsForUser` on the User Pool. On Terraform/ECS this is wired automatically when `cognito_enabled = true`; if you deployed before that wiring existed, re-apply so the `cognito_iam_read` policy is attached. Check the registry logs for an `AccessDenied` from `cognito-idp` to confirm.
 
 ### Wrong region / token validation failure
 

--- a/docs/idp/cognito.md
+++ b/docs/idp/cognito.md
@@ -1,0 +1,249 @@
+# Amazon Cognito Setup Guide
+
+This guide walks through configuring Amazon Cognito as the identity provider for the MCP Gateway Registry across all three deployment surfaces.
+
+Cognito is an AWS-managed service, so unlike the bundled PingFederate dev container there is no mode where the registry runs Cognito for you. In every mode you bring your own Cognito User Pool and App Client and supply their values via configuration. The application code is identical across all three modes; only the deployment surface differs.
+
+This guide covers the deployment wiring. For the step-by-step Cognito console walkthrough (creating the User Pool, App Client, groups, and users, including the agent-identity M2M setup), see [docs/cognito.md](../cognito.md).
+
+## Prerequisites
+
+- An AWS account with permission to create and manage a Cognito User Pool.
+- A Cognito User Pool with an App Client configured for the OAuth Authorization Code flow. See [Console Configuration](#console-configuration) below; this part is the same regardless of deployment mode.
+- The App Client must have a client secret (the registry uses a confidential client).
+
+## Variable reference
+
+The same set of variables is set across all three deployment modes; only the file you edit and the variable name casing differ. Every variable maps 1:1 across surfaces.
+
+| What it is | `.env` (Docker Compose) | Terraform variable | Helm value |
+|---|---|---|---|
+| Active provider switch | `AUTH_PROVIDER=cognito` | `cognito_enabled = true` (no `auth_provider` variable; see note) | `global.authProvider.type: cognito` |
+| Show login button | `COGNITO_ENABLED=true` | `cognito_enabled = true` | `cognito.enabled` is implied by `authProvider.type` |
+| User Pool ID | `COGNITO_USER_POOL_ID` | `cognito_user_pool_id` | `cognito.userPoolId` |
+| App Client (web login) ID | `COGNITO_CLIENT_ID` | `cognito_client_id` | `cognito.clientId` |
+| App Client secret (web login, **secret**) | `COGNITO_CLIENT_SECRET` | `cognito_client_secret` | `cognito.clientSecret` |
+| Hosted UI domain (optional) | `COGNITO_DOMAIN` | `cognito_domain` | `cognito.domain` |
+| AWS region of the User Pool | `AWS_REGION` | `AWS_REGION` (provider/region, injected automatically) | `cognito.region` |
+
+Note on the provider switch: Docker (`AUTH_PROVIDER`) and Helm (`authProvider.type`) take a provider-name string. The Terraform module has no `auth_provider` variable; you enable exactly one provider by setting its boolean `*_enabled` flag to true (leave the others false), and the module derives the `AUTH_PROVIDER` value for the containers. If you enable none, Keycloak is the default. So for Terraform, `cognito_enabled = true` is the only switch needed.
+
+Note on the domain: `COGNITO_DOMAIN` is optional. When left empty, the auth-server derives the hosted UI domain from the User Pool ID, as `https://<pool-id-without-underscore>.auth.<region>.amazoncognito.com`. Set it only if you configured a custom hosted UI domain prefix.
+
+Note on the region: Cognito needs the AWS region to build the issuer and JWKS URLs. `AWS_REGION` is already injected into the registry and auth-server containers on the Terraform surface, so there is no separate Cognito region variable there.
+
+The "secret" row must be sourced from a secrets store in production (AWS Secrets Manager for Terraform, a Kubernetes Secret for Helm). Don't paste the client secret into `terraform.tfvars` or `values.yaml` checked into git.
+
+For full cross-surface parameter reference, see [docs/unified-parameter-reference.md](../unified-parameter-reference.md).
+
+## Mode 1: Docker Compose (BYO Cognito)
+
+There is no bundled Cognito container. Create the User Pool and App Client in the AWS console first (see [Console Configuration](#console-configuration)), then point the registry at them.
+
+### Step 1: Set Cognito config in `.env`
+
+```bash
+# Tell the registry to use Cognito
+AUTH_PROVIDER=cognito
+COGNITO_ENABLED=true
+
+# User Pool and App Client created in the Cognito console
+COGNITO_USER_POOL_ID=us-east-1_XXXXXXXXX
+COGNITO_CLIENT_ID=your_cognito_client_id_here
+COGNITO_CLIENT_SECRET=your_cognito_client_secret_here
+
+# Region of the User Pool
+AWS_REGION=us-east-1
+
+# Optional: only if you set a custom hosted UI domain prefix
+# COGNITO_DOMAIN=your-custom-domain
+```
+
+### Step 2: Configure the App Client redirect URI
+
+In the Cognito App Client, add the registry's callback URL as an allowed callback URL:
+
+- Local Docker Compose: `http://localhost:8888/oauth2/callback/cognito`
+- Production: `https://your-gateway.example.com/oauth2/callback/cognito`
+
+### Step 3: Start the stack
+
+```bash
+docker compose up -d
+```
+
+Log in to the registry and you will be redirected to the Cognito hosted UI. After login, groups come from the `cognito:groups` claim in the ID token.
+
+## Mode 2: Terraform / AWS ECS (BYO Cognito)
+
+The Terraform module does NOT create the Cognito User Pool. You create the User Pool and App Client (in the console, or via separate Terraform/IaC you manage), and the module wires those values into the registry and auth-server task definitions, with the client secret stored in AWS Secrets Manager.
+
+### Step 1: Create the User Pool and App Client
+
+Follow [Console Configuration](#console-configuration) below. Note the User Pool ID, App Client ID, App Client secret, and the region.
+
+### Step 2: Set the variables in `terraform.tfvars`
+
+Use a separate non-committed `*.auto.tfvars` file (e.g. `secrets.auto.tfvars`) for the secret value, OR populate the AWS Secrets Manager secret value out-of-band via `aws secretsmanager update-secret` after `terraform apply` — the secret resource has `lifecycle { ignore_changes = [secret_string] }` so future plans won't drift.
+
+Note: the Terraform module has no `auth_provider` variable (that name is the Docker `.env` / Helm `values.yaml` switch). On this surface the provider is selected by the boolean flag below; setting `cognito_enabled = true` is what makes the module emit `AUTH_PROVIDER=cognito` to the containers.
+
+```hcl
+# terraform.tfvars
+cognito_enabled       = true
+
+# User Pool and App Client
+cognito_user_pool_id  = "us-east-1_XXXXXXXXX"
+cognito_client_id     = "your_cognito_client_id_here"
+cognito_client_secret = "<set in secrets.auto.tfvars or via aws secretsmanager>"
+
+# Optional: only if you set a custom hosted UI domain prefix
+# cognito_domain      = "your-custom-domain"
+```
+
+The User Pool's region is taken from the module's AWS region, which is already injected into both containers as `AWS_REGION`, so there is no separate Cognito region variable.
+
+### Step 3: Apply
+
+```bash
+terraform plan
+terraform apply
+```
+
+One Secrets Manager entry is created (`cognito_client_secret`) and the registry/auth-server tasks read it via `valueFrom` at boot. The plain (non-secret) values are wired as regular environment variables.
+
+### Step 4: Configure the App Client redirect URI
+
+In the Cognito App Client, add the registry's callback URL as an allowed callback URL:
+
+- `https://<your-registry-domain>/oauth2/callback/cognito`
+
+This must match the auth-server's external URL, which Terraform sets from your `domain_name`.
+
+## Mode 3: Helm / Kubernetes (BYO Cognito)
+
+The Helm chart does NOT create a Cognito User Pool. You bring your own User Pool and App Client and supply their endpoint and credentials.
+
+### Step 1: Create the User Pool and App Client
+
+Same as the Terraform mode — follow [Console Configuration](#console-configuration) once in the AWS console.
+
+### Step 2: Create the Kubernetes secret (recommended for production)
+
+```bash
+kubectl create secret generic cognito-credentials \
+  --from-literal=COGNITO_CLIENT_SECRET='<your client secret>'
+```
+
+### Step 3: Configure values
+
+```yaml
+# values.yaml override
+global:
+  authProvider:
+    type: cognito
+
+cognito:
+  userPoolId: "us-east-1_XXXXXXXXX"
+  clientId: "your_cognito_client_id_here"
+  clientSecret: "your_cognito_client_secret_here"  # or reference an existing secret
+  region: "us-east-1"
+  # domain: "your-custom-domain"   # optional; derived from userPoolId if unset
+```
+
+For the umbrella stack chart (`charts/mcp-gateway-registry-stack`), the same keys live under both `registry:` and `auth-server:` stanzas, since both services read the Cognito configuration.
+
+### Step 4: Install
+
+```bash
+helm install mcp-gateway-registry charts/mcp-gateway-registry-stack \
+  --namespace mcp-gateway --create-namespace \
+  -f values.yaml
+```
+
+### Step 5: Configure the App Client redirect URI
+
+Add `https://<your-registry-domain>/oauth2/callback/cognito` as an allowed callback URL on the Cognito App Client.
+
+## Console Configuration
+
+These are the one-time steps you must perform in the AWS Cognito console. They are the same across all three deployment modes. For the full walkthrough with screenshots and the agent-identity (M2M) setup, see [docs/cognito.md](../cognito.md).
+
+### 1. Create the User Pool
+
+1. Open the [Amazon Cognito console](https://console.aws.amazon.com/cognito/) and select your region.
+2. Create a User Pool with email (and optionally username) as the sign-in identifier.
+3. Note the **User Pool ID** (e.g. `us-east-1_XXXXXXXXX`).
+
+### 2. Create the App Client
+
+1. Under the User Pool, create an App Client of type "Traditional Web App" (confidential client).
+2. Enable **Authorization code grant** and the `openid`, `email`, and `profile` scopes.
+3. Generate a **client secret** and save it into your secret store.
+4. Add the registry callback URL as an allowed callback URL:
+   - Local Docker Compose: `http://localhost:8888/oauth2/callback/cognito`
+   - Production: `https://your-gateway.example.com/oauth2/callback/cognito`
+5. Note the **App Client ID** and **client secret**.
+
+### 3. Create groups (not scopes)
+
+You do NOT configure OAuth scopes or a resource server in Cognito for this. The only thing Cognito contributes is group membership; the actual permissions are defined in the registry. See [How groups map to access](#how-groups-map-to-access) below for the full model.
+
+1. In the User Pool, create the **groups** your users will belong to. Use the same names the registry expects, e.g. `mcp-registry-admin` (built-in admin) and a non-admin group such as `public-mcp-users`.
+2. Assign users to those groups. Cognito places group memberships in the `cognito:groups` claim of the ID token.
+3. Make sure a matching group mapping exists in the registry (next section). The group name in Cognito is the contract: it must match a group mapping in the registry exactly.
+
+### 4. (Optional) Custom hosted UI domain
+
+If you want a friendly hosted UI domain, configure a domain prefix on the User Pool and set `COGNITO_DOMAIN` (or `cognito_domain` / `cognito.domain`). If you skip this, the registry derives the default `amazoncognito.com` domain from the User Pool ID automatically.
+
+## How groups map to access
+
+There is nothing to configure on the Cognito side beyond groups. Cognito does not own scopes or permissions for the registry; it only owns which groups a user belongs to. The split is:
+
+- **Cognito owns** the group-to-user assignment. At login, Cognito emits the user's groups in the `cognito:groups` claim of the ID token.
+- **The registry owns** the group-to-scope mapping, stored in **DocumentDB** (managed through the registry's **IAM > Groups / Scopes** UI). There is no scopes file to edit on this path: the auth-server's `map_groups_to_scopes()` queries DocumentDB directly for each group's scopes.
+
+The flow at login:
+
+1. Cognito returns the user's groups in `cognito:groups` (configured as `groups_claim: "cognito:groups"` in `auth_server/oauth2_providers.yml`).
+2. The auth-server looks up each group name in DocumentDB and collects the mapped scopes.
+3. Those scopes drive what the user can see and do (including agent visibility filtering and MCP server/tool access).
+
+This is the same groups-to-scopes path used by every other IdP (Keycloak, Entra, Okta, Auth0, PingFederate); only the claim name differs (`cognito:groups` instead of `groups`). No Cognito-specific mapping logic is involved.
+
+So to set up, for example, an admin group and a general-user group:
+
+1. In Cognito, create groups `mcp-registry-admin` and `public-mcp-users`, and assign users.
+2. In the registry's IAM > Groups / Scopes UI (backed by DocumentDB), make sure a group mapping exists for each of those exact names with the scopes you want. `mcp-registry-admin` is the built-in admin scope; `public-mcp-users` (or any name you choose) is whatever read-only/limited scope set you define.
+3. Nothing else is configured in Cognito: no resource server, no custom OAuth scopes, no scope-to-group rules.
+
+If a Cognito group name has no matching mapping in DocumentDB, that group simply contributes no scopes (the user may end up with no access). The group names must match exactly.
+
+For agents that authenticate with their own identity (M2M / client credentials), see the agent-identity section in [docs/cognito.md](../cognito.md).
+
+## Troubleshooting
+
+### Redirect URI mismatch
+
+**Symptom:** Cognito returns `redirect_mismatch` or an error page after login.
+
+**Fix:** The callback URL registered on the App Client must exactly match `<protocol>://<auth-server-host>/oauth2/callback/cognito`. Confirm the protocol (http vs https), the host, and the path. On Terraform/ECS and Helm the host is your registry domain; on local Docker Compose it is `http://localhost:8888`.
+
+### Empty groups after login
+
+**Symptom:** The user logs in but has no permissions.
+
+**Fix:** Confirm the user is assigned to at least one Cognito group, and that a group mapping with that exact name exists in the registry's DocumentDB (IAM > Groups / Scopes UI). Cognito only emits `cognito:groups` for groups the user actually belongs to, and a group with no DocumentDB mapping contributes no scopes.
+
+### Wrong region / token validation failure
+
+**Symptom:** Auth-server logs show JWKS fetch failures or issuer mismatch.
+
+**Fix:** `AWS_REGION` must match the region of the User Pool. The issuer and JWKS URLs are built from the region and User Pool ID; a region mismatch makes token validation fail.
+
+### Hosted UI domain not found
+
+**Symptom:** The login redirect lands on a non-existent `amazoncognito.com` domain.
+
+**Fix:** Either configure a hosted UI domain on the User Pool and set `COGNITO_DOMAIN`, or leave `COGNITO_DOMAIN` empty so the registry derives the default domain from the User Pool ID. A custom domain prefix that was never created in Cognito will 404.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ nav:
     - Registry API Authentication: registry-api-auth.md
     - IAM Settings UI: iam-settings-ui.md
     - Amazon Cognito Setup: cognito.md
+    - Amazon Cognito (Deployment Surfaces): idp/cognito.md
     - PingFederate Setup: idp/pingfederate.md
     - Access Control & Scopes: scopes.md
     - JWT Token Vending: jwt-token-vending.md

--- a/registry/utils/cognito_manager.py
+++ b/registry/utils/cognito_manager.py
@@ -1,0 +1,188 @@
+"""
+Amazon Cognito IAM helper functions.
+
+Read-only group and user listing against a Cognito User Pool, used by the
+CognitoIAMManager. Cognito's boto3 client is synchronous, so each call is run
+in a worker thread to keep the public interface async and non-blocking.
+
+Write operations (create/delete group, create user, etc.) are intentionally
+not implemented here yet; see CognitoIAMManager for the supported surface.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import boto3
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+# Cognito caps these list calls at 60 per page; paginate to get everything.
+_MAX_PAGE_SIZE: int = 60
+
+
+def _get_region() -> str:
+    """Return the AWS region for the Cognito User Pool."""
+    return os.environ.get("AWS_REGION", "us-east-1")
+
+
+def _get_user_pool_id() -> str:
+    """Return the configured Cognito User Pool ID.
+
+    Raises:
+        ValueError: If COGNITO_USER_POOL_ID is not set.
+    """
+    pool_id = os.environ.get("COGNITO_USER_POOL_ID")
+    if not pool_id:
+        raise ValueError("COGNITO_USER_POOL_ID is not set; cannot manage Cognito IAM")
+    return pool_id
+
+
+def _get_client() -> Any:
+    """Create a boto3 cognito-idp client for the configured region."""
+    return boto3.client("cognito-idp", region_name=_get_region())
+
+
+def _extract_email(
+    attributes: list[dict[str, str]],
+) -> str | None:
+    """Pull the email value out of a Cognito user's attribute list."""
+    for attr in attributes:
+        if attr.get("Name") == "email":
+            return attr.get("Value")
+    return None
+
+
+def _list_groups_sync() -> list[dict[str, Any]]:
+    """List all groups in the User Pool (synchronous, paginated)."""
+    client = _get_client()
+    pool_id = _get_user_pool_id()
+
+    groups: list[dict[str, Any]] = []
+    next_token: str | None = None
+
+    while True:
+        kwargs: dict[str, Any] = {"UserPoolId": pool_id, "Limit": _MAX_PAGE_SIZE}
+        if next_token:
+            kwargs["NextToken"] = next_token
+
+        response = client.list_groups(**kwargs)
+        for group in response.get("Groups", []):
+            groups.append(
+                {
+                    "id": group.get("GroupName"),
+                    "name": group.get("GroupName"),
+                    "description": group.get("Description", ""),
+                    "path": group.get("GroupName"),
+                }
+            )
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+    logger.info(f"Retrieved {len(groups)} groups from Cognito")
+    return groups
+
+
+def _list_users_sync(
+    max_results: int,
+    include_groups: bool,
+) -> list[dict[str, Any]]:
+    """List users in the User Pool (synchronous, paginated)."""
+    client = _get_client()
+    pool_id = _get_user_pool_id()
+
+    users: list[dict[str, Any]] = []
+    pagination_token: str | None = None
+
+    while len(users) < max_results:
+        kwargs: dict[str, Any] = {"UserPoolId": pool_id, "Limit": _MAX_PAGE_SIZE}
+        if pagination_token:
+            kwargs["PaginationToken"] = pagination_token
+
+        response = client.list_users(**kwargs)
+        for user in response.get("Users", []):
+            attributes = user.get("Attributes", [])
+            username = user.get("Username")
+            user_data: dict[str, Any] = {
+                "id": username,
+                "username": username,
+                "email": _extract_email(attributes),
+                "status": user.get("UserStatus"),
+                "enabled": user.get("Enabled", True),
+                "groups": [],
+            }
+
+            if include_groups:
+                user_data["groups"] = _list_groups_for_user_sync(client, pool_id, username)
+
+            users.append(user_data)
+
+        pagination_token = response.get("PaginationToken")
+        if not pagination_token:
+            break
+
+    logger.info(f"Retrieved {len(users)} users from Cognito")
+    return users[:max_results]
+
+
+def _list_groups_for_user_sync(
+    client: Any,
+    pool_id: str,
+    username: str,
+) -> list[str]:
+    """List the group names a single user belongs to (synchronous, paginated)."""
+    group_names: list[str] = []
+    next_token: str | None = None
+
+    while True:
+        kwargs: dict[str, Any] = {
+            "UserPoolId": pool_id,
+            "Username": username,
+            "Limit": _MAX_PAGE_SIZE,
+        }
+        if next_token:
+            kwargs["NextToken"] = next_token
+
+        response = client.admin_list_groups_for_user(**kwargs)
+        for group in response.get("Groups", []):
+            group_names.append(group.get("GroupName"))
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+    return group_names
+
+
+async def list_cognito_groups() -> list[dict[str, Any]]:
+    """List all groups from the Cognito User Pool.
+
+    Returns:
+        List of group dictionaries with id, name, description, and path.
+    """
+    return await asyncio.to_thread(_list_groups_sync)
+
+
+async def list_cognito_users(
+    max_results: int = 500,
+    include_groups: bool = True,
+) -> list[dict[str, Any]]:
+    """List users from the Cognito User Pool.
+
+    Args:
+        max_results: Maximum number of users to return.
+        include_groups: Whether to look up each user's group memberships.
+
+    Returns:
+        List of user dictionaries.
+    """
+    return await asyncio.to_thread(_list_users_sync, max_results, include_groups)

--- a/registry/utils/iam_manager.py
+++ b/registry/utils/iam_manager.py
@@ -2,7 +2,8 @@
 IAM Manager factory for multi-provider support.
 
 This module provides a unified interface for IAM operations across
-different identity providers (Keycloak, Entra ID, Okta, Auth0).
+different identity providers (Keycloak, Entra ID, Okta, Auth0, PingFederate,
+and Amazon Cognito).
 """
 
 import logging
@@ -748,6 +749,94 @@ class PingFederateIAMManager:
         }
 
 
+# Message shared by every write method that Cognito IAM management does not yet
+# support from the UI. Group/user administration for Cognito is currently done
+# out-of-band (AWS console or `aws cognito-idp ...`); see docs/idp/cognito.md.
+_COGNITO_WRITE_UNSUPPORTED: str = (
+    "Cognito IAM write operations are not supported from the registry UI yet. "
+    "Manage Cognito groups and users via the AWS console or the AWS CLI "
+    "(aws cognito-idp ...). See docs/idp/cognito.md."
+)
+
+
+class CognitoIAMManager:
+    """Amazon Cognito IAM manager (read-only).
+
+    Listing groups and users is implemented against the Cognito User Pool.
+    Write operations are not yet supported and raise NotImplementedError with a
+    clear message pointing operators to the AWS console / CLI.
+    """
+
+    async def list_users(
+        self, search: str | None = None, max_results: int = 500, include_groups: bool = True
+    ) -> list[dict[str, Any]]:
+        """List users from the Cognito User Pool."""
+        from .cognito_manager import list_cognito_users
+
+        return await list_cognito_users(
+            max_results=max_results, include_groups=include_groups
+        )
+
+    async def list_groups(self) -> list[dict[str, Any]]:
+        """List groups from the Cognito User Pool, filtered by IDP_GROUP_FILTER_PREFIX if set."""
+        from .cognito_manager import list_cognito_groups
+
+        groups = await list_cognito_groups()
+        return _filter_groups_by_prefix(groups, IDP_GROUP_FILTER_PREFIXES)
+
+    async def group_exists(self, group_name: str) -> bool:
+        """Check if a group exists in the Cognito User Pool."""
+        from .cognito_manager import list_cognito_groups
+
+        try:
+            groups = await list_cognito_groups()
+            return any(g.get("name", "").lower() == group_name.lower() for g in groups)
+        except Exception:
+            return False
+
+    async def create_human_user(
+        self,
+        username: str,
+        email: str,
+        first_name: str,
+        last_name: str,
+        groups: list[str],
+        password: str | None = None,
+    ) -> dict[str, Any]:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def delete_user(self, username: str) -> bool:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def create_group(self, group_name: str, description: str = "") -> dict[str, Any]:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def delete_group(self, group_name: str) -> bool:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def create_service_account(
+        self, client_id: str, groups: list[str], description: str | None = None
+    ) -> dict[str, Any]:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def update_user_groups(self, username: str, groups: list[str]) -> dict[str, Any]:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+    async def update_group(
+        self,
+        group_name: str,
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Not supported yet for Cognito."""
+        raise NotImplementedError(_COGNITO_WRITE_UNSUPPORTED)
+
+
 def get_iam_manager() -> IAMManager:
     """
     Factory function to get the appropriate IAM manager based on AUTH_PROVIDER.
@@ -776,6 +865,10 @@ def get_iam_manager() -> IAMManager:
     elif provider == "pingfederate":
         logger.debug("Using PingFederate IAM manager")
         return PingFederateIAMManager()
+
+    elif provider == "cognito":
+        logger.debug("Using Cognito IAM manager")
+        return CognitoIAMManager()
 
     else:
         logger.warning(f"Unknown AUTH_PROVIDER '{provider}', defaulting to Keycloak")

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -154,6 +154,13 @@ module "mcp_gateway" {
   idp_group_filter_prefix                   = var.idp_group_filter_prefix
   idp_user_group_fallback_enabled_providers = var.idp_user_group_fallback_enabled_providers
 
+  # Amazon Cognito configuration
+  cognito_enabled       = var.cognito_enabled
+  cognito_user_pool_id  = var.cognito_user_pool_id
+  cognito_client_id     = var.cognito_client_id
+  cognito_client_secret = var.cognito_client_secret
+  cognito_domain        = var.cognito_domain
+
   # Okta configuration
   okta_enabled           = var.okta_enabled
   okta_domain            = var.okta_domain

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -121,7 +121,24 @@ module "ecs_service_auth" {
         },
         {
           name  = "AUTH_PROVIDER"
-          value = var.pingfederate_enabled ? "pingfederate" : (var.auth0_enabled ? "auth0" : (var.okta_enabled ? "okta" : (var.entra_enabled ? "entra" : (var.keycloak_domain != "" ? "keycloak" : "default"))))
+          value = var.pingfederate_enabled ? "pingfederate" : (var.auth0_enabled ? "auth0" : (var.okta_enabled ? "okta" : (var.entra_enabled ? "entra" : (var.cognito_enabled ? "cognito" : (var.keycloak_domain != "" ? "keycloak" : "default")))))
+        },
+        # Amazon Cognito configuration (COGNITO_CLIENT_SECRET via Secrets Manager below)
+        {
+          name  = "COGNITO_ENABLED"
+          value = tostring(var.cognito_enabled)
+        },
+        {
+          name  = "COGNITO_USER_POOL_ID"
+          value = var.cognito_user_pool_id
+        },
+        {
+          name  = "COGNITO_CLIENT_ID"
+          value = var.cognito_client_id
+        },
+        {
+          name  = "COGNITO_DOMAIN"
+          value = var.cognito_domain
         },
         {
           name  = "KEYCLOAK_URL"
@@ -480,6 +497,12 @@ module "ecs_service_auth" {
             valueFrom = aws_secretsmanager_secret.entra_client_secret[0].arn
           }
         ] : [],
+        var.cognito_enabled ? [
+          {
+            name      = "COGNITO_CLIENT_SECRET"
+            valueFrom = aws_secretsmanager_secret.cognito_client_secret[0].arn
+          }
+        ] : [],
         var.okta_enabled ? [
           {
             name      = "OKTA_CLIENT_SECRET"
@@ -781,7 +804,24 @@ module "ecs_service_registry" {
         },
         {
           name  = "AUTH_PROVIDER"
-          value = var.pingfederate_enabled ? "pingfederate" : (var.auth0_enabled ? "auth0" : (var.okta_enabled ? "okta" : (var.entra_enabled ? "entra" : (var.keycloak_domain != "" ? "keycloak" : "default"))))
+          value = var.pingfederate_enabled ? "pingfederate" : (var.auth0_enabled ? "auth0" : (var.okta_enabled ? "okta" : (var.entra_enabled ? "entra" : (var.cognito_enabled ? "cognito" : (var.keycloak_domain != "" ? "keycloak" : "default")))))
+        },
+        # Amazon Cognito configuration (COGNITO_CLIENT_SECRET via Secrets Manager below)
+        {
+          name  = "COGNITO_ENABLED"
+          value = tostring(var.cognito_enabled)
+        },
+        {
+          name  = "COGNITO_USER_POOL_ID"
+          value = var.cognito_user_pool_id
+        },
+        {
+          name  = "COGNITO_CLIENT_ID"
+          value = var.cognito_client_id
+        },
+        {
+          name  = "COGNITO_DOMAIN"
+          value = var.cognito_domain
         },
         {
           name  = "ENTRA_ENABLED"
@@ -1415,6 +1455,12 @@ module "ecs_service_registry" {
           {
             name      = "ENTRA_CLIENT_SECRET"
             valueFrom = aws_secretsmanager_secret.entra_client_secret[0].arn
+          }
+        ] : [],
+        var.cognito_enabled ? [
+          {
+            name      = "COGNITO_CLIENT_SECRET"
+            valueFrom = aws_secretsmanager_secret.cognito_client_secret[0].arn
           }
         ] : [],
         var.okta_enabled ? [

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -712,6 +712,10 @@ module "ecs_service_registry" {
     var.aws_registry_federation_enabled ? {
       BedrockAgentCoreAccess = aws_iam_policy.bedrock_agentcore_access[0].arn
     } : {},
+    # Cognito read-only access for the registry IAM management UI (list groups/users)
+    var.cognito_enabled ? {
+      CognitoIamRead = aws_iam_policy.cognito_iam_read[0].arn
+    } : {},
     # Issue #1122: per-task ADOT sidecar needs AMP remote-write permission
     var.enable_observability ? {
       AMPRemoteWrite = aws_iam_policy.adot_amp_write[0].arn

--- a/terraform/aws-ecs/modules/mcp-gateway/iam.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/iam.tf
@@ -22,6 +22,7 @@ resource "aws_iam_policy" "ecs_secrets_access" {
           ],
           var.documentdb_credentials_secret_arn != "" ? [var.documentdb_credentials_secret_arn] : [],
           var.entra_enabled ? [aws_secretsmanager_secret.entra_client_secret[0].arn] : [],
+          var.cognito_enabled ? [aws_secretsmanager_secret.cognito_client_secret[0].arn] : [],
           var.okta_enabled ? [
             aws_secretsmanager_secret.okta_client_secret[0].arn,
             aws_secretsmanager_secret.okta_m2m_client_secret[0].arn,

--- a/terraform/aws-ecs/modules/mcp-gateway/iam.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/iam.tf
@@ -126,6 +126,33 @@ resource "aws_iam_policy" "bedrock_agentcore_access" {
 }
 
 
+# Cognito read-only access for the registry IAM management UI.
+# The registry's CognitoIAMManager lists groups and users from the User Pool to
+# populate the IAM > Groups / Users pages. Read-only: no create/delete actions.
+resource "aws_iam_policy" "cognito_iam_read" {
+  count       = var.cognito_enabled ? 1 : 0
+  name_prefix = "${local.name_prefix}-cognito-iam-read-"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "CognitoIdpReadOnly"
+        Effect = "Allow"
+        Action = [
+          "cognito-idp:ListGroups",
+          "cognito-idp:ListUsers",
+          "cognito-idp:AdminListGroupsForUser"
+        ]
+        Resource = "arn:aws:cognito-idp:*:*:userpool/${var.cognito_user_pool_id}"
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+
 # IAM policy for ECS Exec - task role
 resource "aws_iam_policy" "ecs_exec_task" {
   name_prefix = "${local.name_prefix}-ecs-exec-task-"

--- a/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
@@ -203,6 +203,30 @@ resource "aws_secretsmanager_secret_version" "entra_client_secret" {
 }
 
 
+# Amazon Cognito App Client secret (for OAuth authentication)
+#checkov:skip=CKV2_AWS_57:IdP client secret managed in the Cognito App Client, not rotatable via Secrets Manager
+resource "aws_secretsmanager_secret" "cognito_client_secret" {
+  count = var.cognito_enabled ? 1 : 0
+
+  name_prefix             = "${local.name_prefix}-cognito-client-secret-"
+  description             = "Amazon Cognito App Client secret for OAuth authentication"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.secrets.id
+  tags                    = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "cognito_client_secret" {
+  count = var.cognito_enabled ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.cognito_client_secret[0].id
+  secret_string = var.cognito_client_secret
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+
 # Okta client secret (for OAuth authentication)
 #checkov:skip=CKV2_AWS_57:IdP client secret managed in Okta admin console, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "okta_client_secret" {

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -598,6 +598,41 @@ variable "idp_user_group_fallback_enabled_providers" {
 }
 
 # =============================================================================
+# AMAZON COGNITO CONFIGURATION
+# =============================================================================
+
+variable "cognito_enabled" {
+  description = "Enable Amazon Cognito as the authentication provider"
+  type        = bool
+  default     = false
+}
+
+variable "cognito_user_pool_id" {
+  description = "Cognito User Pool ID (e.g. us-east-1_XXXXXXXXX)"
+  type        = string
+  default     = ""
+}
+
+variable "cognito_client_id" {
+  description = "Cognito App Client ID for web login"
+  type        = string
+  default     = ""
+}
+
+variable "cognito_client_secret" {
+  description = "Cognito App Client secret for web login"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cognito_domain" {
+  description = "Optional Cognito hosted UI domain prefix or custom domain. Leave empty to derive it from the User Pool ID."
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
 # OKTA CONFIGURATION
 # =============================================================================
 

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -565,6 +565,45 @@ variable "idp_user_group_fallback_enabled_providers" {
 }
 
 # =============================================================================
+# AMAZON COGNITO CONFIGURATION
+# =============================================================================
+# Bring-your-own User Pool: create the User Pool and App Client in the Cognito
+# console (or separately), then pass the values below. This module does not
+# create the User Pool. AWS_REGION is already injected into both containers and
+# is reused as the Cognito region.
+
+variable "cognito_enabled" {
+  description = "Enable Amazon Cognito as the authentication provider"
+  type        = bool
+  default     = false
+}
+
+variable "cognito_user_pool_id" {
+  description = "Cognito User Pool ID (e.g. us-east-1_XXXXXXXXX)"
+  type        = string
+  default     = ""
+}
+
+variable "cognito_client_id" {
+  description = "Cognito App Client ID for web login"
+  type        = string
+  default     = ""
+}
+
+variable "cognito_client_secret" {
+  description = "Cognito App Client secret for web login"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "cognito_domain" {
+  description = "Optional Cognito hosted UI domain prefix or custom domain. Leave empty to derive it from the User Pool ID (e.g. https://<pool-id-without-underscore>.auth.<region>.amazoncognito.com)."
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
 # OKTA CONFIGURATION
 # =============================================================================
 

--- a/tests/unit/test_iam_manager.py
+++ b/tests/unit/test_iam_manager.py
@@ -189,6 +189,27 @@ class TestGetIAMManagerFactory:
         # Assert
         assert isinstance(manager, iam_module.OktaIAMManager)
 
+    def test_returns_cognito_manager_when_auth_provider_is_cognito(
+        self,
+        monkeypatch,
+    ):
+        """Test returns CognitoIAMManager when AUTH_PROVIDER is 'cognito'."""
+        # Arrange
+        monkeypatch.setenv("AUTH_PROVIDER", "cognito")
+
+        # Need to reimport to pick up the new env var
+        import importlib
+
+        import registry.utils.iam_manager as iam_module
+
+        importlib.reload(iam_module)
+
+        # Act
+        manager = iam_module.get_iam_manager()
+
+        # Assert
+        assert isinstance(manager, iam_module.CognitoIAMManager)
+
     def test_defaults_to_keycloak_when_auth_provider_not_set(
         self,
         monkeypatch,
@@ -756,3 +777,65 @@ class TestIAMManagerProtocol:
         assert callable(manager.create_group)
         assert callable(manager.delete_group)
         assert callable(manager.create_service_account)
+
+
+# =============================================================================
+# TEST: CognitoIAMManager (read-only)
+# =============================================================================
+
+
+class TestCognitoIAMManager:
+    """Tests for the read-only Cognito IAM manager."""
+
+    @pytest.mark.asyncio
+    async def test_list_groups_delegates_to_cognito_helper(self):
+        """list_groups returns the groups from the cognito helper."""
+        from registry.utils.iam_manager import CognitoIAMManager
+
+        sample = [{"id": "registry-admins", "name": "registry-admins", "description": "", "path": "registry-admins"}]
+        manager = CognitoIAMManager()
+        with patch(
+            "registry.utils.cognito_manager.list_cognito_groups",
+            new=AsyncMock(return_value=sample),
+        ):
+            result = await manager.list_groups()
+
+        assert result == sample
+
+    @pytest.mark.asyncio
+    async def test_list_users_delegates_to_cognito_helper(self):
+        """list_users forwards max_results/include_groups and returns the users."""
+        from registry.utils.iam_manager import CognitoIAMManager
+
+        sample = [{"id": "u1", "username": "u1", "email": "u1@example.com", "groups": ["public-mcp-users"]}]
+        manager = CognitoIAMManager()
+        with patch(
+            "registry.utils.cognito_manager.list_cognito_users",
+            new=AsyncMock(return_value=sample),
+        ) as mock_list:
+            result = await manager.list_users(max_results=10, include_groups=True)
+
+        assert result == sample
+        mock_list.assert_awaited_once_with(max_results=10, include_groups=True)
+
+    @pytest.mark.asyncio
+    async def test_write_methods_raise_not_implemented(self):
+        """Every write method raises NotImplementedError with a clear message."""
+        from registry.utils.iam_manager import CognitoIAMManager
+
+        manager = CognitoIAMManager()
+
+        with pytest.raises(NotImplementedError):
+            await manager.create_group("g")
+        with pytest.raises(NotImplementedError):
+            await manager.delete_group("g")
+        with pytest.raises(NotImplementedError):
+            await manager.update_group("g", "desc")
+        with pytest.raises(NotImplementedError):
+            await manager.create_human_user("u", "u@example.com", "U", "Ser", [])
+        with pytest.raises(NotImplementedError):
+            await manager.delete_user("u")
+        with pytest.raises(NotImplementedError):
+            await manager.update_user_groups("u", [])
+        with pytest.raises(NotImplementedError):
+            await manager.create_service_account("client", [])


### PR DESCRIPTION
## Summary

Adds first-class Amazon Cognito support to the MCP Gateway Registry. Previously Cognito worked in the application code and on Docker/Helm, but was not wired into the Terraform/ECS module, and the IAM management UI could not list Cognito groups/users (it silently fell back to the Keycloak manager and failed with a 502).

This PR closes those gaps:

### Terraform / AWS ECS (bring-your-own User Pool)
- New `cognito_*` variables (root + module): `cognito_enabled`, `cognito_user_pool_id`, `cognito_client_id`, `cognito_client_secret`, `cognito_domain`. Region reuses the already-injected `AWS_REGION`.
- Client secret stored in Secrets Manager with `ignore_changes` on the value.
- `COGNITO_*` env vars injected into both the registry and auth-server containers; `COGNITO_CLIENT_SECRET` via `valueFrom`; the `AUTH_PROVIDER` ternary now resolves to `cognito` when enabled.
- New conditional `cognito_iam_read` IAM policy (`cognito-idp:ListGroups`, `ListUsers`, `AdminListGroupsForUser`, scoped to the User Pool) attached to the registry task role.

### IAM manager (read-only)
- New `CognitoIAMManager` plus `registry/utils/cognito_manager.py` boto3 helpers. `list_groups`, `list_users`, and `group_exists` are implemented; write operations raise `NotImplementedError` with a clear message pointing to the AWS console / CLI.
- Wired `provider == "cognito"` into `get_iam_manager()` (it previously fell through to Keycloak).
- Unit tests for factory selection, read delegation, and write methods raising.

### Docs
- New `docs/idp/cognito.md` deployment-surfaces guide (Docker Compose, Terraform/ECS, Helm), covering callback **and** sign-out URL registration, the groups-not-scopes model, DocumentDB group-to-scope seeding, the read-only IAM limitation, and troubleshooting (logout error, "Unable to list IAM groups", empty-admin-permissions).
- Refreshed the existing `docs/cognito.md` (scopes.yml -> DocumentDB, dead snippet/path fixes).

## Testing
- `terraform fmt` + `terraform validate`: pass.
- `uv run pytest tests/unit/test_iam_manager.py`: 29 passed (incl. 4 new Cognito tests).
- `py_compile` clean on all changed Python files.

## Notes / follow-ups
- Read-only first: creating/deleting Cognito groups and users from the registry UI is intentionally not implemented yet (raises a clear error). Group/user administration is done via the AWS console or CLI in the meantime.
- Requires a registry image rebuild + `terraform apply` to take effect on an existing deployment.