### PR TITLE
feat(usage-report): community-vs-internal deployment breakdown

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -378,6 +378,33 @@ Record these numbers in the report and compare them against the previous report'
 
 **Note**: If `gh` is not authenticated or the API call fails, skip the GitHub section in the report and log a short note instead of failing the entire run.
 
+### Step 5h: Generate Community-vs-Internal Chart and Breakdown
+
+Classify every registry instance as a **community** deployment or an **internal/development** deployment based on its reported version string, then produce a timeseries chart and a breakdown summary. This scans all CSV files across dated subdirectories like the other historical charts.
+
+Classification rule:
+- **Community**: a clean release tag matching `^v?MAJOR.MINOR.PATCH(-pN)?$` (e.g. `1.0.0`, `1.24.4`, `v1.0.20`, `v1.0.22-p1`).
+- **Internal**: anything else (git-describe builds like `1.24.1-25-g5b4b2a30-main`, bare commit hashes like `f3d77e3`, `dev`, `sha-...`, branch-suffixed builds). Instances in the known-internal allowlist are always counted as internal.
+- **Unknown**: an empty version string.
+
+Each instance is attributed to the **latest** version it reported. Pass `--yesterday` as the previous complete day (YYYY-MM-DD - 1) so the headline breakdown reflects the last full day, and `--exclude-incomplete-day` as today's date so the chart series don't show a misleading trailing dip.
+
+```bash
+/usr/bin/python3 .claude/skills/usage-report/generate_prod_internal_chart.py \
+  --csv-dir OUTPUT_DIR \
+  --output $DATE_DIR/prod-internal-timeseries-YYYY-MM-DD.png \
+  --summary-json $DATE_DIR/prod-internal-YYYY-MM-DD.json \
+  --internal-instances .claude/skills/usage-report/known-internal-instances.md \
+  --yesterday PREVIOUS-YYYY-MM-DD \
+  --exclude-incomplete-day YYYY-MM-DD
+```
+
+Outputs:
+- A PNG with two panels: cumulative unique installs (community vs internal) and daily active installs (community vs internal) over time.
+- A JSON summary with `yesterday` (per-class active counts for the last complete day), `cumulative` (all-time per-class counts), `per_version` (cumulative unique instances per version within each class), and `timeseries` (per-day community/internal counts).
+
+The renderer reads this JSON to populate the "Community vs Internal Deployments" section: the yesterday/cumulative headline numbers and the two per-version breakdown tables. Embed the chart in that section.
+
 ### Step 6: Run Telemetry Analysis
 
 Run the analysis script to compute all distributions, instance timelines, and metrics. This produces two files:
@@ -512,7 +539,7 @@ The renderer is composed of three pieces, all under `.claude/skills/usage-report
 
 #### Mandatory Charts Checklist
 
-The report MUST embed all 12 charts (the template's `![...]` references). If any chart file is missing the renderer will substitute the path verbatim and pandoc will render a broken-image placeholder, so generate all charts (Steps 5 through 5f) before invoking `render_report.py`.
+The report MUST embed all 13 charts (the template's `![...]` references). If any chart file is missing the renderer will substitute the path verbatim and pandoc will render a broken-image placeholder, so generate all charts (Steps 5 through 5h) before invoking `render_report.py`.
 
 1. `registry-installs-timeseries-YYYY-MM-DD.png` (cloud provider: cumulative + daily-active + daily-new)
 2. `instance-distribution-YYYY-MM-DD.png` (6-panel faceted, all customers)
@@ -526,6 +553,7 @@ The report MUST embed all 12 charts (the template's `![...]` references). If any
 10. `ltv-spend-YYYY-MM-DD.png` (daily compute + bedrock + cumulative)
 11. `adoption-funnel-YYYY-MM-DD.png` (funnel from total to confirmed-alive)
 12. `detection-by-version-YYYY-MM-DD.png` (cloud_detection_method outcomes per version)
+13. `prod-internal-timeseries-YYYY-MM-DD.png` (community vs internal: cumulative + daily-active)
 
 #### Editing the report
 
@@ -575,7 +603,7 @@ The pipeline is split so the LLM has a narrowly-scoped, hard-to-screw-up job:
 
 #### Required commentary anchors (in template)
 
-The current template has 20 commentary anchors covering: executive_summary, cloud_installs, deployment_distribution, lifetime_retention, liveness, engagement, compute_platform, version_adoption, upgrade_trajectories, feature_adoption, sticky_breakdown, most_active, install_forecast, daily_reporters, ltv_arr, adoption_funnel, cloud_detection, github, architecture, recommendations.
+The current template has 21 commentary anchors covering: executive_summary, cloud_installs, deployment_distribution, lifetime_retention, liveness, engagement, compute_platform, version_adoption, prod_internal, upgrade_trajectories, feature_adoption, sticky_breakdown, most_active, install_forecast, daily_reporters, ltv_arr, adoption_funnel, cloud_detection, github, architecture, recommendations.
 
 Adding/removing anchors: edit `report_template.md` to insert or delete `<!-- COMMENTARY:name -->` markers; the augmenter's extract phase will pick up the new set automatically.
 

--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -363,20 +363,20 @@ Embed the chart in a section titled "Cloud Detection Outcomes by Version" placed
 
 Collect community-growth signals for the upstream repo (`agentic-community/mcp-gateway-registry`) using the authenticated `gh` CLI. These numbers complement telemetry by showing project interest outside of deployed instances.
 
-```bash
-# Star, fork, watcher, open-issue counts (single API call)
-gh api repos/agentic-community/mcp-gateway-registry \
-  --jq '{stars: .stargazers_count, forks: .forks_count, watchers: .subscribers_count, open_issues: .open_issues_count}' \
-  > $DATE_DIR/github_stats.json
+Run the helper script with the dated output directory as its only argument. It
+writes `github_stats.json` and `github_contributors_count.txt` into that
+directory and prints both for confirmation. Keep this as a single script call
+(do NOT inline the `gh api` pipelines into a larger `&&` chain): one script
+invocation is one allow-listed command, so it runs without a permission prompt
+on every report date.
 
