### PR TITLE
Fix datetime serialization and token lifetime enforcement (#573, #889)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2983,7 +2983,20 @@ async def generate_user_token(
             )
 
             current_time = int(time.time())
-            expires_in = DEFAULT_TOKEN_LIFETIME_HOURS * 3600  # 8 hours default
+            # Honour the caller's requested lifetime, clamped to the
+            # server-wide maximum (#889).  Values <= 0 or above the cap
+            # are silently clamped; omitted values fall back to the
+            # default (8 h).
+            effective_hours = min(
+                max(request.expires_in_hours, 1),
+                MAX_TOKEN_LIFETIME_HOURS,
+            )
+            expires_in = effective_hours * 3600
+            if request.expires_in_hours != DEFAULT_TOKEN_LIFETIME_HOURS:
+                logger.info(
+                    f"Token lifetime: requested={request.expires_in_hours}h, "
+                    f"effective={effective_hours}h (max={MAX_TOKEN_LIFETIME_HOURS}h)"
+                )
 
             # Build JWT claims
             jwt_claims = {

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -4756,7 +4756,12 @@ async def get_group_api(
                 detail=f"Group '{group_name}' not found",
             )
 
-        return JSONResponse(status_code=200, content=group_data)
+        # Round-trip through json.dumps with default=str to convert
+        # datetime objects from DocumentDB into ISO-format strings (#573).
+        return JSONResponse(
+            status_code=200,
+            content=json.loads(json.dumps(group_data, default=str)),
+        )
 
     except HTTPException:
         raise

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -2914,3 +2914,76 @@ class TestLogScopesLoaded:
         mock_logger.warning.assert_not_called()
         mock_logger.info.assert_called_once()
         assert "1 group mappings" in mock_logger.info.call_args[0][0]
+
+
+# =============================================================================
+# TOKEN LIFETIME ENFORCEMENT (#889)
+# =============================================================================
+
+
+class TestTokenLifetimeEnforcement:
+    """Verify that expires_in_hours is honoured and clamped to
+    MAX_TOKEN_LIFETIME_HOURS (#889).
+    """
+
+    def _generate_self_signed_token(
+        self,
+        auth_env_vars: dict,
+        expires_in_hours: int = 8,
+    ) -> dict:
+        """Helper: call /internal/tokens with an OAuth user context so
+        the self-signed JWT path is taken, and return the decoded claims.
+        """
+        import auth_server.server as server_module
+
+        server_module.user_token_generation_counts.clear()
+
+        client = TestClient(server_module.app)
+        body = {
+            "user_context": {
+                "username": "alice",
+                "scopes": ["mcp-servers/read"],
+                "groups": ["mcp-registry-user"],
+                "auth_method": "oauth2",
+                "provider": "keycloak",
+            },
+            "requested_scopes": ["mcp-servers/read"],
+            "expires_in_hours": expires_in_hours,
+            "description": "lifetime test",
+        }
+        response = client.post(
+            "/internal/tokens",
+            json=body,
+            headers=_internal_auth_headers(auth_env_vars),
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        token = data["access_token"]
+        claims = jwt.decode(
+            token,
+            server_module.SECRET_KEY,
+            algorithms=["HS256"],
+            audience="mcp-registry",
+        )
+        return {**data, "claims": claims}
+
+    def test_default_lifetime_is_8_hours(self, auth_env_vars):
+        """Omitting expires_in_hours defaults to 8 h."""
+        result = self._generate_self_signed_token(auth_env_vars)
+        assert result["expires_in"] == 8 * 3600
+
+    def test_custom_lifetime_honoured(self, auth_env_vars):
+        """A caller-requested 4 h lifetime must be respected (#889)."""
+        result = self._generate_self_signed_token(auth_env_vars, expires_in_hours=4)
+        assert result["expires_in"] == 4 * 3600
+
+    def test_lifetime_clamped_to_max(self, auth_env_vars):
+        """Requesting > MAX_TOKEN_LIFETIME_HOURS (24) must be clamped."""
+        result = self._generate_self_signed_token(auth_env_vars, expires_in_hours=48)
+        # MAX_TOKEN_LIFETIME_HOURS = 24
+        assert result["expires_in"] == 24 * 3600
+
+    def test_lifetime_floor_is_one_hour(self, auth_env_vars):
+        """Requesting 0 or negative hours must be clamped to 1 h."""
+        result = self._generate_self_signed_token(auth_env_vars, expires_in_hours=0)
+        assert result["expires_in"] == 1 * 3600

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -2620,3 +2620,89 @@ class TestServerGetMetadataNormalization:
         response = test_client_admin.get("/api/servers/legacy-meta")
         assert response.status_code == 200
         assert response.json()["metadata"] == {}
+
+
+# =============================================================================
+# TEST GET /servers/groups/{group_name} — datetime serialization (#573)
+# =============================================================================
+
+
+class TestGetGroupApi:
+    """Tests for GET /api/servers/groups/{group_name}.
+
+    Verifies that the endpoint correctly serializes datetime objects
+    returned by the DocumentDB scope repository instead of raising a
+    500 Internal Server Error (#573).
+    """
+
+    @pytest.fixture
+    def test_client_admin(self, mock_auth_admin):
+        """Test client authenticated as admin."""
+        from registry.main import app
+
+        return TestClient(app, cookies={"mcp_gateway_session": "test-session"})
+
+    def test_get_group_with_datetime_fields(self, test_client_admin):
+        """Datetime objects in group_data must be serialized to strings (#573)."""
+        from datetime import datetime
+
+        group_data = {
+            "scope_name": "test-group",
+            "scope_type": "server_scope",
+            "description": "A test group",
+            "server_access": [{"server": "test-server", "permissions": ["read"]}],
+            "group_mappings": ["test-group"],
+            "ui_permissions": {"list_service": ["test-server"]},
+            "created_at": datetime(2026, 1, 15, 10, 30, 0),
+            "updated_at": datetime(2026, 6, 1, 14, 0, 0),
+        }
+
+        with patch(
+            "registry.services.scope_service.get_group",
+            new_callable=AsyncMock,
+            return_value=group_data,
+        ):
+            response = test_client_admin.get("/api/servers/groups/test-group")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scope_name"] == "test-group"
+        # datetime objects must be converted to strings, not cause a 500
+        assert isinstance(data["created_at"], str)
+        assert isinstance(data["updated_at"], str)
+        assert "2026" in data["created_at"]
+
+    def test_get_group_not_found(self, test_client_admin):
+        """Non-existent group returns 404."""
+        with patch(
+            "registry.services.scope_service.get_group",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            response = test_client_admin.get("/api/servers/groups/nonexistent")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"]
+
+    def test_get_group_without_datetime_fields(self, test_client_admin):
+        """File-backend groups (string timestamps) still serialize correctly."""
+        group_data = {
+            "scope_name": "file-group",
+            "scope_type": "server_scope",
+            "description": "",
+            "server_access": [],
+            "group_mappings": ["file-group"],
+            "ui_permissions": {},
+            "created_at": "",
+            "updated_at": "",
+        }
+
+        with patch(
+            "registry.services.scope_service.get_group",
+            new_callable=AsyncMock,
+            return_value=group_data,
+        ):
+            response = test_client_admin.get("/api/servers/groups/file-group")
+
+        assert response.status_code == 200
+        assert response.json()["scope_name"] == "file-group"


### PR DESCRIPTION
datetime serialization and token lifetime enforcement (fixes #573, #889)

- **#573**: `GET /api/servers/groups/{group_name}` returned 500 because datetime objects from DocumentDB are not JSON-serializable. Fixed by round-tripping through `json.dumps(default=str)`, matching the pattern used elsewhere in the codebase.
- **#889**: `MAX_TOKEN_LIFETIME_HOURS` (24 h) was declared but never enforced, and the caller-provided `expires_in_hours` was ignored — all self-signed tokens were hardcoded to 8 hours. Fixed by honouring the request field and clamping to `[1, MAX_TOKEN_LIFETIME_HOURS]`.

Note: the original version of this PR also addressed #959 (drop the `groups` claim from self-signed JWTs to fight token bloat). That change was reverted during review because it broke group-restricted resource visibility — the registry's visibility filter reads `user_context["groups"]` at request time, and dropping the claim left every group-restricted resource invisible for non-PingFederate IdPs. The bloat motivation is independently addressed by #1279 (group filtering at login) and #1281 (bulk group→scope lookup), both merged 2026-06-21. #959 will get a separate PR that doesn't regress visibility.