### PR TITLE
feat: Enable use of existing VPC and subnets for AWS ECS deployment.

### DIFF
--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -699,6 +699,13 @@ These have no `.env` equivalent because they describe the infrastructure, not th
 | `aws_region` | Deploy region. |
 | `name` | Deployment name prefix. |
 | `vpc_cidr` | VPC CIDR. |
+| `use_existing_vpc` | Deploy into an existing VPC/subnets instead of creating a new VPC. Defaults to `false`. |
+| `existing_vpc_id` | Existing VPC ID to use when `use_existing_vpc` is true. |
+| `existing_public_subnet_ids` | Existing public subnet IDs for internet-facing ALBs (existing-VPC mode). |
+| `existing_private_subnet_ids` | Existing private subnet IDs for ECS tasks, databases, Lambda, and EFS (existing-VPC mode). |
+| `existing_private_route_table_ids` | Existing private route table IDs for VPC gateway endpoints, required when `use_existing_vpc` and `create_vpc_endpoints` are both true. |
+| `existing_nat_public_ips` | Optional public egress IPs that private tasks use to reach the Keycloak public ALB (existing-VPC mode). |
+| `create_vpc_endpoints` | Create STS and S3 VPC endpoints. Set false when the existing VPC already provides endpoint/egress routing. Defaults to `true`. |
 | `enable_monitoring` | CloudWatch dashboards. |
 | `alarm_email` | SNS destination. |
 | `currenttime_replicas`, `mcpgw_replicas`, `realserverfaketools_replicas`, `flight_booking_agent_replicas`, `travel_assistant_agent_replicas` | ECS service desired counts. |

--- a/terraform/aws-ecs/README.md
+++ b/terraform/aws-ecs/README.md
@@ -302,6 +302,38 @@ If you are running this from an EC2 instance, you may also want to run `curl -s 
 
 **Warning:** Setting `ingress_cidr_blocks` to `["0.0.0.0/0"]` opens access to anyone on the internet. While authentication (username/password) is still required, this is not recommended for production environments.
 
+#### Optional: Use an Existing VPC
+
+By default, this deployment creates a new VPC, public subnets, private subnets, NAT gateways, and VPC endpoints. To deploy into a VPC that is already managed by your organization, set `use_existing_vpc = true` and provide the VPC and subnet IDs.
+
+```hcl
+use_existing_vpc = true
+existing_vpc_id  = "vpc-0123456789abcdef0"
+
+existing_public_subnet_ids = [
+  "subnet-0123456789abcdef0",
+  "subnet-0123456789abcdef1",
+]
+
+existing_private_subnet_ids = [
+  "subnet-0123456789abcdef2",
+  "subnet-0123456789abcdef3",
+]
+```
+
+When `create_vpc_endpoints = true`, also provide the private route table IDs so Terraform can attach the S3 gateway endpoint:
+
+```hcl
+existing_private_route_table_ids = [
+  "rtb-0123456789abcdef0",
+  "rtb-0123456789abcdef1",
+]
+```
+
+Set `create_vpc_endpoints = false` when the existing VPC already provides the required AWS service access through centrally managed endpoints, NAT, firewall, or proxy routing.
+
+`existing_nat_public_ips` is optional. Add the public egress IPs that private ECS tasks use when they call the Keycloak public ALB URL through a NAT gateway, firewall, or proxy. This is only needed when Keycloak ALB ingress is restricted and those egress IPs are not already included in `ingress_cidr_blocks` or managed elsewhere.
+
 **Example terraform.tfvars for Mode 1 (CloudFront Only - Easiest):**
 
 ```hcl

