### PR TITLE
chore: usage-report skill — LTV counting rule, regrounded rates, daily-reporters chart

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -228,8 +228,8 @@ Customer-only (internal UUIDs excluded), AWS-only (GCP/Azure/unknown excluded be
 | Platform | Daily rate | Grounding |
 |---|---:|---|
 | `docker` | $3.99 | 1 × t3.xlarge on-demand ($0.1664/hr), customer VM |
-| `ecs` | $19.03 | From `terraform/aws-ecs/terraform.tfstate`: 10 Fargate tasks ($7.67) + DocumentDB db.t3.medium ($1.87) + RDS Aurora Serverless v2 avg 1 ACU ($2.88) + 2 ALBs ($1.35) + 3 NAT Gateways ($3.24) + 2 CloudFront ($0.50) + S3 logs ($0.05) + CloudWatch ($1.00) + EFS/SM/DT ($0.50) |
-| `kubernetes` | $11.17 | From `charts/` Helm defaults + aws-load-balancer-controller: EKS control plane ($2.40) + 2 × t3.large nodes ($3.99) + 4 ALB ingresses ($2.70) + 1 NAT Gateway ($1.08) + EBS ($0.50) + CloudWatch Container Insights ($0.30) + data transfer ($0.20) |
+| `ecs` | $26.04 | From a measured Cost Explorer day (May-30) for the `terraform/aws-ecs` deployment, excl shared-account overhead (CloudTrail, Others) and the standalone EC2-Instances box: Fargate/ECS ($7.66) + EC2-Other NAT/EBS/data ($7.39) + RDS Keycloak ($4.47) + DocumentDB ($2.03) + VPC ($1.80) + CloudWatch ($1.61) + ELB/ALBs ($1.08) |
+| `kubernetes` | $18.58 | From the measured EKS reference deployment: EKS control plane ($2.40) + 3 × m6i.xlarge nodes ($13.82) + EBS gp3 ~41Gi ($0.11) + 1 ALB ($0.92) + 1 NAT Gateway + 5 GB egress ($1.31) + ACM public cert ($0.00) + Route 53 hosted zone ($0.02) |
 | `ec2` / `unknown` / other | $3.99 | Docker-compose fallback (single VM) |
 
 Platform for a given instance is resolved via its **most-recent non-empty `compute` field**. If an instance migrates across platforms mid-window, it's billed at the latest platform's rate for the whole window.
@@ -248,23 +248,64 @@ Platform for a given instance is resolved via its **most-recent non-empty `compu
 
 > When `--exclude-incomplete-day` is passed, the JSON summary's `yesterday` block refers to the **last complete day** (typically YYYY-MM-DD - 1), not today. Headline tables in the report should label this clearly (e.g. "Yesterday (2026-05-16, last complete day)").
 
+**Three counting rules** are emitted side by side so the report can show a range and pick a headline:
+- **all-days** (upper bound): charge every distinct (AWS customer instance, day) pair, including 1-day trial installs.
+- **persisted** (HEADLINE): charge every day an instance reported, but only if it reported on **>= 2 distinct days** total (i.e. it came back on a separate day rather than installing and vanishing the same day). Unlike `proven`, the instance's first day IS charged once it qualifies. This is the "real running deployment, count every day it phoned home" definition the maintainer settled on: it excludes install-and-delete instances and double-counts nothing.
+- **proven** (lower bound): charge an instance on day D only if it had events on D AND any prior day. Excludes every instance's first-ever active day.
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_ltv_spend.py \
+  --csv-dir OUTPUT_DIR \
+  --output $DATE_DIR/ltv-spend-YYYY-MM-DD.png \
+  --internal-instances .claude/skills/usage-report/known-internal-instances.md \
+  --csv-out $DATE_DIR/ltv-spend-YYYY-MM-DD.csv \
+  --summary-json $DATE_DIR/ltv-spend-YYYY-MM-DD.json \
+  --exclude-incomplete-day YYYY-MM-DD
+```
+
 Outputs:
-- PNG chart with three panels: daily EC2 compute USD (all-days + proven overlay), daily Bedrock USD, cumulative LTV USD (both lines with shaded range between them).
-- CSV sidecar per day: `date, aws_instances, aws_instances_persistent, <platform>_instances[_persistent], bedrock_queries[_persistent], compute_usd[_persistent], bedrock_usd[_persistent], total_usd[_persistent], cum_total_usd[_persistent]`.
-- JSON summary with headline numbers under `yesterday.all_days` vs `yesterday.proven`, `last_7_days.{all_days_total_usd, proven_total_usd}`, `ltv.{all_days, proven}`, and per-platform LTV breakdown for both models.
+- PNG chart with three panels: daily EC2 compute USD (all-days bar + persisted overlay), daily Bedrock USD, cumulative LTV USD (all-days / persisted / proven lines with shaded range).
+- CSV sidecar per day with `_persistent` (proven) and `_persisted` (>= 2 distinct days) variants of every column alongside the all-days columns.
+- JSON summary with headline numbers under `yesterday.{all_days, persisted, proven}`, `last_7_days.{all_days_total_usd, persisted_total_usd, proven_total_usd}`, `ltv.{all_days, persisted, proven}`, and per-platform LTV breakdown for all three models.
 
-Embed the chart in the report's **Customer Infra Spend (AWS)** section. Include a single summary table that shows both numbers as a range (e.g. "yesterday: $292.67 – $346.01"), one short paragraph explaining the two counting rules, and the per-platform LTV breakdown (both models side by side). Flag clearly that the cost model is hypothetical (we don't actually bill these customers; these are "what it would cost them at list price").
+Embed the chart in the report's **Customer Infra Spend (AWS)** section. Lead with the **persisted** number as the headline, and show all three as a range in the summary table. Include one short paragraph explaining the three counting rules and the per-platform LTV breakdown. Flag clearly that the cost model is hypothetical (we don't actually bill these customers; these are "what it would cost them at list price").
 
