### PR TITLE
feat(connect-config): persist per-server oauth_client_id and append_mcp_path

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -1097,6 +1097,8 @@ async def register_service(
     source_updated_at: Annotated[str | None, Form()] = None,
     deployment: Annotated[str, Form()] = "remote",
     local_runtime: Annotated[str | None, Form()] = None,
+    oauth_client_id: Annotated[str | None, Form()] = None,
+    append_mcp_path: Annotated[bool | None, Form()] = None,
     user_context: Annotated[dict, Depends(enhanced_auth)] = None,
 ):
     """Register a new service (requires register_service UI permission).
@@ -1211,6 +1213,13 @@ async def register_service(
             server_entry["mcp_endpoint"] = mcp_endpoint
         if sse_endpoint:
             server_entry["sse_endpoint"] = sse_endpoint
+
+    # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
+    # None = unset (auto-detect / fall back to the registry-wide default).
+    if oauth_client_id is not None:
+        server_entry["oauth_client_id"] = oauth_client_id
+    if append_mcp_path is not None:
+        server_entry["append_mcp_path"] = append_mcp_path
 
     # Add metadata if provided (expects JSON string)
     if metadata:
@@ -2088,6 +2097,8 @@ async def edit_server_submit(
     deployment: Annotated[str | None, Form()] = None,
     local_runtime: Annotated[str | None, Form()] = None,
     custom_headers: Annotated[str | None, Form()] = None,
+    oauth_client_id: Annotated[str | None, Form()] = None,
+    append_mcp_path: Annotated[bool | None, Form()] = None,
     _csrf: Annotated[None, Depends(verify_csrf_token_flexible)] = None,
 ):
     """Handle server edit form submission (requires modify_service UI permission).
