### PR TITLE
docs(connect-config): document write path for per-server oauth_client_id / append_mcp_path

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MCP Gateway Registry",
     "description": "A registry and management system for Model Context Protocol (MCP) servers",
-    "version": "1.24.5"
+    "version": "1.24.7"
   },
   "paths": {
     "/api/version": {
@@ -1738,7 +1738,7 @@
           "Server Management"
         ],
         "summary": "Register Service Api",
-        "description": "Register a service via JWT Bearer Token authentication (External API).\n\nSupports both deployment types:\n- Remote (default): proxy_pass_url required, registry proxies HTTP requests.\n- Local: local_runtime JSON required (admin-only). Registry stores the\n  launch recipe for stdio MCP servers; it does NOT execute the server.\n\n**Authentication:** JWT Bearer token (via nginx X-User header)\n**Authorization:** Requires valid JWT token. Local registration requires admin.\n\n**Request body (form data):**\n- `name` (required): Service name\n- `description` (required): Service description\n- `path` (required): Service path (e.g., /myservice)\n- `deployment` (optional): 'remote' (default) or 'local'\n- `proxy_pass_url` (required for remote): Proxy URL (e.g., http://localhost:8000)\n- `local_runtime` (required for local): JSON-encoded launch recipe\n- `tags` (optional): Comma-separated tags\n- `num_tools` (optional): Number of tools\n- `license` (optional): License name\n- `overwrite` (optional): Overwrite if exists (boolean, default true)\n- `auth_scheme` (optional): Auth scheme (none, bearer, api_key). Forced to 'none' for local.\n- `auth_credential` (optional): Plaintext credential (encrypted before storage)\n- `mcp_endpoint` (optional): Full URL for custom MCP endpoint (remote only)\n- `sse_endpoint` (optional): Full URL for custom SSE endpoint (remote only)\n- `metadata` (optional): JSON string of custom metadata\n- `version` (optional): Server version (e.g., v1.0.0)\n- `status` (optional): Lifecycle status (active, deprecated, draft, beta)\n\n**Example (remote):**\n```bash\ncurl -X POST https://registry.example.com/api/servers/register \\\n  -H \"Authorization: Bearer $JWT_TOKEN\" \\\n  -F \"name=My Service\" \\\n  -F \"description=My MCP Service\" \\\n  -F \"path=/myservice\" \\\n  -F \"proxy_pass_url=http://localhost:8000\"\n```\n\n**Example (local):**\n```bash\ncurl -X POST https://registry.example.com/api/servers/register \\\n  -H \"Authorization: Bearer $JWT_TOKEN\" \\\n  -F \"name=My Local MCP\" \\\n  -F \"description=Stdio MCP server\" \\\n  -F \"path=/my-local-mcp\" \\\n  -F \"deployment=local\" \\\n  -F 'local_runtime={\"type\":\"npx\",\"package\":\"@acme/mcp\",\"version\":\"1.0.0\",\"args\":[],\"env\":{},\"required_env\":[\"API_KEY\"]}'\n```",
+        "description": "Register a service via JWT Bearer Token authentication (External API).\n\nSupports both deployment types:\n- Remote (default): proxy_pass_url required, registry proxies HTTP requests.\n- Local: local_runtime JSON required (admin-only). Registry stores the\n  launch recipe for stdio MCP servers; it does NOT execute the server.\n\n**Authentication:** JWT Bearer token (via nginx X-User header)\n**Authorization:** Requires valid JWT token. Local registration requires admin.\n\n**Request body (form data):**\n- `name` (required): Service name\n- `description` (required): Service description\n- `path` (required): Service path (e.g., /myservice)\n- `deployment` (optional): 'remote' (default) or 'local'\n- `proxy_pass_url` (required for remote): Proxy URL (e.g., http://localhost:8000)\n- `local_runtime` (required for local): JSON-encoded launch recipe\n- `tags` (optional): Comma-separated tags\n- `num_tools` (optional): Number of tools\n- `license` (optional): License name\n- `overwrite` (optional): Overwrite if exists (boolean, default true)\n- `auth_scheme` (optional): Auth scheme (none, bearer, api_key). Forced to 'none' for local.\n- `auth_credential` (optional): Plaintext credential (encrypted before storage)\n- `mcp_endpoint` (optional): Full URL for custom MCP endpoint (remote only)\n- `sse_endpoint` (optional): Full URL for custom SSE endpoint (remote only)\n- `metadata` (optional): JSON string of custom metadata\n- `version` (optional): Server version (e.g., v1.0.0)\n- `status` (optional): Lifecycle status (active, deprecated, draft, beta)\n- `oauth_client_id` (optional): Per-server public OAuth client_id advertised in\n  the Connect config so IDEs run the OAuth/PKCE login instead of embedding a\n  static token. Overrides the registry-wide IDE_OAUTH_CLIENT_ID default.\n- `append_mcp_path` (optional, bool): Force/suppress the trailing '/mcp' transport\n  segment on the gateway Connect URL. Omit to auto-detect from proxy_pass_url;\n  set false for root-endpoint servers (e.g. AWS Knowledge) that serve MCP at the\n  server path itself.\n\n**Example (remote):**\n```bash\ncurl -X POST https://registry.example.com/api/servers/register \\\n  -H \"Authorization: Bearer $JWT_TOKEN\" \\\n  -F \"name=My Service\" \\\n  -F \"description=My MCP Service\" \\\n  -F \"path=/myservice\" \\\n  -F \"proxy_pass_url=http://localhost:8000\"\n```\n\n**Example (local):**\n```bash\ncurl -X POST https://registry.example.com/api/servers/register \\\n  -H \"Authorization: Bearer $JWT_TOKEN\" \\\n  -F \"name=My Local MCP\" \\\n  -F \"description=Stdio MCP server\" \\\n  -F \"path=/my-local-mcp\" \\\n  -F \"deployment=local\" \\\n  -F 'local_runtime={\"type\":\"npx\",\"package\":\"@acme/mcp\",\"version\":\"1.0.0\",\"args\":[],\"env\":{},\"required_env\":[\"API_KEY\"]}'\n```",
         "operationId": "register_service_api_api_servers_register_post",
         "requestBody": {
           "content": {
@@ -14031,6 +14031,28 @@
               }
             ],
             "title": "Custom Headers"
+          },
+          "oauth_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Client Id"
+          },
+          "append_mcp_path": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Append Mcp Path"
           }
         },
         "type": "object",
