### PR TITLE
dynamically generate mongodb password

### DIFF
--- a/charts/mcp-gateway-registry-stack/templates/mongodb-secret.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/mongodb-secret.yaml
@@ -1,5 +1,11 @@
 {{ if .Values.mongodb.enabled }}
 {{- if not .Values.mongodb.existingPasswordSecret }}
+{{- $mongodbPassword := "" }}
+{{- if .Values.mongodb.password }}
+  {{- $mongodbPassword = .Values.mongodb.password }}
+{{- else }}
+  {{- $mongodbPassword = randAlphaNum 64 }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +13,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
-  password: {{ .Values.mongodb.password | b64enc | quote}}
+  password: {{ $mongodbPassword | b64enc | quote}}
 {{- end }}
 {{ end }}

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -96,7 +96,7 @@ mongodb-kubernetes:
 mongodb:
   enabled: true
   user: &mongoUser my-user # username for MongoDB
-  password: &mongoPassword CHANGEME # Set the password for the MongoDB user
+  password: &mongoPassword "" # Set the password for the MongoDB user or a random one is generated
   database: &mongoDatabase mcp_registry
   existingPasswordSecret: "" # If set, skip creating my-user-password secret and use this name instead
   # connectionString: Full MongoDB URI override (MongoDB Atlas, externally-

--- a/charts/mongodb-configure/templates/job.yaml
+++ b/charts/mongodb-configure/templates/job.yaml
@@ -18,7 +18,7 @@ spec:
             - |
               echo "Installing pymongo..."
               pip install --no-cache-dir pymongo
-              
+
               echo "Waiting for MongoDB replica set to be ready..."
               python3 /app/wait.py
           volumeMounts:
@@ -32,6 +32,14 @@ spec:
           args: [
             "pip install --no-cache-dir pyyaml motor && python /app/script.py"
           ]
+{{- if not $.Values.mongodb.password}}
+          env:
+            - name: DOCUMENTDB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: my-user-password
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ $existingSecret | default "mongo-credentials" }}

--- a/charts/mongodb-configure/templates/secret.yaml
+++ b/charts/mongodb-configure/templates/secret.yaml
@@ -17,7 +17,9 @@ data:
   MONGODB_CONNECTION_STRING: {{.Values.mongodb.connectionString | b64enc | quote}}
   {{- else }}
   DOCUMENTDB_HOST: {{ if contains "." .Values.mongodb.host }}{{ .Values.mongodb.host | b64enc | quote }}{{ else }}{{ printf "%s.%s.svc.cluster.local" .Values.mongodb.host .Release.Namespace | b64enc | quote }}{{ end }}
+  {{- if .Values.mongodb.password}}
   DOCUMENTDB_PASSWORD: {{.Values.mongodb.password | b64enc | quote}}
+  {{- end }}
   DOCUMENTDB_PORT: {{.Values.mongodb.port | toString | b64enc | quote}}
   DOCUMENTDB_REPLICA_SET: {{.Values.mongodb.replica_set | b64enc | quote}}
   DOCUMENTDB_USERNAME: {{.Values.mongodb.username | b64enc | quote}}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Defaults to automatically generating a mongodb password for the helm charts. A password can be provided to retain the old behavior. If no password is set, it is only generated in the mongodb `my-user-password` secret and pulled into the mongodb configure job, otherwise the password is duplicated in both secrets (if provided). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
