### PR TITLE
fix(mcpgw): dedupe discovery candidates and itemize withheld results

### DIFF
--- a/docs/dynamic-tool-discovery.md
+++ b/docs/dynamic-tool-discovery.md
@@ -45,21 +45,21 @@ The receipt is a caller-visible eval/debugging signal, not an operator audit tra
 
 A useful receipt answers four questions:
 
-1. **What was requested?** The natural-language discovery query and correlation identifiers.
-2. **What was exposed?** The tools, agents, or skills returned to the agent, with scores and the configured result limits.
-3. **What stayed out?** The count or categories of candidate results that were intentionally withheld because they were outside the current intent, policy scope, or result budget.
-4. **What happened next?** Whether a discovered tool was invoked, skipped, denied, or fell back to another path.
+1. **What was requested?** The natural-language discovery query.
+2. **What was exposed?** The tools, agents, or skills returned to the agent, with scores and the configured result limit.
+3. **What stayed out?** How many candidate results were withheld because they fell outside the result budget, plus the highest-scoring withheld items themselves (`top_withheld`) so you can tell whether the tool you wanted was a near miss or genuinely absent.
+4. **What was the outcome?** The overall `status` and a `stop_reason` describing why discovery ended.
+
+The receipt is built from the candidate results the registry returned, after de-duplicating tools that appear in both the top-level `tools` array and a server's `matching_tools` list. Candidates beyond the requested limit (`max_results` / `top_n`) become the withheld set; the full withheld count is always reported, while `top_withheld` lists at most the first few (capped by `MAX_WITHHELD_ITEMS`, default 5) to keep the receipt compact.
 
 Example shape:
 
 ```json
 {
   "event": "registry.discovery_receipt",
-  "request_id": "req_123",
-  "session_id": "sess_456",
   "query": "weather forecast for tomorrow",
   "limits": {
-    "max_results": 1
+    "max_results": 2
   },
   "exposed_results": [
     {
@@ -67,32 +67,43 @@ Example shape:
       "service_path": "/weather",
       "name": "get_forecast",
       "similarity_score": 0.91
+    },
+    {
+      "asset_type": "tool",
+      "service_path": "/weather",
+      "name": "get_current_conditions",
+      "similarity_score": 0.78
     }
   ],
   "withheld": {
-    "candidate_result_count": 42,
-    "reason": "outside_intent_or_budget"
+    "candidate_result_count": 3,
+    "reason": "outside_intent_or_budget",
+    "top_withheld": [
+      {
+        "asset_type": "agent",
+        "service_path": "/travel-planner",
+        "name": "trip_advisor_agent",
+        "similarity_score": 0.55
+      },
+      {
+        "asset_type": "skill",
+        "service_path": "/packing",
+        "name": "what_to_pack",
+        "similarity_score": 0.41
+      }
+    ]
   },
-  "invocation": {
-    "tool_name": "get_forecast",
-    "status": "ok",
-    "args_shape": {
-      "fields": ["location", "days"],
-      "redacted": true
-    },
-    "result_shape": "forecast",
-    "duration_ms": 245
-  },
-  "stop_reason": "tool_invoked"
+  "status": "success",
+  "stop_reason": "results_returned"
 }
 ```
 
 Keep discovery receipts compact and privacy-safe:
 
-- Store shapes, counts, categories, scores, and correlation IDs; avoid raw user prompts beyond the discovery query unless your retention policy allows them.
-- Redact tool arguments and results by default. The receipt should show the class of data used, not copy sensitive payloads into observability storage.
+- Store shapes, counts, categories, and scores; avoid raw user prompts beyond the discovery query unless your retention policy allows them.
+- The receipt records result metadata (asset type, service path, name, similarity score), never raw tool arguments or tool outputs. Keep it that way if you extend the shape.
 - Keep metrics lower-cardinality than receipts. Good metric labels include service family, status, and stop reason; avoid labels such as raw query text, user IDs, arguments, or result values.
-- Treat withheld results as a first-class signal. If many useful tools, agents, or skills are repeatedly withheld for the same task, split services, improve descriptions, or adjust discovery limits.
+- Treat withheld results as a first-class signal. If useful tools, agents, or skills repeatedly show up in `top_withheld` for the same task, raise the discovery limit, split services, or improve descriptions so the right candidate ranks high enough to be exposed.
 
 ## Architecture
 

--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -42,6 +42,11 @@ MAX_QUERY_LENGTH: int = 500
 MIN_TOP_N: int = 1
 MAX_TOP_N: int = 50
 
+# Max number of withheld candidates itemized in a discovery receipt. The full
+# count is always reported; this caps the listed near-miss items so the receipt
+# stays compact and low-token for eval/agent-dev callers.
+MAX_WITHHELD_ITEMS: int = 5
+
 logger.info(f"Registry URL: {REGISTRY_URL}")
 if REGISTRY_EXTERNAL_URL:
     logger.info(f"Registry External URL: {REGISTRY_EXTERNAL_URL}")
