### PR TITLE
feat(frontend): add Copy canonical toggle to server details modal

### DIFF
--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -1011,6 +1011,7 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
         onClose={() => { setShowDetails(false); setFullServerDetails(null); }}
         loading={detailsLoading}
         fullDetails={fullServerDetails}
+        authToken={authToken}
       />
 
     </>

--- a/frontend/src/components/ServerDetailsModal.tsx
+++ b/frontend/src/components/ServerDetailsModal.tsx
@@ -135,7 +135,7 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
             <div className="flex items-center gap-4">
               <label
                 className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none"
-                title="Show and copy the canonical server.json, compliant with the MCP Registry server schema"
+                title="Show and copy the canonical server.json, compliant with the official Model Context Protocol (MCP) server schema"
               >
                 <input
                   type="checkbox"
@@ -171,7 +171,8 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
 
           {useCanonical && !canonicalError && (
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              Canonical server.json, compliant with the MCP Registry server schema.
+              Canonical server.json, compliant with the official Model Context Protocol (MCP) server
+              schema.
             </p>
           )}
 

--- a/frontend/src/components/ServerDetailsModal.tsx
+++ b/frontend/src/components/ServerDetailsModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 import { ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';
 import DetailsModal from './DetailsModal';
 import ResourceBoundTokenButton from './ResourceBoundTokenButton';
@@ -11,6 +12,7 @@ interface ServerDetailsModalProps {
   error?: string | null;
   fullDetails?: any;
   onCopy?: (data: any) => Promise<void> | void;
+  authToken?: string | null;
 }
 
 /**
@@ -30,16 +32,65 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
   error = null,
   fullDetails,
   onCopy,
+  authToken,
 }) => {
-  const dataToCopy = fullDetails || server;
+  const storedDetails = fullDetails || server;
   const [copied, setCopied] = useState(false);
+
+  // When checked, show and copy the canonical server.json projection
+  // (GET /api/servers/{path}/server.json) instead of the stored document.
+  const [useCanonical, setUseCanonical] = useState(false);
+  const [canonicalDetails, setCanonicalDetails] = useState<any>(null);
+  const [canonicalLoading, setCanonicalLoading] = useState(false);
+  const [canonicalError, setCanonicalError] = useState<string | null>(null);
+
+  // The doc shown in the preview and placed on the clipboard. Falls back to the
+  // stored document until the canonical fetch completes.
+  const dataToShow = useCanonical && canonicalDetails ? canonicalDetails : storedDetails;
+
+  // Reset canonical state when the modal switches to a different server, so the
+  // previous server's canonical doc and checkbox state never leak across opens.
+  useEffect(() => {
+    setUseCanonical(false);
+    setCanonicalDetails(null);
+    setCanonicalError(null);
+    setCanonicalLoading(false);
+  }, [server?.path]);
+
+  const _fetchCanonical = async () => {
+    if (canonicalDetails || !server?.path) {
+      return;
+    }
+    setCanonicalLoading(true);
+    setCanonicalError(null);
+    try {
+      const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+      const response = await axios.get(
+        `/api/servers${server.path}/server.json`,
+        headers ? { headers } : undefined
+      );
+      setCanonicalDetails(response.data);
+    } catch (err) {
+      console.error('Failed to fetch canonical server.json:', err);
+      setCanonicalError('Could not load canonical server.json.');
+    } finally {
+      setCanonicalLoading(false);
+    }
+  };
+
+  const handleToggleCanonical = async (checked: boolean) => {
+    setUseCanonical(checked);
+    if (checked) {
+      await _fetchCanonical();
+    }
+  };
 
   const handleCopy = async () => {
     try {
-      if (onCopy) {
-        await onCopy(dataToCopy);
+      if (onCopy && !useCanonical) {
+        await onCopy(dataToShow);
       } else {
-        await navigator.clipboard.writeText(JSON.stringify(dataToCopy, null, 2));
+        await navigator.clipboard.writeText(JSON.stringify(dataToShow, null, 2));
       }
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -78,31 +129,51 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
 
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <h4 className="font-medium text-gray-900 dark:text-white">Server JSON Schema:</h4>
-            <button
-              onClick={handleCopy}
-              className={`flex items-center gap-2 px-3 py-2 text-white rounded-lg transition-colors duration-200 ${
-                copied
-                  ? 'bg-green-600'
-                  : 'bg-blue-600 hover:bg-blue-700'
-              }`}
-            >
-              {copied ? (
-                <>
-                  <CheckIcon className="h-4 w-4" />
-                  Copied
-                </>
-              ) : (
-                <>
-                  <ClipboardDocumentIcon className="h-4 w-4" />
-                  Copy JSON
-                </>
-              )}
-            </button>
+            <h4 className="font-medium text-gray-900 dark:text-white">
+              {useCanonical ? 'Canonical server.json:' : 'Server JSON Schema:'}
+            </h4>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={useCanonical}
+                  onChange={(e) => handleToggleCanonical(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                />
+                Copy canonical
+              </label>
+              <button
+                onClick={handleCopy}
+                disabled={useCanonical && canonicalLoading}
+                className={`flex items-center gap-2 px-3 py-2 text-white rounded-lg transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                  copied
+                    ? 'bg-green-600'
+                    : 'bg-blue-600 hover:bg-blue-700'
+                }`}
+              >
+                {copied ? (
+                  <>
+                    <CheckIcon className="h-4 w-4" />
+                    Copied
+                  </>
+                ) : (
+                  <>
+                    <ClipboardDocumentIcon className="h-4 w-4" />
+                    Copy JSON
+                  </>
+                )}
+              </button>
+            </div>
           </div>
 
+          {useCanonical && canonicalError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{canonicalError}</p>
+          )}
+
           <pre className="p-4 bg-gray-50 dark:bg-gray-900 border dark:border-gray-700 rounded-lg overflow-x-auto text-xs text-gray-900 dark:text-gray-100 max-h-[30vh] overflow-y-auto">
-            {JSON.stringify(dataToCopy, null, 2)}
+            {useCanonical && canonicalLoading
+              ? 'Loading canonical server.json...'
+              : JSON.stringify(dataToShow, null, 2)}
           </pre>
         </div>
 

--- a/frontend/src/components/ServerDetailsModal.tsx
+++ b/frontend/src/components/ServerDetailsModal.tsx
@@ -133,14 +133,17 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
               {useCanonical ? 'Canonical server.json:' : 'Server JSON Schema:'}
             </h4>
             <div className="flex items-center gap-4">
-              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+              <label
+                className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none"
+                title="Show and copy the canonical server.json, compliant with the MCP Registry server schema"
+              >
                 <input
                   type="checkbox"
                   checked={useCanonical}
                   onChange={(e) => handleToggleCanonical(e.target.checked)}
                   className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
-                Copy canonical
+                Canonical
               </label>
               <button
                 onClick={handleCopy}
@@ -165,6 +168,12 @@ const ServerDetailsModal: React.FC<ServerDetailsModalProps> = ({
               </button>
             </div>
           </div>
+
+          {useCanonical && !canonicalError && (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Canonical server.json, compliant with the MCP Registry server schema.
+            </p>
+          )}
 
           {useCanonical && canonicalError && (
             <p className="text-sm text-red-600 dark:text-red-400">{canonicalError}</p>


### PR DESCRIPTION
## Summary

Adds a **"Copy canonical"** checkbox to the server **Full Details (JSON)** modal. When checked, it fetches the canonical MCP Registry `server.json` projection and switches both the preview pane and the clipboard to it, so what the user sees equals what they copy.

This is a UI-only change. The backend endpoint already exists:

```
GET /api/servers/{path}/server.json
```

(shipped in #1225 / #1187 - projects the stored document into a doc conforming to the upstream `server.schema.json`, with the same access check as the bespoke server read and backend-URL redaction for non-admins in with-gateway mode).

## Changes

- **`ServerDetailsModal.tsx`**: checkbox next to Copy JSON; on tick, fetches `GET /api/servers/{path}/server.json` (Bearer header), swaps preview + clipboard to the canonical doc, with loading and error states. Canonical doc is fetched once and cached per open; unticking returns to the stored document. A `useEffect` keyed on `server.path` resets the toggle and cached doc when the modal opens for a different server so state never leaks across opens.
- **`ServerCard.tsx`**: passes `authToken` to the modal so the canonical fetch is authenticated like the other card calls.

## Testing

- `npx tsc --noEmit` passes.
- `npm run build` succeeds.
- Manual: tick/untick toggles preview and clipboard between stored and canonical docs.

## Notes

For non-admin users in with-gateway mode, the canonical endpoint redacts backend URLs by design, so a non-admin's canonical copy will legitimately differ from the stored doc there. This is existing backend access policy, not overridden by this UI.

Closes #1238
