### PR TITLE
docs: tell contributors to install pre-commit hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ reported the issue. Please try to include as much information as you can. Detail
 * Anything unusual about your environment or deployment
 
 
+## Setting up your development environment
+Before you make your first commit, install the pre-commit hooks. The repository ships a `.pre-commit-config.yaml` that runs `ruff` (linter and formatter), Bandit, and a few file checks, but pre-commit is opt-in per clone: it only runs if you install it.
+
+```bash
+# one-time per clone
+pip install pre-commit
+pre-commit install
+
+# optional: run the hooks against the whole tree
+pre-commit run --all-files
+```
+
+Once installed, `git commit` automatically runs `ruff check --fix` and `ruff format` on your changes, so formatting and lint issues are fixed locally instead of failing CI later. If you skip this step, the same `ruff check` and `ruff format --check` run in CI and will fail the pull request until the formatting is fixed.
+
+
 ## Contributing via Pull Requests
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 


### PR DESCRIPTION
## Summary

Adds a "Setting up your development environment" section to `CONTRIBUTING.md` instructing contributors to run `pre-commit install` before their first commit.

## Why

The repo ships a `.pre-commit-config.yaml` with `ruff` (lint + format) and Bandit, but pre-commit is opt-in per clone, it only runs if each contributor installs it. When a contributor (often an external fork author) hasn't run `pre-commit install`, `git commit` does no lint/format, so issues reach CI and fail the PR instead of being auto-fixed locally. This note closes that documentation gap.

Docs-only change. `docs/CONTRIBUTING.md` is a symlink to the root file, so it reflects the change automatically.