### PR TITLE
fix(auth): warn loudly when scopes collection is empty (#1248)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -178,6 +178,29 @@ def _read_mcp_proxy_max_body_bytes() -> int:
 # Global scopes configuration (will be loaded during FastAPI startup)
 SCOPES_CONFIG = {}
 
+
+def _log_scopes_loaded(scopes_config: dict) -> None:
+    """Log the loaded scopes config, loudly when the collection is empty.
+
+    An empty scopes collection means every authenticated user falls back to
+    read-only access regardless of group membership. Scopes are not auto-seeded,
+    so an empty config is almost always a skipped post-deployment step. Emit a
+    WARNING with actionable remediation in that case (issue #1248); otherwise
+    keep the existing INFO line unchanged.
+    """
+    group_mappings = scopes_config.get("group_mappings", {})
+    if not group_mappings:
+        logger.warning(
+            "Loaded scopes configuration on startup with 0 group mappings. "
+            "The scopes collection is EMPTY — all users will be read-only. "
+            "Seed scopes via the post-deployment init (run-documentdb-init.sh) "
+            "or load-scopes.py."
+        )
+    else:
+        logger.info(
+            f"Loaded scopes configuration on startup with {len(group_mappings)} group mappings"
+        )
+
 # Static token auth: use static API key instead of IdP JWT for Registry API
 _registry_static_token_requested: bool = (
     os.environ.get("REGISTRY_STATIC_TOKEN_AUTH_ENABLED", "false").lower() == "true"
@@ -1113,9 +1136,7 @@ async def lifespan(app: FastAPI):
     global SCOPES_CONFIG
     try:
         SCOPES_CONFIG = await reload_scopes_config()
-        logger.info(
-            f"Loaded scopes configuration on startup with {len(SCOPES_CONFIG.get('group_mappings', {}))} group mappings"
-        )
+        _log_scopes_loaded(SCOPES_CONFIG)
     except Exception as e:
         logger.error(f"Failed to load scopes configuration on startup: {e}", exc_info=True)
         # Fall back to empty config
@@ -1187,9 +1208,7 @@ async def startup_event():
     global SCOPES_CONFIG
     try:
         SCOPES_CONFIG = await reload_scopes_config()
-        logger.info(
-            f"Loaded scopes configuration on startup with {len(SCOPES_CONFIG.get('group_mappings', {}))} group mappings"
-        )
+        _log_scopes_loaded(SCOPES_CONFIG)
     except Exception as e:
         logger.error(f"Failed to load scopes configuration on startup: {e}", exc_info=True)
         # Fall back to empty config

--- a/registry/common/scopes_loader.py
+++ b/registry/common/scopes_loader.py
@@ -77,10 +77,23 @@ async def load_scopes_from_repository(
                 if ui_permissions:
                     ui_scopes[group_name] = ui_permissions
 
-            logger.info(
-                f"Loaded from repository: {len(group_mappings)} group mappings, "
-                f"{len(scopes_config)} scope definitions, {len(ui_scopes)} UI scopes"
-            )
+            if not group_mappings:
+                # An empty scopes collection means every authenticated user
+                # falls back to read-only access regardless of group membership.
+                # Scopes are not auto-seeded; this is almost always a skipped
+                # post-deployment step rather than an intentional empty config.
+                logger.warning(
+                    "Loaded from repository: 0 group mappings, "
+                    f"{len(scopes_config)} scope definitions, {len(ui_scopes)} UI scopes. "
+                    "The scopes collection is EMPTY — all users will be read-only. "
+                    "Seed scopes via the post-deployment init (run-documentdb-init.sh) "
+                    "or load-scopes.py."
+                )
+            else:
+                logger.info(
+                    f"Loaded from repository: {len(group_mappings)} group mappings, "
+                    f"{len(scopes_config)} scope definitions, {len(ui_scopes)} UI scopes"
+                )
 
             # Build the complete config structure
             config = {"group_mappings": group_mappings, "UI-Scopes": ui_scopes}

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -2832,3 +2832,53 @@ class TestMcpProxyEndpointHeaderPassthrough:
         assert response.status_code == 401
         assert response.headers.get("www-authenticate", "").startswith("Bearer")
         assert response.headers.get("retry-after") == "15"
+
+
+# =============================================================================
+# SCOPES STARTUP LOGGING TESTS (issue #1248)
+# =============================================================================
+
+
+class TestLogScopesLoaded:
+    """Tests for _log_scopes_loaded empty-vs-populated startup logging.
+
+    The auth-server reconfigures the root logger with custom handlers
+    (registry.utils.logging_setup), which makes pytest's caplog fixture
+    unreliable here. Patch the module logger directly and assert on the calls.
+    """
+
+    def test_empty_scopes_emits_warning_with_remediation(self):
+        """0 group mappings -> WARNING with actionable seeding hint."""
+        from auth_server import server as server_module
+
+        with patch.object(server_module, "logger") as mock_logger:
+            server_module._log_scopes_loaded({"group_mappings": {}})
+
+        mock_logger.warning.assert_called_once()
+        mock_logger.info.assert_not_called()
+        msg = mock_logger.warning.call_args[0][0]
+        assert "EMPTY" in msg
+        assert "read-only" in msg
+        assert "load-scopes.py" in msg
+
+    def test_missing_group_mappings_key_treated_as_empty(self):
+        """A config dict with no group_mappings key still warns."""
+        from auth_server import server as server_module
+
+        with patch.object(server_module, "logger") as mock_logger:
+            server_module._log_scopes_loaded({})
+
+        mock_logger.warning.assert_called_once()
+
+    def test_populated_scopes_logs_info_no_warning(self):
+        """Non-empty group mappings -> INFO only, no warning (unchanged behaviour)."""
+        from auth_server import server as server_module
+
+        with patch.object(server_module, "logger") as mock_logger:
+            server_module._log_scopes_loaded(
+                {"group_mappings": {"mcp-registry-admin": ["admin"]}}
+            )
+
+        mock_logger.warning.assert_not_called()
+        mock_logger.info.assert_called_once()
+        assert "1 group mappings" in mock_logger.info.call_args[0][0]


### PR DESCRIPTION
## Summary

Closes #1248.

When the auth server starts against an **empty** scopes collection, it logged `0 group mappings` at `INFO` and proceeded normally — so a skipped post-deployment seeding step silently left every authenticated user read-only, discoverable only by digging through logs. This makes that case loud and actionable.

## Changes

- **`registry/common/scopes_loader.py`** (shared repository load path): when 0 group mappings are loaded, emit a `WARNING` with remediation text instead of `INFO`.
- **`auth_server/server.py`**: add a small `_log_scopes_loaded()` helper that branches WARNING-on-empty vs INFO-on-populated, and use it from both startup paths (the lifespan handler and the legacy `@app.on_event("startup")`), replacing the two duplicated INFO log lines.

Example warning:

```
Loaded scopes configuration on startup with 0 group mappings. The scopes
collection is EMPTY — all users will be read-only. Seed scopes via the
post-deployment init (run-documentdb-init.sh) or load-scopes.py.
```

## Scope / non-goals

- **No behaviour change** to seeding (still not auto-seeded) or access control.
- Populated case is unchanged (still `INFO`, no spurious warning).
- Backend-agnostic — the empty check is on the loaded dict, so it applies to DocumentDB and file backends alike.
- The optional health/readiness signal from the issue (point 3) is **not** included here — left as a follow-up to keep this change small and observability-only.

## Testing

- 3 new unit tests in `tests/auth_server/unit/test_server.py::TestLogScopesLoaded` (empty → WARNING with remediation; missing key → WARNING; populated → INFO only, no warning).
- Full auth-server server suite passes (119 passed); `ruff check` clean.

## Acceptance criteria

- [x] 0 group mappings → `WARNING` with actionable remediation text.
- [x] Scopes present → output unchanged (`INFO`, no warning).
- [x] Works across storage backends (check is on the loaded dict).
- [x] No change to seeding or access-control logic.