@@ -14583,6 +14605,28 @@
               }
             ],
             "title": "Allowed Groups"
+          },
+          "oauth_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Client Id"
+          },
+          "append_mcp_path": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Append Mcp Path"
           }
         },
         "type": "object",
@@ -14790,6 +14834,28 @@
               }
             ],
             "title": "Local Runtime"
+          },
+          "oauth_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Client Id"
+          },
+          "append_mcp_path": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Append Mcp Path"
           }
         },
         "type": "object",
@@ -18438,6 +18504,28 @@
             ],
             "title": "Headers"
           },
+          "oauth_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Client Id"
+          },
+          "append_mcp_path": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Append Mcp Path"
+          },
           "auth_provider": {
             "anyOf": [
               {
@@ -19056,6 +19144,28 @@
               }
             ],
             "title": "Headers"
+          },
+          "oauth_client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Oauth Client Id"
+          },
+          "append_mcp_path": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Append Mcp Path"
           },
           "auth_provider": {
             "anyOf": [

--- a/docs/connection-methods/client-id.md
+++ b/docs/connection-methods/client-id.md
@@ -28,9 +28,10 @@ preserves full per-user auditability (see "Auditability" below).
 2. The registry advertises that client id. Configure it two ways:
    - **Registry-wide default:** set `IDE_OAUTH_CLIENT_ID` on the registry. Every
      server's Connect dialog uses it.
-   - **Per-server override:** set `oauth_client_id` on an individual server entry
-     (registration form or server JSON). This wins over the global default for
-     that server.
+   - **Per-server override:** set `oauth_client_id` on an individual server entry.
+     This wins over the global default for that server. See
+     "[Setting the per-server overrides](#setting-the-per-server-overrides)" below
+     for the API/UI fields that write it.
    Resolution happens server-side in `GET /api/servers/{path}/connect-config`
    (`server_info.oauth_client_id` || `settings.ide_oauth_client_id`), so the
    frontend receives a single resolved value.
@@ -308,6 +309,55 @@ Knowledge) serve MCP at the server path itself and break on `/mcp`. Set
 `append_mcp_path: false` on that server entry to emit the URL without the suffix;
 set `true` to force it; leave unset to auto-detect from `proxy_pass_url`. For an
 entirely custom endpoint, use `mcp_endpoint`.
+
+## Setting the per-server overrides
+
+Both per-server overrides (`oauth_client_id` and `append_mcp_path`) are written
+through the same surfaces that manage any other server field. Omitting a field leaves
+it unset, so existing servers are unaffected (`oauth_client_id` falls back to the
+registry-wide `IDE_OAUTH_CLIENT_ID`; `append_mcp_path` auto-detects from
+`proxy_pass_url`).
+
+### Registry UI
+
+Set both fields on the server **Register** and **Edit** forms. After saving, the
+server's **Connect** dialog reflects the values immediately.
+
+### Register API (JWT Bearer)
+
+Pass them as optional form fields to `POST /api/servers/register`:
+
+```bash
+curl -X POST https://registry.example.com/api/servers/register \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -F "name=AWS Knowledge" \
+  -F "description=Root-endpoint MCP server" \
+  -F "path=/aws-knowledge" \
+  -F "proxy_pass_url=https://knowledge-mcp.example.com" \
+  -F "oauth_client_id=mcp-gateway" \
+  -F "append_mcp_path=false"
+```
+
+### Update API (PUT / PATCH)
+
+`PUT /api/servers/{path}` (full replace) and `PATCH /api/servers/{path}` (partial)
+both accept the fields in the JSON body:
+
+```bash
+curl -X PATCH https://registry.example.com/api/servers/aws-knowledge \
+  -H "Authorization: Bearer $JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"oauth_client_id": "mcp-gateway", "append_mcp_path": false}'
+```
+
+PATCH merges (only the fields you send change); PUT replaces, so a field omitted from a
+PUT body is cleared back to unset.
+
+### Reading back the resolved values
+
+`GET /api/servers/{path}/connect-config` returns the effective `oauth_client_id`
+(per-server value, else the registry-wide default) and the stored `append_mcp_path`.
+This is the value the frontend Connect dialog consumes.
 
 ## Related
 


### PR DESCRIPTION
## Problem

PR #1241 added the API write path for the per-server connect-config overrides
`oauth_client_id` and `append_mcp_path`. The connection-method doc
(`docs/connection-methods/client-id.md`) already describes both fields, but it stated you
set `oauth_client_id` via "registration form or server JSON" — which was not actually
possible through the API before #1241. The doc also had no concrete "how to set it"
guidance.

## Change

- Correct the per-server override bullet in "How it works" to point at a new
  step-by-step section instead of implying a JSON-only / form-only path.
- Add a "Setting the per-server overrides" section documenting all the write surfaces
  now wired by #1241: the Registry UI register/edit forms, `POST /api/servers/register`
  (form fields), and `PUT` / `PATCH /api/servers/{path}` (JSON body), plus how to read
  the resolved values back via `GET /api/servers/{path}/connect-config`.

No code changes. No deployment-parameter changes (these are per-server record fields, not
config), so `docs/unified-parameter-reference.md` is intentionally untouched.

## Related

Documents the capability shipped in #1241.
