### PR TITLE
feat(embeddings): stale-embedding CLI, no-op cleanup feedback, and FAQ (#1232 follow-up)

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "MCP Gateway Registry",
     "description": "A registry and management system for Model Context Protocol (MCP) servers",
-    "version": "1.24.7"
+    "version": "1.24.8"
   },
   "paths": {
     "/api/version": {
@@ -84,6 +84,45 @@
             "content": {
               "application/json": {
                 "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/system/update-check": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Get Update Check",
+        "description": "Return cached update-check state for admins.\n\nReads the most recent result of the background poller defined in\n``registry.core.update_check``. Never makes a network call itself.\nNon-admins receive 403 \u2014 the registry running version is admin-only\noperational metadata, and the GitHub release tag would otherwise leak\nto any authenticated user.\n\nUses ``nginx_proxied_auth`` (not ``enhanced_auth``) so the endpoint works\nwith both a browser session cookie AND a Bearer JWT (validated by nginx,\nforwarded as identity headers). This matches the sibling ``/api/stats`` and\n``/api/system/telemetry-detection`` routes and lets CLI / token-file callers\nreach it the same way they reach the rest of ``/api/*``.",
+        "operationId": "get_update_check_api_system_update_check_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Update Check Api System Update Check Get"
+                }
               }
             }
           },
@@ -7528,7 +7567,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CustomTypeDescriptor-Input"
+                "$ref": "#/components/schemas/CustomTypeDescriptor"
               }
             }
           },
@@ -7540,7 +7579,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomTypeDescriptor-Output"
+                  "$ref": "#/components/schemas/CustomTypeDescriptor"
                 }
               }
             }
@@ -7591,7 +7630,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomTypeDescriptor-Output"
+                  "$ref": "#/components/schemas/CustomTypeDescriptor"
                 }
               }
             }
@@ -7650,7 +7689,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CustomTypeDescriptor-Output"
+                  "$ref": "#/components/schemas/CustomTypeDescriptor"
                 }
               }
             }
@@ -10988,6 +11027,90 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MissingEmbeddingsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/embeddings/stale": {
+      "get": {
+        "tags": [
+          "Embeddings Admin"
+        ],
+        "summary": "Get Stale Embeddings",
+        "description": "Scan for orphaned embeddings with no source registry document.\n\nCompares the embeddings collection against source collections\n(servers, agents, skills, virtual servers) and returns index entries\nwhose source entity was deleted without removing the vector (issue #1145).",
+        "operationId": "get_stale_embeddings_api_admin_embeddings_stale_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaleEmbeddingsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/admin/embeddings/stale/cleanup": {
+      "post": {
+        "tags": [
+          "Embeddings Admin"
+        ],
+        "summary": "Cleanup Stale Embeddings",
+        "description": "Remove orphaned embedding documents from the search index.",
+        "operationId": "cleanup_stale_embeddings_api_admin_embeddings_stale_cleanup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StaleCleanupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StaleCleanupResponse"
                 }
               }
             }
@@ -15602,82 +15725,7 @@
         "title": "CustomFieldType",
         "description": "Allowed datatypes for a custom-type field (v1: scalars + scalar arrays)."
       },
