### PR TITLE
Add canonical server.json export endpoint (#1187)

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -39,6 +39,7 @@ from ..schemas.server_update_models import (
     ServerCardPatch,
     ServerUpdateRequest,
 )
+from ..services.canonical_export import redact_backend_urls, to_canonical
 from ..services.registration_gate_service import check_registration_gate
 from ..services.security_scanner import security_scanner_service
 from ..services.server_service import server_service
@@ -2491,6 +2492,63 @@ async def get_server_details(
         server_info["default_version"] = current_version
 
     return server_info
+
+
+@router.get("/servers/{path:path}/server.json")
+async def get_server_canonical(
+    request: Request,
+    path: str,
+    user_context: Annotated[dict, Depends(nginx_proxied_auth)],
+):
+    """Return a server projected into the canonical MCP Registry server.json shape.
+
+    Read-only export. Storage stays bespoke; this endpoint projects the stored
+    document into a doc conforming to the upstream server.schema.json (see
+    issue #1187). Auth mirrors the bespoke server read: same access check, and
+    in with-gateway mode the backend URLs are redacted for non-admin callers.
+    """
+    service_path = _normalize_server_path(path)
+
+    set_audit_action(
+        request,
+        "read",
+        "server",
+        resource_id=service_path,
+        description=f"Read canonical server.json for {service_path}",
+    )
+
+    server_info = await server_service.get_server_info(service_path)
+    if not server_info:
+        raise HTTPException(status_code=404, detail="Service path not registered")
+
+    is_admin = user_context.get("is_admin", False)
+
+    # Non-admin callers may only export servers they can access.
+    if not is_admin:
+        if not await server_service.user_can_access_server_path(
+            service_path, user_context.get("accessible_servers", [])
+        ):
+            logger.warning(
+                f"User {user_context.get('username')} attempted canonical export of "
+                f"{service_path} without access"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this server",
+            )
+
+    canonical, truncated = to_canonical(server_info)
+
+    # In with-gateway mode non-admin clients reach servers through the gateway,
+    # so the raw backend URL must not leak. Walk every _meta namespace plus the
+    # top-level remotes block to strip proxy_pass_url and remotes[].url. Mirrors
+    # the proxy_pass_url stripping in GET /api/servers/{path}: strip unless
+    # registry-only, where users need the URL to connect directly.
+    if not is_admin and settings.deployment_mode != DeploymentMode.REGISTRY_ONLY:
+        canonical = redact_backend_urls(canonical)
+
+    headers = {"X-Description-Truncated": "true"} if truncated else None
+    return JSONResponse(content=canonical, headers=headers)
 
 
 @router.get("/tools/{service_path:path}")

--- a/registry/services/canonical_export.py
+++ b/registry/services/canonical_export.py
@@ -1,0 +1,229 @@
+"""Project a stored (bespoke) server document into a canonical MCP Registry server.json.
+
+Read-only, pure functions. See issue #1187 and the LLD for the field mapping.
+Private helpers (prefixed _) first, public functions after.
+"""
+
+import logging
+import re
+from functools import lru_cache
+from typing import Any
+from urllib.parse import urlparse
+
+from ..core.config import settings
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCHEMA_URL: str = (
+    "https://raw.githubusercontent.com/modelcontextprotocol/registry/"
+    "main/docs/reference/server-json/draft/server.schema.json"
+)
+MAX_CANONICAL_DESCRIPTION: int = 100
+
+# Map the registry's local_runtime.type to a canonical packages[].registryType.
+# registryType is a FREE-FORM string in the upstream schema (examples only, no enum),
+# so any value validates. There is no package-registry analogue for a raw "command",
+# so it maps to "mcpb" (the upstream example value for a packaged/bundled server).
+RUNTIME_TO_REGISTRY_TYPE: dict[str, str] = {
+    "npx": "npm",
+    "uvx": "pypi",
+    "docker": "oci",
+    "command": "mcpb",
+}
+
+INTERNAL_FIELDS: list[str] = [
+    "id",
+    "server_name",
+    "tags",
+    "num_tools",
+    "license",
+    "deployment",
+    "registered_by",
+    "proxy_pass_url",
+    "auth_scheme",
+    "auth_provider",
+    "path",
+    "is_active",
+    "is_enabled",
+    "registered_at",
+    "updated_at",
+    "tool_list",
+    "visibility",
+    "allowed_groups",
+    "status",
+    "provider_organization",
+    "provider_url",
+    "source_created_at",
+    "source_updated_at",
+    "mcp_server_version",
+    "health_status",
+    "last_checked_iso",
+]
+
+LOCAL_EXTRA_FIELDS: list[str] = ["image_digest", "platforms"]
+
+
+@lru_cache(maxsize=1)
+def _reverse_dns_base(registry_url: str) -> str:
+    """Convert a registry URL host into a reverse-DNS base label.
+
+    https://mcpgateway.mycorp.com -> com.mycorp.mcpgateway
+    http://localhost:8000        -> localhost
+    """
+    host = urlparse(registry_url).hostname or "localhost"
+    labels = [label for label in host.split(".") if label]
+    reversed_host = ".".join(reversed(labels)) if len(labels) > 1 else host
+    # Namespace segment may contain only [a-zA-Z0-9.-]; map illegal chars to '-'.
+    return re.sub(r"[^a-zA-Z0-9.-]", "-", reversed_host)
+
+
+def _meta_namespace() -> str:
+    """Reverse-DNS namespace for the registry's own _meta block, derived from REGISTRY_URL."""
+    return f"{_reverse_dns_base(settings.registry_url)}/internal"
+
+
+def _name_vendor() -> str:
+    """Vendor prefix for synthesized canonical names, derived from REGISTRY_URL."""
+    return _reverse_dns_base(settings.registry_url)
+
+
+def _derive_canonical_name(stored: dict) -> str:
+    """Synthesize a reverse-DNS name when the original wasn't preserved."""
+    name = stored.get("server_name", "") or ""
+    if "/" in name and "." in name.split("/", 1)[0]:
+        return name
+    slug = (stored.get("path") or "").lstrip("/")
+    return f"{_name_vendor()}/{slug or 'unknown'}"
+
+
+def _truncate_description(text: str) -> tuple[str, bool]:
+    """Return (possibly-truncated description, was_truncated)."""
+    if len(text) <= MAX_CANONICAL_DESCRIPTION:
+        return text, False
+    return text[: MAX_CANONICAL_DESCRIPTION - 1] + "…", True
+
+
+def _build_remotes(
+    stored: dict,
+    spec: dict,
+) -> list[dict] | None:
+    """Prefer preserved remotes; else synthesize from proxy_pass_url."""
+    if spec.get("remotes"):
+        return spec["remotes"]
+    if stored.get("proxy_pass_url"):
+        transport = (stored.get("supported_transports") or ["streamable-http"])[0]
+        return [{"type": transport, "url": stored["proxy_pass_url"]}]
+    return None
+
+
+def _local_runtime_to_package(lr: dict) -> dict:
+    """Inverse of _derive_local_runtime in mcp_registry_transform.py."""
+    env_vars: list[dict[str, Any]] = []
+    seen: dict[str, int] = {}
+
+    for name in lr.get("required_env", []) or []:
+        seen[name] = len(env_vars)
+        env_vars.append({"name": name, "isRequired": True})
+
+    for key, value in (lr.get("env") or {}).items():
+        if key in seen:
+            env_vars[seen[key]]["default"] = value
+        else:
+            env_vars.append({"name": key, "default": value})
+
+    pkg: dict[str, Any] = {
+        # registryType is REQUIRED on a package by the upstream schema, so we always
+        # emit it (never omit). It is free-form, so "mcpb" for command-type is valid.
+        "registryType": RUNTIME_TO_REGISTRY_TYPE.get(lr.get("type", ""), "mcpb"),
+        "identifier": lr.get("package", ""),
+        "version": lr.get("version") or "1.0.0",
+        "transport": {"type": "stdio"},
+        "runtimeHint": lr.get("type", "command"),
+    }
+    if env_vars:
+        pkg["environmentVariables"] = env_vars
+    return pkg
+
+
+def _build_packages(
+    stored: dict,
+    spec: dict,
+) -> list[dict] | None:
+    """Prefer preserved packages; else synthesize from local_runtime."""
+    if spec.get("packages"):
+        return spec["packages"]
+    lr = stored.get("local_runtime")
+    if not lr:
+        return None
+    return [_local_runtime_to_package(lr)]
+
+
+def _build_internal_meta(
+    stored: dict,
+    truncated_full: str | None,
+) -> dict:
+    """Assemble the registry's own _meta block."""
+    internal: dict[str, Any] = {k: stored[k] for k in INTERNAL_FIELDS if k in stored}
+
+    lr = stored.get("local_runtime") or {}
+    for extra_key in LOCAL_EXTRA_FIELDS:
+        if extra_key in lr and lr[extra_key] is not None:
+            internal[extra_key] = lr[extra_key]
+
+    extra_meta = {
+        k: v
+        for k, v in (stored.get("metadata") or {}).items()
+        if k != "mcp_registry_spec"
+    }
+    if extra_meta:
+        internal["metadata"] = extra_meta
+
+    if truncated_full is not None:
+        internal["description_full"] = truncated_full
+
+    return internal
+
+
+def to_canonical(stored: dict) -> tuple[dict, bool]:
+    """Project a stored server dict into a canonical server.json.
+
+    Returns (canonical_doc, description_was_truncated).
+    """
+    spec = (stored.get("metadata") or {}).get("mcp_registry_spec") or {}
+
+    raw_description = stored.get("description", "") or ""
+    description, truncated = _truncate_description(raw_description)
+
+    used_spec = bool(spec)
+    logger.debug(
+        "canonical_export: path=%s used_spec=%s",
+        stored.get("path"),
+        used_spec,
+    )
+
+    out: dict[str, Any] = {
+        "$schema": spec.get("$schema", DEFAULT_SCHEMA_URL),
+        "name": spec.get("original_name") or _derive_canonical_name(stored),
+        "description": description,
+        "version": stored.get("version") or spec.get("version") or "0.0.0",
+    }
+
+    remotes = _build_remotes(stored, spec)
+    if remotes:
+        out["remotes"] = remotes
+
+    packages = _build_packages(stored, spec)
+    if packages:
+        out["packages"] = packages
+
+    if spec.get("repository"):
+        out["repository"] = spec["repository"]
+
+    preserved_meta = spec.get("_meta") or {}
+    internal = _build_internal_meta(
+        stored,
+        raw_description if truncated else None,
+    )
+    out["_meta"] = {**preserved_meta, _meta_namespace(): internal}
+
+    return out, truncated

--- a/registry/services/canonical_export.py
+++ b/registry/services/canonical_export.py
@@ -6,6 +6,7 @@ Private helpers (prefixed _) first, public functions after.
 
 import logging
 import re
+import copy
 from functools import lru_cache
 from typing import Any
 from urllib.parse import urlparse
@@ -227,3 +228,37 @@ def to_canonical(stored: dict) -> tuple[dict, bool]:
     out["_meta"] = {**preserved_meta, _meta_namespace(): internal}
 
     return out, truncated
+
+
+def _strip_remote_urls(remotes: Any) -> None:
+    """Strip the backend `url` from each entry in a `remotes` list, in-place."""
+    if not isinstance(remotes, list):
+        return
+    for remote in remotes:
+        if isinstance(remote, dict):
+            remote.pop("url", None)
+
+
+def _redact_node(node: Any) -> None:
+    """Recursively strip backend URLs from a canonical-doc subtree, in-place."""
+    if isinstance(node, dict):
+        # proxy_pass_url is the registry's internal backend URL. It lives in our
+        # own _meta namespace, but a preserved upstream namespace could echo it
+        # too, so drop it wherever it appears.
+        node.pop("proxy_pass_url", None)
+        # `url` is a backend URL only inside a `remotes` entry. Scope the removal
+        # so non-backend URLs (repository.url, provider_url, ...) are preserved.
+        if "remotes" in node:
+            _strip_remote_urls(node["remotes"])
+        for value in node.values():
+            _redact_node(value)
+    elif isinstance(node, list):
+        for item in node:
+            _redact_node(item)
+
+
+def redact_backend_urls(canonical: dict) -> dict:
+    """Return a redacted COPY of a canonical doc. Does NOT mutate the input."""
+    redacted = copy.deepcopy(canonical)
+    _redact_node(redacted)
+    return redacted

--- a/registry/services/canonical_export.py
+++ b/registry/services/canonical_export.py
@@ -4,9 +4,9 @@ Read-only, pure functions. See issue #1187 and the LLD for the field mapping.
 Private helpers (prefixed _) first, public functions after.
 """
 
+import copy
 import logging
 import re
-import copy
 from functools import lru_cache
 from typing import Any
 from urllib.parse import urlparse
@@ -172,9 +172,7 @@ def _build_internal_meta(
             internal[extra_key] = lr[extra_key]
 
     extra_meta = {
-        k: v
-        for k, v in (stored.get("metadata") or {}).items()
-        if k != "mcp_registry_spec"
+        k: v for k, v in (stored.get("metadata") or {}).items() if k != "mcp_registry_spec"
     }
     if extra_meta:
         internal["metadata"] = extra_meta

--- a/tests/unit/api/test_server_canonical_endpoint.py
+++ b/tests/unit/api/test_server_canonical_endpoint.py
@@ -152,7 +152,9 @@ def test_client_admin(mock_settings, mock_server_service, _mock_auth_admin, admi
 
 
 @pytest.fixture
-def test_client_regular(mock_settings, mock_server_service, _mock_auth_regular, regular_user_context):
+def test_client_regular(
+    mock_settings, mock_server_service, _mock_auth_regular, regular_user_context
+):
     yield from _create_test_client(mock_server_service, regular_user_context)
 
 
@@ -162,7 +164,9 @@ def test_client_regular(mock_settings, mock_server_service, _mock_auth_regular, 
 
 
 class TestCanonicalEndpoint:
-    def test_returns_canonical_shape(self, test_client_admin, mock_server_service, canonical_server_info):
+    def test_returns_canonical_shape(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
         """200 + canonical shape. The $schema field also confirms the request
         routed here and not to the catch-all /servers/{path}."""
         mock_server_service.get_server_info.return_value = canonical_server_info
@@ -188,7 +192,9 @@ class TestCanonicalEndpoint:
         response = test_client_regular.get(URL)
         assert response.status_code == 403
 
-    def test_admin_bypasses_access_check(self, test_client_admin, mock_server_service, canonical_server_info):
+    def test_admin_bypasses_access_check(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
         mock_server_service.get_server_info.return_value = canonical_server_info
         response = test_client_admin.get(URL)
         assert response.status_code == 200
@@ -201,14 +207,18 @@ class TestCanonicalEndpoint:
         test_client_admin.get(URL)
         mock_server_service.get_server_info.assert_called_once_with("/calculator")
 
-    def test_nested_path_matches(self, test_client_admin, mock_server_service, canonical_server_info):
+    def test_nested_path_matches(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
         """Greedy {path:path} must capture a nested path before the .json suffix."""
         mock_server_service.get_server_info.return_value = canonical_server_info
         response = test_client_admin.get("/api/servers/team/calculator/server.json")
         assert response.status_code == 200
         mock_server_service.get_server_info.assert_called_once_with("/team/calculator")
 
-    def test_local_server_returns_packages(self, test_client_admin, mock_server_service, local_server_info):
+    def test_local_server_returns_packages(
+        self, test_client_admin, mock_server_service, local_server_info
+    ):
         mock_server_service.get_server_info.return_value = local_server_info
         response = test_client_admin.get("/api/servers/local-calc/server.json")
         assert response.status_code == 200
@@ -224,7 +234,9 @@ class TestCanonicalEndpoint:
         mock_server_service.get_server_info.return_value = dict(canonical_server_info)
         mock_server_service.user_can_access_server_path.return_value = True
 
-        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY):
+        with patch(
+            "registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY
+        ):
             response = test_client_regular.get(URL)
 
         assert response.status_code == 200
@@ -239,7 +251,9 @@ class TestCanonicalEndpoint:
         mock_server_service.get_server_info.return_value = dict(canonical_server_info)
         mock_server_service.user_can_access_server_path.return_value = True
 
-        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.REGISTRY_ONLY):
+        with patch(
+            "registry.api.server_routes.settings.deployment_mode", DeploymentMode.REGISTRY_ONLY
+        ):
             response = test_client_regular.get(URL)
 
         assert response.status_code == 200
@@ -252,7 +266,9 @@ class TestCanonicalEndpoint:
 
         mock_server_service.get_server_info.return_value = dict(canonical_server_info)
 
-        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY):
+        with patch(
+            "registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY
+        ):
             response = test_client_admin.get(URL)
 
         assert response.status_code == 200
@@ -261,7 +277,9 @@ class TestCanonicalEndpoint:
     def test_truncation_header_present_when_truncated(
         self, test_client_admin, mock_server_service, canonical_server_info
     ):
-        mock_server_service.get_server_info.return_value = dict(canonical_server_info, description="x" * 150)
+        mock_server_service.get_server_info.return_value = dict(
+            canonical_server_info, description="x" * 150
+        )
         response = test_client_admin.get(URL)
         assert response.status_code == 200
         assert response.headers.get("X-Description-Truncated") == "true"

--- a/tests/unit/api/test_server_canonical_endpoint.py
+++ b/tests/unit/api/test_server_canonical_endpoint.py
@@ -1,0 +1,285 @@
+"""Unit tests for GET /api/servers/{path}/server.json (canonical export endpoint).
+
+Exercises the HTTP route added in #1187:
+- returns the canonical server.json shape (and routes correctly past the
+  catch-all /servers/{path} endpoint)
+- 404 when the server is not registered
+- 403 when a non-admin lacks access; admin bypasses the access check
+- path normalization and greedy nested-path matching
+- backend-URL redaction for non-admin callers in with-gateway mode, plus the
+  cases where the URL is kept (registry-only mode, and admin callers)
+- the X-Description-Truncated response header
+- audit logging
+"""
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+logger = logging.getLogger(__name__)
+
+# Backend URL that must be redacted from non-admin, with-gateway responses.
+BACKEND_URL = "http://internal-backend:8080/mcp"
+
+URL = "/api/servers/calculator/server.json"
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+
+@pytest.fixture
+def admin_user_context() -> dict[str, Any]:
+    return {
+        "username": "admin",
+        "is_admin": True,
+        "accessible_servers": ["all"],
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def regular_user_context() -> dict[str, Any]:
+    return {
+        "username": "testuser",
+        "is_admin": False,
+        "accessible_servers": ["calculator"],
+        "auth_method": "session",
+    }
+
+
+@pytest.fixture
+def canonical_server_info() -> dict[str, Any]:
+    """Remote server, no preserved spec. to_canonical synthesizes remotes from
+    proxy_pass_url, so both remotes[].url and the internal _meta carry the
+    backend URL that redaction must strip."""
+    return {
+        "id": "srv-1",
+        "server_name": "Calculator",
+        "path": "/calculator",
+        "description": "A calculator MCP server",
+        "version": "1.2.0",
+        "proxy_pass_url": BACKEND_URL,
+        "deployment": "remote",
+        "supported_transports": ["streamable-http"],
+        "tags": ["math"],
+        "num_tools": 1,
+        "tool_list": [{"name": "add"}],
+        "auth_scheme": "none",
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def local_server_info() -> dict[str, Any]:
+    """Local stdio server, no spec. to_canonical synthesizes a packages[] entry."""
+    return {
+        "id": "srv-2",
+        "server_name": "Local Calc",
+        "path": "/local-calc",
+        "description": "Local stdio MCP server",
+        "version": "1.0.0",
+        "deployment": "local",
+        "supported_transports": ["stdio"],
+        "local_runtime": {
+            "type": "npx",
+            "package": "@example/calc-mcp",
+            "version": "1.0.0",
+        },
+        "metadata": {},
+    }
+
+
+@pytest.fixture
+def mock_server_service():
+    mock_service = MagicMock()
+    mock_service.get_server_info = AsyncMock(return_value=None)
+    mock_service.user_can_access_server_path = AsyncMock(return_value=True)
+    return mock_service
+
+
+@pytest.fixture
+def _mock_auth_admin(admin_user_context, mock_settings):
+    from registry.auth.dependencies import enhanced_auth, nginx_proxied_auth
+    from registry.main import app
+
+    app.dependency_overrides[enhanced_auth] = lambda: admin_user_context
+    app.dependency_overrides[nginx_proxied_auth] = lambda: admin_user_context
+    yield admin_user_context
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def _mock_auth_regular(regular_user_context, mock_settings):
+    from registry.auth.dependencies import enhanced_auth, nginx_proxied_auth
+    from registry.main import app
+
+    app.dependency_overrides[enhanced_auth] = lambda: regular_user_context
+    app.dependency_overrides[nginx_proxied_auth] = lambda: regular_user_context
+    yield regular_user_context
+    app.dependency_overrides.clear()
+
+
+def _create_test_client(mock_server_service, user_context):
+    def mock_enhanced_auth_func(session=None):
+        return user_context
+
+    with (
+        patch("registry.api.server_routes.server_service", mock_server_service),
+        patch("registry.search.service.faiss_service", MagicMock()),
+        patch("registry.health.service.health_service", MagicMock()),
+        patch("registry.core.nginx_service.nginx_service", MagicMock()),
+        patch("registry.api.server_routes.security_scanner_service", MagicMock()),
+        patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
+        patch("registry.api.server_routes.enhanced_auth", mock_enhanced_auth_func),
+    ):
+        from registry.auth.csrf import verify_csrf_token_flexible
+        from registry.main import app
+
+        app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+        client = TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+        yield client
+        app.dependency_overrides.pop(verify_csrf_token_flexible, None)
+
+
+@pytest.fixture
+def test_client_admin(mock_settings, mock_server_service, _mock_auth_admin, admin_user_context):
+    yield from _create_test_client(mock_server_service, admin_user_context)
+
+
+@pytest.fixture
+def test_client_regular(mock_settings, mock_server_service, _mock_auth_regular, regular_user_context):
+    yield from _create_test_client(mock_server_service, regular_user_context)
+
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+
+class TestCanonicalEndpoint:
+    def test_returns_canonical_shape(self, test_client_admin, mock_server_service, canonical_server_info):
+        """200 + canonical shape. The $schema field also confirms the request
+        routed here and not to the catch-all /servers/{path}."""
+        mock_server_service.get_server_info.return_value = canonical_server_info
+
+        response = test_client_admin.get(URL)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "$schema" in data
+        assert {"name", "description", "version"}.issubset(data.keys())
+        assert "_meta" in data
+
+    def test_not_found(self, test_client_admin, mock_server_service):
+        mock_server_service.get_server_info.return_value = None
+        response = test_client_admin.get("/api/servers/missing/server.json")
+        assert response.status_code == 404
+
+    def test_forbidden_for_non_admin_without_access(
+        self, test_client_regular, mock_server_service, canonical_server_info
+    ):
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        mock_server_service.user_can_access_server_path.return_value = False
+        response = test_client_regular.get(URL)
+        assert response.status_code == 403
+
+    def test_admin_bypasses_access_check(self, test_client_admin, mock_server_service, canonical_server_info):
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        response = test_client_admin.get(URL)
+        assert response.status_code == 200
+        mock_server_service.user_can_access_server_path.assert_not_called()
+
+    def test_path_normalized_with_leading_slash(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        test_client_admin.get(URL)
+        mock_server_service.get_server_info.assert_called_once_with("/calculator")
+
+    def test_nested_path_matches(self, test_client_admin, mock_server_service, canonical_server_info):
+        """Greedy {path:path} must capture a nested path before the .json suffix."""
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        response = test_client_admin.get("/api/servers/team/calculator/server.json")
+        assert response.status_code == 200
+        mock_server_service.get_server_info.assert_called_once_with("/team/calculator")
+
+    def test_local_server_returns_packages(self, test_client_admin, mock_server_service, local_server_info):
+        mock_server_service.get_server_info.return_value = local_server_info
+        response = test_client_admin.get("/api/servers/local-calc/server.json")
+        assert response.status_code == 200
+        data = response.json()
+        assert "packages" in data
+        assert "remotes" not in data
+
+    def test_backend_url_redacted_for_non_admin_with_gateway(
+        self, test_client_regular, mock_server_service, canonical_server_info
+    ):
+        from registry.core.config import DeploymentMode
+
+        mock_server_service.get_server_info.return_value = dict(canonical_server_info)
+        mock_server_service.user_can_access_server_path.return_value = True
+
+        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY):
+            response = test_client_regular.get(URL)
+
+        assert response.status_code == 200
+        assert BACKEND_URL not in response.text
+        assert "url" not in response.json()["remotes"][0]
+
+    def test_backend_url_kept_for_non_admin_registry_only(
+        self, test_client_regular, mock_server_service, canonical_server_info
+    ):
+        from registry.core.config import DeploymentMode
+
+        mock_server_service.get_server_info.return_value = dict(canonical_server_info)
+        mock_server_service.user_can_access_server_path.return_value = True
+
+        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.REGISTRY_ONLY):
+            response = test_client_regular.get(URL)
+
+        assert response.status_code == 200
+        assert BACKEND_URL in response.text
+
+    def test_backend_url_kept_for_admin_with_gateway(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
+        from registry.core.config import DeploymentMode
+
+        mock_server_service.get_server_info.return_value = dict(canonical_server_info)
+
+        with patch("registry.api.server_routes.settings.deployment_mode", DeploymentMode.WITH_GATEWAY):
+            response = test_client_admin.get(URL)
+
+        assert response.status_code == 200
+        assert BACKEND_URL in response.text
+
+    def test_truncation_header_present_when_truncated(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
+        mock_server_service.get_server_info.return_value = dict(canonical_server_info, description="x" * 150)
+        response = test_client_admin.get(URL)
+        assert response.status_code == 200
+        assert response.headers.get("X-Description-Truncated") == "true"
+
+    def test_truncation_header_absent_when_not_truncated(
+        self, test_client_admin, mock_server_service, canonical_server_info
+    ):
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        response = test_client_admin.get(URL)
+        assert response.status_code == 200
+        assert "x-description-truncated" not in response.headers
+
+    def test_audit_logged(self, test_client_admin, mock_server_service, canonical_server_info):
+        mock_server_service.get_server_info.return_value = canonical_server_info
+        with patch("registry.api.server_routes.set_audit_action") as mock_audit:
+            response = test_client_admin.get(URL)
+        assert response.status_code == 200
+        mock_audit.assert_called_once()
+        args = mock_audit.call_args[0]
+        assert args[1] == "read"
+        assert args[2] == "server"

--- a/tests/unit/services/test_canonical_export.py
+++ b/tests/unit/services/test_canonical_export.py
@@ -1,0 +1,525 @@
+"""Unit tests for the canonical server.json transform.
+
+The transform is a pure function over a stored server dict. These tests
+exercise the round-trip path (when metadata.mcp_registry_spec is present),
+the synthesis fallback path (legacy/bespoke documents), the description
+truncation rule, and the reverse-DNS namespace derivation.
+"""
+
+import pytest
+
+from registry.services import canonical_export
+from registry.services.canonical_export import (
+    DEFAULT_SCHEMA_URL,
+    MAX_CANONICAL_DESCRIPTION,
+    _reverse_dns_base,
+    to_canonical,
+)
+
+
+# =============================================================================
+# Fixtures and helpers
+# =============================================================================
+
+
+def _stored_remote_with_spec() -> dict:
+    """Stored doc registered from canonical server.json (spec preserved)."""
+    spec = {
+        "$schema": (
+            "https://raw.githubusercontent.com/modelcontextprotocol/registry/"
+            "main/docs/reference/server-json/draft/server.schema.json"
+        ),
+        "original_name": "io.example/calculator-mcp",
+        "version": "1.2.0",
+        "repository": {
+            "url": "https://github.com/example/calculator-mcp",
+            "source": "github",
+        },
+        "remotes": [
+            {
+                "type": "streamable-http",
+                "url": "https://backend.example/mcp",
+                "headers": [
+                    {"name": "X-Tenant", "value": "acme"},
+                ],
+            }
+        ],
+        "_meta": {
+            "io.modelcontextprotocol.registry/publisher-provided": {
+                "publisher": "example",
+            }
+        },
+    }
+    return {
+        "id": "srv-1",
+        "server_name": "Calculator",
+        "path": "/calculator",
+        "description": "A calculator MCP server",
+        "version": "1.2.0",
+        "proxy_pass_url": "https://backend.example/mcp",
+        "deployment": "remote",
+        "supported_transports": ["streamable-http"],
+        "tags": ["math"],
+        "num_tools": 3,
+        "tool_list": [{"name": "add"}],
+        "auth_scheme": "none",
+        "is_active": True,
+        "is_enabled": True,
+        "metadata": {"mcp_registry_spec": spec, "extra_field": "kept"},
+    }
+
+
+def _stored_remote_no_spec() -> dict:
+    """Legacy/bespoke remote server: no mcp_registry_spec preserved."""
+    return {
+        "id": "srv-2",
+        "server_name": "Legacy Remote",
+        "path": "/legacy-remote",
+        "description": "Bespoke remote server.",
+        "version": "0.5.0",
+        "proxy_pass_url": "https://legacy.example/mcp",
+        "deployment": "remote",
+        "supported_transports": ["sse"],
+        "tags": ["legacy"],
+        "num_tools": 0,
+        "auth_scheme": "bearer",
+        "metadata": {},
+    }
+
+
+def _stored_local_no_spec() -> dict:
+    """Legacy/bespoke local stdio server: no mcp_registry_spec preserved."""
+    return {
+        "id": "srv-3",
+        "server_name": "Local Calc",
+        "path": "/local-calc",
+        "description": "Local stdio MCP server.",
+        "version": "2.0.0",
+        "deployment": "local",
+        "supported_transports": ["stdio"],
+        "tags": ["math", "local"],
+        "num_tools": 1,
+        "tool_list": [{"name": "compute"}],
+        "auth_scheme": "none",
+        "local_runtime": {
+            "type": "npx",
+            "package": "@example/calc-mcp",
+            "version": "1.4.2",
+            "env": {"LOG_LEVEL": "info"},
+            "required_env": ["API_KEY"],
+        },
+        "metadata": {},
+    }
+
+
+def _stored_local_command() -> dict:
+    """Local server with command-type runtime; tests registryType -> 'mcpb'."""
+    return {
+        "id": "srv-4",
+        "server_name": "Cmd Server",
+        "path": "/cmd",
+        "description": "Direct command launcher.",
+        "version": "1.0.0",
+        "deployment": "local",
+        "supported_transports": ["stdio"],
+        "local_runtime": {
+            "type": "command",
+            "package": "/usr/local/bin/my-mcp",
+            "version": "1.0.0",
+        },
+        "metadata": {},
+    }
+
+
+def _stored_docker_local() -> dict:
+    """Docker local runtime carrying image_digest and platforms."""
+    return {
+        "id": "srv-5",
+        "server_name": "Docker Server",
+        "path": "/docker",
+        "description": "Containerized stdio server.",
+        "version": "1.0.0",
+        "deployment": "local",
+        "supported_transports": ["stdio"],
+        "local_runtime": {
+            "type": "docker",
+            "package": "example/mcp-image",
+            "version": "1.0.0",
+            "image_digest": "sha256:abc123",
+            "platforms": ["linux/amd64", "linux/arm64"],
+        },
+        "metadata": {},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_reverse_dns_cache():
+    """Clear the lru_cache on _reverse_dns_base between tests so REGISTRY_URL changes apply."""
+    _reverse_dns_base.cache_clear()
+    yield
+    _reverse_dns_base.cache_clear()
+
+
+@pytest.fixture
+def patch_registry_url(monkeypatch: pytest.MonkeyPatch):
+    """Helper to set the registry_url used by namespace derivation."""
+
+    def _set(url: str) -> None:
+        monkeypatch.setattr(canonical_export.settings, "registry_url", url)
+        _reverse_dns_base.cache_clear()
+
+    return _set
+
+
+# =============================================================================
+# Reverse-DNS derivation
+# =============================================================================
+
+
+class TestReverseDnsBase:
+    """Cover _reverse_dns_base derivation per LLD table."""
+
+    def test_corp_domain_reverses(self):
+        assert _reverse_dns_base("https://mcpgateway.mycorp.com") == "com.mycorp.mcpgateway"
+
+    def test_localhost_with_port_strips_port(self):
+        assert _reverse_dns_base("http://localhost:8000") == "localhost"
+
+    def test_multi_label_with_region(self):
+        assert (
+            _reverse_dns_base("https://registry.us-east-1.mycorp.click")
+            == "click.mycorp.us-east-1.registry"
+        )
+
+    def test_illegal_chars_sanitized(self):
+        # underscore must be mapped to '-' since the canonical name pattern excludes _
+        assert _reverse_dns_base("http://my_host.example.com") == "com.example.my-host"
+
+    def test_missing_host_falls_back_to_localhost(self):
+        # urlparse on a bare string yields no host
+        assert _reverse_dns_base("not-a-url") == "localhost"
+
+
+# =============================================================================
+# Round-trip: spec preserved
+# =============================================================================
+
+
+class TestRoundtripPreservesCanonicalFields:
+    """When metadata.mcp_registry_spec is present, canonical fields come through verbatim."""
+
+    def test_schema_name_version_repository_remotes_preserved(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_with_spec()
+        spec = stored["metadata"]["mcp_registry_spec"]
+
+        out, truncated = to_canonical(stored)
+
+        assert truncated is False
+        assert out["$schema"] == spec["$schema"]
+        assert out["name"] == spec["original_name"]
+        assert out["version"] == "1.2.0"
+        assert out["repository"] == spec["repository"]
+        assert out["remotes"] == spec["remotes"]
+
+    def test_preserved_meta_merged_with_internal(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_with_spec()
+        spec = stored["metadata"]["mcp_registry_spec"]
+
+        out, _ = to_canonical(stored)
+
+        meta = out["_meta"]
+        # preserved upstream namespace is present
+        assert (
+            meta["io.modelcontextprotocol.registry/publisher-provided"]
+            == spec["_meta"]["io.modelcontextprotocol.registry/publisher-provided"]
+        )
+        # internal namespace appears alongside, derived from REGISTRY_URL
+        internal_ns = "com.mycorp.mcpgateway/internal"
+        assert internal_ns in meta
+        internal = meta[internal_ns]
+        assert internal["id"] == "srv-1"
+        assert internal["server_name"] == "Calculator"
+        assert internal["path"] == "/calculator"
+        assert internal["tool_list"] == [{"name": "add"}]
+        # extra metadata (non-spec keys) preserved under "metadata"
+        assert internal["metadata"] == {"extra_field": "kept"}
+
+    def test_description_under_cap_unchanged(self):
+        stored = _stored_remote_with_spec()
+        out, truncated = to_canonical(stored)
+
+        assert truncated is False
+        assert out["description"] == stored["description"]
+
+
+# =============================================================================
+# Synthesis: no spec
+# =============================================================================
+
+
+class TestSynthesizesValidDocNoSpec:
+    """A bespoke document without mcp_registry_spec gets a schema-shape doc synthesized."""
+
+    def test_required_top_level_fields_present(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_no_spec()
+
+        out, _ = to_canonical(stored)
+
+        # The three top-level required canonical fields must always appear.
+        assert set(["name", "description", "version"]).issubset(out.keys())
+        assert out["$schema"] == DEFAULT_SCHEMA_URL
+        assert out["version"] == "0.5.0"
+
+    def test_internal_meta_namespace_used(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_no_spec()
+
+        out, _ = to_canonical(stored)
+
+        assert "com.mycorp.mcpgateway/internal" in out["_meta"]
+
+    def test_version_default_when_absent(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+        stored.pop("version")
+        # also strip metadata so neither path has it
+        stored["metadata"] = {}
+
+        out, _ = to_canonical(stored)
+
+        assert out["version"] == "0.0.0"
+
+
+class TestRemoteSynthesis:
+    """No spec, remote => remotes synthesized from proxy_pass_url + supported_transports."""
+
+    def test_remote_url_and_type_from_stored(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+
+        out, _ = to_canonical(stored)
+
+        assert out["remotes"] == [
+            {"type": "sse", "url": "https://legacy.example/mcp"},
+        ]
+        # remote-only servers must not synthesize a packages array
+        assert "packages" not in out
+
+    def test_default_transport_when_unspecified(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+        stored.pop("supported_transports")
+
+        out, _ = to_canonical(stored)
+
+        assert out["remotes"][0]["type"] == "streamable-http"
+
+
+class TestLocalSynthesis:
+    """No spec, local stdio => packages[0] synthesized from local_runtime."""
+
+    def test_stdio_transport_and_environment_variables(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_local_no_spec()
+
+        out, _ = to_canonical(stored)
+
+        assert "remotes" not in out
+        pkg = out["packages"][0]
+        assert pkg["registryType"] == "npm"
+        assert pkg["identifier"] == "@example/calc-mcp"
+        assert pkg["version"] == "1.4.2"
+        assert pkg["transport"] == {"type": "stdio"}
+        assert pkg["runtimeHint"] == "npx"
+
+        env_by_name = {ev["name"]: ev for ev in pkg["environmentVariables"]}
+        assert env_by_name["API_KEY"]["isRequired"] is True
+        assert "default" not in env_by_name["API_KEY"]
+        assert env_by_name["LOG_LEVEL"]["default"] == "info"
+
+    def test_required_and_env_overlap_merges(self, patch_registry_url):
+        """Validator at ingest forbids overlap, but legacy data may have it; merge into one entry."""
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_local_no_spec()
+        stored["local_runtime"]["env"] = {"API_KEY": "default-value"}
+        stored["local_runtime"]["required_env"] = ["API_KEY"]
+
+        out, _ = to_canonical(stored)
+
+        env_vars = out["packages"][0]["environmentVariables"]
+        api_entries = [ev for ev in env_vars if ev["name"] == "API_KEY"]
+        assert len(api_entries) == 1
+        assert api_entries[0]["isRequired"] is True
+        assert api_entries[0]["default"] == "default-value"
+
+    def test_docker_extras_stashed_in_internal_meta(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_docker_local()
+
+        out, _ = to_canonical(stored)
+
+        internal = out["_meta"]["com.mycorp.mcpgateway/internal"]
+        assert internal["image_digest"] == "sha256:abc123"
+        assert internal["platforms"] == ["linux/amd64", "linux/arm64"]
+
+
+class TestCommandLocalRegistryType:
+    """`command`-type local servers must emit packages[0].registryType = 'mcpb'."""
+
+    def test_command_maps_to_mcpb(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_local_command()
+
+        out, _ = to_canonical(stored)
+
+        assert "packages" in out
+        pkg = out["packages"][0]
+        assert pkg["registryType"] == "mcpb"
+        assert pkg["runtimeHint"] == "command"
+        # registryType must never be omitted for a package
+        assert "registryType" in pkg
+
+
+# =============================================================================
+# Description truncation
+# =============================================================================
+
+
+class TestDescriptionTruncation:
+    """Description over 100 chars is truncated; full text moves to _meta.<ns>.description_full."""
+
+    def test_long_description_truncates_and_flags(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_no_spec()
+        stored["description"] = "x" * 200
+
+        out, truncated = to_canonical(stored)
+
+        assert truncated is True
+        assert len(out["description"]) == MAX_CANONICAL_DESCRIPTION
+        assert out["description"].endswith("…")
+        internal = out["_meta"]["com.mycorp.mcpgateway/internal"]
+        assert internal["description_full"] == "x" * 200
+
+    def test_exactly_100_chars_not_truncated(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+        stored["description"] = "y" * 100
+
+        out, truncated = to_canonical(stored)
+
+        assert truncated is False
+        assert out["description"] == "y" * 100
+        internal = out["_meta"]["localhost/internal"]
+        assert "description_full" not in internal
+
+    def test_empty_description_handled(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+        stored["description"] = ""
+
+        out, truncated = to_canonical(stored)
+
+        assert truncated is False
+        assert out["description"] == ""
+
+
+# =============================================================================
+# Name synthesis
+# =============================================================================
+
+
+class TestNameSynthesisReverseDns:
+    """If server_name isn't already reverse-DNS, synthesize <vendor>/<slug>."""
+
+    def test_bare_name_becomes_vendor_slug(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_no_spec()
+        # server_name is "Legacy Remote" (no slash), path is "/legacy-remote"
+        out, _ = to_canonical(stored)
+
+        assert out["name"] == "com.mycorp.mcpgateway/legacy-remote"
+
+    def test_already_reverse_dns_preserved(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_no_spec()
+        stored["server_name"] = "io.example/already-canonical"
+
+        out, _ = to_canonical(stored)
+
+        assert out["name"] == "io.example/already-canonical"
+
+    def test_unknown_slug_when_no_path(self, patch_registry_url):
+        patch_registry_url("http://localhost:8000")
+        stored = _stored_remote_no_spec()
+        stored.pop("path")
+        stored["server_name"] = "anonymous"
+
+        out, _ = to_canonical(stored)
+
+        assert out["name"] == "localhost/unknown"
+
+    def test_spec_original_name_wins_over_synthesis(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_with_spec()
+
+        out, _ = to_canonical(stored)
+
+        assert out["name"] == "io.example/calculator-mcp"
+
+
+# =============================================================================
+# Round-trip byte-equality (modulo key order) for canonical input fields
+# =============================================================================
+
+
+class TestRoundtripByteEquality:
+    """Canonical fields are byte-for-byte identical modulo key ordering."""
+
+    def test_canonical_fields_byte_identical_modulo_order(self, patch_registry_url):
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        stored = _stored_remote_with_spec()
+        spec = stored["metadata"]["mcp_registry_spec"]
+
+        out, truncated = to_canonical(stored)
+
+        assert truncated is False
+        # Canonical input fields are returned exactly as preserved.
+        assert out["$schema"] == spec["$schema"]
+        assert out["name"] == spec["original_name"]
+        assert out["version"] == spec["version"]
+        assert out["repository"] == spec["repository"]
+        assert out["remotes"] == spec["remotes"]
+
+    def test_preserved_packages_passed_through_verbatim(self, patch_registry_url):
+        """A local server registered from canonical input round-trips its packages array."""
+        patch_registry_url("https://mcpgateway.mycorp.com")
+        preserved_packages = [
+            {
+                "registryType": "npm",
+                "identifier": "@example/calc-mcp",
+                "version": "1.4.2",
+                "transport": {"type": "stdio"},
+                "runtimeHint": "npx",
+                "environmentVariables": [
+                    {"name": "API_KEY", "isRequired": True},
+                ],
+            }
+        ]
+        stored = _stored_local_no_spec()
+        stored["metadata"] = {
+            "mcp_registry_spec": {
+                "original_name": "io.example/calc-mcp",
+                "version": "1.4.2",
+                "packages": preserved_packages,
+            }
+        }
+
+        out, _ = to_canonical(stored)
+
+        # Synthesis path must not run; preserved array passes through unchanged.
+        assert out["packages"] == preserved_packages
+        assert "remotes" not in out

--- a/tests/unit/services/test_canonical_export.py
+++ b/tests/unit/services/test_canonical_export.py
@@ -5,15 +5,20 @@ exercise the round-trip path (when metadata.mcp_registry_spec is present),
 the synthesis fallback path (legacy/bespoke documents), the description
 truncation rule, and the reverse-DNS namespace derivation.
 """
+import copy
 
 import pytest
 
+
+
 from registry.services import canonical_export
+
 from registry.services.canonical_export import (
     DEFAULT_SCHEMA_URL,
     MAX_CANONICAL_DESCRIPTION,
     _reverse_dns_base,
     to_canonical,
+    redact_backend_urls,
 )
 
 
@@ -523,3 +528,26 @@ class TestRoundtripByteEquality:
         # Synthesis path must not run; preserved array passes through unchanged.
         assert out["packages"] == preserved_packages
         assert "remotes" not in out
+
+def test_redaction_does_not_mutate_source_server():
+    """Redaction works on a copy: source untouched, output stripped."""
+    stored = {
+        "path": "/test",
+        "description": "test server",
+        "metadata": {
+            "mcp_registry_spec": {
+                "remotes": [
+                    {"type": "streamable-http", "url": "http://backend:8000/mcp"}
+                ]
+            }
+        },
+    }
+    before = copy.deepcopy(stored)
+
+    canonical, _ = to_canonical(stored)
+    redacted = redact_backend_urls(canonical)   # capture the returned copy
+
+    # source the caller passed in is untouched (no cache corruption)...
+    assert stored == before, "redaction leaked back into the stored server"
+    # ...and the returned doc actually has the backend url stripped
+    assert "url" not in redacted["remotes"][0], "backend url was not redacted"

--- a/tests/unit/services/test_canonical_export.py
+++ b/tests/unit/services/test_canonical_export.py
@@ -5,22 +5,19 @@ exercise the round-trip path (when metadata.mcp_registry_spec is present),
 the synthesis fallback path (legacy/bespoke documents), the description
 truncation rule, and the reverse-DNS namespace derivation.
 """
+
 import copy
 
 import pytest
 
-
-
 from registry.services import canonical_export
-
 from registry.services.canonical_export import (
     DEFAULT_SCHEMA_URL,
     MAX_CANONICAL_DESCRIPTION,
     _reverse_dns_base,
-    to_canonical,
     redact_backend_urls,
+    to_canonical,
 )
-
 
 # =============================================================================
 # Fixtures and helpers
@@ -274,7 +271,7 @@ class TestSynthesizesValidDocNoSpec:
         out, _ = to_canonical(stored)
 
         # The three top-level required canonical fields must always appear.
-        assert set(["name", "description", "version"]).issubset(out.keys())
+        assert {"name", "description", "version"}.issubset(out.keys())
         assert out["$schema"] == DEFAULT_SCHEMA_URL
         assert out["version"] == "0.5.0"
 
@@ -529,6 +526,7 @@ class TestRoundtripByteEquality:
         assert out["packages"] == preserved_packages
         assert "remotes" not in out
 
+
 def test_redaction_does_not_mutate_source_server():
     """Redaction works on a copy: source untouched, output stripped."""
     stored = {
@@ -536,16 +534,14 @@ def test_redaction_does_not_mutate_source_server():
         "description": "test server",
         "metadata": {
             "mcp_registry_spec": {
-                "remotes": [
-                    {"type": "streamable-http", "url": "http://backend:8000/mcp"}
-                ]
+                "remotes": [{"type": "streamable-http", "url": "http://backend:8000/mcp"}]
             }
         },
     }
     before = copy.deepcopy(stored)
 
     canonical, _ = to_canonical(stored)
-    redacted = redact_backend_urls(canonical)   # capture the returned copy
+    redacted = redact_backend_urls(canonical)  # capture the returned copy
 
     # source the caller passed in is untouched (no cache corruption)...
     assert stored == before, "redaction leaked back into the stored server"


### PR DESCRIPTION
*Issue #, if available:* #1187

*Description of changes:*

Adds GET /api/servers/{path}/server.json, a read-only endpoint that projects a stored server into the canonical MCP Registry server.json shape (#1187). Storage stays bespoke; this only projects on read.
Backend-URL redaction: For non-admin callers in with-gateway mode, backend URLs are stripped — proxy_pass_url in every _meta namespace plus remotes[].url — since those clients reach servers through the gateway. Admins and registry-only mode keep them. Mirrors the existing stripping in GET /api/servers/{path}. The redaction helper returns a redacted deep copy rather than mutating in place: get_server_info returns only a shallow copy, so an in-place walk would corrupt the in-memory cache for any server with a preserved mcp_registry_spec.
Tests: a transform-level cache-safety regression test, plus 13 endpoint tests covering canonical shape + routing, 403/404, admin bypass, path normalization and nested paths, redaction by role/mode, the truncation header, and audit logging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