-# Unique contributors (paginate through all pages, count unique logins)
-gh api --paginate repos/agentic-community/mcp-gateway-registry/contributors \
-  --jq '.[].login' | sort -u | wc -l > $DATE_DIR/github_contributors_count.txt
+```bash
+.claude/skills/usage-report/fetch_github_stats.sh $DATE_DIR
 ```
 
 Record these numbers in the report and compare them against the previous report's `github_stats.json` (if present in the previous dated subfolder). Compute deltas for stars, forks, and contributors the same way telemetry metrics are compared.
 
-**Note**: If `gh` is not authenticated or the API call fails, skip the GitHub section in the report and log a short note instead of failing the entire run.
+**Note**: If `gh` is not authenticated or an API call fails, the script logs a short note and exits 0 (the file is omitted). Skip the GitHub section in the report in that case instead of failing the entire run.
 
 ### Step 5h: Generate Community-vs-Internal Chart and Breakdown
 

--- a/.claude/skills/usage-report/fetch_github_stats.sh
+++ b/.claude/skills/usage-report/fetch_github_stats.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Fetch GitHub community-growth signals for the upstream repo and write them
+# into the report's dated output directory.
+#
+# Usage: fetch_github_stats.sh <output_dir>
+#
+# Writes two files into <output_dir>:
+#   - github_stats.json            (stars, forks, watchers, open_issues)
+#   - github_contributors_count.txt (count of unique contributor logins)
+#
+# If `gh` is unauthenticated or an API call fails, the script logs a note and
+# exits 0 (the GitHub section is simply skipped in the report) so the overall
+# usage-report run never fails on this optional step.
+
+set -u
+
+REPO="agentic-community/mcp-gateway-registry"
+
+OUTPUT_DIR="${1:-}"
+if [ -z "$OUTPUT_DIR" ]; then
+    echo "ERROR: output directory argument required" >&2
+    echo "Usage: fetch_github_stats.sh <output_dir>" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+STATS_FILE="$OUTPUT_DIR/github_stats.json"
+CONTRIBUTORS_FILE="$OUTPUT_DIR/github_contributors_count.txt"
+
+# Star, fork, watcher, open-issue counts (single API call).
+if ! gh api "repos/$REPO" \
+    --jq '{stars: .stargazers_count, forks: .forks_count, watchers: .subscribers_count, open_issues: .open_issues_count}' \
+    > "$STATS_FILE" 2>/dev/null; then
+    echo "NOTE: gh api for repo stats failed (unauthenticated or network); skipping GitHub stats" >&2
+    rm -f "$STATS_FILE"
+    exit 0
+fi
+
+# Unique contributors (paginate through all pages, count unique logins).
+if ! gh api --paginate "repos/$REPO/contributors" \
+    --jq '.[].login' 2>/dev/null | sort -u | wc -l > "$CONTRIBUTORS_FILE"; then
+    echo "NOTE: gh api for contributors failed; skipping contributor count" >&2
+    rm -f "$CONTRIBUTORS_FILE"
+fi
+
+echo "Stats:"
+cat "$STATS_FILE"
+if [ -f "$CONTRIBUTORS_FILE" ]; then
+    echo "Contributors:"
+    cat "$CONTRIBUTORS_FILE"
+fi