-      "CustomTypeDescriptor-Input": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 64,
-            "minLength": 1,
-            "pattern": "^[a-z0-9_-]+$",
-            "title": "Name",
-            "description": "URL-safe, IMMUTABLE type name; used as path prefix and entity_type"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 200
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name",
-            "description": "Optional human label for the tab"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 2000
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "fields": {
-            "items": {
-              "$ref": "#/components/schemas/CustomFieldDescriptor"
-            },
-            "type": "array",
-            "maxItems": 100,
-            "minItems": 1,
-            "title": "Fields"
-          },
-          "schema_version": {
-            "type": "integer",
-            "title": "Schema Version",
-            "description": "Descriptor schema version for future compat",
-            "default": 1
-          },
-          "created_by": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created By"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "fields"
-        ],
-        "title": "CustomTypeDescriptor",
-        "description": "Admin-authored schema for a custom entity type. Stored in mcp_custom_types.\n\n``extra=\"ignore\"``: the type repo splats raw Mongo docs\n(``CustomTypeDescriptor(**doc)``) which carry an ``_id`` key, so the\nmodel must tolerate the extra key."
-      },
-      "CustomTypeDescriptor-Output": {
+      "CustomTypeDescriptor": {
         "properties": {
           "name": {
             "type": "string",
@@ -20291,6 +20339,154 @@
         ],
         "title": "SkillTier1_Metadata",
         "description": "Tier 1: Always available, ~100 tokens."
+      },
+      "StaleCleanupDetailEntry": {
+        "properties": {
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "path",
+          "status"
+        ],
+        "title": "StaleCleanupDetailEntry",
+        "description": "Per-path result of stale embedding removal.\n\n``status`` is ``removed`` (a stale embedding existed and was deleted),\n``not_found`` (no-op: nothing indexed at this path), or ``failed``."
+      },
+      "StaleCleanupRequest": {
+        "properties": {
+          "paths": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 100,
+            "minItems": 1,
+            "title": "Paths",
+            "description": "Embedding paths to remove (max 100)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "paths"
+        ],
+        "title": "StaleCleanupRequest",
+        "description": "Request body for removing orphaned embedding documents."
+      },
+      "StaleCleanupResponse": {
+        "properties": {
+          "removed": {
+            "type": "integer",
+            "title": "Removed"
+          },
+          "not_found": {
+            "type": "integer",
+            "title": "Not Found"
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "details": {
+            "items": {
+              "$ref": "#/components/schemas/StaleCleanupDetailEntry"
+            },
+            "type": "array",
+            "title": "Details"
+          }
+        },
+        "type": "object",
+        "required": [
+          "removed",
+          "not_found",
+          "failed",
+          "total",
+          "details"
+        ],
+        "title": "StaleCleanupResponse",
+        "description": "Response for the stale embedding cleanup operation.\n\nCounts are reported separately so admins can tell a real cleanup from a\nno-op: ``removed`` paths actually had an orphaned embedding deleted, while\n``not_found`` paths matched nothing (e.g. a typo or an already-clean path)."
+      },
+      "StaleEmbeddingEntry": {
+        "properties": {
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "entity_type": {
+            "type": "string",
+            "title": "Entity Type"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "is_enabled": {
+            "type": "boolean",
+            "title": "Is Enabled",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "path",
+          "entity_type",
+          "name"
+        ],
+        "title": "StaleEmbeddingEntry",
+        "description": "An embedding-index document with no matching source registry record."
+      },
+      "StaleEmbeddingsResponse": {
+        "properties": {
+          "stale": {
+            "items": {
+              "$ref": "#/components/schemas/StaleEmbeddingEntry"
+            },
+            "type": "array",
+            "title": "Stale"
+          },
+          "total_stale": {
+            "type": "integer",
+            "title": "Total Stale"
+          },
+          "total_indexed": {
+            "type": "integer",
+            "title": "Total Indexed"
+          },
+          "total_source": {
+            "type": "integer",
+            "title": "Total Source"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stale",
+          "total_stale",
+          "total_indexed",
+          "total_source"
+        ],
+        "title": "StaleEmbeddingsResponse",
+        "description": "Response for the stale embeddings scan."
       },
       "StatusDistribution": {
         "properties": {

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -5494,6 +5494,131 @@ def cmd_embeddings_reindex(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_embeddings_stale(args: argparse.Namespace) -> int:
+    """Find orphaned embeddings (indexed but no source document).
+
+    The inverse of ``embeddings-missing``: detects vectors left in the search
+    index after a server/agent/skill was deleted (issue #1145).
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        client = _create_client(args)
+
+        response = client._make_request(
+            method="GET",
+            endpoint="/api/admin/embeddings/stale",
+        )
+
+        data = response.json()
+        total_stale = data.get("total_stale", 0)
+        total_indexed = data.get("total_indexed", 0)
+        total_source = data.get("total_source", 0)
+
+        if getattr(args, "json", False):
+            print(json.dumps(data, indent=2))
+            return 0
+
+        print("\nEmbeddings Index Status:")
+        print(f"  Source documents:  {total_source}")
+        print(f"  Indexed:           {total_indexed}")
+        print(f"  Stale (orphaned):  {total_stale}")
+
+        if total_stale == 0:
+            print("\n  No stale embeddings found.")
+            return 0
+
+        print(f"\nStale embeddings ({total_stale}):\n")
+        print(f"  {'Path':<50} {'Type':<15} {'Name'}")
+        print(f"  {'-' * 50} {'-' * 15} {'-' * 30}")
+        for entry in data.get("stale", []):
+            print(f"  {entry['path']:<50} {entry['entity_type']:<15} {entry['name']}")
+
+        return 0
+
+    except Exception as e:
+        logger.error(f"Embeddings stale check failed: {e}")
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+def cmd_embeddings_stale_cleanup(args: argparse.Namespace) -> int:
+    """Remove orphaned embeddings by path, or all stale ones with --all-stale.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        client = _create_client(args)
+
+        paths = getattr(args, "paths", None)
+
+        if getattr(args, "all_stale", False):
+            response = client._make_request(
+                method="GET",
+                endpoint="/api/admin/embeddings/stale",
+            )
+            stale_data = response.json()
+            paths = [entry["path"] for entry in stale_data.get("stale", [])]
+            if not paths:
+                print("No stale embeddings found. Nothing to clean up.")
+                return 0
+            print(f"Found {len(paths)} stale embeddings. Cleaning up...")
+
+        if not paths:
+            print("Error: provide --paths or --all-stale", file=sys.stderr)
+            return 1
+
+        batch_size = 100
+        total_removed = 0
+        total_not_found = 0
+        total_failed = 0
+
+        for i in range(0, len(paths), batch_size):
+            batch = paths[i : i + batch_size]
+            response = client._make_request(
+                method="POST",
+                endpoint="/api/admin/embeddings/stale/cleanup",
+                data={"paths": batch},
+            )
+            result = response.json()
+            total_removed += result.get("removed", 0)
+            total_not_found += result.get("not_found", 0)
+            total_failed += result.get("failed", 0)
+
+            if getattr(args, "json", False):
+                print(json.dumps(result, indent=2))
+            else:
+                print(
+                    f"  Batch {i // batch_size + 1}: "
+                    f"{result.get('removed', 0)} removed, "
+                    f"{result.get('not_found', 0)} not_found, "
+                    f"{result.get('failed', 0)} failed"
+                )
+
+                for detail in result.get("details", []):
+                    if detail.get("status") == "failed":
+                        print(f"    FAILED: {detail['path']} - {detail.get('error', 'unknown')}")
+
+        print(
+            f"\nCleanup complete: {total_removed} removed, "
+            f"{total_not_found} not_found, {total_failed} failed"
+        )
+        return 0 if total_failed == 0 else 1
+
+    except Exception as e:
+        logger.error(f"Embeddings stale cleanup failed: {e}")
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
 def main() -> int:
     """
     Main entry point for the CLI.
@@ -6828,6 +6953,30 @@ Examples:
         "--json", action="store_true", help="Output raw JSON per batch"
     )
 
+    embeddings_stale_parser = subparsers.add_parser(
+        "embeddings-stale",
+        help="Find orphaned embeddings with no source document (admin only)",
+    )
+    embeddings_stale_parser.add_argument("--json", action="store_true", help="Output raw JSON")
+
+    embeddings_stale_cleanup_parser = subparsers.add_parser(
+        "embeddings-stale-cleanup",
+        help="Remove orphaned embeddings from the search index (admin only)",
+    )
+    embeddings_stale_cleanup_parser.add_argument(
+        "--paths",
+        nargs="+",
+        help="Specific stale paths to remove (e.g. /old-server /old-agent)",
+    )
+    embeddings_stale_cleanup_parser.add_argument(
+        "--all-stale",
+        action="store_true",
+        help="Remove all orphaned embeddings detected by embeddings-stale",
+    )
+    embeddings_stale_cleanup_parser.add_argument(
+        "--json", action="store_true", help="Output raw JSON per batch"
+    )
+
     logs_parser = subparsers.add_parser("logs", help="Query application logs (admin only)")
     logs_parser.add_argument("--service", help="Filter by service name")
     logs_parser.add_argument(
@@ -6986,6 +7135,8 @@ Examples:
         # Embeddings admin commands
         "embeddings-missing": cmd_embeddings_missing,
         "embeddings-reindex": cmd_embeddings_reindex,
+        "embeddings-stale": cmd_embeddings_stale,
+        "embeddings-stale-cleanup": cmd_embeddings_stale_cleanup,
     }
 
     handler = command_handlers.get(args.command)

--- a/docs/faq/fix-stale-search-embeddings.md
+++ b/docs/faq/fix-stale-search-embeddings.md
@@ -1,0 +1,130 @@
+# Why do I sometimes see search results for assets that no longer exist?
+
+## Question
+
+Semantic search (or the registration duplicate-check) sometimes returns a server, agent, or skill
+that I already deleted. Clicking through to it 404s or shows an empty page, because the underlying
+record is gone. Why does the deleted asset still show up, and how do I clean it up?
+
+## Answer
+
+This is the inverse of [missing embeddings](fix-missing-search-embeddings.md). Here the source
+record was deleted but its **embedding vector was left behind in the search index** (issue #1145).
+Semantic search and the dedup check query the embedding index, so an orphaned vector surfaces as a
+"phantom" result that no longer exists in the database.
+
+### Why this normally should not happen anymore
+
+Deleting a server, agent, skill, or virtual server now removes its embedding as part of the delete
+flow. The removal is retried (up to 3 attempts with backoff), and the source record is **not**
+deleted unless the embedding removal succeeds first, so a delete cannot silently leave an orphan.
+If the removal ever fails after all retries, the registry increments the
+`mcp_registry_embedding_removal_failures_total` metric so operators can alert on it.
+
+Orphans you might still see come from one of:
+
+- Embeddings created before this safeguard shipped (a pre-existing backlog).
+- A rare delete where the search backend was unavailable through all retries (the failure metric
+  fires in that case).
+- Records removed out-of-band (directly in the database, bypassing the service layer).
+
+The registry provides admin APIs and CLI commands to detect and remove these.
+
+## How to detect stale embeddings
+
+### Via CLI (registry_management.py)
+
+```bash
+uv run python api/registry_management.py \
+    --registry-url https://your-registry-url --token-file .token \
+    embeddings-stale
+```
+
+Example output:
+
+```
+Embeddings Index Status:
+  Source documents:  364
+  Indexed:           487
+  Stale (orphaned):  123
+
+Stale embeddings (123):
+
+  Path                                               Type            Name
+  -------------------------------------------------- --------------- ------------------------------
+  /llm_prompt/157ffff8-...                           skill           Some Prompt
+  /agents/agentcore-record_6d0je                     a2a_agent       Stale Agent
+```
+
+### Via REST API
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+    https://your-registry/api/admin/embeddings/stale | jq .
+```
+
+## How to fix stale embeddings
+
+### Remove all stale embeddings
+
+```bash
+uv run python api/registry_management.py \
+    --registry-url https://your-registry-url --token-file .token \
+    embeddings-stale-cleanup --all-stale
+```
+
+This finds every orphaned embedding and removes it in batches of 100.
+
+### Remove specific paths
+
+```bash
+uv run python api/registry_management.py \
+    --registry-url https://your-registry-url --token-file .token \
+    embeddings-stale-cleanup --paths /llm_prompt/157ffff8-... /agents/agentcore-record_6d0je
+```
+
+### Via REST API
+
+```bash
+curl -s -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"paths": ["/llm_prompt/157ffff8-...", "/agents/agentcore-record_6d0je"]}' \
+    https://your-registry/api/admin/embeddings/stale/cleanup | jq .
+```
+
+### Reading the cleanup result
+
+Each path is reported as one of:
+
+- `removed` - an orphaned embedding existed and was deleted.
+- `not_found` - nothing was indexed at that path (e.g. a typo, or it was already cleaned). This is
+  a no-op, not an error, and is counted separately from `removed` so you can tell a real cleanup
+  from one that matched nothing.
+- `failed` - the delete raised an error (the path is left in place; retry later).
+
+```json
+{
+  "removed": 2,
+  "not_found": 0,
+  "failed": 0,
+  "total": 2,
+  "details": [
+    {"path": "/llm_prompt/157ffff8-...", "status": "removed", "error": null},
+    {"path": "/agents/agentcore-record_6d0je", "status": "removed", "error": null}
+  ]
+}
+```
+
+## When should I run this?
+
+- After upgrading to a version that adds this safeguard, to clear any pre-existing orphan backlog.
+- If `mcp_registry_embedding_removal_failures_total` is non-zero (a delete-time cleanup failed).
+- After deleting records out-of-band (directly in the database).
+- As a periodic reconciliation check, alongside `embeddings-missing`.
+
+## Requirements
+
+- Admin permissions required (use the "Get JWT Token" button in the registry UI).
+- Batch limit: 100 paths per API call (the CLI handles batching automatically).
+- Supported on the DocumentDB/MongoDB search backend.

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -23,6 +23,8 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [How do I monitor the health of MCP servers?](monitoring-server-health.md)
 - [How do I configure MongoDB Atlas instead of MongoDB CE?](configuring-mongodb-atlas-backend.md)
+- [Why are some of my assets not showing up in semantic search?](fix-missing-search-embeddings.md)
+- [Why do I sometimes see search results for assets that no longer exist?](fix-stale-search-embeddings.md)
 
 ## Amazon Bedrock AgentCore
 

--- a/registry/api/embeddings_admin_routes.py
+++ b/registry/api/embeddings_admin_routes.py
@@ -106,7 +106,11 @@ class StaleCleanupRequest(BaseModel):
 
 
 class StaleCleanupDetailEntry(BaseModel):
-    """Per-path result of stale embedding removal."""
+    """Per-path result of stale embedding removal.
+
+    ``status`` is ``removed`` (a stale embedding existed and was deleted),
+    ``not_found`` (no-op: nothing indexed at this path), or ``failed``.
+    """
 
     path: str
     status: str
@@ -114,9 +118,15 @@ class StaleCleanupDetailEntry(BaseModel):
 
 
 class StaleCleanupResponse(BaseModel):
-    """Response for the stale embedding cleanup operation."""
+    """Response for the stale embedding cleanup operation.
 
-    success: int
+    Counts are reported separately so admins can tell a real cleanup from a
+    no-op: ``removed`` paths actually had an orphaned embedding deleted, while
+    ``not_found`` paths matched nothing (e.g. a typo or an already-clean path).
+    """
+
+    removed: int
+    not_found: int
     failed: int
     total: int
     details: list[StaleCleanupDetailEntry]
@@ -209,8 +219,9 @@ async def cleanup_stale_embeddings(
     result = await remove_stale(request.paths)
 
     logger.info(
-        "Stale embedding cleanup: %d success, %d failed",
-        result["success"],
+        "Stale embedding cleanup: %d removed, %d not_found, %d failed",
+        result["removed"],
+        result["not_found"],
         result["failed"],
     )
 

--- a/registry/repositories/documentdb/search_repository.py
+++ b/registry/repositories/documentdb/search_repository.py
@@ -1527,25 +1527,36 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
     ) -> dict[str, Any]:
         """Remove orphaned embedding documents by path.
 
+        Deletes inline (not via ``remove_entity``) so the caller can see whether
+        each path was actually removed or was a no-op. ``remove_entity`` returns
+        True for a not-found path on purpose (delete flows must proceed when no
+        embedding exists), which would otherwise mask a typo'd or already-clean
+        path here as ``removed``. Distinguishing the two gives admins honest
+        feedback during manual cleanup.
+
+        Per-path ``status`` is one of:
+          - ``removed``   - a stale embedding existed and was deleted
+          - ``not_found`` - nothing to delete at this path (no-op)
+          - ``failed``    - the delete raised an error
+
         Args:
             paths: Embedding index paths to remove (max 100).
 
         Returns:
-            Dictionary with success/failed counts and per-path details.
+            Dictionary with removed/not_found/failed counts and per-path details.
         """
-        details = []
+        collection = await self._get_collection()
+        details: list[dict[str, Any]] = []
 
         for path in paths:
             try:
-                removed = await self.remove_entity(path)
-                if removed:
-                    details.append({"path": path, "status": "success"})
+                result = await collection.delete_one({"_id": path})
+                if result.deleted_count > 0:
+                    logger.info("Removed stale embedding '%s' from search index", path)
+                    details.append({"path": path, "status": "removed", "error": None})
                 else:
-                    details.append({
-                        "path": path,
-                        "status": "failed",
-                        "error": "Failed to remove stale embedding",
-                    })
+                    logger.warning("Stale embedding '%s' not found (no-op)", path)
+                    details.append({"path": path, "status": "not_found", "error": None})
             except Exception as e:
                 logger.error("Failed to remove stale embedding '%s': %s", path, e)
                 details.append({
@@ -1554,18 +1565,21 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     "error": "Failed to remove stale embedding",
                 })
 
-        success_count = sum(1 for d in details if d["status"] == "success")
+        removed_count = sum(1 for d in details if d["status"] == "removed")
+        not_found_count = sum(1 for d in details if d["status"] == "not_found")
         failed_count = sum(1 for d in details if d["status"] == "failed")
 
         logger.info(
-            "Stale embedding cleanup: %d success, %d failed out of %d paths",
-            success_count,
+            "Stale embedding cleanup: %d removed, %d not_found, %d failed out of %d paths",
+            removed_count,
+            not_found_count,
             failed_count,
             len(paths),
         )
 
         return {
-            "success": success_count,
+            "removed": removed_count,
+            "not_found": not_found_count,
             "failed": failed_count,
             "total": len(paths),
             "details": details,

--- a/tests/unit/api/test_embeddings_admin_routes.py
+++ b/tests/unit/api/test_embeddings_admin_routes.py
@@ -269,10 +269,11 @@ class TestCleanupStaleEmbeddings:
         """Admin can remove orphaned embeddings by path."""
         mock_search_repo.remove_stale_embeddings = AsyncMock(
             return_value={
-                "success": 1,
+                "removed": 1,
+                "not_found": 0,
                 "failed": 0,
                 "total": 1,
-                "details": [{"path": "/ghost-server", "status": "success", "error": None}],
+                "details": [{"path": "/ghost-server", "status": "removed", "error": None}],
             }
         )
 
@@ -283,6 +284,29 @@ class TestCleanupStaleEmbeddings:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["success"] == 1
+        assert data["removed"] == 1
+        assert data["not_found"] == 0
         assert data["failed"] == 0
+
+    def test_reports_not_found_for_noop_path(self, admin_client, mock_search_repo):
+        """A path that matched nothing is reported as not_found, not removed."""
+        mock_search_repo.remove_stale_embeddings = AsyncMock(
+            return_value={
+                "removed": 0,
+                "not_found": 1,
+                "failed": 0,
+                "total": 1,
+                "details": [{"path": "/typo-path", "status": "not_found", "error": None}],
+            }
+        )
+
+        response = admin_client.post(
+            "/api/admin/embeddings/stale/cleanup",
+            json={"paths": ["/typo-path"]},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["removed"] == 0
+        assert data["not_found"] == 1
 

--- a/tests/unit/repositories/test_search_stale_embeddings.py
+++ b/tests/unit/repositories/test_search_stale_embeddings.py
@@ -62,35 +62,44 @@ class TestRemoveStaleEmbeddings:
     """Tests for remove_stale_embeddings."""
 
     @pytest.mark.asyncio
-    async def test_calls_remove_entity_per_path(self):
+    async def test_reports_removed_when_embedding_existed(self):
+        # delete_one reporting deleted_count > 0 means a stale embedding was
+        # actually removed -> status "removed".
         repo = _make_repo()
+        repo._collection.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
 
-        with patch.object(
-            repo,
-            "remove_entity",
-            new_callable=AsyncMock,
-            return_value=True,
-        ) as mock_remove:
-            result = await repo.remove_stale_embeddings(["/ghost-a", "/ghost-b"])
+        result = await repo.remove_stale_embeddings(["/ghost-a", "/ghost-b"])
 
-        assert result["success"] == 2
+        assert result["removed"] == 2
+        assert result["not_found"] == 0
         assert result["failed"] == 0
         assert result["total"] == 2
-        assert mock_remove.await_count == 2
+        assert all(d["status"] == "removed" for d in result["details"])
 
     @pytest.mark.asyncio
-    async def test_records_failure_when_remove_returns_false(self):
+    async def test_reports_not_found_for_noop_path(self):
+        # deleted_count == 0 means nothing was indexed at that path (typo or
+        # already-clean) -> status "not_found", NOT a misleading success.
         repo = _make_repo()
+        repo._collection.delete_one = AsyncMock(return_value=MagicMock(deleted_count=0))
 
-        with patch.object(
-            repo,
-            "remove_entity",
-            new_callable=AsyncMock,
-            side_effect=[True, False],
-        ):
-            result = await repo.remove_stale_embeddings(["/ghost-a", "/ghost-b"])
+        result = await repo.remove_stale_embeddings(["/does-not-exist"])
 
-        assert result["success"] == 1
+        assert result["removed"] == 0
+        assert result["not_found"] == 1
+        assert result["failed"] == 0
+        assert result["details"][0]["status"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_records_failure_when_delete_raises(self):
+        repo = _make_repo()
+        repo._collection.delete_one = AsyncMock(
+            side_effect=[MagicMock(deleted_count=1), Exception("db error")]
+        )
+
+        result = await repo.remove_stale_embeddings(["/ghost-a", "/ghost-b"])
+
+        assert result["removed"] == 1
         assert result["failed"] == 1
         assert result["details"][1]["status"] == "failed"
 

--- a/tests/unit/test_virtual_server_service.py
+++ b/tests/unit/test_virtual_server_service.py
@@ -327,7 +327,18 @@ class TestVirtualServerServiceCRUD:
         )
         mock_vs_repo.delete.return_value = True
 
-        with patch.object(service, "_trigger_nginx_reload", new_callable=AsyncMock):
+        # Delete now removes the search-index embedding first (and aborts if that
+        # fails), so the search repo must report a successful removal.
+        mock_search_repo = MagicMock()
+        mock_search_repo.remove_entity = AsyncMock(return_value=True)
+
+        with (
+            patch.object(service, "_trigger_nginx_reload", new_callable=AsyncMock),
+            patch(
+                "registry.services.virtual_server_service.get_search_repository",
+                return_value=mock_search_repo,
+            ),
+        ):
             result = await service.delete_virtual_server("/virtual/dev")
 
         assert result is True
@@ -738,7 +749,18 @@ class TestNginxTrigger:
         )
         mock_vs_repo.delete.return_value = True
 
-        with patch.object(service, "_trigger_nginx_reload", new_callable=AsyncMock) as mock_reload:
+        mock_search_repo = MagicMock()
+        mock_search_repo.remove_entity = AsyncMock(return_value=True)
+
+        with (
+            patch.object(
+                service, "_trigger_nginx_reload", new_callable=AsyncMock
+            ) as mock_reload,
+            patch(
+                "registry.services.virtual_server_service.get_search_repository",
+                return_value=mock_search_repo,
+            ),
+        ):
             await service.delete_virtual_server("/virtual/dev")
             mock_reload.assert_called_once()
 
@@ -1198,11 +1220,20 @@ class TestNginxReloadFailureHandling:
         )
         mock_vs_repo.delete.return_value = True
 
-        with patch.object(
-            service,
-            "_trigger_nginx_reload",
-            new_callable=AsyncMock,
-            return_value=False,
+        mock_search_repo = MagicMock()
+        mock_search_repo.remove_entity = AsyncMock(return_value=True)
+
+        with (
+            patch.object(
+                service,
+                "_trigger_nginx_reload",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "registry.services.virtual_server_service.get_search_repository",
+                return_value=mock_search_repo,
+            ),
         ):
             result = await service.delete_virtual_server("/virtual/dev")
 


### PR DESCRIPTION
## Summary

Follow-up to #1232 (stale embeddings after delete, issue #1145). That PR added delete-time embedding cleanup (with retry + failure metric) and the `/api/admin/embeddings/stale` + `/stale/cleanup` endpoints. This PR closes the remaining gaps surfaced during review and live testing.

## Changes

**CLI (`registry_management.py`)**
- Add `embeddings-stale` and `embeddings-stale-cleanup` subcommands, mirroring the existing `embeddings-missing` / `embeddings-reindex` pattern (`--paths` / `--all-stale`, 100-path batching, `--json`). The new endpoints had no CLI wrapper before.

**No-op feedback (`remove_stale_embeddings`)**
- During testing, cleaning up a non-existent / typo'd path reported `success`. That happened because `remove_entity` intentionally returns `True` for a not-found path (delete flows must proceed when no embedding exists), which masked no-ops as removals.
- `remove_stale_embeddings` now deletes inline and reports per-path status as **`removed`** / **`not_found`** / **`failed`**, with separate counts, so admins can tell a real cleanup from one that matched nothing. Response model + handler logging updated to match. (DocumentDB backend only; the file backend is deprecated and has no stale support.)

**Docs**
- New FAQ `docs/faq/fix-stale-search-embeddings.md`: why deleted assets sometimes still appear in semantic search / dedup, why it shouldn't normally happen now (delete-time cleanup + failure metric), and how to detect/clean leftovers via CLI and REST. Indexed both embedding FAQs in `faq/index.md`.

**Tests + spec**
- Fix the three `test_virtual_server_service` delete tests left stale by #1232 (mock the search repo so the delete proceeds past the new index-removal step). These were the only real CI failures on #1232 not attributable to a stale branch.
- Add coverage for the `removed` / `not_found` split (repo + API).
- Regenerate `api/openapi.json` to include the `/stale` endpoints (also picked up `/api/system/update-check` that the committed spec was missing); version `1.24.8`.

## Test plan

- `uv run pytest tests/unit/test_virtual_server_service.py tests/unit/repositories/test_search_stale_embeddings.py tests/unit/api/test_embeddings_admin_routes.py tests/unit/services/test_search_index_cleanup.py` - 96 passed
- `tests/security/test_container_security.py` - 49 passed
- `ruff check` - clean on all changed files
- CLI verified: `embeddings-stale` and `embeddings-stale-cleanup` register and dispatch

## Notes

- There is a real backlog of stale embeddings on existing deployments (the live ECS registry showed 123); operators can clear them with `embeddings-stale-cleanup --all-stale` once this lands.

Cc: @omrishiv