### PR TITLE
Batch per-scope reads on the auth hot path to cut /api/auth/me latency

### DIFF
--- a/registry/auth/access_resolver.py
+++ b/registry/auth/access_resolver.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,23 +73,27 @@ async def resolve_scope_access(
 
         scope_repo = get_scope_repository()
     except Exception as exc:
-        logger.error(
-            "resolve_scope_access: scope repo unavailable: %s", exc, exc_info=True
-        )
+        logger.error("resolve_scope_access: scope repo unavailable: %s", exc, exc_info=True)
         return UserAccess()
 
     servers: set[str] = set()
     tools: ToolAllowlist = {}
 
-    for scope in user_scopes:
-        try:
-            scope_config = await scope_repo.get_server_scopes(scope)
-        except Exception as exc:
-            logger.error(
-                "resolve_scope_access: get_server_scopes(%s) failed: %s", scope, exc
-            )
-            continue
+    # Fetch every scope's rules in one round-trip rather than one per scope.
+    # The sticky-wildcard / union semantics below depend on iterating
+    # `user_scopes` in order, NOT on DB return order, so we look each scope
+    # up in the prefetched map while preserving the original loop. Do NOT
+    # "optimize" this into `for scope in scope_rules:` — dict order is the
+    # $in/sort order, not the user's scope order, and that would let a later
+    # restricted scope lose to an earlier wildcard (or vice versa).
+    try:
+        scope_rules = await scope_repo.get_server_scopes_bulk(user_scopes)
+    except Exception as exc:
+        logger.error("resolve_scope_access: get_server_scopes_bulk failed: %s", exc, exc_info=True)
+        return UserAccess()
 
+    for scope in user_scopes:
+        scope_config = scope_rules.get(scope)
         if not scope_config:
             continue
 
@@ -209,17 +212,13 @@ async def audit_legacy_scopes_on_startup() -> int:
 
         scope_repo = get_scope_repository()
     except Exception as exc:
-        logger.error(
-            "audit_legacy_scopes_on_startup: scope repo unavailable: %s", exc
-        )
+        logger.error("audit_legacy_scopes_on_startup: scope repo unavailable: %s", exc)
         return 0
 
     try:
         scope_names = await scope_repo.list_scope_names()
     except Exception as exc:
-        logger.error(
-            "audit_legacy_scopes_on_startup: list_scope_names failed: %s", exc
-        )
+        logger.error("audit_legacy_scopes_on_startup: list_scope_names failed: %s", exc)
         return 0
 
     warnings_emitted = 0
@@ -254,11 +253,7 @@ async def audit_legacy_scopes_on_startup() -> int:
             elif (
                 isinstance(tools, list)
                 and not tools
-                and (
-                    "tools/call" in methods
-                    or "all" in methods
-                    or "*" in methods
-                )
+                and ("tools/call" in methods or "all" in methods or "*" in methods)
             ):
                 logger.warning(
                     "empty_tools_list_with_call_method scope=%s server=%s",

--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -183,8 +183,14 @@ async def get_ui_permissions_for_user(user_scopes: list[str]) -> dict[str, list[
     ui_permissions = {}
     scope_repo = get_scope_repository()
 
+    # One round-trip for all scopes instead of one find_one per scope — on a
+    # remote cluster the per-scope fan-out dominated /api/auth/me latency for
+    # users with many groups. Iterate user_scopes (not the map) to keep the
+    # merge order deterministic.
+    scope_configs = await scope_repo.get_ui_scopes_bulk(user_scopes)
+
     for scope in user_scopes:
-        scope_config = await scope_repo.get_ui_scopes(scope)
+        scope_config = scope_configs.get(scope)
         if scope_config:
             logger.debug(f"Processing UI scope '{scope}' with config: {scope_config}")
 

--- a/registry/main.py
+++ b/registry/main.py
@@ -35,10 +35,10 @@ from registry.api.embeddings_admin_routes import router as embeddings_admin_rout
 from registry.api.export_routes import router as export_router
 from registry.api.federation_export_routes import router as federation_export_router
 from registry.api.federation_routes import router as federation_router
+from registry.api.iam_user_groups_routes import router as iam_user_groups_router
 from registry.api.internal_routes import router as internal_router
 from registry.api.log_routes import router as log_router
 from registry.api.m2m_management_routes import router as m2m_management_router
-from registry.api.iam_user_groups_routes import router as iam_user_groups_router
 from registry.api.management_routes import router as management_router
 from registry.api.okta_m2m_routes import router as okta_m2m_router
 from registry.api.peer_management_routes import router as peer_management_router
@@ -58,7 +58,6 @@ from registry.audit.routes import router as audit_router
 
 # Import auth dependencies
 from registry.auth.dependencies import (
-    get_ui_permissions_for_user,
     nginx_proxied_auth,
 )
 
@@ -131,18 +130,12 @@ def _resolve_internal_deployment_classification() -> None:
                 "is false; forcing to 'none'.",
                 current_type.value,
             )
-            object.__setattr__(
-                settings, "internal_deployment_type", InternalDeploymentType.NONE
-            )
+            object.__setattr__(settings, "internal_deployment_type", InternalDeploymentType.NONE)
         return
 
     if current_type == InternalDeploymentType.NONE:
-        logger.info(
-            "INTERNAL_ONLY_DEPLOYMENT is true with no type set; defaulting to 'dev'."
-        )
-        object.__setattr__(
-            settings, "internal_deployment_type", InternalDeploymentType.DEV
-        )
+        logger.info("INTERNAL_ONLY_DEPLOYMENT is true with no type set; defaulting to 'dev'.")
+        object.__setattr__(settings, "internal_deployment_type", InternalDeploymentType.DEV)
 
 
 def _log_startup_configuration() -> None:
@@ -1204,8 +1197,10 @@ async def get_current_user(user_context: dict[str, Any] = Depends(nginx_proxied_
     # Get user's scopes
     user_scopes = user_context.get("scopes", [])
 
-    # Get UI permissions for the user based on their scopes
-    ui_permissions = await get_ui_permissions_for_user(user_scopes)
+    # UI permissions are already derived by nginx_proxied_auth/_derive_user_context
+    # and carried on user_context — reuse them instead of re-querying the scope
+    # repo here, which previously ran a second per-scope fan-out per /me call.
+    ui_permissions = user_context.get("ui_permissions", {})
 
     # Return user info with scopes and UI permissions for token generation
     return {

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -24,6 +24,28 @@ def _looks_like_guid(
     return bool(_GUID_RE.match(value or ""))
 
 
+def _flatten_server_access(
+    server_access: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Flatten a scope document's ``server_access`` into a flat rule list.
+
+    Handles two on-disk formats:
+    1. New format: ``{"scope_name": "...", "access_rules": [...]}``
+    2. Old/direct format: ``{"server": "...", "methods": [...], "tools": [...]}``
+
+    Entries that are neither (e.g. agent-permission blocks) are skipped.
+    Shared by ``get_server_scopes`` and ``get_server_scopes_bulk`` so the
+    single and batch paths produce byte-identical rule lists.
+    """
+    all_rules: list[dict[str, Any]] = []
+    for scope_entry in server_access:
+        if "access_rules" in scope_entry:
+            all_rules.extend(scope_entry.get("access_rules", []))
+        elif "server" in scope_entry:
+            all_rules.append(scope_entry)
+    return all_rules
+
+
 def _backfill_is_idp_managed(
     doc: dict,
 ) -> bool:
@@ -158,23 +180,8 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                 logger.debug(f"DocumentDB READ: Scope '{scope_name}' not found")
                 return []
 
-            # Extract server access rules from the server_access array
-            server_access = group_doc.get("server_access", [])
-
-            # Flatten the access rules from all scope entries
-            # Handle two formats:
-            # 1. New format: {"scope_name": "...", "access_rules": [...]}
-            # 2. Old/direct format: {"server": "...", "methods": [...], "tools": [...]}
-            all_rules = []
-            for scope_entry in server_access:
-                # Check if this entry has "access_rules" (new format)
-                if "access_rules" in scope_entry:
-                    access_rules = scope_entry.get("access_rules", [])
-                    all_rules.extend(access_rules)
-                # Check if this entry is a direct server access rule (old format)
-                elif "server" in scope_entry:
-                    all_rules.append(scope_entry)
-                # Skip entries that are not server access rules (e.g., agent permissions)
+            # Extract and flatten the access rules from the server_access array.
+            all_rules = _flatten_server_access(group_doc.get("server_access", []))
 
             logger.debug(
                 f"DocumentDB READ: Found {len(all_rules)} access rules for scope '{scope_name}'"
@@ -183,6 +190,67 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         except Exception as e:
             logger.error(f"Error getting server scopes for '{scope_name}': {e}", exc_info=True)
             return []
+
+    async def get_server_scopes_bulk(
+        self,
+        scope_names: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetch server access rules for many scopes in a single ``$in`` query.
+
+        Collapses the per-scope ``find_one`` fan-out (one round-trip per
+        scope) into one round-trip. On a remote cluster a user with many
+        groups would otherwise pay one network latency per scope here.
+        """
+        unique = sorted({s for s in scope_names if s})
+        if not unique:
+            return {}
+
+        collection = await self._get_collection()
+        try:
+            cursor = collection.find({"_id": {"$in": unique}})
+            result: dict[str, list[dict[str, Any]]] = {}
+            async for doc in cursor:
+                rules = _flatten_server_access(doc.get("server_access", []))
+                if rules:
+                    result[doc["_id"]] = rules
+            logger.debug(
+                f"DocumentDB READ: bulk server scopes for {len(unique)} scopes "
+                f"-> {len(result)} with rules"
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Error getting bulk server scopes: {e}", exc_info=True)
+            return {}
+
+    async def get_ui_scopes_bulk(
+        self,
+        group_names: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Fetch UI scopes for many groups/scopes in a single ``$in`` query.
+
+        Batch equivalent of ``get_ui_scopes``; same round-trip collapsing
+        rationale as ``get_server_scopes_bulk``.
+        """
+        unique = sorted({g for g in group_names if g})
+        if not unique:
+            return {}
+
+        collection = await self._get_collection()
+        try:
+            cursor = collection.find({"_id": {"$in": unique}})
+            result: dict[str, dict[str, Any]] = {}
+            async for doc in cursor:
+                ui_permissions = doc.get("ui_permissions", {})
+                if ui_permissions:
+                    result[doc["_id"]] = ui_permissions
+            logger.debug(
+                f"DocumentDB READ: bulk UI scopes for {len(unique)} groups "
+                f"-> {len(result)} with permissions"
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Error getting bulk UI scopes: {e}", exc_info=True)
+            return {}
 
     async def add_server_scope(
         self,
@@ -294,9 +362,7 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             self._scopes_cache.setdefault("UI-Scopes", {})[group_name] = {}
             self._scopes_cache.setdefault("group_mappings", {})[group_name] = []
 
-            logger.info(
-                f"Created group '{group_name}' (is_idp_managed={is_idp_managed})"
-            )
+            logger.info(f"Created group '{group_name}' (is_idp_managed={is_idp_managed})")
             return True
         except Exception as e:
             logger.error(f"Failed to create group in DocumentDB: {e}", exc_info=True)

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -498,6 +498,60 @@ class ScopeRepositoryBase(ABC):
         """
         pass
 
+    async def get_server_scopes_bulk(
+        self,
+        scope_names: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Get server access rules for many scopes in one call.
+
+        Batch equivalent of ``get_server_scopes``. On the cookie-auth hot
+        path a user with many groups resolves to many scopes, and issuing
+        one query per scope serializes a round-trip per scope — cheap on a
+        local Mongo, seconds on a remote Atlas cluster (Issue: scope
+        fan-out latency). Backends that can fetch all scopes in a single
+        query (DocumentDB ``$in``) override this; the default loops over
+        the per-scope method so in-memory backends (file) stay correct
+        with no extra cost.
+
+        Args:
+            scope_names: Scope names to fetch.
+
+        Returns:
+            Dict mapping scope name to its access-rule list. Scopes with no
+            rules are omitted (mirrors the empty-list return of the single
+            getter, while keeping the map compact).
+        """
+        result: dict[str, list[dict[str, Any]]] = {}
+        for scope_name in scope_names:
+            rules = await self.get_server_scopes(scope_name)
+            if rules:
+                result[scope_name] = rules
+        return result
+
+    async def get_ui_scopes_bulk(
+        self,
+        group_names: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        """Get UI scopes for many groups/scopes in one call.
+
+        Batch equivalent of ``get_ui_scopes`` — see ``get_server_scopes_bulk``
+        for the latency rationale. Backends with a single-query path override
+        this; the default loops over the per-scope getter.
+
+        Args:
+            group_names: Group/scope names to fetch.
+
+        Returns:
+            Dict mapping group/scope name to its UI-permissions dict. Names
+            with no UI permissions are omitted.
+        """
+        result: dict[str, dict[str, Any]] = {}
+        for group_name in group_names:
+            scopes = await self.get_ui_scopes(group_name)
+            if scopes:
+                result[group_name] = scopes
+        return result
+
     @abstractmethod
     async def load_all(self) -> None:
         """

--- a/tests/unit/auth/test_access_resolver.py
+++ b/tests/unit/auth/test_access_resolver.py
@@ -25,7 +25,6 @@ from registry.auth.access_resolver import (
     resolve_scope_access,
 )
 
-
 # =============================================================================
 # FIXTURES
 # =============================================================================
@@ -37,6 +36,20 @@ def mock_repo():
     repo = AsyncMock()
     repo.get_server_scopes = AsyncMock(return_value=[])
     repo.list_scope_names = AsyncMock(return_value=[])
+
+    # resolve_scope_access now batches via get_server_scopes_bulk. Delegate to
+    # the per-scope mock at call time so each test's return_value/side_effect on
+    # get_server_scopes still drives behavior, and a raising single still
+    # propagates (mirrors the base-class default impl, which doesn't swallow).
+    async def _bulk(scope_names: list[str]):
+        out: dict[str, list] = {}
+        for name in scope_names:
+            rules = await repo.get_server_scopes(name)
+            if rules:
+                out[name] = rules
+        return out
+
+    repo.get_server_scopes_bulk = AsyncMock(side_effect=_bulk)
     return repo
 
 
@@ -182,9 +195,7 @@ async def test_resolve_scope_access_union_of_two_scopes(patched_factory):
     access = await resolve_scope_access(["scope-a", "scope-b"])
 
     # Assert
-    assert access.tools == {
-        "current_time": {"current_time_by_timezone", "current_time_utc"}
-    }
+    assert access.tools == {"current_time": {"current_time_by_timezone", "current_time_utc"}}
 
 
 @pytest.mark.asyncio
@@ -326,9 +337,7 @@ async def test_get_user_accessible_tools_thin_wrapper(patched_factory):
 
 
 @pytest.mark.asyncio
-async def test_audit_legacy_scopes_no_warnings_on_clean_deployment(
-    patched_factory, caplog
-):
+async def test_audit_legacy_scopes_no_warnings_on_clean_deployment(patched_factory, caplog):
     """A deployment with only well-formed scopes emits zero warnings."""
     # Arrange
     patched_factory.list_scope_names.return_value = ["scope-a", "scope-b"]
@@ -358,9 +367,7 @@ async def test_audit_legacy_scopes_no_warnings_on_clean_deployment(
 
 
 @pytest.mark.asyncio
-async def test_audit_legacy_scopes_warns_on_missing_tools_key(
-    patched_factory, caplog
-):
+async def test_audit_legacy_scopes_warns_on_missing_tools_key(patched_factory, caplog):
     """A scope row missing the `tools` key triggers a WARN line."""
     # Arrange
     patched_factory.list_scope_names.return_value = ["tla-consumer-legacy"]
@@ -379,9 +386,7 @@ async def test_audit_legacy_scopes_warns_on_missing_tools_key(
 
 
 @pytest.mark.asyncio
-async def test_audit_legacy_scopes_warns_on_empty_tools_with_call_method(
-    patched_factory, caplog
-):
+async def test_audit_legacy_scopes_warns_on_empty_tools_with_call_method(patched_factory, caplog):
     """tools=[] combined with a call-capable method triggers a WARN."""
     # Arrange
     patched_factory.list_scope_names.return_value = ["tla-consumer-empty"]
@@ -427,6 +432,26 @@ async def test_audit_legacy_scopes_handles_repo_error(patched_factory, caplog):
 # =============================================================================
 
 
+def _wire_bulk_from_single(repo: AsyncMock) -> None:
+    """Wire get_server_scopes_bulk to delegate to the single getter.
+
+    resolve_scope_access batches via get_server_scopes_bulk; bare AsyncMock
+    repos that only configure get_server_scopes need the bulk method to defer
+    to it (matching the base-class default contract: dict keyed by scope,
+    empties omitted).
+    """
+
+    async def _bulk(scope_names: list[str]):
+        out: dict[str, list] = {}
+        for name in scope_names:
+            rules = await repo.get_server_scopes(name)
+            if rules:
+                out[name] = rules
+        return out
+
+    repo.get_server_scopes_bulk = AsyncMock(side_effect=_bulk)
+
+
 @pytest.mark.asyncio
 async def test_resolve_scope_access_tools_wildcard_as_bare_string(monkeypatch):
     """tools: "*" (string, not list) is treated as wildcard."""
@@ -435,9 +460,8 @@ async def test_resolve_scope_access_tools_wildcard_as_bare_string(monkeypatch):
     mock_repo.get_server_scopes.return_value = [
         {"server": "currenttime", "methods": ["all"], "tools": "*"},
     ]
-    monkeypatch.setattr(
-        "registry.repositories.factory.get_scope_repository", lambda: mock_repo
-    )
+    _wire_bulk_from_single(mock_repo)
+    monkeypatch.setattr("registry.repositories.factory.get_scope_repository", lambda: mock_repo)
 
     # Act
     access = await resolve_scope_access(["public-mcp-users"])
@@ -455,9 +479,8 @@ async def test_resolve_scope_access_tools_all_as_bare_string(monkeypatch):
     mock_repo.get_server_scopes.return_value = [
         {"server": "currenttime", "methods": ["all"], "tools": "all"},
     ]
-    monkeypatch.setattr(
-        "registry.repositories.factory.get_scope_repository", lambda: mock_repo
-    )
+    _wire_bulk_from_single(mock_repo)
+    monkeypatch.setattr("registry.repositories.factory.get_scope_repository", lambda: mock_repo)
 
     # Act
     access = await resolve_scope_access(["s"])
@@ -474,9 +497,8 @@ async def test_resolve_scope_access_tools_single_tool_as_bare_string(monkeypatch
     mock_repo.get_server_scopes.return_value = [
         {"server": "currenttime", "methods": ["tools/call"], "tools": "current_time_by_timezone"},
     ]
-    monkeypatch.setattr(
-        "registry.repositories.factory.get_scope_repository", lambda: mock_repo
-    )
+    _wire_bulk_from_single(mock_repo)
+    monkeypatch.setattr("registry.repositories.factory.get_scope_repository", lambda: mock_repo)
 
     # Act
     access = await resolve_scope_access(["s"])

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -212,10 +212,31 @@ def mock_scopes_config(sample_scopes_config: dict[str, Any], monkeypatch):
             return scope_config
         return []
 
+    # Bulk variants delegate to the single getters, mirroring the base-class
+    # default impl (dict keyed by scope name, empties omitted). Production code
+    # on the hot path now calls these instead of looping the singles.
+    async def mock_get_server_scopes_bulk(scope_names: list[str]):
+        out: dict[str, list] = {}
+        for name in scope_names:
+            rules = await mock_get_server_scopes(name)
+            if rules:
+                out[name] = rules
+        return out
+
+    async def mock_get_ui_scopes_bulk(group_names: list[str]):
+        out: dict[str, dict] = {}
+        for name in group_names:
+            scopes = await mock_get_ui_scopes(name)
+            if scopes:
+                out[name] = scopes
+        return out
+
     mock_repo.get_group_mappings.side_effect = mock_get_group_mappings
     mock_repo.get_all_group_mappings.side_effect = mock_get_all_group_mappings
     mock_repo.get_ui_scopes.side_effect = mock_get_ui_scopes
     mock_repo.get_server_scopes.side_effect = mock_get_server_scopes
+    mock_repo.get_server_scopes_bulk.side_effect = mock_get_server_scopes_bulk
+    mock_repo.get_ui_scopes_bulk.side_effect = mock_get_ui_scopes_bulk
 
     # Patch get_scope_repository to return our mock using patch context manager
     # Since it's imported locally in functions, we need to patch the import

--- a/tests/unit/repositories/test_scope_repository_bulk.py
+++ b/tests/unit/repositories/test_scope_repository_bulk.py
@@ -1,0 +1,189 @@
+"""Unit tests for the bulk scope-fetch methods on the scope repositories.
+
+Covers ``get_server_scopes_bulk`` / ``get_ui_scopes_bulk``, added to collapse
+the per-scope ``find_one`` fan-out on the ``/api/auth/me`` hot path into a
+single ``$in`` query (one round-trip instead of one-per-scope, which dominated
+latency on a remote Atlas cluster for users with many groups).
+
+The DocumentDB implementation overrides the methods with a single query; the
+file implementation inherits the base-class default that loops the per-scope
+getters. Both must produce the same dict-keyed-by-scope, empties-omitted shape.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from registry.repositories.documentdb.scope_repository import (
+    DocumentDBScopeRepository,
+    _flatten_server_access,
+)
+from registry.repositories.file.scope_repository import FileScopeRepository
+
+
+def _make_cursor(items: list[dict]) -> MagicMock:
+    cursor = MagicMock()
+    cursor.__aiter__ = lambda self: self
+    cursor._items = items
+    cursor._index = 0
+
+    async def anext_impl(self):
+        if self._index >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._index]
+        self._index += 1
+        return item
+
+    cursor.__anext__ = anext_impl
+    return cursor
+
+
+@pytest.fixture
+def mock_collection():
+    collection = AsyncMock()
+    collection.find = MagicMock(return_value=_make_cursor([]))
+    return collection
+
+
+@pytest.fixture
+def repo(mock_collection):
+    r = DocumentDBScopeRepository.__new__(DocumentDBScopeRepository)
+    r._collection = mock_collection
+    r._collection_name = "mcp_scopes_test"
+    r._scopes_cache = {}
+    return r
+
+
+class TestFlattenServerAccess:
+    """The shared flatten helper must handle both on-disk formats so the
+    single and bulk paths agree byte-for-byte."""
+
+    def test_new_format_access_rules(self):
+        access = [{"scope_name": "s", "access_rules": [{"server": "a"}, {"server": "b"}]}]
+        assert _flatten_server_access(access) == [{"server": "a"}, {"server": "b"}]
+
+    def test_old_direct_format(self):
+        access = [{"server": "a", "methods": ["all"]}]
+        assert _flatten_server_access(access) == [{"server": "a", "methods": ["all"]}]
+
+    def test_skips_non_server_entries(self):
+        access = [{"agent_permissions": ["x"]}, {"server": "a"}]
+        assert _flatten_server_access(access) == [{"server": "a"}]
+
+    def test_empty_returns_empty(self):
+        assert _flatten_server_access([]) == []
+
+
+class TestGetServerScopesBulk:
+    async def test_empty_input_skips_query(self, repo, mock_collection):
+        assert await repo.get_server_scopes_bulk([]) == {}
+        mock_collection.find.assert_not_called()
+
+    async def test_only_falsy_input_skips_query(self, repo, mock_collection):
+        assert await repo.get_server_scopes_bulk(["", None]) == {}
+        mock_collection.find.assert_not_called()
+
+    async def test_uses_in_query_with_deduped_sorted_ids(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor([])
+        await repo.get_server_scopes_bulk(["b", "a", "b", ""])
+        # One $in query, deduped and sorted, blanks dropped.
+        mock_collection.find.assert_called_once_with({"_id": {"$in": ["a", "b"]}})
+
+    async def test_returns_flattened_rules_keyed_by_id(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor(
+            [
+                {
+                    "_id": "scope-a",
+                    "server_access": [{"scope_name": "scope-a", "access_rules": [{"server": "x"}]}],
+                },
+                {
+                    "_id": "scope-b",
+                    "server_access": [{"server": "y", "methods": ["all"]}],
+                },
+            ]
+        )
+        result = await repo.get_server_scopes_bulk(["scope-a", "scope-b"])
+        assert result == {
+            "scope-a": [{"server": "x"}],
+            "scope-b": [{"server": "y", "methods": ["all"]}],
+        }
+
+    async def test_omits_scopes_with_no_rules(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor(
+            [
+                {"_id": "scope-a", "server_access": [{"server": "x"}]},
+                {"_id": "scope-empty", "server_access": []},
+            ]
+        )
+        result = await repo.get_server_scopes_bulk(["scope-a", "scope-empty"])
+        assert "scope-empty" not in result
+        assert result == {"scope-a": [{"server": "x"}]}
+
+    async def test_error_returns_empty(self, repo, mock_collection):
+        mock_collection.find.side_effect = Exception("db error")
+        assert await repo.get_server_scopes_bulk(["scope-a"]) == {}
+
+
+class TestGetUIScopesBulk:
+    async def test_empty_input_skips_query(self, repo, mock_collection):
+        assert await repo.get_ui_scopes_bulk([]) == {}
+        mock_collection.find.assert_not_called()
+
+    async def test_uses_in_query_with_deduped_sorted_ids(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor([])
+        await repo.get_ui_scopes_bulk(["b", "a", "a"])
+        mock_collection.find.assert_called_once_with({"_id": {"$in": ["a", "b"]}})
+
+    async def test_returns_ui_permissions_keyed_by_id(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor(
+            [
+                {"_id": "admin", "ui_permissions": {"list_service": ["all"]}},
+                {"_id": "user", "ui_permissions": {"list_service": ["mcpgw"]}},
+            ]
+        )
+        result = await repo.get_ui_scopes_bulk(["admin", "user"])
+        assert result == {
+            "admin": {"list_service": ["all"]},
+            "user": {"list_service": ["mcpgw"]},
+        }
+
+    async def test_omits_scopes_with_no_permissions(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor(
+            [
+                {"_id": "admin", "ui_permissions": {"list_service": ["all"]}},
+                {"_id": "noperm", "ui_permissions": {}},
+                {"_id": "missing"},
+            ]
+        )
+        result = await repo.get_ui_scopes_bulk(["admin", "noperm", "missing"])
+        assert result == {"admin": {"list_service": ["all"]}}
+
+    async def test_error_returns_empty(self, repo, mock_collection):
+        mock_collection.find.side_effect = Exception("db error")
+        assert await repo.get_ui_scopes_bulk(["admin"]) == {}
+
+
+class TestFileBackendBulkDefault:
+    """The file backend has no override, so it uses the base-class default
+    that loops the per-scope getters. Verify the same shape contract."""
+
+    @pytest.fixture
+    def file_repo(self):
+        r = FileScopeRepository.__new__(FileScopeRepository)
+        r._scopes_data = {
+            "scope-a": [{"server": "x", "methods": ["all"]}],
+            "scope-empty": [],
+            "UI-Scopes": {
+                "admin": {"list_service": ["all"]},
+                "noperm": {},
+            },
+        }
+        return r
+
+    async def test_server_scopes_bulk_loops_singles(self, file_repo):
+        result = await file_repo.get_server_scopes_bulk(["scope-a", "scope-empty", "missing"])
+        assert result == {"scope-a": [{"server": "x", "methods": ["all"]}]}
+
+    async def test_ui_scopes_bulk_loops_singles(self, file_repo):
+        result = await file_repo.get_ui_scopes_bulk(["admin", "noperm", "missing"])
+        assert result == {"admin": {"list_service": ["all"]}}


### PR DESCRIPTION
A user's many groups map to many scopes, and authorization derivation issued one serial find_one per scope, three times per request:

  - resolve_scope_access:        one find_one({_id: scope}) per scope
  - get_ui_permissions_for_user: one find_one({_id: scope}) per scope
  - the /me handler then re-ran get_ui_permissions_for_user a third time

On a local Mongo each round-trip was sub-millisecond, so the fan-out was invisible; on Atlas each round-trip is tens of milliseconds, so the same serialized calls multiplied into seconds. 

Fix:
- Add get_server_scopes_bulk / get_ui_scopes_bulk to ScopeRepositoryBase. The base class ships a default that loops the existing per-scope getters, so the file backend (which reads an in-memory dict and was already free) needs no change. DocumentDB overrides both with a single $in query, collapsing N serial round-trips into one.
- resolve_scope_access prefetches all rules in one call, then iterates user_scopes in original order against the prefetched map. Iteration order is preserved deliberately: the sticky-wildcard and tool-union semantics depend on user-scope order, not DB return order.
- get_ui_permissions_for_user does the same single-call prefetch.
- The /me handler reuses user_context["ui_permissions"] (already derived by _derive_user_context on every auth path) instead of re-querying the scope repo — removing the duplicate third fan-out entirely.
- Extract the server_access flatten logic into _flatten_server_access so the single and bulk DocumentDB paths produce byte-identical rule lists.

Error semantics: the bulk call fails closed. A backend error now yields an empty UserAccess / empty permissions rather than the old per-scope behavior that skipped only the failing scope. For an authorization path this is the correct posture — partial results could grant a permission set that doesn't match the configured scopes.

Tests:
- New tests/unit/repositories/test_scope_repository_bulk.py covers the $in query shape, dedup/sort of inputs, empty-input short-circuit, empties omitted from the result map, error-returns-empty, the shared _flatten_server_access helper (both on-disk formats), and the file backend's inherited default.
- test_access_resolver.py and test_dependencies.py fixtures wire the bulk mocks to delegate to the per-scope getters, mirroring the base-class default contract so all existing scope-semantics cases stay valid.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