@@ -205,12 +210,46 @@ def _validate_query(query: str) -> str:
     return query.strip()
 
 
+def _dedupe_candidates(
+    candidates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Remove duplicate discovery candidates while preserving order.
+
+    The registry can return the same tool in both the top-level ``tools`` array
+    and a server's ``matching_tools`` list. Without dedup the receipt counts that
+    single tool twice, which inflates exposed_results and skews the withheld
+    count. Candidates are keyed by (asset_type, service_path, name); on a
+    collision the entry with the higher similarity_score is kept.
+    """
+    deduped: dict[tuple[str, str, str], dict[str, Any]] = {}
+    order: list[tuple[str, str, str]] = []
+    for candidate in candidates:
+        key = (
+            candidate.get("asset_type", ""),
+            candidate.get("service_path", ""),
+            candidate.get("name", ""),
+        )
+        existing = deduped.get(key)
+        if existing is None:
+            deduped[key] = candidate
+            order.append(key)
+            continue
+
+        # Keep the higher score on collision (scores may be None).
+        existing_score = existing.get("similarity_score") or 0
+        new_score = candidate.get("similarity_score") or 0
+        if new_score > existing_score:
+            deduped[key] = candidate
+
+    return [deduped[key] for key in order]
+
+
 def _build_discovery_receipt(
     *,
     query: str,
     limit: int,
     exposed_results: list[dict[str, Any]],
-    total_candidates: int,
+    withheld_results: list[dict[str, Any]],
     status: str,
     stop_reason: str,
 ) -> dict[str, Any]:
@@ -219,6 +258,10 @@ def _build_discovery_receipt(
     The receipt deliberately records shapes/counts and ranking metadata rather
     than raw tool arguments, tool outputs, or user data. It is an opt-in
     eval/agent-development signal; server-side audit should use logs or OTel.
+
+    Withheld candidates are itemized (capped at MAX_WITHHELD_ITEMS) so an eval
+    can see whether the right tool was starved out by a tight limit, not just
+    how many were held back.
     """
     return {
         "event": "registry.discovery_receipt",
@@ -226,8 +269,9 @@ def _build_discovery_receipt(
         "limits": {"max_results": limit},
         "exposed_results": exposed_results,
         "withheld": {
-            "candidate_result_count": max(total_candidates - len(exposed_results), 0),
+            "candidate_result_count": len(withheld_results),
             "reason": "outside_intent_or_budget",
+            "top_withheld": withheld_results[:MAX_WITHHELD_ITEMS],
         },
         "status": status,
         "stop_reason": stop_reason,
@@ -667,7 +711,12 @@ async def search_registry(
                     "similarity_score": skill.get("relevance_score") or skill.get("score"),
                 }
             )
+        # Dedupe so a tool returned in both tools[] and a server's matching_tools
+        # is counted once. Then split into what the caller saw vs what the limit
+        # held back.
+        candidate_results = _dedupe_candidates(candidate_results)
         exposed_results = candidate_results[:max_results]
+        withheld_results = candidate_results[max_results:]
 
         total_results = len(servers) + len(tools) + len(agents) + len(skills)
         result = {
@@ -684,7 +733,7 @@ async def search_registry(
                 query=query,
                 limit=max_results,
                 exposed_results=exposed_results,
-                total_candidates=len(candidate_results),
+                withheld_results=withheld_results,
                 status="success",
                 stop_reason="results_returned" if total_results else "no_match",
             )
@@ -762,7 +811,7 @@ async def intelligent_tool_finder(
 
         # Flatten matching_tools from all servers into ToolSearchResult objects
         result_list = []
-        exposed_tools = []
+        candidate_results = []
         for server in servers:
             server_path = server.get("path", "")
             server_name = server.get("server_name", "")
@@ -776,19 +825,17 @@ async def intelligent_tool_finder(
                         path=server_path,
                     ).model_dump()
                 )
-                exposed_tools.append(
+                candidate_results.append(
                     {
+                        "asset_type": "tool",
                         "service_path": server_path,
-                        "tool_name": tool.get("tool_name", ""),
+                        "name": tool.get("tool_name", ""),
                         "similarity_score": tool.get("relevance_score"),
                     }
                 )
 
-        total_candidates = len(result_list)
-
         # Enforce client-side limit (safety net in case registry returns more)
         result_list = result_list[:top_n]
-        exposed_tools = exposed_tools[:top_n]
         result = {
             "results": result_list,
             "query": query,
@@ -796,19 +843,13 @@ async def intelligent_tool_finder(
             "status": "success",
         }
         if include_discovery_receipt:
+            # Dedupe before splitting so a duplicate tool isn't reported as withheld.
+            candidate_results = _dedupe_candidates(candidate_results)
             result["discovery_receipt"] = _build_discovery_receipt(
                 query=query,
                 limit=top_n,
-                exposed_results=[
-                    {
-                        "asset_type": "tool",
-                        "service_path": tool["service_path"],
-                        "name": tool["tool_name"],
-                        "similarity_score": tool["similarity_score"],
-                    }
-                    for tool in exposed_tools
-                ],
-                total_candidates=total_candidates,
+                exposed_results=candidate_results[:top_n],
+                withheld_results=candidate_results[top_n:],
                 status="success",
                 stop_reason="results_returned" if result_list else "no_match",
             )

--- a/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
+++ b/tests/unit/servers/mcpgw/test_intelligent_tool_finder.py
@@ -33,6 +33,7 @@ if _mcpgw_path not in sys.path:
 
 from servers.mcpgw.server import (
     _build_discovery_receipt,
+    _dedupe_candidates,
     _validate_top_n,
     intelligent_tool_finder,
     search_registry,
@@ -294,6 +295,15 @@ async def test_discovery_receipt_records_exposed_and_withheld_tools():
     assert receipt["withheld"] == {
         "candidate_result_count": 2,
         "reason": "outside_intent_or_budget",
+        "top_withheld": [
+            {"asset_type": "tool", "service_path": "/a", "name": "tool_2", "similarity_score": 0.9},
+            {
+                "asset_type": "tool",
+                "service_path": "/a",
+                "name": "tool_3",
+                "similarity_score": 0.85,
+            },
+        ],
     }
     assert receipt["stop_reason"] == "results_returned"
 
@@ -340,10 +350,12 @@ async def test_search_registry_receipt_counts_withheld_matching_tools():
         {"asset_type": "tool", "service_path": "/a", "name": "tool_0", "similarity_score": 1.0},
         {"asset_type": "tool", "service_path": "/a", "name": "tool_1", "similarity_score": 0.95},
     ]
-    assert receipt["withheld"] == {
-        "candidate_result_count": 2,
-        "reason": "outside_intent_or_budget",
-    }
+    assert receipt["withheld"]["candidate_result_count"] == 2
+    assert receipt["withheld"]["reason"] == "outside_intent_or_budget"
+    assert receipt["withheld"]["top_withheld"] == [
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_2", "similarity_score": 0.9},
+        {"asset_type": "tool", "service_path": "/a", "name": "tool_3", "similarity_score": 0.85},
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -406,7 +418,12 @@ async def test_search_registry_receipt_counts_agents_and_skills():
     assert result["total_results"] == 3
     assert receipt["exposed_results"] == [
         {"asset_type": "tool", "service_path": "/a", "name": "tool_0", "similarity_score": 1.0},
-        {"asset_type": "agent", "service_path": "/agent", "name": "agent_0", "similarity_score": 0.9},
+        {
+            "asset_type": "agent",
+            "service_path": "/agent",
+            "name": "agent_0",
+            "similarity_score": 0.9,
+        },
     ]
     assert receipt["withheld"]["candidate_result_count"] == 1
 
@@ -429,7 +446,20 @@ def test_discovery_receipt_helper_does_not_leak_payloads():
                 "similarity_score": 0.9,
             }
         ],
-        total_candidates=3,
+        withheld_results=[
+            {
+                "asset_type": "tool",
+                "service_path": "/crm",
+                "name": "list_orders",
+                "similarity_score": 0.4,
+            },
+            {
+                "asset_type": "tool",
+                "service_path": "/crm",
+                "name": "list_tickets",
+                "similarity_score": 0.3,
+            },
+        ],
         status="success",
         stop_reason="results_returned",
     )
@@ -437,3 +467,122 @@ def test_discovery_receipt_helper_does_not_leak_payloads():
     assert "raw_args" not in receipt
     assert "raw_result" not in receipt
     assert receipt["withheld"]["candidate_result_count"] == 2
+    assert receipt["withheld"]["top_withheld"] == [
+        {
+            "asset_type": "tool",
+            "service_path": "/crm",
+            "name": "list_orders",
+            "similarity_score": 0.4,
+        },
+        {
+            "asset_type": "tool",
+            "service_path": "/crm",
+            "name": "list_tickets",
+            "similarity_score": 0.3,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# test_search_registry_receipt_dedupes_tool_in_both_arrays
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_registry_receipt_dedupes_tool_in_both_arrays():
+    """A tool returned in both tools[] and matching_tools is counted once.
+
+    The real registry returns a matched tool in both arrays. Without dedup the
+    receipt double-counts it: exposed_results lists it twice and withheld is
+    inflated. This is the case the pre-fix unit tests missed.
+    """
+    mock_resp = _make_mock_response()
+    mock_resp.json.return_value = {
+        "servers": [
+            {
+                "server_name": "server-a",
+                "path": "/a",
+                "matching_tools": [
+                    {"tool_name": "get_weather", "relevance_score": 0.45},
+                ],
+            }
+        ],
+        "tools": [
+            {"server_path": "/a", "tool_name": "get_weather", "relevance_score": 0.45},
+        ],
+        "agents": [],
+        "skills": [],
+    }
+
+    result = await _call_search_registry(
+        mock_resp,
+        query="weather forecast",
+        max_results=2,
+        include_discovery_receipt=True,
+    )
+
+    receipt = result["discovery_receipt"]
+    # One unique tool: exposed once, nothing withheld.
+    assert receipt["exposed_results"] == [
+        {
+            "asset_type": "tool",
+            "service_path": "/a",
+            "name": "get_weather",
+            "similarity_score": 0.45,
+        },
+    ]
+    assert receipt["withheld"]["candidate_result_count"] == 0
+    assert receipt["withheld"]["top_withheld"] == []
+
+
+# ---------------------------------------------------------------------------
+# test_dedupe_candidates_keeps_higher_score
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_candidates_keeps_higher_score():
+    """Dedup keeps one entry per (asset_type, service_path, name), higher score."""
+    candidates = [
+        {"asset_type": "tool", "service_path": "/a", "name": "foo", "similarity_score": 0.3},
+        {"asset_type": "tool", "service_path": "/a", "name": "foo", "similarity_score": 0.9},
+        {"asset_type": "tool", "service_path": "/b", "name": "bar", "similarity_score": 0.5},
+    ]
+
+    deduped = _dedupe_candidates(candidates)
+
+    assert deduped == [
+        {"asset_type": "tool", "service_path": "/a", "name": "foo", "similarity_score": 0.9},
+        {"asset_type": "tool", "service_path": "/b", "name": "bar", "similarity_score": 0.5},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# test_discovery_receipt_caps_top_withheld_items
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discovery_receipt_caps_top_withheld_items():
+    """top_withheld is capped (MAX_WITHHELD_ITEMS) while the count stays full."""
+    server = _make_server_with_tools(10, server_name="server-a", path="/a")
+    mock_resp = _make_mock_response(servers=[server])
+
+    result = await _call_search_registry(
+        mock_resp,
+        query="many tools",
+        max_results=1,
+        include_discovery_receipt=True,
+    )
+
+    receipt = result["discovery_receipt"]
+    # 10 unique tools, 1 exposed, 9 withheld; only 5 itemized.
+    assert receipt["withheld"]["candidate_result_count"] == 9
+    assert len(receipt["withheld"]["top_withheld"]) == 5
+    # The itemized ones are the highest-scoring withheld (tool_1..tool_5).
+    assert [item["name"] for item in receipt["withheld"]["top_withheld"]] == [
+        "tool_1",
+        "tool_2",
+        "tool_3",
+        "tool_4",
+        "tool_5",
+    ]


### PR DESCRIPTION
## Summary

Follow-up to #1203. Fixes a correctness bug in the `discovery_receipt` and makes the withheld set actually useful for evals.

The receipt added in #1203 double-counted any tool the registry returns in **both** the top-level `tools[]` array and a server's `matching_tools` list (the real backend does exactly this). That inflated `exposed_results` and skewed `withheld.candidate_result_count`. The original unit tests missed it because each fixture used only one of the two arrays, never the same tool in both.

## Changes

- **Dedup:** new `_dedupe_candidates()` keyed by `(asset_type, service_path, name)`, keeping the higher `similarity_score` on collision. Applied in both `search_registry` and `intelligent_tool_finder`.
- **Itemize withheld:** the withheld set is built from the deduped candidates beyond the requested limit and listed as `top_withheld` (capped by `MAX_WITHHELD_ITEMS`, default 5). The full count is still reported; the items let an eval see whether the tool it wanted was a near miss or genuinely absent.
- **Docs:** `docs/dynamic-tool-discovery.md` example JSON now matches the shape the code actually returns. The previous example showed fields that were never emitted (`request_id`, `session_id`, the entire `invocation` block); these are removed, and `top_withheld` + the dedup behavior are documented.
- **Tests:** updated existing assertions for the new shape; added dedup-across-both-arrays, higher-score retention, and the `top_withheld` cap.

## Verification

- `uv run pytest tests/unit/servers/mcpgw/test_intelligent_tool_finder.py` — 16 passed
- `uv run ruff check` / `ruff format` — clean
- Verified live against a deployed `mcpgw`: a tool returned in both arrays is now counted once, and `top_withheld` lists the held-back near-miss results by name and score.

This is purely additive and opt-in (`include_discovery_receipt=false` by default), so default responses are unchanged.