--- a/terraform/aws-ecs/documentdb.tf
+++ b/terraform/aws-ecs/documentdb.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "documentdb" {
 
   name        = "${var.name}-v2-documentdb-sg"
   description = "Security group for DocumentDB Elastic Cluster" # Keep original description to avoid recreation
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,
@@ -261,7 +261,7 @@ resource "aws_docdb_subnet_group" "registry" {
   count = local.is_aws_documentdb ? 1 : 0
 
   name       = "${var.name}-registry-subnet-group"
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = local.selected_private_subnet_ids
 
   tags = merge(
     local.common_tags,

--- a/terraform/aws-ecs/keycloak-alb.tf
+++ b/terraform/aws-ecs/keycloak-alb.tf
@@ -103,7 +103,7 @@ resource "aws_lb_listener" "keycloak_https" {
 }
 
 # HTTP Listener - behavior depends on deployment mode
-# Mode 2 (Custom Domain â†’ ALB): redirect to HTTPS
+# Mode 2 (Custom Domain → ALB): redirect to HTTPS
 # Mode 1 & 3 (CloudFront enabled): forward to target (CloudFront handles HTTPS)
 resource "aws_lb_listener" "keycloak_http" {
   load_balancer_arn = aws_lb.keycloak.arn

--- a/terraform/aws-ecs/keycloak-alb.tf
+++ b/terraform/aws-ecs/keycloak-alb.tf
@@ -16,7 +16,7 @@ resource "aws_lb" "keycloak" {
     [aws_security_group.keycloak_lb.id],
     local.cloudfront_prefix_list_name != "" ? [aws_security_group.keycloak_lb_cloudfront[0].id] : []
   )
-  subnets = module.vpc.public_subnets
+  subnets = local.selected_public_subnet_ids
 
   access_logs {
     bucket  = aws_s3_bucket.alb_logs.id
@@ -50,7 +50,7 @@ resource "aws_lb_target_group" "keycloak" {
   port                 = 8080
   protocol             = "HTTP"
   target_type          = "ip"
-  vpc_id               = module.vpc.vpc_id
+  vpc_id               = local.selected_vpc_id
   deregistration_delay = 30
 
   health_check {
@@ -103,7 +103,7 @@ resource "aws_lb_listener" "keycloak_https" {
 }
 
 # HTTP Listener - behavior depends on deployment mode
-# Mode 2 (Custom Domain → ALB): redirect to HTTPS
+# Mode 2 (Custom Domain â†’ ALB): redirect to HTTPS
 # Mode 1 & 3 (CloudFront enabled): forward to target (CloudFront handles HTTPS)
 resource "aws_lb_listener" "keycloak_http" {
   load_balancer_arn = aws_lb.keycloak.arn

--- a/terraform/aws-ecs/keycloak-database.tf
+++ b/terraform/aws-ecs/keycloak-database.tf
@@ -15,7 +15,7 @@ resource "aws_db_proxy" "keycloak" {
   }
 
   role_arn               = aws_iam_role.rds_proxy_role.arn
-  vpc_subnet_ids         = module.vpc.private_subnets
+  vpc_subnet_ids         = local.selected_private_subnet_ids
   vpc_security_group_ids = [aws_security_group.keycloak_db.id]
 
   require_tls = false
@@ -98,7 +98,7 @@ resource "aws_rds_cluster_instance" "keycloak" {
 # DB Subnet Group
 resource "aws_db_subnet_group" "keycloak" {
   name       = "keycloak-subnet-group"
-  subnet_ids = module.vpc.private_subnets
+  subnet_ids = local.selected_private_subnet_ids
 
   tags = merge(
     local.common_tags,

--- a/terraform/aws-ecs/keycloak-ecs.tf
+++ b/terraform/aws-ecs/keycloak-ecs.tf
@@ -20,7 +20,7 @@ locals {
     {
       # Issue #1122: KC_PROXY=edge was deprecated in Keycloak 24+; KC25 ignores
       # it. Replaced with KC_PROXY_HEADERS=xforwarded so Keycloak trusts the
-      # X-Forwarded-Proto/Host headers from CloudFront → ALB and recognizes
+      # X-Forwarded-Proto/Host headers from CloudFront â†’ ALB and recognizes
       # the connection as HTTPS. Without this, KC25 returns "HTTPS required"
       # for all OIDC endpoints.
       name  = "KC_PROXY_HEADERS"
@@ -40,7 +40,7 @@ locals {
     {
       # Issue #1122: KC25 listens HTTPS-only (8443) by default; KC23 listened
       # HTTP (8080). The ALB target group health checks port 8080, so we must
-      # explicitly enable the HTTP listener on KC25. CloudFront → ALB is
+      # explicitly enable the HTTP listener on KC25. CloudFront â†’ ALB is
       # already TLS-terminated by ALB/CloudFront, so HTTP between ALB and
       # Keycloak is fine within the VPC. KC_PROXY_HEADERS=xforwarded above
       # makes Keycloak still recognize the client connection as HTTPS.
@@ -348,7 +348,7 @@ resource "aws_ecs_service" "keycloak" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets          = module.vpc.private_subnets
+    subnets          = local.selected_private_subnet_ids
     security_groups  = [aws_security_group.keycloak_ecs.id]
     assign_public_ip = false
   }

--- a/terraform/aws-ecs/keycloak-ecs.tf
+++ b/terraform/aws-ecs/keycloak-ecs.tf
@@ -20,7 +20,7 @@ locals {
     {
       # Issue #1122: KC_PROXY=edge was deprecated in Keycloak 24+; KC25 ignores
       # it. Replaced with KC_PROXY_HEADERS=xforwarded so Keycloak trusts the
-      # X-Forwarded-Proto/Host headers from CloudFront â†’ ALB and recognizes
+      # X-Forwarded-Proto/Host headers from CloudFront → ALB and recognizes
       # the connection as HTTPS. Without this, KC25 returns "HTTPS required"
       # for all OIDC endpoints.
       name  = "KC_PROXY_HEADERS"
@@ -40,7 +40,7 @@ locals {
     {
       # Issue #1122: KC25 listens HTTPS-only (8443) by default; KC23 listened
       # HTTP (8080). The ALB target group health checks port 8080, so we must
-      # explicitly enable the HTTP listener on KC25. CloudFront â†’ ALB is
+      # explicitly enable the HTTP listener on KC25. CloudFront → ALB is
       # already TLS-terminated by ALB/CloudFront, so HTTP between ALB and
       # Keycloak is fine within the VPC. KC_PROXY_HEADERS=xforwarded above
       # makes Keycloak still recognize the client connection as HTTPS.

--- a/terraform/aws-ecs/keycloak-security-groups.tf
+++ b/terraform/aws-ecs/keycloak-security-groups.tf
@@ -6,7 +6,7 @@
 resource "aws_security_group" "keycloak_ecs" {
   name        = "keycloak-ecs"
   description = "Security group for Keycloak ECS tasks"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,
@@ -76,7 +76,7 @@ resource "aws_security_group_rule" "keycloak_ecs_ingress_lb_cloudfront" {
 resource "aws_security_group" "keycloak_lb" {
   name        = "keycloak-lb"
   description = "Security group for Keycloak load balancer"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,
@@ -112,7 +112,7 @@ resource "aws_security_group" "keycloak_lb_cloudfront" {
   count       = local.cloudfront_prefix_list_name != "" ? 1 : 0
   name        = "keycloak-lb-cloudfront"
   description = "Security group for CloudFront access to Keycloak ALB"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,
@@ -173,12 +173,14 @@ resource "aws_security_group_rule" "keycloak_lb_ingress_auth_server" {
 # When ECS tasks in private subnets call Keycloak's public DNS name, traffic goes through NAT gateway.
 # The source IP becomes the NAT gateway's public IP, not the ECS task's security group.
 resource "aws_security_group_rule" "keycloak_lb_ingress_nat_gateway" {
+  count = length(local.selected_nat_public_ips) > 0 ? 1 : 0
+
   description       = "Ingress from NAT gateways to Keycloak load balancer (HTTPS)"
   type              = "ingress"
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = [for ip in module.vpc.nat_public_ips : "${ip}/32"]
+  cidr_blocks       = [for ip in local.selected_nat_public_ips : "${ip}/32"]
   security_group_id = aws_security_group.keycloak_lb.id
 }
 
@@ -208,7 +210,7 @@ resource "aws_security_group_rule" "keycloak_lb_egress_ecs" {
 resource "aws_security_group" "keycloak_db" {
   name        = "keycloak-db"
   description = "Security group for Keycloak database"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -27,9 +27,9 @@ module "mcp_gateway" {
   name = "${var.name}-v2"
 
   # Network configuration
-  vpc_id              = module.vpc.vpc_id
-  private_subnet_ids  = module.vpc.private_subnets
-  public_subnet_ids   = module.vpc.public_subnets
+  vpc_id              = local.selected_vpc_id
+  private_subnet_ids  = local.selected_private_subnet_ids
+  public_subnet_ids   = local.selected_public_subnet_ids
   ingress_cidr_blocks = var.ingress_cidr_blocks
 
   # ALB logging
@@ -48,8 +48,8 @@ module "mcp_gateway" {
   # Domain name for the registry - determines REGISTRY_URL and OAuth redirect URIs
   # Simplified to 3 modes (no dual-access):
   #   Mode 1: CloudFront-only - use CloudFront domain
-  #   Mode 2: Custom Domain → ALB - use custom domain
-  #   Mode 3: Custom Domain → CloudFront - use custom domain (traffic flows through CloudFront)
+  #   Mode 2: Custom Domain â†’ ALB - use custom domain
+  #   Mode 3: Custom Domain â†’ CloudFront - use custom domain (traffic flows through CloudFront)
   domain_name = var.enable_route53_dns ? "registry.${local.root_domain}" : (
     var.enable_cloudfront ? aws_cloudfront_distribution.mcp_gateway[0].domain_name : ""
   )
@@ -394,12 +394,12 @@ resource "null_resource" "dual_ingress_warning" {
     command = <<-EOT
       echo ""
       echo "============================================================"
-      echo "INFO: Custom Domain → CloudFront Configuration (Mode 3)"
+      echo "INFO: Custom Domain â†’ CloudFront Configuration (Mode 3)"
       echo "============================================================"
       echo "Both CloudFront (enable_cloudfront=true) and Route53 DNS"
       echo "(enable_route53_dns=true) are enabled."
       echo ""
-      echo "Traffic flow: Custom Domain → CloudFront → ALB → ECS"
+      echo "Traffic flow: Custom Domain â†’ CloudFront â†’ ALB â†’ ECS"
       echo ""
       echo "Access URL: https://registry.${local.root_domain}"
       echo ""

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -48,8 +48,8 @@ module "mcp_gateway" {
   # Domain name for the registry - determines REGISTRY_URL and OAuth redirect URIs
   # Simplified to 3 modes (no dual-access):
   #   Mode 1: CloudFront-only - use CloudFront domain
-  #   Mode 2: Custom Domain â†’ ALB - use custom domain
-  #   Mode 3: Custom Domain â†’ CloudFront - use custom domain (traffic flows through CloudFront)
+  #   Mode 2: Custom Domain → ALB - use custom domain
+  #   Mode 3: Custom Domain → CloudFront - use custom domain (traffic flows through CloudFront)
   domain_name = var.enable_route53_dns ? "registry.${local.root_domain}" : (
     var.enable_cloudfront ? aws_cloudfront_distribution.mcp_gateway[0].domain_name : ""
   )
@@ -394,12 +394,12 @@ resource "null_resource" "dual_ingress_warning" {
     command = <<-EOT
       echo ""
       echo "============================================================"
-      echo "INFO: Custom Domain â†’ CloudFront Configuration (Mode 3)"
+      echo "INFO: Custom Domain → CloudFront Configuration (Mode 3)"
       echo "============================================================"
       echo "Both CloudFront (enable_cloudfront=true) and Route53 DNS"
       echo "(enable_route53_dns=true) are enabled."
       echo ""
-      echo "Traffic flow: Custom Domain â†’ CloudFront â†’ ALB â†’ ECS"
+      echo "Traffic flow: Custom Domain → CloudFront → ALB → ECS"
       echo ""
       echo "Access URL: https://registry.${local.root_domain}"
       echo ""

--- a/terraform/aws-ecs/outputs.tf
+++ b/terraform/aws-ecs/outputs.tf
@@ -3,22 +3,22 @@
 # VPC Outputs
 output "vpc_id" {
   description = "VPC ID"
-  value       = module.vpc.vpc_id
+  value       = local.selected_vpc_id
 }
 
 output "vpc_cidr" {
   description = "VPC CIDR block"
-  value       = module.vpc.vpc_cidr_block
+  value       = local.selected_vpc_cidr_block
 }
 
 output "private_subnet_ids" {
   description = "Private subnet IDs"
-  value       = module.vpc.private_subnets
+  value       = local.selected_private_subnet_ids
 }
 
 output "public_subnet_ids" {
   description = "Public subnet IDs"
-  value       = module.vpc.public_subnets
+  value       = local.selected_public_subnet_ids
 }
 
 # ECS Cluster Outputs
@@ -93,8 +93,9 @@ output "deployment_summary" {
     mcp_gateway_deployed = true
     https_enabled        = var.enable_route53_dns || var.enable_cloudfront
     monitoring_enabled   = var.enable_monitoring
-    multi_az_nat         = true
+    multi_az_nat         = !var.use_existing_vpc
     autoscaling_enabled  = true
+    network_mode         = var.use_existing_vpc ? "existing-vpc" : "managed-vpc"
     deployment_mode      = var.enable_cloudfront && !var.enable_route53_dns ? "cloudfront" : (var.enable_route53_dns ? "custom-domain" : "development")
   }
 }

--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -139,7 +139,7 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc_execution" {
 resource "aws_security_group" "rotation_lambda" {
   name        = "${var.name}-rotation-lambda-sg"
   description = "Security group for secret rotation Lambda functions"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   tags = merge(
     local.common_tags,
@@ -327,7 +327,7 @@ resource "aws_lambda_function" "documentdb_rotation" {
   memory_size      = 256
 
   vpc_config {
-    subnet_ids         = module.vpc.private_subnets
+    subnet_ids         = local.selected_private_subnet_ids
     security_group_ids = [aws_security_group.rotation_lambda.id]
   }
 
@@ -374,7 +374,7 @@ resource "aws_lambda_function" "rds_rotation" {
   memory_size      = 256
 
   vpc_config {
-    subnet_ids         = module.vpc.private_subnets
+    subnet_ids         = local.selected_private_subnet_ids
     security_group_ids = [aws_security_group.rotation_lambda.id]
   }
 

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -137,6 +137,42 @@ keycloak_database_password = "CHANGE-ME-DB-PASSWORD"
 # Default: "10.0.0.0/16"
 # vpc_cidr = "10.0.0.0/16"
 
+# Use an existing VPC instead of creating a new VPC and subnets.
+# Default: false
+# use_existing_vpc = false
+#
+# When use_existing_vpc = true, provide the VPC and subnet IDs below.
+# existing_vpc_id = "vpc-0123456789abcdef0"
+# existing_public_subnet_ids = [
+#   "subnet-0123456789abcdef0",
+#   "subnet-0123456789abcdef1",
+# ]
+# existing_private_subnet_ids = [
+#   "subnet-0123456789abcdef2",
+#   "subnet-0123456789abcdef3",
+# ]
+#
+# Required only when use_existing_vpc = true and create_vpc_endpoints = true.
+# existing_private_route_table_ids = [
+#   "rtb-0123456789abcdef0",
+#   "rtb-0123456789abcdef1",
+# ]
+#
+# Optional. Add the public egress IPs that private ECS tasks use when they call
+# the Keycloak public ALB URL through a NAT gateway, firewall, or proxy.
+# This is only needed when Keycloak ALB ingress is restricted and those egress
+# IPs are not already included in ingress_cidr_blocks or managed elsewhere.
+# existing_nat_public_ips = [
+#   "203.0.113.10",
+#   "203.0.113.11",
+# ]
+#
+# Create STS and S3 VPC endpoints.
+# Default: true
+# Set false when using an existing VPC that already provides endpoints,
+# firewall egress, or internet/NAT routing.
+# create_vpc_endpoints = true
+
 # Enable CloudWatch monitoring
 # Default: true
 # enable_monitoring = true

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -16,6 +16,48 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
+variable "use_existing_vpc" {
+  description = "Use an existing VPC and subnet IDs instead of creating a new VPC for this deployment."
+  type        = bool
+  default     = false
+}
+
+variable "existing_vpc_id" {
+  description = "Existing VPC ID to use when use_existing_vpc is true."
+  type        = string
+  default     = ""
+}
+
+variable "existing_public_subnet_ids" {
+  description = "Existing public subnet IDs for internet-facing ALBs when use_existing_vpc is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_private_subnet_ids" {
+  description = "Existing private subnet IDs for ECS tasks, databases, Lambda functions, and EFS when use_existing_vpc is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_private_route_table_ids" {
+  description = "Existing private route table IDs used for VPC gateway endpoints when use_existing_vpc is true and create_vpc_endpoints is true."
+  type        = list(string)
+  default     = []
+}
+
+variable "existing_nat_public_ips" {
+  description = "Optional public NAT or firewall egress IPs for existing-VPC deployments, used to allow private tasks to reach the Keycloak ALB via its public URL."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_vpc_endpoints" {
+  description = "Create STS and S3 VPC endpoints. Set false when using an existing VPC that already provides endpoint, firewall, or internet egress routing."
+  type        = bool
+  default     = true
+}
+
 variable "ingress_cidr_blocks" {
   description = "List of CIDR blocks allowed to access the ALB (main ALB + auth server + registry)"
   type        = list(string)

--- a/terraform/aws-ecs/vpc.tf
+++ b/terraform/aws-ecs/vpc.tf
@@ -14,10 +14,18 @@ locals {
   gateway_endpoint_prefix   = "com.amazonaws"
 }
 
+data "aws_vpc" "existing" {
+  count = var.use_existing_vpc && trimspace(var.existing_vpc_id) != "" ? 1 : 0
+
+  id = var.existing_vpc_id
+}
+
 #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 6.0"
+
+  create_vpc = !var.use_existing_vpc
 
   name = "${var.name}-vpc"
   cidr = var.vpc_cidr
@@ -46,36 +54,77 @@ module "vpc" {
   }
 }
 
+locals {
+  selected_vpc_id                  = var.use_existing_vpc ? var.existing_vpc_id : module.vpc.vpc_id
+  selected_vpc_cidr_block          = var.use_existing_vpc ? try(data.aws_vpc.existing[0].cidr_block, "") : module.vpc.vpc_cidr_block
+  selected_private_subnet_ids      = var.use_existing_vpc ? var.existing_private_subnet_ids : module.vpc.private_subnets
+  selected_public_subnet_ids       = var.use_existing_vpc ? var.existing_public_subnet_ids : module.vpc.public_subnets
+  selected_private_route_table_ids = var.use_existing_vpc ? var.existing_private_route_table_ids : module.vpc.private_route_table_ids
+  selected_nat_public_ips          = var.use_existing_vpc ? var.existing_nat_public_ips : module.vpc.nat_public_ips
+}
+
+resource "terraform_data" "existing_vpc_configuration" {
+  input = var.use_existing_vpc ? var.existing_vpc_id : "managed-vpc"
+
+  lifecycle {
+    precondition {
+      condition     = !var.use_existing_vpc || trimspace(var.existing_vpc_id) != ""
+      error_message = "existing_vpc_id must be set when use_existing_vpc is true."
+    }
+
+    precondition {
+      condition     = !var.use_existing_vpc || length(var.existing_private_subnet_ids) >= 2
+      error_message = "existing_private_subnet_ids must contain at least two subnet IDs when use_existing_vpc is true."
+    }
+
+    precondition {
+      condition     = !var.use_existing_vpc || length(var.existing_public_subnet_ids) >= 2
+      error_message = "existing_public_subnet_ids must contain at least two subnet IDs when use_existing_vpc is true."
+    }
+
+    precondition {
+      condition     = !var.use_existing_vpc || !var.create_vpc_endpoints || length(var.existing_private_route_table_ids) > 0
+      error_message = "existing_private_route_table_ids must be set when use_existing_vpc and create_vpc_endpoints are both true."
+    }
+  }
+}
+
 # VPC Endpoints for AWS services
 resource "aws_vpc_endpoint" "sts" {
-  vpc_id             = module.vpc.vpc_id
+  count = var.create_vpc_endpoints ? 1 : 0
+
+  vpc_id             = local.selected_vpc_id
   service_name       = "${local.interface_endpoint_prefix}.${data.aws_region.current.region}.sts"
   vpc_endpoint_type  = "Interface"
-  subnet_ids         = module.vpc.private_subnets
-  security_group_ids = [aws_security_group.vpc_endpoints.id]
+  subnet_ids         = local.selected_private_subnet_ids
+  security_group_ids = [aws_security_group.vpc_endpoints[0].id]
 
   private_dns_enabled = true
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = module.vpc.vpc_id
+  count = var.create_vpc_endpoints ? 1 : 0
+
+  vpc_id            = local.selected_vpc_id
   service_name      = "${local.gateway_endpoint_prefix}.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids   = module.vpc.private_route_table_ids
+  route_table_ids   = local.selected_private_route_table_ids
 }
 
 # Security group for VPC endpoints
 resource "aws_security_group" "vpc_endpoints" {
+  count = var.create_vpc_endpoints ? 1 : 0
+
   name        = "${var.name}-vpc-endpoints"
   description = "Security group for VPC interface endpoints allowing HTTPS from within VPC"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.selected_vpc_id
 
   ingress {
     description = "Allow HTTPS from VPC CIDR for AWS service endpoints"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [module.vpc.vpc_cidr_block]
+    cidr_blocks = [local.selected_vpc_cidr_block]
   }
 
   tags = merge(


### PR DESCRIPTION
*Description of changes:*
Enable use of existing VPC and subnets for AWS ECS deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