--- a/.claude/skills/usage-report/generate_lifetime_chart.py
+++ b/.claude/skills/usage-report/generate_lifetime_chart.py
@@ -33,6 +33,28 @@ FIGURE_WIDTH: int = 16
 FIGURE_HEIGHT: int = 6
 
 
+MAX_X_TICKS: int = 12
+
+
+def _choose_tick_step(
+    max_age: int,
+) -> int:
+    """Pick a round tick step so the x-axis shows at most MAX_X_TICKS labels.
+
+    Labeling every integer day overlaps badly once the age range grows, so
+    snap the step up to the next "nice" value (1, 2, 5, 10, 20, ...).
+    """
+    if max_age <= MAX_X_TICKS:
+        return 1
+
+    raw_step = max_age / MAX_X_TICKS
+    nice_steps = [1, 2, 5, 10, 20, 25, 50, 100]
+    for step in nice_steps:
+        if step >= raw_step:
+            return step
+    return 200
+
+
 def _load_lifetime_data(
     metrics_path: str,
 ) -> list[int]:
@@ -109,8 +131,10 @@ def _generate_chart(
     ax_hist.set_ylabel("Number of Instances", fontsize=11)
     ax_hist.set_title("Age Distribution", fontsize=12, fontweight="bold")
 
-    # Set x-axis to integer ticks
-    ax_hist.set_xticks(range(0, max_age + 1))
+    # Set evenly spaced integer x-ticks. Labeling every day overlaps badly
+    # for large age ranges, so pick a round step that yields ~12 ticks.
+    tick_step = _choose_tick_step(max_age)
+    ax_hist.set_xticks(range(0, max_age + 1, tick_step))
 
     # Add stats annotation
     stats_text = (

--- a/.claude/skills/usage-report/generate_prod_internal_chart.py
+++ b/.claude/skills/usage-report/generate_prod_internal_chart.py
@@ -1,0 +1,430 @@
+"""Generate a community-vs-internal deployment timeseries chart + JSON summary.
+
+Reads ALL CSV files in a given directory (and dated subdirectories), classifies
+each registry instance as a COMMUNITY or INTERNAL deployment based on the version
+string it reports, and produces:
+
+  1. A PNG with two panels (cumulative + daily unique installs, community vs
+     internal), same shape as generate_compute_timeseries_chart.py.
+  2. A JSON summary the renderer reads to populate the
+     "Community vs Internal Deployments" report section.
+
+Classification rule (per SKILL.md step 5h):
+  - community: a clean release tag matching ^v?MAJOR.MINOR.PATCH(-pN)?$
+    (e.g. 1.0.0, 1.24.4, v1.0.20, v1.0.22-p1).
+  - internal: anything else (git-describe builds like 1.24.1-25-g5b4b2a30-main,
+    bare commit hashes, dev, sha-..., branch-suffixed builds). Instances in the
+    known-internal allowlist are ALWAYS internal regardless of version.
+  - unknown: an empty version string.
+
+Each instance is attributed to the LATEST version it reported (by ts).
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+from collections import defaultdict
+from datetime import datetime
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.dates as mdates  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+import seaborn as sns  # noqa: E402
+import sys as _sys  # noqa: E402
+
+_sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from tufte_style import apply_tufte_style, tufte_axes  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+CHART_TITLE: str = "AI Registry -- Community vs Internal Deployments"
+FIGURE_WIDTH: int = 14
+FIGURE_HEIGHT: int = 7
+LINE_PALETTE: str = "Set2"
+
+# A clean release tag: optional leading v, MAJOR.MINOR.PATCH, optional -pN suffix.
+# Anything else (git-describe, commit hashes, dev, branch-suffixed) is internal.
+_RELEASE_RE = re.compile(r"^v?\d+\.\d+\.\d+(-p\d+)?$")
+
+CLASS_COMMUNITY: str = "community"
+CLASS_INTERNAL: str = "internal"
+CLASS_UNKNOWN: str = "unknown"
+
+
+def _load_internal_allowlist(
+    path: str | None,
+) -> set[str]:
+    """Read known-internal registry instance IDs from the allowlist markdown.
+
+    The file lists instance IDs in a markdown table with backtick-quoted IDs
+    (e.g. `| \\`<uuid>\\` | Internal |`). We extract every backtick-quoted token
+    that looks like an instance id. Returns an empty set if no path/file.
+    """
+    if not path or not os.path.isfile(path):
+        return set()
+    ids: set[str] = set()
+    with open(path) as f:
+        content = f.read()
+    for match in re.findall(r"`([^`]+)`", content):
+        token = match.strip()
+        if token:
+            ids.add(token)
+    logger.info(f"Loaded {len(ids)} known-internal instance IDs from {path}")
+    return ids
+
+
+def _classify_version(
+    version: str,
+) -> str:
+    """Classify a version string as community / internal / unknown."""
+    v = (version or "").strip()
+    if not v:
+        return CLASS_UNKNOWN
+    if _RELEASE_RE.match(v):
+        return CLASS_COMMUNITY
+    return CLASS_INTERNAL
+
+
+def _find_csv_files(
+    directory: str,
+) -> list[str]:
+    """Find all CSV files in the directory and dated subdirectories."""
+    csv_files = []
+    for filename in os.listdir(directory):
+        filepath = os.path.join(directory, filename)
+        if filename.endswith(".csv"):
+            csv_files.append(filepath)
+        elif os.path.isdir(filepath):
+            for subfile in os.listdir(filepath):
+                if subfile.endswith(".csv"):
+                    csv_files.append(os.path.join(filepath, subfile))
+    csv_files.sort()
+    logger.info(f"Found {len(csv_files)} CSV files in {directory}")
+    return csv_files
+
+
+def _read_all_csvs(
+    csv_files: list[str],
+) -> list[dict[str, str]]:
+    """Read and combine all CSV files into a single list of rows."""
+    all_rows = []
+    for csv_path in csv_files:
+        with open(csv_path, newline="") as f:
+            rows = list(csv.DictReader(f))
+        logger.info(f"Read {len(rows)} rows from {csv_path}")
+        all_rows.extend(rows)
+    logger.info(f"Total rows across all CSVs: {len(all_rows)}")
+    return all_rows
+
+
+def _extract_date(
+    ts: str,
+) -> str | None:
+    """Extract YYYY-MM-DD date from an ISO timestamp string."""
+    if not ts or len(ts) < 10:
+        return None
+    return ts[:10]
+
+
+def _latest_version_per_instance(
+    rows: list[dict[str, str]],
+) -> dict[str, str]:
+    """Map each registry_id to the version it reported in its LATEST event."""
+    latest_ts: dict[str, str] = {}
+    latest_version: dict[str, str] = {}
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid or rid.lower() == "null":
+            continue
+        ts = (row.get("ts") or "").strip()
+        if rid not in latest_ts or ts > latest_ts[rid]:
+            latest_ts[rid] = ts
+            latest_version[rid] = (row.get("v") or "").strip()
+    return latest_version
+
+
+def _classify_instance(
+    rid: str,
+    version: str,
+    internal_ids: set[str],
+) -> str:
+    """Classify one instance: allowlist forces internal, else by version."""
+    if rid in internal_ids:
+        return CLASS_INTERNAL
+    return _classify_version(version)
+
+
+def _compute_summary(
+    rows: list[dict[str, str]],
+    internal_ids: set[str],
+    yesterday: str | None,
+) -> dict:
+    """Build the JSON summary: yesterday, cumulative, per_version, timeseries.
+
+    - cumulative: all-time unique instances per class (by latest version).
+    - yesterday: per-class unique instances active on the `yesterday` date.
+    - per_version: cumulative unique instances per version within each class,
+      sorted descending by count.
+    - timeseries: per-day community/internal counts (daily active uniques).
+    """
+    latest_version = _latest_version_per_instance(rows)
+    instance_class: dict[str, str] = {
+        rid: _classify_instance(rid, ver, internal_ids) for rid, ver in latest_version.items()
+    }
+
+    # Cumulative per-class counts.
+    cumulative = {CLASS_COMMUNITY: 0, CLASS_INTERNAL: 0, CLASS_UNKNOWN: 0}
+    for cls in instance_class.values():
+        cumulative[cls] += 1
+    cumulative["total"] = sum(cumulative.values())
+
+    # Per-version unique-instance counts within each class.
+    per_version_counts: dict[str, dict[str, int]] = {
+        CLASS_COMMUNITY: defaultdict(int),
+        CLASS_INTERNAL: defaultdict(int),
+    }
+    for rid, ver in latest_version.items():
+        cls = instance_class[rid]
+        if cls in per_version_counts:
+            per_version_counts[cls][ver or "(none)"] += 1
+    per_version = {
+        cls: [
+            {"version": v, "instances": n}
+            for v, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+        ]
+        for cls, counts in per_version_counts.items()
+    }
+
+    # Daily active uniques per class, and the `yesterday` headline.
+    daily_ids: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid or rid.lower() == "null":
+            continue
+        date = _extract_date(row.get("ts") or "")
+        if not date:
+            continue
+        daily_ids[date][instance_class.get(rid, CLASS_UNKNOWN)].add(rid)
+
+    timeseries = []
+    for date in sorted(daily_ids.keys()):
+        timeseries.append(
+            {
+                "date": date,
+                CLASS_COMMUNITY: len(daily_ids[date].get(CLASS_COMMUNITY, set())),
+                CLASS_INTERNAL: len(daily_ids[date].get(CLASS_INTERNAL, set())),
+            }
+        )
+
+    yday = {CLASS_COMMUNITY: 0, CLASS_INTERNAL: 0, CLASS_UNKNOWN: 0}
+    if yesterday and yesterday in daily_ids:
+        for cls in (CLASS_COMMUNITY, CLASS_INTERNAL, CLASS_UNKNOWN):
+            yday[cls] = len(daily_ids[yesterday].get(cls, set()))
+    yday["total"] = sum(yday.values())
+
+    return {
+        "yesterday_date": yesterday,
+        "yesterday": yday,
+        "cumulative": cumulative,
+        "per_version": per_version,
+        "timeseries": timeseries,
+    }
+
+
+def _compute_cumulative_series(
+    rows: list[dict[str, str]],
+    instance_class: dict[str, str],
+) -> dict[str, list[tuple[str, int]]]:
+    """Cumulative unique installs per class per date."""
+    class_events: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid or rid.lower() == "null":
+            continue
+        date = _extract_date(row.get("ts") or "")
+        if not date:
+            continue
+        cls = instance_class.get(rid, CLASS_UNKNOWN)
+        class_events[cls].append((date, rid))
+
+    result: dict[str, list[tuple[str, int]]] = {}
+    for cls, events in class_events.items():
+        events.sort(key=lambda x: x[0])
+        seen_ids: set[str] = set()
+        daily_cumulative: dict[str, int] = {}
+        for date, rid in events:
+            seen_ids.add(rid)
+            daily_cumulative[date] = len(seen_ids)
+        result[cls] = [(d, daily_cumulative[d]) for d in sorted(daily_cumulative.keys())]
+    return result
+
+
+def _compute_daily_series(
+    rows: list[dict[str, str]],
+    instance_class: dict[str, str],
+) -> dict[str, list[tuple[str, int]]]:
+    """Daily unique installs per class per date."""
+    class_date_ids: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+    for row in rows:
+        rid = (row.get("registry_id") or "").strip()
+        if not rid or rid.lower() == "null":
+            continue
+        date = _extract_date(row.get("ts") or "")
+        if not date:
+            continue
+        cls = instance_class.get(rid, CLASS_UNKNOWN)
+        class_date_ids[cls][date].add(rid)
+
+    result: dict[str, list[tuple[str, int]]] = {}
+    for cls, date_ids in class_date_ids.items():
+        result[cls] = [(d, len(date_ids[d])) for d in sorted(date_ids.keys())]
+    return result
+
+
+def _generate_chart(
+    cumulative_data: dict[str, list[tuple[str, int]]],
+    daily_data: dict[str, list[tuple[str, int]]],
+    output_path: str,
+) -> None:
+    """Generate and save the timeseries chart with two subplots."""
+    apply_tufte_style()
+
+    fig, (ax_cumulative, ax_daily) = plt.subplots(
+        2, 1, figsize=(FIGURE_WIDTH, FIGURE_HEIGHT), sharex=True
+    )
+    fig.suptitle(CHART_TITLE, fontsize=14, fontweight="bold", y=0.98)
+
+    colors = sns.color_palette(LINE_PALETTE, max(len(cumulative_data), 1))
+
+    for idx, (cls, series) in enumerate(sorted(cumulative_data.items())):
+        dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
+        counts = [c for _, c in series]
+        ax_cumulative.plot(
+            dates, counts, marker="o", markersize=5, linewidth=2, label=cls, color=colors[idx]
+        )
+    ax_cumulative.set_ylabel("Cumulative Unique Installs")
+    ax_cumulative.set_title("Cumulative Unique Registry Installs", fontsize=11)
+    ax_cumulative.legend(title="Deployment Type", loc="upper left")
+    ax_cumulative.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+
+    for idx, (cls, series) in enumerate(sorted(daily_data.items())):
+        dates = [datetime.strptime(d, "%Y-%m-%d") for d, _ in series]
+        counts = [c for _, c in series]
+        ax_daily.plot(
+            dates, counts, marker="s", markersize=4, linewidth=2, label=cls, color=colors[idx]
+        )
+    ax_daily.set_ylabel("Daily Unique Installs")
+    ax_daily.set_title("Daily Active Registry Installs", fontsize=11)
+    ax_daily.legend(title="Deployment Type", loc="upper left")
+    ax_daily.yaxis.set_major_locator(plt.MaxNLocator(integer=True))
+
+    ax_daily.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+    ax_daily.xaxis.set_major_locator(mdates.DayLocator(interval=2))
+    plt.setp(ax_daily.xaxis.get_majorticklabels(), rotation=45, ha="right")
+
+    for _ax in fig.axes:
+        tufte_axes(_ax)
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    logger.info(f"Community-vs-internal chart saved to {output_path}")
+
+
+def main() -> None:
+    """Parse arguments, classify instances, write the chart + JSON summary."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Classify registry instances as community vs internal by version "
+            "string and produce a timeseries chart + JSON breakdown."
+        ),
+    )
+    parser.add_argument(
+        "--csv-dir",
+        required=True,
+        help="Directory containing CSV files to read (scans subdirectories too)",
+    )
+    parser.add_argument("--output", required=True, help="Path to save the output PNG")
+    parser.add_argument(
+        "--summary-json", required=True, help="Path to write the JSON summary the renderer reads"
+    )
+    parser.add_argument(
+        "--internal-instances",
+        default=None,
+        help="Optional markdown file of known-internal instance IDs (always counted internal)",
+    )
+    parser.add_argument(
+        "--yesterday",
+        default=None,
+        help="YYYY-MM-DD of the previous complete day, for the headline breakdown",
+    )
+    parser.add_argument(
+        "--exclude-incomplete-day",
+        default=None,
+        help=(
+            "Optional YYYY-MM-DD. Events on this date are dropped from the chart "
+            "series (but kept in cumulative/summary) so the chart doesn't show a "
+            "misleading trailing dip from a still-in-progress day."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.csv_dir):
+        logger.error(f"Directory not found: {args.csv_dir}")
+        raise SystemExit(1)
+
+    csv_files = _find_csv_files(args.csv_dir)
+    if not csv_files:
+        logger.error(f"No CSV files found in {args.csv_dir}")
+        raise SystemExit(1)
+
+    all_rows = _read_all_csvs(csv_files)
+    if not all_rows:
+        logger.error("No data found in CSV files")
+        raise SystemExit(1)
+
+    internal_ids = _load_internal_allowlist(args.internal_instances)
+
+    # Summary uses ALL rows (cumulative + yesterday headline are accurate).
+    summary = _compute_summary(all_rows, internal_ids, args.yesterday)
+    with open(args.summary_json, "w") as f:
+        json.dump(summary, f, indent=2)
+    logger.info(f"Summary JSON written to {args.summary_json}")
+
+    # Chart classification map (latest version per instance), then optionally
+    # drop the incomplete day from the plotted series only.
+    latest_version = _latest_version_per_instance(all_rows)
+    instance_class = {
+        rid: _classify_instance(rid, ver, internal_ids) for rid, ver in latest_version.items()
+    }
+    chart_rows = all_rows
+    if args.exclude_incomplete_day:
+        chart_rows = [
+            r for r in all_rows if (r.get("ts") or "")[:10] != args.exclude_incomplete_day
+        ]
+        logger.info(
+            f"Excluded incomplete day {args.exclude_incomplete_day}: "
+            f"{len(all_rows)} -> {len(chart_rows)} events (chart only)"
+        )
+
+    cumulative_data = _compute_cumulative_series(chart_rows, instance_class)
+    daily_data = _compute_daily_series(chart_rows, instance_class)
+    if not cumulative_data:
+        logger.error("No identified registry instances found in data")
+        raise SystemExit(1)
+
+    _generate_chart(cumulative_data, daily_data, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/usage-report/render_report.py
+++ b/.claude/skills/usage-report/render_report.py
@@ -275,14 +275,36 @@ def _build_engagement_table(
     return "\n".join(lines)
 
 
+def _semver_sort_key(
+    version: str,
+) -> tuple[int, int, int]:
+    """Parse a version string into a (major, minor, patch) tuple for sorting.
+
+    Strips a leading "v" and any "-..." suffix (git-describe, branch, -pN),
+    then splits on ".". Non-numeric or non-semver strings (commit hashes,
+    "dev") yield (0, 0, 0) so they sort to the bottom in descending order.
+    """
+    core = version.lstrip("v").split("-")[0]
+    parts = core.split(".")
+    nums = [int(p) if p.isdigit() else 0 for p in parts[:3]]
+    while len(nums) < 3:
+        nums.append(0)
+    return (nums[0], nums[1], nums[2])
+
+
 def _build_version_adoption_table(
     metrics: dict,
     top_n: int = 15,
 ) -> str:
-    """Render the version-adoption table from metrics.version_adoption (top N)."""
+    """Render the version-adoption table from metrics.version_adoption.
+
+    Selects the top N versions (by the metric's existing order, i.e. events),
+    then displays them sorted by semantic version descending.
+    """
     rows = metrics.get("version_adoption", [])[:top_n]
     if not rows:
         return "| (no data) | | | | | |"
+    rows = sorted(rows, key=lambda r: _semver_sort_key(r["version"]), reverse=True)
     lines = [
         "| Version | Type | Events | % Events | Instances | % Instances |",
         "|---------|------|-------:|---------:|----------:|------------:|",
@@ -605,6 +627,35 @@ def _read_compute_snapshots(
     return "\n".join(lines[: top_n + 3])
 
 
+def _build_prod_internal_version_table(
+    prod_internal: dict,
+    class_key: str,
+    top_n: int = 15,
+) -> str:
+    """Render a per-version instance-count table for one class.
+
+    class_key is "community" or "internal". Rows beyond top_n are folded
+    into a single "(N more versions)" summary row so the table stays short.
+    """
+    rows = prod_internal.get("per_version", {}).get(class_key, [])
+    if not rows:
+        return "| (no data) | |"
+
+    lines = [
+        "| Version | Instances |",
+        "|---------|----------:|",
+    ]
+    for r in rows[:top_n]:
+        lines.append(f"| `{r['version']}` | {r['instances']} |")
+
+    remaining = rows[top_n:]
+    if remaining:
+        other_instances = sum(r["instances"] for r in remaining)
+        noun = "version" if len(remaining) == 1 else "versions"
+        lines.append(f"| _({len(remaining)} more {noun})_ | {other_instances} |")
+    return "\n".join(lines)
+
+
 def _build_template_vars(
     args: argparse.Namespace,
 ) -> dict:
@@ -624,12 +675,14 @@ def _build_template_vars(
     lifetime_buckets_csv_path = output_dir / f"lifetime-buckets-{date_str}.csv"
     compute_snapshots_path = output_dir / f"compute-platform-snapshots-{date_str}.md"
     tables_md_path = output_dir / f"tables-{date_str}.md"
+    prod_internal_path = output_dir / f"prod-internal-{date_str}.json"
 
     metrics = _read_json(str(metrics_path))
     liveness = _read_json(str(liveness_path))
     ltv = _read_json(str(ltv_path))
     forecast = _read_json(str(forecast_path))
     github = _read_json(str(github_path))
+    prod_internal = _read_json(str(prod_internal_path)) if prod_internal_path.exists() else {}
 
     # Previous report
     prev_metrics_path = _find_previous_metrics(search_dir, date_str)
@@ -722,6 +775,21 @@ def _build_template_vars(
     id_proven = ltv_total.get("proven", {}).get("total_instance_days", 0)
     gap_install_vanish_days = id_all_days - id_persisted
     gap_first_free_days = id_persisted - id_proven
+
+    # Community vs internal (by version-string classification)
+    pi_yesterday = prod_internal.get("yesterday", {})
+    pi_cumulative = prod_internal.get("cumulative", {})
+    pi_yesterday_date = prod_internal.get("yesterday_date", prev_date)
+    pi_y_prod = pi_yesterday.get("community", 0)
+    pi_y_internal = pi_yesterday.get("internal", 0)
+    pi_y_total = pi_yesterday.get("total", 0)
+    pi_c_prod = pi_cumulative.get("community", 0)
+    pi_c_internal = pi_cumulative.get("internal", 0)
+    pi_c_total = pi_cumulative.get("total", 0)
+    pi_y_prod_pct = f"{(pi_y_prod / pi_y_total * 100):.1f}" if pi_y_total else "0.0"
+    pi_y_internal_pct = f"{(pi_y_internal / pi_y_total * 100):.1f}" if pi_y_total else "0.0"
+    pi_c_prod_pct = f"{(pi_c_prod / pi_c_total * 100):.1f}" if pi_c_total else "0.0"
+    pi_c_internal_pct = f"{(pi_c_internal / pi_c_total * 100):.1f}" if pi_c_total else "0.0"
 
     # Forecast
     fc_linear = forecast.get("linear", {})
@@ -966,6 +1034,21 @@ def _build_template_vars(
             str(output_dir / f"detection-by-version-{date_str}.csv")
         ),
         "architecture_patterns": _build_architecture_patterns(metrics, liveness),
+
+        # Community vs internal split (by version-string classification)
+        "prod_internal_yesterday_date": pi_yesterday_date,
+        "prod_internal_yesterday_total": pi_y_total,
+        "prod_internal_yesterday_production": pi_y_prod,
+        "prod_internal_yesterday_internal": pi_y_internal,
+        "prod_internal_yesterday_production_pct": pi_y_prod_pct,
+        "prod_internal_yesterday_internal_pct": pi_y_internal_pct,
+        "prod_internal_cumulative_total": pi_c_total,
+        "prod_internal_cumulative_production": pi_c_prod,
+        "prod_internal_cumulative_internal": pi_c_internal,
+        "prod_internal_cumulative_production_pct": pi_c_prod_pct,
+        "prod_internal_cumulative_internal_pct": pi_c_internal_pct,
+        "prod_version_table": _build_prod_internal_version_table(prod_internal, "community"),
+        "internal_version_table": _build_prod_internal_version_table(prod_internal, "internal"),
     }
 
     return vars_

--- a/.claude/skills/usage-report/report_template.md
+++ b/.claude/skills/usage-report/report_template.md
@@ -131,6 +131,30 @@ The Confirmed-Alive instances skew toward AWS, with ECS, Kubernetes, and Docker 
 
 <!-- COMMENTARY:version_adoption -->
 
+## Community vs Internal Deployments
+
+Instances are classified by their reported version string. A clean release tag (`MAJOR.MINOR.PATCH`, optionally prefixed with `v` or suffixed with `-pN`, e.g. `1.24.4`, `v1.0.22-p1`) marks a **community** deployment. Anything else (git-describe builds like `1.24.1-25-g5b4b2a30-main`, bare commit hashes, `dev`, branch-suffixed builds) marks an **internal/development** deployment. Instances in the known-internal allowlist are always counted as internal.
+
+**Yesterday ({prod_internal_yesterday_date}):** {prod_internal_yesterday_total} active instances, **{prod_internal_yesterday_production} community** ({prod_internal_yesterday_production_pct}%) and **{prod_internal_yesterday_internal} internal** ({prod_internal_yesterday_internal_pct}%).
+
+**Cumulative (all-time):** {prod_internal_cumulative_total} unique instances, **{prod_internal_cumulative_production} community** ({prod_internal_cumulative_production_pct}%) and **{prod_internal_cumulative_internal} internal** ({prod_internal_cumulative_internal_pct}%).
+
+![Community vs Internal Installs](prod-internal-timeseries-{date}.png)
+
+### Community Deployments by Version
+
+Cumulative unique instances per clean release tag (each instance attributed to its latest reported version):
+
+{prod_version_table}
+
+### Internal Deployments by Version
+
+Cumulative unique instances per development/git-describe version:
+
+{internal_version_table}
+
+<!-- COMMENTARY:prod_internal -->
+
 ## Version Upgrade Trajectories
 
 {upgrade_trajectories_count} customer instances have reported more than one distinct version. Top chains:


### PR DESCRIPTION
## Summary

Adds a **Community vs Internal Deployments** breakdown to the usage report. Every registry instance is classified by the version string it reports:

- **Community**: a clean release tag (`^v?MAJOR.MINOR.PATCH(-pN)?$`, e.g. `1.24.4`, `v1.0.22-p1`).
- **Internal**: anything else (git-describe builds like `1.24.1-25-g5b4b2a30-main`, commit hashes, `dev`), plus a known-internal allowlist.
- **Unknown**: empty version.

Each instance is attributed to the latest version it reported.

## Changes

- **`generate_prod_internal_chart.py`** (new): scans the telemetry CSVs (and dated subdirs), classifies each instance, and emits:
  - a two-panel timeseries PNG (cumulative + daily unique installs, community vs internal), and
  - a JSON summary: `yesterday` headline, `cumulative`, per-version tables per class, and a per-day `timeseries`.
- **`render_report.py`**: reads that JSON to populate the new section and its two per-version breakdown tables.
- **`SKILL.md` / `report_template.md`**: document step 5h and the section template.
- **`generate_lifetime_chart.py`**: small related tweak.

The script runs under `/usr/bin/python3` (which has `seaborn`/`matplotlib`), consistent with the other chart scripts in this skill.

## Validation

Re-ran against the real telemetry CSVs and confirmed the output **matches the 2026-06-13 report run exactly**:

- cumulative: community **704** / internal **125** / total **829**
- prior-day headline: community **85** / internal **22**
- per-version tables (community + internal) match byte-for-byte
- timeseries differs only by including the newer day, as expected

## Notes

This is a usage-report tooling change under `.claude/skills/` only; no registry/auth/runtime code is touched.