-**ARR projection (mandatory):** below the cumulative LTV table, add a short subsection titled **"Annualized Run Rate (ARR) Projection"** that takes the 7-day daily-average spend and projects it forward 365 days. Compute as `last_7_days.<model>_total_usd / 7 * 365`, divided by 1,000,000, formatted to 2 decimal places in millions. Render BOTH models (proven and all-days) as a small two-row table:
+**Formula clarification (mandatory):** below the spend table, include the "How the three numbers relate" block (the template renders this from `ltv.{all_days,persisted,proven}.total_instance_days`). The key points the reader needs:
+- All three rules multiply the **same** per-platform daily rates by a count of **instance-days** (one (instance, day) pair = one charge). They differ ONLY in which instance-days qualify, so `all-days >= persisted >= proven` always holds.
+- `all-days - persisted` = the count of single-calendar-day (install-and-vanish) instance-days that persisted drops.
+- `persisted - proven` = exactly the number of persisted instances (proven frees each instance's first-ever day; persisted keeps it). This identity is a useful self-check: if it doesn't equal the persisted-instance count, something is wrong.
+- At the trailing edge of the window the persisted and proven **daily** figures converge (an instance active on the last complete day cannot still be on its first-ever day, so proven charges it too) -- this is why yesterday's persisted and proven numbers are typically identical while the cumulative ones diverge.
+
+**ARR projection (mandatory):** below the cumulative LTV table, add a short subsection titled **"Annualized Run Rate (ARR) Projection"** that takes the 7-day daily-average spend and projects it forward 365 days. Compute as `last_7_days.<model>_total_usd / 7 * 365`, divided by 1,000,000, formatted to 2 decimal places in millions. Render all three models, with **persisted** as the headline row:
 
 ```
 | Model | 7-day daily avg | x 365 = ARR |
 |-------|----------------:|------------:|
-| Proven | $X | $Y.YYM |
+| Persisted (headline) | $X | $Y.YYM |
 | All-days | $X | $Y.YYM |
+| Proven | $X | $Y.YYM |
 ```
 
 Frame the ARR as "what the active customer fleet would cost AWS customers per year at list price if today's run rate held constant." Include the same hypothetical disclaimer (we do not bill these customers). The ARR is a useful complement to install-count growth: it tracks the real economic footprint of the customer fleet, not just the headcount of registry instances.
+
+### Step 5c3b: Generate Daily Reporters Chart
+
+Plot the daily count of AWS customer instances reporting home, with two persistence-filtered overlays that exclude install-and-vanish-within-a-day instances. This is the visual companion to the **persisted** LTV counting rule: the green ">= 2 distinct days" line is exactly the daily instance count that drives the headline infra-spend number.
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_daily_reporters_chart.py \
+  --csv-dir OUTPUT_DIR \
+  --output $DATE_DIR/daily-reporters-YYYY-MM-DD.png \
+  --internal-instances .claude/skills/usage-report/known-internal-instances.md \
+  --csv-out $DATE_DIR/daily-reporters-YYYY-MM-DD.csv \
+  --exclude-incomplete-day YYYY-MM-DD
+```
+
+This produces:
+- A PNG with three overlaid daily series (AWS-only, customer-only): all reporters, persisted (>= 2 events ever), persisted (>= 2 distinct days).
+- A CSV sidecar per day: `date, all_reporters, persisted_2events, persisted_2days`.
+
+Same data-sourcing behavior as the other historical charts (scans all CSVs across dated subdirectories). Embed in the report's **Customer Infra Spend (AWS)** section, directly above or beside the LTV chart, so the reader sees how the headline daily instance count (~the green line) is derived. Add a short narrative noting how little the install-and-vanish filter moves the line (the daily fleet is overwhelmingly persistent), and that the gap between "all reporters" and ">= 2 distinct days" is the single-calendar-day cohort.
 
 ### Step 5d: Generate Install Forecast Chart
 
@@ -461,7 +502,7 @@ The renderer is composed of three pieces, all under `.claude/skills/usage-report
 
 #### Mandatory Charts Checklist
 
-The report MUST embed all 11 charts (the template's `![...]` references). If any chart file is missing the renderer will substitute the path verbatim and pandoc will render a broken-image placeholder, so generate all charts (Steps 5 through 5f) before invoking `render_report.py`.
+The report MUST embed all 12 charts (the template's `![...]` references). If any chart file is missing the renderer will substitute the path verbatim and pandoc will render a broken-image placeholder, so generate all charts (Steps 5 through 5f) before invoking `render_report.py`.
 
 1. `registry-installs-timeseries-YYYY-MM-DD.png` (cloud provider: cumulative + daily-active + daily-new)
 2. `instance-distribution-YYYY-MM-DD.png` (6-panel faceted, all customers)
@@ -471,9 +512,10 @@ The report MUST embed all 11 charts (the template's `![...]` references). If any
 6. `active-instances-YYYY-MM-DD.png` (DAI + MA7 + streak)
 7. `compute-installs-timeseries-YYYY-MM-DD.png` (compute platform cumulative + daily)
 8. `install-forecast-YYYY-MM-DD.png` (OLS + recent-pace to 1,000)
-9. `ltv-spend-YYYY-MM-DD.png` (daily compute + bedrock + cumulative)
-10. `adoption-funnel-YYYY-MM-DD.png` (funnel from total to confirmed-alive)
-11. `detection-by-version-YYYY-MM-DD.png` (cloud_detection_method outcomes per version)
+9. `daily-reporters-YYYY-MM-DD.png` (daily AWS reporters: all + persisted >=2 events + persisted >=2 days)
+10. `ltv-spend-YYYY-MM-DD.png` (daily compute + bedrock + cumulative)
+11. `adoption-funnel-YYYY-MM-DD.png` (funnel from total to confirmed-alive)
+12. `detection-by-version-YYYY-MM-DD.png` (cloud_detection_method outcomes per version)
 
 #### Editing the report
 
@@ -523,7 +565,7 @@ The pipeline is split so the LLM has a narrowly-scoped, hard-to-screw-up job:
 
 #### Required commentary anchors (in template)
 
-The current template has 19 commentary anchors covering: executive_summary, cloud_installs, deployment_distribution, lifetime_retention, liveness, engagement, compute_platform, version_adoption, upgrade_trajectories, feature_adoption, sticky_breakdown, most_active, install_forecast, ltv_arr, adoption_funnel, cloud_detection, github, architecture, recommendations.
+The current template has 20 commentary anchors covering: executive_summary, cloud_installs, deployment_distribution, lifetime_retention, liveness, engagement, compute_platform, version_adoption, upgrade_trajectories, feature_adoption, sticky_breakdown, most_active, install_forecast, daily_reporters, ltv_arr, adoption_funnel, cloud_detection, github, architecture, recommendations.
 
 Adding/removing anchors: edit `report_template.md` to insert or delete `<!-- COMMENTARY:name -->` markers; the augmenter's extract phase will pick up the new set automatically.
 

--- a/.claude/skills/usage-report/generate_daily_reporters_chart.py
+++ b/.claude/skills/usage-report/generate_daily_reporters_chart.py
@@ -1,0 +1,330 @@
+"""Generate a timeseries chart of daily AWS customer instances reporting home.
+
+Reads ALL CSV files in a given directory (and dated subdirectories),
+deduplicates events, filters out known internal instances, and produces a PNG
+line chart with three overlaid series, each counting unique AWS customer
+registry_ids that sent at least one event (startup OR heartbeat) on that day:
+
+  1. All reporters       -- every AWS customer instance that reported that day,
+                            including instances that install and vanish the same
+                            day (single-event installs).
+  2. Persisted (>=2 evt) -- instances that emitted at least 2 events EVER. Drops
+                            the true install-and-vanish-in-one-shot cohort.
+  3. Persisted (>=2 day) -- instances that reported on at least 2 DISTINCT days
+                            EVER. This is the "real running deployment"
+                            definition used as the headline LTV counting rule:
+                            an instance only counts if it came back on a
+                            separate day rather than installing and deleting
+                            within a single day.
+
+This chart is the visual companion to the "persisted" counting rule in
+generate_ltv_spend.py: the green (>=2 distinct days) line is the daily
+instance count that drives the headline infra-spend number.
+
+Filters: customer-only (internal UUIDs excluded), AWS-only (cloud == "aws"),
+matching generate_ltv_spend.py so the counts reconcile.
+
+A CSV sidecar of the daily values is written alongside the chart so the report
+can quote exact numbers and future reports can diff against it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import re
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import sys as _sys
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = (
+    "AI Registry -- Daily AWS customer instances reporting home\n"
+    "(filtered to exclude install-and-vanish-within-a-day)"
+)
+FIGURE_WIDTH: int = 13
+FIGURE_HEIGHT: int = 6
+PERSIST_MIN_EVENTS: int = 2
+PERSIST_MIN_DAYS: int = 2
+
+ALL_COLOR: str = "#bbbbbb"
+EVT_COLOR: str = "#1f77b4"
+DAY_COLOR: str = "#2ca02c"
+
+
+def _find_csv_files(
+    directory: str,
+) -> list[str]:
+    """Find all registry_metrics.csv files in the directory and dated subdirectories."""
+    csv_files: list[str] = []
+    for filename in os.listdir(directory):
+        filepath = os.path.join(directory, filename)
+        if filename.endswith(".csv"):
+            csv_files.append(filepath)
+        elif os.path.isdir(filepath):
+            for subfile in os.listdir(filepath):
+                if subfile.endswith(".csv"):
+                    csv_files.append(os.path.join(filepath, subfile))
+    csv_files.sort()
+    logger.info(f"Found {len(csv_files)} CSV files in {directory}")
+    return csv_files
+
+
+def _load_internal_instance_ids(
+    path: str | None,
+) -> set[str]:
+    """Parse the known-internal-instances.md file into a set of full UUIDs."""
+    if not path or not Path(path).exists():
+        return set()
+    pattern = re.compile(r"`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`")
+    ids: set[str] = set()
+    with open(path) as f:
+        for line in f:
+            for match in pattern.findall(line):
+                ids.add(match)
+    logger.info(f"Loaded {len(ids)} known internal instance IDs from {path}")
+    return ids
+
+
+def _read_all_csvs(
+    csv_files: list[str],
+) -> list[dict[str, str]]:
+    """Read and concatenate all CSV files."""
+    all_rows: list[dict[str, str]] = []
+    for csv_path in csv_files:
+        with open(csv_path, newline="") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+        all_rows.extend(rows)
+    logger.info(f"Total rows across all CSVs: {len(all_rows)}")
+    return all_rows
+
+
+def _dedupe_by_id_ts(
+    rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Drop duplicate rows by (registry_id, ts)."""
+    seen: set[tuple[str, str]] = set()
+    out: list[dict[str, str]] = []
+    for r in rows:
+        rid = (r.get("registry_id") or "").strip()
+        ts = (r.get("ts") or "").strip()
+        key = (rid, ts)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(r)
+    logger.info(f"Deduplicated: {len(rows)} -> {len(out)} unique events")
+    return out
+
+
+def _is_aws_customer(
+    r: dict[str, str],
+    internal_ids: set[str],
+) -> bool:
+    """Return True if this row is an AWS customer event (not internal)."""
+    rid = (r.get("registry_id") or "").strip()
+    if not rid or rid in internal_ids:
+        return False
+    cloud = (r.get("cloud") or "").strip()
+    return cloud == "aws"
+
+
+def _compute_daily_counts(
+    rows: list[dict[str, str]],
+    internal_ids: set[str],
+    exclude_day: str | None = None,
+) -> list[dict[str, int | str]]:
+    """Compute per-day reporter counts under three persistence definitions.
+
+    Returns a list of per-day dicts with keys: date, all_reporters,
+    persisted_2events, persisted_2days.
+    """
+    by_day: dict[str, set[str]] = defaultdict(set)
+    instance_event_count: dict[str, int] = defaultdict(int)
+    instance_days: dict[str, set[str]] = defaultdict(set)
+
+    for r in rows:
+        if not _is_aws_customer(r, internal_ids):
+            continue
+        rid = r["registry_id"].strip()
+        d = (r.get("ts") or "")[:10]
+        if len(d) < 10:
+            continue
+        # Event count is computed across ALL days (the persistence test looks at
+        # an instance's whole history), but the per-day series and the
+        # distinct-day test exclude the in-progress day.
+        instance_event_count[rid] += 1
+        if exclude_day and d == exclude_day:
+            continue
+        by_day[d].add(rid)
+        instance_days[rid].add(d)
+
+    persisted_events = {
+        rid for rid, n in instance_event_count.items() if n >= PERSIST_MIN_EVENTS
+    }
+    persisted_days = {
+        rid for rid, ds in instance_days.items() if len(ds) >= PERSIST_MIN_DAYS
+    }
+
+    logger.info(
+        f"Unique AWS customer instances: {len(instance_event_count)} "
+        f"(>= {PERSIST_MIN_EVENTS} events: {len(persisted_events)}, "
+        f">= {PERSIST_MIN_DAYS} distinct days: {len(persisted_days)})"
+    )
+
+    out: list[dict[str, int | str]] = []
+    for d in sorted(by_day.keys()):
+        active = by_day[d]
+        out.append(
+            {
+                "date": d,
+                "all_reporters": len(active),
+                "persisted_2events": len(active & persisted_events),
+                "persisted_2days": len(active & persisted_days),
+            }
+        )
+    return out
+
+
+def _write_csv_sidecar(
+    daily: list[dict[str, int | str]],
+    path: str,
+) -> None:
+    """Write per-day reporter counts to a CSV sidecar."""
+    if not daily:
+        return
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=list(daily[0].keys()))
+        w.writeheader()
+        for row in daily:
+            w.writerow(row)
+    logger.info(f"CSV sidecar written to {path}")
+
+
+def _generate_chart(
+    daily: list[dict[str, int | str]],
+    output_path: str,
+) -> None:
+    """Render the three-series daily-reporters line chart."""
+    apply_tufte_style()
+    fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))
+
+    dates = [datetime.strptime(str(r["date"]), "%Y-%m-%d") for r in daily]
+    all_reporters = [r["all_reporters"] for r in daily]
+    p_events = [r["persisted_2events"] for r in daily]
+    p_days = [r["persisted_2days"] for r in daily]
+
+    ax.plot(
+        dates, all_reporters, lw=2.2, marker="o", ms=3, color=ALL_COLOR,
+        label="All AWS reporters (incl. single-event installs)",
+    )
+    ax.plot(
+        dates, p_events, lw=2.5, marker="s", ms=3, color=EVT_COLOR,
+        label="Persisted: >= 2 events ever",
+    )
+    ax.plot(
+        dates, p_days, lw=2.0, marker="^", ms=3, color=DAY_COLOR,
+        label="Persisted: >= 2 distinct days (headline LTV rule)",
+    )
+    ax.set_title(CHART_TITLE, fontsize=12, fontweight="bold")
+    ax.set_ylabel("unique instances reporting that day")
+    ax.legend(loc="upper left", fontsize=9)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax.xaxis.set_major_locator(mdates.DayLocator(interval=max(1, len(dates) // 14)))
+    plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha="right")
+    tufte_axes(ax)
+    plt.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments and generate the daily-reporters chart and CSV sidecar."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot daily AWS customer instances reporting home, with two "
+            "persistence-filtered series that exclude install-and-vanish "
+            "instances. The >= 2-distinct-days series is the headline LTV "
+            "counting rule (see generate_ltv_spend.py)."
+        ),
+    )
+    parser.add_argument(
+        "--csv-dir",
+        required=True,
+        help="Directory containing CSV files (scans subdirectories too)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to save the output PNG chart",
+    )
+    parser.add_argument(
+        "--internal-instances",
+        default=None,
+        help="Path to known-internal-instances.md. Internal IDs are excluded.",
+    )
+    parser.add_argument(
+        "--csv-out",
+        default=None,
+        help="Optional path to write per-day reporter counts CSV",
+    )
+    parser.add_argument(
+        "--exclude-incomplete-day",
+        default=None,
+        help=(
+            "Optional YYYY-MM-DD. Events on this date are dropped from the "
+            "per-day series so a still-in-progress day doesn't show as a dip. "
+            "An instance's events on this day still count toward its lifetime "
+            "event total for the persistence test."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.csv_dir):
+        logger.error(f"Directory not found: {args.csv_dir}")
+        raise SystemExit(1)
+
+    csv_files = _find_csv_files(args.csv_dir)
+    if not csv_files:
+        logger.error(f"No CSV files found in {args.csv_dir}")
+        raise SystemExit(1)
+
+    internal_ids = _load_internal_instance_ids(args.internal_instances)
+    all_rows = _read_all_csvs(csv_files)
+    unique_rows = _dedupe_by_id_ts(all_rows)
+    daily = _compute_daily_counts(
+        unique_rows,
+        internal_ids,
+        args.exclude_incomplete_day,
+    )
+    if not daily:
+        logger.error("No AWS customer events found after filtering")
+        raise SystemExit(1)
+
+    _generate_chart(daily, args.output)
+    if args.csv_out:
+        _write_csv_sidecar(daily, args.csv_out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/usage-report/generate_ltv_spend.py
+++ b/.claude/skills/usage-report/generate_ltv_spend.py
@@ -13,56 +13,48 @@ Cost model (auditable, documented below):
                    24h * $0.1664/hr = $3.99.
                    Customer VM; no managed-AWS services implied.
 
-     ecs        -> $19.03/day : grounded in terraform/aws-ecs/terraform.tfstate.
-                   Itemized:
-                     10 Fargate tasks (5 @ 1vCPU/2GB + 5 @ 0.5vCPU/1GB)
-                       = $7.67/day
-                       (vCPU $0.04048/hr + GB $0.004445/hr, 24h, us-east-1)
-                     DocumentDB db.t3.medium  ($0.078/hr, 1 instance)
-                       = $1.87/day
-                     RDS Aurora Serverless v2 (Keycloak, avg 1 ACU @ $0.12/hr)
-                       = $2.88/day
-                     2 Application Load Balancers ($0.0225/hr + LCUs)
-                       = $1.35/day
-                     3 NAT Gateways ($0.045/hr each, excludes data processing)
-                       = $3.24/day
-                     2 CloudFront distributions (PriceClass_100, low traffic)
-                       = $0.50/day
-                     S3 (ALB + CloudFront logs)
-                       = $0.05/day
-                     CloudWatch log groups + metric alarms (14 + 12)
-                       = $1.00/day
-                     EFS + Secrets Manager + data transfer overhead
-                       = $0.50/day
-                   See terraform/aws-ecs/modules/mcp-gateway/*.tf for
-                   resource definitions, cpu/memory defaults, and the
-                   ALB / NAT / CloudFront wiring.
+     ecs        -> $26.04/day : grounded in a measured AWS Cost Explorer
+                   day (May-30) for the terraform/aws-ecs deployment.
+                   Excludes shared-account overhead (CloudTrail, Others) and
+                   the standalone EC2-Instances row (a separate box, not ECS).
+                   Itemized (per-day, from the bill):
+                     Elastic Container Service (Fargate vCPU + memory)
+                       = $7.66/day
+                     EC2-Other (NAT-per-AZ + EBS + inter-AZ data transfer)
+                       = $7.39/day
+                     RDS (Keycloak)
+                       = $4.47/day
+                     DocumentDB (with MongoDB compatibility)
+                       = $2.03/day
+                     VPC (endpoints, etc.)
+                       = $1.80/day
+                     CloudWatch (logs + metric alarms)
+                       = $1.61/day
+                     Elastic Load Balancing (ALBs)
+                       = $1.08/day
+                   Total = $26.04/day.
+                   ECS tasks run on FARGATE (no EC2-backed cluster); the NAT
+                   cost lands under EC2-Other because Fargate tasks in private
+                   subnets egress through it. See terraform/aws-ecs/*.tf.
 
-     kubernetes -> $11.17/day : grounded in charts/registry/values.yaml
-                   and the stack chart's 4 ALB-backed ingresses.
+     kubernetes -> $18.58/day : grounded in the measured EKS reference
+                   deployment (3-node managed node group + single ALB).
                    Itemized:
                      EKS control plane ($0.10/hr)
                        = $2.40/day
-                     2 x t3.large worker nodes ($0.0832/hr each)
-                       = $3.99/day
-                     4 Application Load Balancers (keycloak, registry,
-                       mcpgw, stack-level) @ $0.0225/hr each + LCUs
-                       = $2.70/day
-                     1 NAT Gateway for private subnets ($0.045/hr)
-                       = $1.08/day
-                     EBS volumes (node storage + mongodb PV)
-                       = $0.50/day
-                     CloudWatch Container Insights
-                       = $0.30/day
-                     Data transfer overhead
-                       = $0.20/day
-                   Pod resource requests from chart defaults:
-                     registry      1 vCPU / 1 GiB
-                     auth-server   1 vCPU / 1 GiB
-                     mcpgw       0.5 vCPU / 1 GiB
-                     keycloak    ~1 vCPU / 1 GiB (in-cluster)
-                     mongodb    ~0.5 vCPU / 2 GiB (in-cluster)
-                   Total ~4 vCPU / 6 GiB fits comfortably on 2 x t3.large.
+                     3 x m6i.xlarge worker nodes
+                       = $13.82/day
+                     EBS gp3 (~41 Gi)
+                       = $0.11/day
+                     1 Application Load Balancer
+                       = $0.92/day
+                     1 NAT Gateway + 5 GB egress
+                       = $1.31/day
+                     ACM public cert
+                       = $0.00/day
+                     Route 53 hosted zone
+                       = $0.02/day
+                   Total = $18.58/day.
 
      ec2        -> $3.99/day : single VM, same as docker fallback.
 
@@ -144,14 +136,17 @@ EC2_DAILY_RATE: float = 24 * EC2_HOURLY_RATE
 
 # Per-compute-platform daily infra rate in USD.
 # See the module docstring for the tfstate + Helm chart grounding.
+# docker / ec2 / unknown / vm all map to a single customer VM running
+# docker-compose, priced off EC2_DAILY_RATE (t3.xlarge) so the hourly-rate
+# constant above stays the single source of truth (no hardcoded duplicate).
 COMPUTE_PLATFORM_DAILY_RATE_USD: dict[str, float] = {
-    "docker": 3.99,
-    "ecs": 19.03,
-    "kubernetes": 11.17,
-    "ec2": 3.99,
-    "unknown": 3.99,
-    "vm": 3.99,
-    "": 3.99,
+    "docker": EC2_DAILY_RATE,
+    "ecs": 26.04,
+    "kubernetes": 18.58,
+    "ec2": EC2_DAILY_RATE,
+    "unknown": EC2_DAILY_RATE,
+    "vm": EC2_DAILY_RATE,
+    "": EC2_DAILY_RATE,
 }
 
 BEDROCK_MODEL: str = "amazon.titan-embed-text-v2"
@@ -171,7 +166,7 @@ FIGURE_WIDTH: int = 14
 FIGURE_HEIGHT: int = 9
 CHART_TITLE: str = (
     "AI Registry -- Customer AWS infra spend "
-    "(per-platform: docker $3.99 / ecs $19.03 / k8s $11.17 per day + Bedrock Titan)"
+    "(per-platform: docker $3.99 / ecs $26.04 / k8s $18.58 per day + Bedrock Titan)"
 )
 
 
@@ -384,6 +379,18 @@ def _compute_daily_spend(
             if cur is None or d < cur:
                 instance_first_day[rid] = d
 
+    # Per-instance distinct-reporting-day count (needed for the "persisted" model:
+    # an instance is only charged at all if it reported on >= 2 distinct days, i.e.
+    # it came back on a separate day rather than installing and vanishing the same
+    # day. Once it qualifies, EVERY day it reported is charged -- including its
+    # first day. This is the "real running deployment" definition: excludes
+    # install-and-delete instances, double-counts nothing.
+    instance_distinct_days: dict[str, int] = defaultdict(int)
+    for ids in by_day_instances.values():
+        for rid in ids:
+            instance_distinct_days[rid] += 1
+    persisted_ids = {rid for rid, n in instance_distinct_days.items() if n >= 2}
+
     # Bedrock instances (latest-backend = bedrock)
     latest_backend = _compute_per_instance_latest_backend(rows, internal_ids)
     bedrock_instance_ids = {rid for rid, ebk in latest_backend.items() if ebk == "bedrock"}
@@ -410,6 +417,7 @@ def _compute_daily_spend(
     out: list[dict[str, float | int | str]] = []
     cum = 0.0
     cum_persistent = 0.0
+    cum_persisted = 0.0
     for d in _date_range(all_days[0], all_days[-1]):
         active = by_day_instances.get(d, set())
         n_inst = len(active)
@@ -418,6 +426,13 @@ def _compute_daily_spend(
         # on any prior day. The instance's first-ever active day is excluded.
         active_persistent = {rid for rid in active if instance_first_day.get(rid) != d}
         n_inst_persistent = len(active_persistent)
+
+        # "Persisted" subset: instance reported on >= 2 distinct days total, AND
+        # was active on D. Unlike "proven", the instance's first day IS charged
+        # once it qualifies. This is the "real running deployment, count every
+        # day it phoned home" definition (excludes install-and-delete instances).
+        active_persisted = active & persisted_ids
+        n_inst_persisted = len(active_persisted)
 
         # Per-platform breakdown for this day (permissive / all-days model)
         platform_counts: dict[str, int] = defaultdict(int)
@@ -428,7 +443,7 @@ def _compute_daily_spend(
             platform_counts[p] += 1
             platform_usd[p] += rate
 
-        # Per-platform breakdown for the persistent subset
+        # Per-platform breakdown for the proven subset
         platform_counts_p: dict[str, int] = defaultdict(int)
         platform_usd_p: dict[str, float] = defaultdict(float)
         for rid in active_persistent:
@@ -437,30 +452,47 @@ def _compute_daily_spend(
             platform_counts_p[p] += 1
             platform_usd_p[p] += rate
 
+        # Per-platform breakdown for the persisted subset
+        platform_counts_d: dict[str, int] = defaultdict(int)
+        platform_usd_d: dict[str, float] = defaultdict(float)
+        for rid in active_persisted:
+            p = latest_platform.get(rid) or "unknown"
+            rate = _daily_rate_for_platform(p)
+            platform_counts_d[p] += 1
+            platform_usd_d[p] += rate
+
         compute_usd = sum(platform_usd.values())
         compute_usd_persistent = sum(platform_usd_p.values())
+        compute_usd_persisted = sum(platform_usd_d.values())
 
         queries = 0
         queries_persistent = 0
+        queries_persisted = 0
         for rid in bedrock_instance_ids:
             if rid in active:
                 delta = by_instance_daily_delta.get(rid, {}).get(d, 0)
                 queries += delta
                 if rid in active_persistent:
                     queries_persistent += delta
+                if rid in active_persisted:
+                    queries_persisted += delta
         bedrock_usd = queries * BEDROCK_COST_PER_QUERY
         bedrock_usd_persistent = queries_persistent * BEDROCK_COST_PER_QUERY
+        bedrock_usd_persisted = queries_persisted * BEDROCK_COST_PER_QUERY
 
         total_usd = compute_usd + bedrock_usd
         total_usd_persistent = compute_usd_persistent + bedrock_usd_persistent
+        total_usd_persisted = compute_usd_persisted + bedrock_usd_persisted
         cum += total_usd
         cum_persistent += total_usd_persistent
+        cum_persisted += total_usd_persisted
 
         out.append(
             {
                 "date": d,
                 "aws_instances": n_inst,
                 "aws_instances_persistent": n_inst_persistent,
+                "aws_instances_persisted": n_inst_persisted,
                 "docker_instances": platform_counts.get("docker", 0),
                 "ecs_instances": platform_counts.get("ecs", 0),
                 "kubernetes_instances": platform_counts.get("kubernetes", 0),
@@ -475,16 +507,28 @@ def _compute_daily_spend(
                     v for k, v in platform_counts_p.items()
                     if k not in ("docker", "ecs", "kubernetes")
                 ),
+                "docker_instances_persisted": platform_counts_d.get("docker", 0),
+                "ecs_instances_persisted": platform_counts_d.get("ecs", 0),
+                "kubernetes_instances_persisted": platform_counts_d.get("kubernetes", 0),
+                "other_platform_instances_persisted": sum(
+                    v for k, v in platform_counts_d.items()
+                    if k not in ("docker", "ecs", "kubernetes")
+                ),
                 "bedrock_queries": queries,
                 "bedrock_queries_persistent": queries_persistent,
+                "bedrock_queries_persisted": queries_persisted,
                 "compute_usd": round(compute_usd, 4),
                 "compute_usd_persistent": round(compute_usd_persistent, 4),
+                "compute_usd_persisted": round(compute_usd_persisted, 4),
                 "bedrock_usd": round(bedrock_usd, 6),
                 "bedrock_usd_persistent": round(bedrock_usd_persistent, 6),
+                "bedrock_usd_persisted": round(bedrock_usd_persisted, 6),
                 "total_usd": round(total_usd, 4),
                 "total_usd_persistent": round(total_usd_persistent, 4),
+                "total_usd_persisted": round(total_usd_persisted, 4),
                 "cum_total_usd": round(cum, 4),
                 "cum_total_usd_persistent": round(cum_persistent, 4),
+                "cum_total_usd_persisted": round(cum_persisted, 4),
             }
         )
     return out, dict(platform_instance_counts)
@@ -532,13 +576,17 @@ def _write_summary_json(
     yesterday = daily[-1]
     ltv = yesterday["cum_total_usd"]
     ltv_persistent = yesterday["cum_total_usd_persistent"]
+    ltv_persisted = yesterday["cum_total_usd_persisted"]
     seven = daily[-7:]
     ltv_7d = round(sum(r["total_usd"] for r in seven), 2)
     ltv_7d_persistent = round(sum(r["total_usd_persistent"] for r in seven), 2)
+    ltv_7d_persisted = round(sum(r["total_usd_persisted"] for r in seven), 2)
     ltv_compute = round(sum(r["compute_usd"] for r in daily), 2)
     ltv_bedrock = round(sum(r["bedrock_usd"] for r in daily), 2)
     ltv_compute_persistent = round(sum(r["compute_usd_persistent"] for r in daily), 2)
     ltv_bedrock_persistent = round(sum(r["bedrock_usd_persistent"] for r in daily), 2)
+    ltv_compute_persisted = round(sum(r["compute_usd_persisted"] for r in daily), 2)
+    ltv_bedrock_persisted = round(sum(r["bedrock_usd_persisted"] for r in daily), 2)
 
     # Platform-level instance-day totals and compute-USD totals (LTV) -- permissive
     platform_instance_days: dict[str, int] = defaultdict(int)
@@ -564,24 +612,37 @@ def _write_summary_json(
         platform_instance_days_p["other"] += other_n
         platform_compute_usd_p["other"] += other_n * _daily_rate_for_platform("unknown")
 
+    # Same breakdown for the persisted model (>= 2 distinct days, all reported days charged)
+    platform_instance_days_d: dict[str, int] = defaultdict(int)
+    platform_compute_usd_d: dict[str, float] = defaultdict(float)
+    for row in daily:
+        for p in ("docker", "ecs", "kubernetes"):
+            n = int(row.get(f"{p}_instances_persisted", 0))
+            platform_instance_days_d[p] += n
+            platform_compute_usd_d[p] += n * _daily_rate_for_platform(p)
+        other_n = int(row.get("other_platform_instances_persisted", 0))
+        platform_instance_days_d["other"] += other_n
+        platform_compute_usd_d["other"] += other_n * _daily_rate_for_platform("unknown")
+
     summary = {
         "cost_model": {
             "per_platform_daily_rate_usd": dict(COMPUTE_PLATFORM_DAILY_RATE_USD),
             "docker_breakdown": "1 x t3.xlarge on-demand ($0.1664/hr)",
             "ecs_breakdown": (
-                "Grounded in terraform/aws-ecs/terraform.tfstate: "
-                "10 Fargate tasks ($7.67) + DocumentDB db.t3.medium ($1.87) "
-                "+ RDS Aurora Serverless v2 avg 1 ACU ($2.88) + 2 ALBs ($1.35) "
-                "+ 3 NAT Gateways ($3.24) + 2 CloudFront distributions ($0.50) "
-                "+ S3 logs ($0.05) + CloudWatch ($1.00) + EFS/SM/DT ($0.50) "
-                "= $19.03/day"
+                "Grounded in a measured Cost Explorer day (May-30) for the "
+                "terraform/aws-ecs deployment, excl shared-account overhead "
+                "(CloudTrail, Others) and the standalone EC2-Instances box: "
+                "Fargate/ECS ($7.66) + EC2-Other NAT/EBS/data ($7.39) "
+                "+ RDS Keycloak ($4.47) + DocumentDB ($2.03) + VPC ($1.80) "
+                "+ CloudWatch ($1.61) + ELB/ALBs ($1.08) "
+                "= $26.04/day"
             ),
             "kubernetes_breakdown": (
-                "Grounded in charts/ Helm defaults + aws-load-balancer-controller: "
-                "EKS control plane ($2.40) + 2 x t3.large nodes ($3.99) "
-                "+ 4 ALB ingresses ($2.70) + 1 NAT Gateway ($1.08) "
-                "+ EBS ($0.50) + CloudWatch Container Insights ($0.30) "
-                "+ Data transfer ($0.20) = $11.17/day"
+                "Grounded in the measured EKS reference deployment: "
+                "EKS control plane ($2.40) + 3 x m6i.xlarge nodes ($13.82) "
+                "+ EBS gp3 ~41Gi ($0.11) + 1 ALB ($0.92) "
+                "+ 1 NAT Gateway + 5 GB egress ($1.31) + ACM public cert ($0.00) "
+                "+ Route 53 hosted zone ($0.02) = $18.58/day"
             ),
             "bedrock_model": BEDROCK_MODEL,
             "bedrock_price_per_1k_tokens_usd": BEDROCK_PRICE_PER_1K_TOKENS,
@@ -602,6 +663,15 @@ def _write_summary_json(
                 "'proven'. ~59% of the current fleet never sends a second "
                 "day of events (one-day wonders) -- they contribute $0 under "
                 "this model."
+            ),
+            "persisted": (
+                "Charge an instance on EVERY day it reported, but only if it "
+                "reported on >= 2 distinct days total (i.e. it came back on a "
+                "separate day rather than installing and vanishing the same "
+                "day). Unlike 'proven', the instance's first day IS charged "
+                "once it qualifies. This is the 'real running deployment' "
+                "definition: excludes install-and-delete instances, "
+                "double-counts nothing. Headline numbers labeled 'persisted'."
             ),
         },
         "yesterday": {
@@ -628,6 +698,17 @@ def _write_summary_json(
                 "bedrock_usd": yesterday["bedrock_usd_persistent"],
                 "total_usd": yesterday["total_usd_persistent"],
             },
+            "persisted": {
+                "aws_instances": yesterday["aws_instances_persisted"],
+                "docker_instances": yesterday.get("docker_instances_persisted", 0),
+                "ecs_instances": yesterday.get("ecs_instances_persisted", 0),
+                "kubernetes_instances": yesterday.get("kubernetes_instances_persisted", 0),
+                "other_platform_instances": yesterday.get("other_platform_instances_persisted", 0),
+                "bedrock_queries": yesterday["bedrock_queries_persisted"],
+                "compute_usd": yesterday["compute_usd_persisted"],
+                "bedrock_usd": yesterday["bedrock_usd_persisted"],
+                "total_usd": yesterday["total_usd_persisted"],
+            },
         },
         "per_platform_unique_instance_totals": platform_instance_counts,
         "per_platform_ltv_breakdown_all_days": {
@@ -644,9 +725,17 @@ def _write_summary_json(
             }
             for p in ("docker", "ecs", "kubernetes", "other")
         },
+        "per_platform_ltv_breakdown_persisted": {
+            p: {
+                "instance_days": platform_instance_days_d[p],
+                "compute_usd": round(platform_compute_usd_d[p], 2),
+            }
+            for p in ("docker", "ecs", "kubernetes", "other")
+        },
         "last_7_days": {
             "all_days_total_usd": ltv_7d,
             "proven_total_usd": ltv_7d_persistent,
+            "persisted_total_usd": ltv_7d_persisted,
         },
         "ltv": {
             "all_days": {
@@ -660,6 +749,12 @@ def _write_summary_json(
                 "bedrock_usd": ltv_bedrock_persistent,
                 "total_usd": ltv_persistent,
                 "total_instance_days": sum(r["aws_instances_persistent"] for r in daily),
+            },
+            "persisted": {
+                "compute_usd": ltv_compute_persisted,
+                "bedrock_usd": ltv_bedrock_persisted,
+                "total_usd": ltv_persisted,
+                "total_instance_days": sum(r["aws_instances_persisted"] for r in daily),
             },
             "first_day": daily[0]["date"],
             "last_day": yesterday["date"],
@@ -688,15 +783,17 @@ def _generate_chart(
     dates = [datetime.strptime(r["date"], "%Y-%m-%d") for r in daily]
     compute = [r["compute_usd"] for r in daily]
     compute_p = [r["compute_usd_persistent"] for r in daily]
+    compute_d = [r["compute_usd_persisted"] for r in daily]
     bedrock = [r["bedrock_usd"] for r in daily]
     cum = [r["cum_total_usd"] for r in daily]
     cum_p = [r["cum_total_usd_persistent"] for r in daily]
-    colors = sns.color_palette("Set2", 4)
+    cum_d = [r["cum_total_usd_persisted"] for r in daily]
+    colors = sns.color_palette("Set2", 5)
 
-    # Daily compute: show permissive as the bar height and overlay the proven
-    # subset so the "first-day wedge" is visible at a glance.
-    ax_compute.bar(dates, compute, color=colors[0], alpha=0.5, label="all-days (incl. first-day installs)")
-    ax_compute.bar(dates, compute_p, color=colors[0], alpha=0.95, label="proven (seen on any prior day)")
+    # Daily compute: show all-days as the faint bar height, overlay the persisted
+    # subset (the headline rule: >= 2 distinct reporting days) as the solid bar.
+    ax_compute.bar(dates, compute, color=colors[0], alpha=0.4, label="all-days (incl. install-and-vanish)")
+    ax_compute.bar(dates, compute_d, color=colors[0], alpha=0.95, label="persisted (>= 2 distinct reporting days)")
     ax_compute.set_title(
         "Daily EC2 compute cost -- per-platform rate * active AWS customer instances",
         fontsize=10,
@@ -718,11 +815,15 @@ def _generate_chart(
         label="all-days (upper bound)",
     )
     ax_cum.plot(
-        dates, cum_p, linewidth=2.5, color=colors[3], marker="s", markersize=3,
-        label="proven (lower bound)",
+        dates, cum_d, linewidth=2.5, color=colors[4], marker="D", markersize=3,
+        label="persisted (headline: >= 2 distinct days)",
     )
-    ax_cum.fill_between(dates, cum_p, cum, color=colors[2], alpha=0.15)
-    ax_cum.set_title("Cumulative LTV spend (compute + Bedrock) -- range between two counting rules", fontsize=10)
+    ax_cum.plot(
+        dates, cum_p, linewidth=1.8, color=colors[3], marker="s", markersize=3,
+        linestyle="--", label="proven (first day free, lower bound)",
+    )
+    ax_cum.fill_between(dates, cum_p, cum, color=colors[2], alpha=0.12)
+    ax_cum.set_title("Cumulative LTV spend (compute + Bedrock) -- range across counting rules", fontsize=10)
     ax_cum.set_ylabel("USD total")
     ax_cum.legend(loc="upper left", fontsize=8)
     ax_cum.yaxis.set_major_locator(plt.MaxNLocator(nbins=6))

--- a/.claude/skills/usage-report/render_report.py
+++ b/.claude/skills/usage-report/render_report.py
@@ -704,10 +704,24 @@ def _build_template_vars(
 
     proven_7d = ltv_last_7d.get("proven_total_usd", 0)
     all_days_7d = ltv_last_7d.get("all_days_total_usd", 0)
+    persisted_7d = ltv_last_7d.get("persisted_total_usd", 0)
     proven_avg = proven_7d / 7 if proven_7d else 0
     all_days_avg = all_days_7d / 7 if all_days_7d else 0
+    persisted_avg = persisted_7d / 7 if persisted_7d else 0
     arr_proven = (proven_avg * 365) / 1_000_000
     arr_all_days = (all_days_avg * 365) / 1_000_000
+    arr_persisted = (persisted_avg * 365) / 1_000_000
+
+    # Instance-day decomposition for the formula-clarification block. The three
+    # rules differ only in which (instance, day) pairs they count; the per-day
+    # rate is identical. all-days >= persisted >= proven, and the two gaps are:
+    #   all-days - persisted = single-calendar-day (install-and-vanish) days
+    #   persisted - proven   = exactly one free first-day per persisted instance
+    id_all_days = ltv_total.get("all_days", {}).get("total_instance_days", 0)
+    id_persisted = ltv_total.get("persisted", {}).get("total_instance_days", 0)
+    id_proven = ltv_total.get("proven", {}).get("total_instance_days", 0)
+    gap_install_vanish_days = id_all_days - id_persisted
+    gap_first_free_days = id_persisted - id_proven
 
     # Forecast
     fc_linear = forecast.get("linear", {})
@@ -848,14 +862,24 @@ def _build_template_vars(
         "yesterday_label": ltv_yesterday.get("date", "?"),
         "ltv_yesterday_proven": f"${ltv_yesterday.get('proven', {}).get('total_usd', 0):,.2f}",
         "ltv_yesterday_all_days": f"${ltv_yesterday.get('all_days', {}).get('total_usd', 0):,.2f}",
+        "ltv_yesterday_persisted": f"${ltv_yesterday.get('persisted', {}).get('total_usd', 0):,.2f}",
         "ltv_last_7_days_proven": f"${proven_7d:,.2f}",
         "ltv_last_7_days_all_days": f"${all_days_7d:,.2f}",
+        "ltv_last_7_days_persisted": f"${persisted_7d:,.2f}",
         "ltv_7day_daily_avg_proven": f"${proven_avg:,.2f}",
         "ltv_7day_daily_avg_all_days": f"${all_days_avg:,.2f}",
+        "ltv_7day_daily_avg_persisted": f"${persisted_avg:,.2f}",
         "ltv_cumulative_proven": f"${ltv_total.get('proven', {}).get('total_usd', 0):,.0f}",
         "ltv_cumulative_all_days": f"${ltv_total.get('all_days', {}).get('total_usd', 0):,.0f}",
+        "ltv_cumulative_persisted": f"${ltv_total.get('persisted', {}).get('total_usd', 0):,.0f}",
         "arr_proven_str": f"${arr_proven:.2f}M",
         "arr_all_days_str": f"${arr_all_days:.2f}M",
+        "arr_persisted_str": f"${arr_persisted:.2f}M",
+        "ltv_instance_days_all_days": f"{id_all_days:,}",
+        "ltv_instance_days_persisted": f"{id_persisted:,}",
+        "ltv_instance_days_proven": f"{id_proven:,}",
+        "ltv_gap_install_vanish_days": f"{gap_install_vanish_days:,}",
+        "ltv_gap_first_free_days": f"{gap_first_free_days:,}",
 
         # Comparison-with-previous
         "prev_total_events": f"{prev_metrics.get('key_metrics', {}).get('total_events', 0):,}",

--- a/.claude/skills/usage-report/report_template.md
+++ b/.claude/skills/usage-report/report_template.md
@@ -195,16 +195,42 @@ The Confirmed-Alive instances skew toward AWS, with ECS, Kubernetes, and Docker 
 
 ## Customer Infra Spend (AWS)
 
+### Daily AWS Customer Instances Reporting Home
+
+![Daily Reporters](daily-reporters-{date}.png)
+
+The headline infra-spend number counts an instance only if it persisted, i.e. reported on **>= 2 distinct days** (it came back on a separate day rather than installing and vanishing the same day). The green line below is that count; the grey line includes single-event install-and-vanish instances. The two lines sit close together, which is the point: the daily reporting fleet is overwhelmingly real, persistent deployments, not install-and-delete churn.
+
+<!-- COMMENTARY:daily_reporters -->
+
 ![LTV Spend](ltv-spend-{date}.png)
 
-Hypothetical AWS infrastructure cost (list price), customer-only:
+Hypothetical AWS infrastructure cost (list price), customer-only. **Persisted** is the headline rule (>= 2 distinct reporting days, every reported day charged); All-Days is the upper bound (includes install-and-vanish); Proven is the lower bound (first day free):
 
-| Window | Proven | All-Days |
-|--------|------:|---------:|
-| Yesterday ({yesterday_label}) | {ltv_yesterday_proven} | {ltv_yesterday_all_days} |
-| Last 7 days | {ltv_last_7_days_proven} | {ltv_last_7_days_all_days} |
-| 7-day daily average | {ltv_7day_daily_avg_proven} | {ltv_7day_daily_avg_all_days} |
-| Cumulative LTV | {ltv_cumulative_proven} | {ltv_cumulative_all_days} |
+| Window | Persisted (headline) | All-Days | Proven |
+|--------|------:|---------:|-------:|
+| Yesterday ({yesterday_label}) | {ltv_yesterday_persisted} | {ltv_yesterday_all_days} | {ltv_yesterday_proven} |
+| Last 7 days | {ltv_last_7_days_persisted} | {ltv_last_7_days_all_days} | {ltv_last_7_days_proven} |
+| 7-day daily average | {ltv_7day_daily_avg_persisted} | {ltv_7day_daily_avg_all_days} | {ltv_7day_daily_avg_proven} |
+| Cumulative LTV | {ltv_cumulative_persisted} | {ltv_cumulative_all_days} | {ltv_cumulative_proven} |
+
+#### How the three numbers relate
+
+All three rules multiply the **same** per-platform daily rates (docker $3.99, ecs $26.04, kubernetes $18.58) by a count of **instance-days** (one (instance, day) pair = one charge). They differ only in which instance-days qualify, so by construction **all-days >= persisted >= proven**:
+
+- **All-days** charges every day any AWS customer instance reported.
+- **Persisted** charges all of an instance's reported days, but only if it reported on >= 2 distinct days (drops install-and-vanish-within-a-day instances).
+- **Proven** is persisted minus each instance's first-ever day (the first day is always free).
+
+Cumulative instance-day decomposition for this window:
+
+| | Instance-days | vs Persisted |
+|---|---:|---|
+| All-days | {ltv_instance_days_all_days} | +{ltv_gap_install_vanish_days} single-calendar-day (install-and-vanish) days |
+| **Persisted (headline)** | **{ltv_instance_days_persisted}** | baseline |
+| Proven | {ltv_instance_days_proven} | -{ltv_gap_first_free_days} first-days freed (one per persisted instance) |
+
+So `persisted - proven` equals the number of persisted instances exactly (each loses one first day), and `all-days - persisted` is the install-and-vanish cohort. At the trailing edge of the window persisted and proven daily figures converge, because an instance active on the last complete day cannot still be on its first-ever day, so proven charges it too.
 
 ### Annualized Run Rate (ARR) Projection
 
@@ -212,8 +238,9 @@ Projecting the last-7-day daily average forward 365 days:
 
 | Model | 7-day daily avg | x 365 = ARR |
 |-------|----------------:|------------:|
-| Proven | {ltv_7day_daily_avg_proven} | **{arr_proven_str}** |
+| Persisted (headline) | {ltv_7day_daily_avg_persisted} | **{arr_persisted_str}** |
 | All-days | {ltv_7day_daily_avg_all_days} | **{arr_all_days_str}** |
+| Proven | {ltv_7day_daily_avg_proven} | **{arr_proven_str}** |
 
 The ARR is hypothetical (we do not bill these customers). It represents the AWS-side infra cost the deployed customer base is generating annually at current run rate, complementing install-count growth as a measure of the fleet's economic footprint.
 


### PR DESCRIPTION
## Summary

Updates to the `usage-report` skill's customer infra-spend (LTV) reporting. No product/runtime code is touched — this is entirely under `.claude/skills/usage-report/`.

## Changes

- **New "persisted" counting rule (headline).** An AWS customer instance is charged on every day it reported, but only if it reported on **>= 2 distinct days** (it came back on a separate day rather than installing and vanishing the same day). This sits alongside the existing **all-days** (upper bound, includes install-and-vanish) and **proven** (lower bound, first day free) rules. Excludes install-and-delete instances without double-counting.
- **Regrounded per-platform daily rates**, each tied to measured data:
  - ECS **$26.04/day** — from a measured Cost Explorer day for the `terraform/aws-ecs` deployment (Fargate + NAT/EC2-Other + RDS + DocumentDB + VPC + CloudWatch + ALBs), excluding shared-account overhead.
  - EKS **$18.58/day** — from a measured EKS reference deployment (3 × m6i.xlarge + control plane + ALB + NAT + EBS + Route 53).
  - docker — now derived from the `EC2_HOURLY_RATE` constant instead of a hardcoded duplicate (removes drift risk).
- **New chart** `generate_daily_reporters_chart.py`: daily AWS customer instances reporting home, with persisted-filter overlays (>= 2 events, >= 2 distinct days). Wired into `SKILL.md` as a numbered step and added to the mandatory-charts checklist (now 12 charts).
- **Report surfacing**: `report_template.md` + `render_report.py` now lead with the persisted number, show all three rules as a range, add an ARR projection row, and include an instance-day decomposition / formula clarification block (all values derived from the LTV summary JSON).
- **Docs**: `SKILL.md` documents all three counting rules, the formula, and the per-platform rate grounding.

## Notes

This work was developed alongside the custom-entities feature (#1173, now merged) but is functionally independent; it was split out into this dedicated PR. Python files compile clean.

## Validation

- `py_compile` passes on all changed/added Python files.
- Charts and report regenerated against live telemetry data during development; numbers reconcile across the chart, CSV sidecar, JSON summary, and rendered report.