@@ -2260,6 +2271,13 @@ async def edit_server_submit(
             updated_server_entry["mcp_endpoint"] = mcp_endpoint
         if sse_endpoint:
             updated_server_entry["sse_endpoint"] = sse_endpoint
+
+    # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
+    # None = unset (auto-detect / fall back to the registry-wide default).
+    if oauth_client_id is not None:
+        updated_server_entry["oauth_client_id"] = oauth_client_id
+    if append_mcp_path is not None:
+        updated_server_entry["append_mcp_path"] = append_mcp_path
 
     # Add optional status if provided
     if service_status:
@@ -3497,6 +3515,8 @@ async def register_service_api(
     local_runtime: Annotated[str | None, Form()] = None,
     visibility: Annotated[str, Form()] = "public",
     allowed_groups: Annotated[str | None, Form()] = None,
+    oauth_client_id: Annotated[str | None, Form()] = None,
+    append_mcp_path: Annotated[bool | None, Form()] = None,
 ):
     """Register a service via JWT Bearer Token authentication (External API).
 
@@ -3526,6 +3546,13 @@ async def register_service_api(
     - `metadata` (optional): JSON string of custom metadata
     - `version` (optional): Server version (e.g., v1.0.0)
     - `status` (optional): Lifecycle status (active, deprecated, draft, beta)
+    - `oauth_client_id` (optional): Per-server public OAuth client_id advertised in
+      the Connect config so IDEs run the OAuth/PKCE login instead of embedding a
+      static token. Overrides the registry-wide IDE_OAUTH_CLIENT_ID default.
+    - `append_mcp_path` (optional, bool): Force/suppress the trailing '/mcp' transport
+      segment on the gateway Connect URL. Omit to auto-detect from proxy_pass_url;
+      set false for root-endpoint servers (e.g. AWS Knowledge) that serve MCP at the
+      server path itself.
 
     **Example (remote):**
     ```bash
@@ -3700,6 +3727,13 @@ async def register_service_api(
     server_entry["visibility"] = visibility
     if allowed_groups_list:
         server_entry["allowed_groups"] = allowed_groups_list
+
+    # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
+    # None = unset (auto-detect / fall back to the registry-wide default).
+    if oauth_client_id is not None:
+        server_entry["oauth_client_id"] = oauth_client_id
+    if append_mcp_path is not None:
+        server_entry["append_mcp_path"] = append_mcp_path
 
     if version:
         server_entry["version"] = version

--- a/registry/schemas/server_update_models.py
+++ b/registry/schemas/server_update_models.py
@@ -124,6 +124,10 @@ class ServerUpdateRequest(BaseModel):
     supported_transports: list[str] | None = None
     headers: list[dict[str, Any]] | None = None
 
+    # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
+    oauth_client_id: str | None = None
+    append_mcp_path: bool | None = None
+
     # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
     # auth_header_name, custom_headers) are intentionally absent.
     # They are owned by PATCH /api/servers/{path}/auth-credential.
@@ -211,6 +215,9 @@ class ServerCardPatch(BaseModel):
     transport: str | None = None
     supported_transports: list[str] | None = None
     headers: list[dict[str, Any]] | None = None
+    # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
+    oauth_client_id: str | None = None
+    append_mcp_path: bool | None = None
     # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
     # auth_header_name, custom_headers, custom_header_names) are
     # intentionally absent and rejected by extra="forbid" with 422.

--- a/tests/unit/api/test_config_ide_oauth.py
+++ b/tests/unit/api/test_config_ide_oauth.py
@@ -66,6 +66,38 @@ class TestPerServerConnectFields:
         assert server.append_mcp_path is False
 
 
+class TestUpdateModelsAcceptConnectFields:
+    """PUT/PATCH bodies accept the per-server connect-config overrides.
+
+    Without these fields on the update models (which are extra="forbid"),
+    a PUT/PATCH carrying oauth_client_id / append_mcp_path would 422 — i.e.
+    there would be no API write path for the values the connect-config GET
+    reads back.
+    """
+
+    def test_server_update_request_accepts_fields(self):
+        from registry.schemas.server_update_models import ServerUpdateRequest
+
+        body = ServerUpdateRequest(
+            server_name="AWS Knowledge",
+            description="AWS docs MCP",
+            oauth_client_id="mcp-gateway",
+            append_mcp_path=False,
+        )
+
+        assert body.oauth_client_id == "mcp-gateway"
+        assert body.append_mcp_path is False
+
+    def test_server_card_patch_accepts_fields(self):
+        from registry.schemas.server_update_models import ServerCardPatch
+
+        patch_body = ServerCardPatch(oauth_client_id="mcp-gateway", append_mcp_path=False)
+        dumped = patch_body.model_dump(exclude_unset=True)
+
+        assert dumped["oauth_client_id"] == "mcp-gateway"
+        assert dumped["append_mcp_path"] is False
+
+
 class TestConnectConfigResolution:
     """connect-config endpoint resolves the effective oauth_client_id.
 

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -1051,6 +1051,83 @@ class TestRegisterService:
             server_entry = mock_server_service.register_server.call_args[0][0]
             assert server_entry["metadata"] == {"team": "platform", "tier": "gold"}
 
+    def test_register_service_persists_connect_config_overrides(
+        self,
+        test_client_admin,
+        mock_server_service,
+        mock_faiss_service,
+        mock_nginx_service,
+        mock_nginx_reload_scheduler,
+        mock_health_service,
+    ):
+        """Per-server oauth_client_id + append_mcp_path are persisted on register."""
+        # Arrange
+        mock_server_service.register_server.return_value = {
+            "success": True,
+            "message": "Server registered successfully",
+            "is_new_version": False,
+        }
+
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service", return_value=True
+        ):
+            # Act - a root-endpoint server that drops the /mcp suffix and uses a
+            # fixed public OAuth client for the IDE login flow.
+            response = test_client_admin.post(
+                "/api/register",
+                data={
+                    "name": "AWS Knowledge",
+                    "description": "Test",
+                    "path": "/aws-knowledge",
+                    "proxy_pass_url": "https://knowledge-mcp.example.com",
+                    "oauth_client_id": "mcp-gateway",
+                    "append_mcp_path": "false",
+                },
+            )
+
+            # Assert
+            assert response.status_code == 201
+            server_entry = mock_server_service.register_server.call_args[0][0]
+            assert server_entry["oauth_client_id"] == "mcp-gateway"
+            assert server_entry["append_mcp_path"] is False
+
+    def test_register_service_omits_connect_config_when_unset(
+        self,
+        test_client_admin,
+        mock_server_service,
+        mock_faiss_service,
+        mock_nginx_service,
+        mock_nginx_reload_scheduler,
+        mock_health_service,
+    ):
+        """Absent overrides are not persisted (None = auto-detect / global default)."""
+        # Arrange
+        mock_server_service.register_server.return_value = {
+            "success": True,
+            "message": "Server registered successfully",
+            "is_new_version": False,
+        }
+
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service", return_value=True
+        ):
+            # Act
+            response = test_client_admin.post(
+                "/api/register",
+                data={
+                    "name": "Plain Server",
+                    "description": "Test",
+                    "path": "/plain",
+                    "proxy_pass_url": "http://localhost:9000",
+                },
+            )
+
+            # Assert
+            assert response.status_code == 201
+            server_entry = mock_server_service.register_server.call_args[0][0]
+            assert "oauth_client_id" not in server_entry
+            assert "append_mcp_path" not in server_entry
+
     def test_register_service_metadata_json_null_defaults_to_empty_dict(
         self,
         test_client_admin,
@@ -2192,6 +2269,24 @@ class TestServerRegisterVisibility:
         call_args = mock_server_service.register_server.call_args
         server_entry = call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
         assert server_entry["visibility"] == "public"
+
+    def test_register_persists_connect_config_overrides(
+        self, test_client_admin, mock_server_service
+    ):
+        """oauth_client_id + append_mcp_path round-trip through the API register handler."""
+        response = test_client_admin.post(
+            "/api/servers/register",
+            data={
+                **self._BASE_FORM,
+                "oauth_client_id": "mcp-gateway",
+                "append_mcp_path": "false",
+            },
+        )
+        assert response.status_code == 201
+        call_args = mock_server_service.register_server.call_args
+        server_entry = call_args.args[0] if call_args.args else call_args.kwargs.get("server_entry")
+        assert server_entry["oauth_client_id"] == "mcp-gateway"
+        assert server_entry["append_mcp_path"] is False
 
     def test_register_rejects_invalid_visibility(
         self, test_client_admin, mock_server_service

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -1860,6 +1860,37 @@ class TestEditLocalServer:
         assert updated_entry["deployment"] == "remote"
         assert updated_entry["proxy_pass_url"] == "http://upstream:9001"
 
+    def test_edit_remote_persists_connect_config_overrides(
+        self,
+        test_client_admin,
+        mock_server_service,
+        mock_faiss_service,
+        mock_nginx_service,
+    ):
+        """Per-server oauth_client_id + append_mcp_path are persisted on edit."""
+        mock_server_service.get_server_info.return_value = self.REMOTE_SERVER_INFO
+        mock_server_service.is_service_enabled.return_value = True
+
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service", return_value=True
+        ):
+            response = test_client_admin.post(
+                "/api/edit/remote-srv",
+                headers={"accept": "application/json"},
+                data={
+                    "name": "Existing Remote",
+                    "description": "updated",
+                    "proxy_pass_url": "https://knowledge-mcp.example.com",
+                    "tags": "",
+                    "oauth_client_id": "mcp-gateway",
+                    "append_mcp_path": "false",
+                },
+            )
+        assert response.status_code == 200
+        updated_entry = mock_server_service.update_server.call_args[0][1]
+        assert updated_entry["oauth_client_id"] == "mcp-gateway"
+        assert updated_entry["append_mcp_path"] is False
+
     def test_edit_remote_requires_proxy_pass_url(
         self,
         test_client_admin,


### PR DESCRIPTION
## Problem

The IDE-OAuth-login work (#1224 / #1235) added per-server `oauth_client_id` and `append_mcp_path` to the `ServerInfo` schema, surfaced them in `GET /servers/{path}/connect-config`, and the frontend reads them. But there is **no API write path** for either field:

- `register_service` (`POST /register`) and `register_service_api` (`POST /servers/register`) don't accept them as form fields.
- `edit_server_submit` (`POST /edit/{path}`) doesn't accept them.
- `ServerUpdateRequest` (PUT) and `ServerCardPatch` (PATCH) are `extra="forbid"`, so a body carrying either field is rejected with 422.

So per-server overrides can never be set: `connect-config` always reads back `None`. In practice a root-endpoint server (e.g. AWS Knowledge, which serves MCP at the server path itself) always gets the auto-detected trailing `/mcp` in its Connect URL, with no way to suppress it — and a server can't opt into a per-server public OAuth `client_id` distinct from the registry-wide `IDE_OAUTH_CLIENT_ID` default.

## Change

Wire the write path the same way existing connect fields like `mcp_endpoint` are threaded:

- **`register_service`, `register_service_api`, `edit_server_submit`**: accept `oauth_client_id: str | None` and `append_mcp_path: bool | None` as optional `Form` fields and persist them into the server entry when provided. `None` = unset (auto-detect / fall back to the registry-wide default), so existing behaviour is unchanged when callers omit them.
- **`ServerUpdateRequest` (PUT) / `ServerCardPatch` (PATCH)**: add both fields. They are not in `SERVER_REGISTRANT_ONLY_FIELDS`, so `_merge_server_update` keeps them; PATCH remains `exclude_unset` (no accidental wipes).

No schema/storage/connect-config changes were needed — those already support the fields; this just lets clients set them.

## Tests

- `POST /register` and `POST /servers/register` persist `oauth_client_id` + `append_mcp_path` into the server entry handed to `register_server`.
- Omitted overrides are not persisted (stay `None` → auto-detect / global default).
- `ServerUpdateRequest` and `ServerCardPatch` accept the fields, and `extra="forbid"` still rejects unknown fields.

Validated locally: `ruff check` passes on all changed files; the new model assertions pass under pydantic. (Couldn't run the full pytest suite in my environment — the `torch` wheel download failed on a TLS cert error — so the endpoint tests will run in CI.)

## Notes

- `api/openapi.json` will need regenerating to reflect the new optional form fields (couldn't run the generator locally for the reason above).

Closes the per-server override gap from the IDE OAuth login feature (#1224).