### PR TITLE
feat(audit): add executive summary band to audit dashboard

### DIFF
--- a/.claude/skills/new-feature-design/SKILL.md
+++ b/.claude/skills/new-feature-design/SKILL.md
@@ -584,6 +584,15 @@ class NewModel(BaseModel):
 ### Database Schema Changes
 {If applicable, show collection/table changes}
 
+### Data Access Plan (avoid N+1)
+{For each read path the feature introduces, state how the data is fetched.
+Any time you need a count or lookup over a list of items, design a single bulk
+query or aggregation (`$group`/`$sum`/`$in`/batched fetch) rather than one
+query per item. Do NOT design a `for` loop that awaits a repository call per
+element. If a per-item read seems unavoidable, justify why and bound the item
+count. Note any new repository method (e.g. a `count_*` aggregation) the design
+needs so it does not fall back to loading and counting in Python.}
+
 ## API Design
 
 ### New Endpoints
@@ -1080,6 +1089,16 @@ Create a review document with feedback from multiple expert personas:
 
 #### Strengths
 - {Positive aspects from backend perspective}
+
+#### N+1 Access Pattern Check (MANDATORY)
+Inspect every data-access path in the design. Flag any pattern that reads from
+a database or data source once per item (a `count()` / `find_one()` / `get()` /
+`distinct()` or repository call inside a `for`/`while`/comprehension/per-item
+callback, or a service that internally queries per element). State the fix: a
+single bulk query or aggregation (`$group`/`$sum`/`$in`/batched fetch) outside
+the loop. `asyncio.gather` over a per-item list is still N+1 round-trips; flag
+it unless the item count is small and bounded.
+- **N+1 patterns:** {None found / FLAGGED: <where + the per-item read and the bulk-query fix>}
 
 #### Concerns
 - {Issues or risks identified}

--- a/.claude/skills/pr-review/personas/backend-developer.md
+++ b/.claude/skills/pr-review/personas/backend-developer.md
@@ -34,6 +34,16 @@
 - Caching strategies
 - Memory usage
 - Response time
+- **N+1 access patterns (MANDATORY CHECK):** Any code that reads from a
+  database or other data source inside a loop, comprehension, or per-item
+  callback is an N+1 pattern and must be flagged. This includes: a `count()` /
+  `find_one()` / `get()` / `distinct()` call per item, awaiting a repository
+  method inside `for`/`while`/`map`, or calling a service that internally
+  queries once per element of a list. The fix is a single bulk query or
+  aggregation (e.g. `$group` / `$sum` / `$in` / batched fetch) outside the
+  loop. Concurrent calls via `asyncio.gather` over a per-item list are still
+  N+1 round-trips and should also be flagged unless the count is small and
+  bounded. Check every changed read path against this before approving.
 
 ### 5. Integration
 - External service integration
@@ -46,6 +56,7 @@
 - What's the data model for this feature?
 - How do we validate incoming requests?
 - What are the performance implications (O(n) vs O(log n))?
+- Does any changed read path query a database or data source inside a loop or per item (N+1)? If so, can it be a single bulk query or aggregation instead?
 - How do we handle concurrent updates?
 - What's the error handling strategy?
 - Do we need database migrations or schema changes?
@@ -78,6 +89,7 @@
 
 #### Performance
 - **Query Efficiency:** {Good/Needs Work}
+- **N+1 Access Patterns:** {None found / FLAGGED: <file:line + the per-item query and the bulk-query fix>}
 - **Memory Usage:** {Good/Needs Work}
 - **Caching:** {Implemented/Not Needed/Should Add}
 

--- a/frontend/src/components/AuditExecutiveSummary.tsx
+++ b/frontend/src/components/AuditExecutiveSummary.tsx
@@ -16,6 +16,14 @@ interface GovernanceScope {
   identities_active: number;
 }
 
+interface RegisteredAssets {
+  servers: number;
+  tools: number;
+  agents: number;
+  skills: number;
+  custom_entities: number;
+}
+
 interface ActiveUsers {
   dau: number;
   wau: number;
@@ -54,6 +62,7 @@ interface ExecutiveSummaryResponse {
   window_days: number;
   retention_days: number;
   governance: GovernanceScope;
+  registered_assets: RegisteredAssets;
   active_users: ActiveUsers;
   active_agents: ActiveAgents;
   traffic_split: TrafficSplit;
@@ -309,13 +318,15 @@ const AuditExecutiveSummary: React.FC = () => {
               </p>
             ) : null}
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {/* Tile 1: Governance scope (the blast radius we control) */}
+            {/* Tile 1: Registered assets (total catalog inventory, not
+                activity-scoped). Headline = servers, with the rest of the
+                inventory on the sub-line. */}
             <HeroTile
               icon={<ServerStackIcon className="h-4 w-4" />}
-              label="Governance Scope"
+              label="Registered Assets"
               value={
                 <span className="whitespace-nowrap">
-                  {data.governance.mcp_servers_governed.toLocaleString()}
+                  {data.registered_assets.servers.toLocaleString()}
                   <span className="text-sm font-normal text-gray-400 dark:text-gray-500">
                     {' '}
                     servers
@@ -324,11 +335,13 @@ const AuditExecutiveSummary: React.FC = () => {
               }
               subLine={
                 <span>
-                  {data.governance.tools_under_policy.toLocaleString()} tools under policy &middot;{' '}
-                  {data.governance.identities_active.toLocaleString()} identities
+                  {data.registered_assets.tools.toLocaleString()} tools &middot;{' '}
+                  {data.registered_assets.agents.toLocaleString()} agents &middot;{' '}
+                  {data.registered_assets.skills.toLocaleString()} skills &middot;{' '}
+                  {data.registered_assets.custom_entities.toLocaleString()} custom
                 </span>
               }
-              title="Servers governed, tools under policy, and active identities under control"
+              title="Total registered inventory in the catalog: servers, the tools they expose, agents, skills, and custom entities"
             />
 
             {/* Tile 2: Weekly Active Users and Agents, side by side with a

--- a/frontend/src/components/AuditExecutiveSummary.tsx
+++ b/frontend/src/components/AuditExecutiveSummary.tsx
@@ -1,0 +1,435 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import {
+  ArrowPathIcon,
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
+  ServerStackIcon,
+  UsersIcon,
+  CpuChipIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline';
+
+interface GovernanceScope {
+  mcp_servers_governed: number;
+  tools_under_policy: number;
+  identities_active: number;
+}
+
+interface ActiveUsers {
+  dau: number;
+  wau: number;
+  mau: number;
+  wau_available: boolean;
+  mau_available: boolean;
+}
+
+interface ActiveAgents {
+  daa: number;
+  waa: number;
+  maa: number;
+  waa_available: boolean;
+  maa_available: boolean;
+}
+
+interface TrafficSplit {
+  human_events: number;
+  agent_events: number;
+  human_pct: number;
+  agent_pct: number;
+}
+
+interface AdoptionMomentum {
+  events_current: number;
+  events_prior: number;
+  events_wow_pct: number | null;
+  active_identities_current: number;
+  active_identities_prior: number;
+  active_agents_current: number;
+  active_agents_prior: number;
+  has_prior_data: boolean;
+}
+
+interface ExecutiveSummaryResponse {
+  window_days: number;
+  retention_days: number;
+  governance: GovernanceScope;
+  active_users: ActiveUsers;
+  active_agents: ActiveAgents;
+  traffic_split: TrafficSplit;
+  momentum: AdoptionMomentum;
+}
+
+const SUMMARY_DAYS = 7;
+
+// Format a count with its singular or plural noun: 1 identity, 2 identities.
+function _plural(count: number, singular: string, plural: string): string {
+  const noun = count === 1 ? singular : plural;
+  return `${count.toLocaleString()} ${noun}`;
+}
+
+// Build a plain-English summary sentence from the live metrics, so a reader
+// can follow the band without decoding each tile. Returns null when there is
+// no governed activity to describe.
+function _buildNarrative(data: ExecutiveSummaryResponse): string | null {
+  const g = data.governance;
+  const days = data.window_days;
+  if (g.identities_active === 0 && g.mcp_servers_governed === 0) {
+    return null;
+  }
+  const identities = _plural(g.identities_active, 'identity', 'identities');
+  const agents = _plural(data.active_agents.waa, 'agent', 'agents');
+  const servers = _plural(g.mcp_servers_governed, 'MCP server', 'MCP servers');
+  const tools = _plural(g.tools_under_policy, 'tool', 'tools');
+  const calls = data.momentum.events_current.toLocaleString();
+  const agentPct = data.traffic_split.agent_pct;
+  return (
+    `In the last ${days} days, ${identities} (including ${agents}) accessed ${servers} ` +
+    `exposing ${tools} under policy, generating ${calls} governed calls ` +
+    `(${agentPct}% of those calls came from agents).`
+  );
+}
+
+// A single hero tile: large number, uppercase label, optional sub-line.
+const HeroTile: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: React.ReactNode;
+  subLine?: React.ReactNode;
+  title?: string;
+}> = ({ icon, label, value, subLine, title }) => {
+  return (
+    <div
+      className="border border-gray-100 dark:border-gray-700 rounded-lg p-3"
+      title={title}
+    >
+      <div className="flex items-center gap-1.5 mb-1">
+        <span className="text-gray-400 dark:text-gray-500">{icon}</span>
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+          {label}
+        </span>
+      </div>
+      <div className="text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
+      {subLine ? (
+        <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{subLine}</div>
+      ) : null}
+    </div>
+  );
+};
+
+// One side of the Active tile: a weekly headline count with daily and monthly
+// sub-counts. Monthly is shown only when retention covers the 30-day window.
+const ActiveCountColumn: React.FC<{
+  label: string;
+  weekly: number;
+  daily: number;
+  monthly: number;
+  monthlyAvailable: boolean;
+  dailyAbbr: string;
+  monthlyAbbr: string;
+  retentionDays: number;
+}> = ({
+  label,
+  weekly,
+  daily,
+  monthly,
+  monthlyAvailable,
+  dailyAbbr,
+  monthlyAbbr,
+  retentionDays,
+}) => {
+  return (
+    <div
+      title={
+        monthlyAvailable
+          ? `Distinct ${label.toLowerCase()} active per day / week / month`
+          : `${monthlyAbbr} hidden: audit retention is ${retentionDays}d (needs 30d).`
+      }
+    >
+      <div className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-0.5">
+        {label}
+      </div>
+      <div className="text-2xl font-bold text-gray-900 dark:text-white">
+        {weekly.toLocaleString()}
+      </div>
+      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+        {dailyAbbr} {daily.toLocaleString()}
+        {monthlyAvailable ? (
+          <>
+            {' '}
+            &middot; {monthlyAbbr} {monthly.toLocaleString()}
+          </>
+        ) : (
+          <span className="text-gray-400 dark:text-gray-500 italic">
+            {' '}
+            &middot; {monthlyAbbr} needs 30d
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// Colored WoW delta chip: green up for positive, red down for negative.
+const DeltaChip: React.FC<{ pct: number }> = ({ pct }) => {
+  const isUp = pct >= 0;
+  const colorClasses = isUp
+    ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+    : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400';
+  const sign = isUp ? '+' : '';
+
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-medium ${colorClasses}`}
+    >
+      {isUp ? (
+        <ArrowTrendingUpIcon className="h-3 w-3" />
+      ) : (
+        <ArrowTrendingDownIcon className="h-3 w-3" />
+      )}
+      {sign}
+      {pct.toFixed(0)}% WoW
+    </span>
+  );
+};
+
+// Thin two-segment bar: agent (purple) vs human (blue).
+const TrafficSplitBar: React.FC<{ split: TrafficSplit }> = ({ split }) => {
+  const total = split.human_events + split.agent_events;
+  if (total === 0) {
+    return (
+      <span className="text-base font-medium text-gray-400 dark:text-gray-500 italic">
+        No governed traffic yet
+      </span>
+    );
+  }
+
+  return (
+    <div>
+      <div className="text-2xl font-bold text-gray-900 dark:text-white">
+        {split.agent_pct}%
+        <span className="text-sm font-normal text-gray-400 dark:text-gray-500">
+          {' '}
+          of calls
+        </span>
+      </div>
+      <div className="flex h-2.5 rounded-full overflow-hidden bg-gray-100 dark:bg-gray-700 my-1.5">
+        {split.agent_events > 0 ? (
+          <div
+            className="bg-purple-500"
+            style={{ width: `${split.agent_pct}%` }}
+            title={`Agent: ${split.agent_events.toLocaleString()} (${split.agent_pct}%)`}
+          />
+        ) : null}
+        {split.human_events > 0 ? (
+          <div
+            className="bg-blue-500"
+            style={{ width: `${split.human_pct}%` }}
+            title={`Human: ${split.human_events.toLocaleString()} (${split.human_pct}%)`}
+          />
+        ) : null}
+      </div>
+      <div className="text-xs text-gray-500 dark:text-gray-400">
+        {split.agent_pct}% of calls from agents &middot; {split.human_pct}% from humans
+      </div>
+    </div>
+  );
+};
+
+
+const AuditExecutiveSummary: React.FC = () => {
+  const [data, setData] = useState<ExecutiveSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSummary = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await axios.get('/api/audit/executive-summary', {
+        params: { days: SUMMARY_DAYS },
+      });
+      setData(res.data);
+    } catch (err) {
+      console.error('Failed to fetch executive summary:', err);
+      setError('Failed to load executive summary');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSummary();
+  }, [fetchSummary]);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 mb-6">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          <ShieldCheckIcon className="h-5 w-5 text-gray-500 dark:text-gray-400" />
+          <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Executive Summary
+          </h3>
+          <span className="text-xs text-gray-400 ml-2">Last {SUMMARY_DAYS} days</span>
+        </div>
+        <button
+          onClick={fetchSummary}
+          disabled={loading}
+          className="p-1.5 text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded transition-colors disabled:opacity-50"
+          title="Refresh executive summary"
+        >
+          <ArrowPathIcon className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="px-4 pb-4">
+        {loading && !data ? (
+          <div className="flex items-center justify-center py-8">
+            <ArrowPathIcon className="h-6 w-6 text-gray-400 animate-spin" />
+            <span className="ml-2 text-sm text-gray-400">Loading executive summary...</span>
+          </div>
+        ) : error ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-red-500">{error}</p>
+            <button
+              onClick={fetchSummary}
+              className="mt-2 text-sm text-blue-500 hover:text-blue-600"
+            >
+              Retry
+            </button>
+          </div>
+        ) : data ? (
+          <>
+            {/* Plain-English summary line so the tiles read as a story */}
+            {_buildNarrative(data) ? (
+              <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                {_buildNarrative(data)}
+              </p>
+            ) : null}
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {/* Tile 1: Governance scope (the blast radius we control) */}
+            <HeroTile
+              icon={<ServerStackIcon className="h-4 w-4" />}
+              label="Governance Scope"
+              value={
+                <span className="whitespace-nowrap">
+                  {data.governance.mcp_servers_governed.toLocaleString()}
+                  <span className="text-sm font-normal text-gray-400 dark:text-gray-500">
+                    {' '}
+                    servers
+                  </span>
+                </span>
+              }
+              subLine={
+                <span>
+                  {data.governance.tools_under_policy.toLocaleString()} tools under policy &middot;{' '}
+                  {data.governance.identities_active.toLocaleString()} identities
+                </span>
+              }
+              title="Servers governed, tools under policy, and active identities under control"
+            />
+
+            {/* Tile 2: Weekly Active Users and Agents, side by side with a
+                divider. Headline number is weekly; daily and monthly sit below.
+                Monthly is gated on 30-day retention. */}
+            <div className="border border-gray-100 dark:border-gray-700 rounded-lg p-3">
+              <div className="flex items-center gap-1.5 mb-2">
+                <span className="text-gray-400 dark:text-gray-500">
+                  <UsersIcon className="h-4 w-4" />
+                </span>
+                <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                  Weekly Active
+                </span>
+              </div>
+              <div className="grid grid-cols-2 gap-3 divide-x divide-gray-100 dark:divide-gray-700">
+                <ActiveCountColumn
+                  label="People"
+                  weekly={data.active_users.wau}
+                  daily={data.active_users.dau}
+                  monthly={data.active_users.mau}
+                  monthlyAvailable={data.active_users.mau_available}
+                  dailyAbbr="DAU"
+                  monthlyAbbr="MAU"
+                  retentionDays={data.retention_days}
+                />
+                <div className="pl-3">
+                  <ActiveCountColumn
+                    label="Agents"
+                    weekly={data.active_agents.waa}
+                    daily={data.active_agents.daa}
+                    monthly={data.active_agents.maa}
+                    monthlyAvailable={data.active_agents.maa_available}
+                    dailyAbbr="DAA"
+                    monthlyAbbr="MAA"
+                    retentionDays={data.retention_days}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Tile 3: Adoption momentum */}
+            <HeroTile
+              icon={<CpuChipIcon className="h-4 w-4" />}
+              label="Events (7d)"
+              value={
+                <span className="flex items-center gap-2 flex-wrap">
+                  {data.momentum.events_current.toLocaleString()}
+                  {data.momentum.has_prior_data && data.momentum.events_wow_pct !== null ? (
+                    <DeltaChip pct={data.momentum.events_wow_pct} />
+                  ) : null}
+                </span>
+              }
+              subLine={
+                <span>
+                  {data.momentum.has_prior_data ? (
+                    <>
+                      Active agents: {data.momentum.active_agents_current.toLocaleString()} (up from{' '}
+                      {data.momentum.active_agents_prior.toLocaleString()})
+                    </>
+                  ) : (
+                    <>
+                      {data.momentum.active_agents_current.toLocaleString()} active agents
+                      <span className="text-gray-400 dark:text-gray-500 italic">
+                        {' '}
+                        &middot; no prior-week data
+                      </span>
+                    </>
+                  )}
+                </span>
+              }
+            />
+
+            {/* Tile 4: Human vs Agent split. "Agent" = non-interactive,
+                token-based callers (bearer token); "Human" = interactive web
+                UI sessions (session cookie). Anonymous traffic is excluded. */}
+            <HeroTile
+              icon={<CpuChipIcon className="h-4 w-4" />}
+              label="Agent vs Human"
+              value={<TrafficSplitBar split={data.traffic_split} />}
+              title="Share of governed CALLS (requests), not identities. Agent = token-based (non-interactive) callers; Human = interactive web UI sessions. Anonymous traffic excluded."
+            />
+            </div>
+
+            {/* Legend: make the agent vs human definition explicit so no one
+                misreads the split. Any non-web-UI access counts as an agent. */}
+            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700 pt-3">
+              <span className="flex items-center gap-1.5">
+                <span className="w-2.5 h-2.5 rounded-full bg-blue-500" />
+                People = interactive web UI sessions
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="w-2.5 h-2.5 rounded-full bg-purple-500" />
+                Agents = all non-web-UI access (API / token callers, incl. CLI and scripts)
+              </span>
+              <span>Anonymous traffic (health checks, probes) is excluded.</span>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default AuditExecutiveSummary;

--- a/frontend/src/components/AuditStatistics.tsx
+++ b/frontend/src/components/AuditStatistics.tsx
@@ -35,6 +35,7 @@ interface AuditStatisticsData {
   top_servers: UsageSummaryItem[];
   top_operations: UsageSummaryItem[];
   activity_timeline: TimeSeriesBucket[];
+  activity_timeline_prior: TimeSeriesBucket[];
   status_distribution: StatusDistribution;
   user_activity: UserActivityItem[];
 }
@@ -143,6 +144,26 @@ function _fillTimelineDays(timeline: TimeSeriesBucket[], days: number): TimeSeri
   return filled;
 }
 
+/**
+ * Align prior-week buckets to the current day slots by index position.
+ * The prior buckets correspond day-for-day to the current filled timeline,
+ * so slot i uses prior[i]. If lengths differ we pad with 0 or truncate so
+ * the returned array is always the same length as the current timeline.
+ */
+function _alignPriorByIndex(
+  prior: TimeSeriesBucket[],
+  currentLength: number
+): number[] {
+  const sorted = [...prior].sort((a, b) => a.period.localeCompare(b.period));
+  const counts: number[] = [];
+
+  for (let i = 0; i < currentLength; i++) {
+    counts.push(sorted[i] ? sorted[i].count : 0);
+  }
+
+  return counts;
+}
+
 function _formatDateLabel(period: string): string {
   const d = new Date(period + 'T00:00:00');
   const weekday = WEEKDAY_NAMES[d.getDay()];
@@ -155,10 +176,24 @@ const VB_W = 600;
 const VB_H = 180;
 const PAD = { top: 20, right: 50, bottom: 32, left: 45 };
 
-const TimelineChart: React.FC<{ timeline: TimeSeriesBucket[]; days: number }> = ({ timeline, days }) => {
+const TimelineChart: React.FC<{
+  timeline: TimeSeriesBucket[];
+  days: number;
+  priorTimeline?: TimeSeriesBucket[];
+}> = ({ timeline, days, priorTimeline }) => {
   const [hoverIndex, setHoverIndex] = useState<number | null>(null);
   const filled = _fillTimelineDays(timeline, days);
-  const maxCount = Math.max(...filled.map((t) => t.count), 1);
+
+  // Align prior-week counts to the current day slots by index position.
+  const hasPrior = Boolean(priorTimeline && priorTimeline.length);
+  const priorCounts = hasPrior
+    ? _alignPriorByIndex(priorTimeline as TimeSeriesBucket[], filled.length)
+    : [];
+
+  // Scale the y-axis to the max across BOTH series so the comparison is honest.
+  const currentMax = Math.max(...filled.map((t) => t.count), 1);
+  const priorMax = hasPrior ? Math.max(...priorCounts, 0) : 0;
+  const maxCount = Math.max(currentMax, priorMax, 1);
 
   if (!filled.length) {
     return <p className="text-sm text-gray-400 italic py-2">No data available</p>;
@@ -167,14 +202,28 @@ const TimelineChart: React.FC<{ timeline: TimeSeriesBucket[]; days: number }> = 
   const plotW = VB_W - PAD.left - PAD.right;
   const plotH = VB_H - PAD.top - PAD.bottom;
 
+  const _xForIndex = (i: number): number =>
+    PAD.left + (filled.length > 1 ? (i / (filled.length - 1)) * plotW : plotW / 2);
+
+  const _yForCount = (count: number): number =>
+    PAD.top + plotH - (count / maxCount) * plotH;
+
   const points = filled.map((b, i) => {
-    const x = PAD.left + (filled.length > 1 ? (i / (filled.length - 1)) * plotW : plotW / 2);
-    const y = PAD.top + plotH - (b.count / maxCount) * plotH;
+    const x = _xForIndex(i);
+    const y = _yForCount(b.count);
     return { x, y, ...b };
   });
 
   const linePath = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
   const areaPath = `${linePath} L${points[points.length - 1].x},${PAD.top + plotH} L${points[0].x},${PAD.top + plotH} Z`;
+
+  // Prior-week overlay line (dashed, muted, no area fill, no data points).
+  const priorPoints = hasPrior
+    ? priorCounts.map((count, i) => ({ x: _xForIndex(i), y: _yForCount(count) }))
+    : [];
+  const priorLinePath = priorPoints
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`)
+    .join(' ');
 
   const gridValues = [0, Math.round(maxCount / 2), maxCount];
   const gridLines = gridValues.map((v) => ({
@@ -213,6 +262,19 @@ const TimelineChart: React.FC<{ timeline: TimeSeriesBucket[]; days: number }> = 
             </text>
           </g>
         ))}
+
+        {/* Prior-week line (drawn underneath the current line) */}
+        {hasPrior && (
+          <path
+            d={priorLinePath}
+            fill="none"
+            className="stroke-gray-400 dark:stroke-gray-500"
+            strokeWidth="1.5"
+            strokeDasharray="4,3"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+          />
+        )}
 
         {/* Area fill */}
         <path d={areaPath} className="fill-blue-500/15 dark:fill-blue-400/15" />
@@ -301,6 +363,22 @@ const TimelineChart: React.FC<{ timeline: TimeSeriesBucket[]; days: number }> = 
           </text>
         ))}
       </svg>
+
+      {/* Legend */}
+      {hasPrior && (
+        <div className="flex items-center justify-end gap-4 text-xs text-gray-500 dark:text-gray-400 mt-1">
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-4 h-0.5 bg-blue-500 dark:bg-blue-400" />
+            This week
+          </span>
+          <span className="flex items-center gap-1">
+            <span
+              className="inline-block w-4 border-t border-dashed border-gray-400 dark:border-gray-500"
+            />
+            Prior week
+          </span>
+        </div>
+      )}
     </div>
   );
 };
@@ -358,9 +436,10 @@ const AuditStatistics: React.FC<AuditStatisticsProps> = ({ stream, days = 7, use
   const [collapsed, setCollapsed] = useState(() => {
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
-      return stored === null ? true : stored === 'true';
+      // Expanded by default; only respect an explicit prior collapse choice.
+      return stored === null ? false : stored === 'true';
     } catch {
-      return true;
+      return false;
     }
   });
 
@@ -538,7 +617,11 @@ const AuditStatistics: React.FC<AuditStatisticsProps> = ({ stream, days = 7, use
                     <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
                       Activity Timeline (Last {days} Days)
                     </h4>
-                    <TimelineChart timeline={data.activity_timeline} days={days} />
+                    <TimelineChart
+                      timeline={data.activity_timeline}
+                      priorTimeline={data.activity_timeline_prior}
+                      days={days}
+                    />
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/AuditLogsPage.tsx
+++ b/frontend/src/pages/AuditLogsPage.tsx
@@ -4,6 +4,7 @@ import AuditFilterBar, { AuditFilters } from '../components/AuditFilterBar';
 import AuditLogTable, { AuditEvent } from '../components/AuditLogTable';
 import AuditEventDetail from '../components/AuditEventDetail';
 import AuditStatistics from '../components/AuditStatistics';
+import AuditExecutiveSummary from '../components/AuditExecutiveSummary';
 import { ShieldExclamationIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 
 interface AuditLogsPageProps {
@@ -126,6 +127,9 @@ const AuditLogsPage: React.FC<AuditLogsPageProps> = ({ embedded = false }) => {
           />
         </div>
 
+        {/* Executive Summary - hero tiles for platform leads */}
+        <AuditExecutiveSummary />
+
         {/* Statistics Dashboard */}
         <AuditStatistics stream={filters.stream} username={filters.username} />
 
@@ -198,6 +202,9 @@ const AuditLogsPage: React.FC<AuditLogsPageProps> = ({ embedded = false }) => {
             onRefresh={handleRefresh}
           />
         </div>
+
+        {/* Executive Summary - hero tiles for platform leads */}
+        <AuditExecutiveSummary />
 
         {/* Statistics Dashboard */}
         <AuditStatistics stream={filters.stream} username={filters.username} />

--- a/registry/audit/routes.py
+++ b/registry/audit/routes.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from ..auth.dependencies import enhanced_auth
+from ..core.config import settings
 from ..repositories.audit_repository import DocumentDBAuditRepository
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,100 @@ router = APIRouter(prefix="/audit", tags=["Audit Logs"])
 
 # Singleton repository instance
 _audit_repository: DocumentDBAuditRepository | None = None
+
+# Credential type that marks non-interactive (agent / programmatic) callers.
+# The web UI authenticates with a session cookie; agents and service accounts
+# send a Bearer token. credential_type is set on every audit record, so it is
+# the reliable signal for the human-vs-agent split. Note: a human using a CLI
+# with a bearer token is counted as agent traffic by this definition, which is
+# acceptable for a gateway whose purpose is non-interactive agent access.
+AGENT_CREDENTIAL_TYPE: str = "bearer_token"
+HUMAN_CREDENTIAL_TYPE: str = "session_cookie"
+# Username assigned to unauthenticated traffic
+ANONYMOUS_USERNAME: str = "anonymous"
+
+
+def _window_match(
+    start: datetime,
+    end: datetime,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Build a MongoDB match filter for a timestamp window.
+
+    Args:
+        start: Inclusive start of the window
+        end: Inclusive end of the window
+        extra: Additional match conditions merged into the filter
+
+    Returns:
+        MongoDB match dictionary spanning [start, end]
+    """
+    match: dict[str, Any] = {"timestamp": {"$gte": start, "$lte": end}}
+    if extra:
+        match.update(extra)
+    return match
+
+
+async def _count_distinct_usernames(
+    repository: DocumentDBAuditRepository,
+    match: dict[str, Any],
+) -> int:
+    """
+    Count distinct non-anonymous usernames matching a filter.
+
+    The repository's distinct() already drops falsy values; this helper
+    additionally drops the anonymous username so only real identities count.
+
+    Args:
+        repository: Audit repository instance
+        match: MongoDB match filter scoping the distinct values
+
+    Returns:
+        Number of distinct non-anonymous usernames
+    """
+    usernames = await repository.distinct("identity.username", match)
+    return len([u for u in usernames if u and u != ANONYMOUS_USERNAME])
+
+
+def _percentage(
+    part: int,
+    total: int,
+) -> float:
+    """
+    Compute a one-decimal percentage of part over total.
+
+    Args:
+        part: Numerator value
+        total: Denominator value
+
+    Returns:
+        Percentage rounded to one decimal, 0.0 when total is zero
+    """
+    if total <= 0:
+        return 0.0
+    return round(part / total * 100, 1)
+
+
+def _non_anonymous_match(
+    start: datetime,
+    end: datetime,
+) -> dict[str, Any]:
+    """
+    Build a window match that excludes anonymous and empty usernames.
+
+    Args:
+        start: Inclusive start of the window
+        end: Inclusive end of the window
+
+    Returns:
+        MongoDB match dictionary scoped to real (non-anonymous) identities
+    """
+    return _window_match(
+        start,
+        end,
+        {"identity.username": {"$nin": [ANONYMOUS_USERNAME, None, ""]}},
+    )
 
 
 def get_audit_repository() -> DocumentDBAuditRepository:
@@ -166,6 +261,13 @@ class AuditStatisticsResponse(BaseModel):
         default_factory=list,
         description="Daily event counts for the time range",
     )
+    activity_timeline_prior: list[TimeSeriesBucket] = Field(
+        default_factory=list,
+        description=(
+            "Daily event counts for the prior window of equal length, "
+            "for week-over-week overlay"
+        ),
+    )
     status_distribution: StatusDistribution = Field(
         default_factory=StatusDistribution,
         description="Distribution of HTTP status codes",
@@ -174,6 +276,122 @@ class AuditStatisticsResponse(BaseModel):
         default_factory=list,
         description="Per-user breakdown of top operations",
     )
+
+
+class GovernanceScope(BaseModel):
+    """Scope of assets currently governed by the gateway."""
+
+    mcp_servers_governed: int = Field(
+        default=0,
+        description="Distinct MCP servers accessed in the current window",
+    )
+    tools_under_policy: int = Field(
+        default=0,
+        description="Distinct MCP tools invoked in the current window",
+    )
+    identities_active: int = Field(
+        default=0,
+        description="Distinct non-anonymous identities active in the current window",
+    )
+
+
+class ActiveUsers(BaseModel):
+    """Active identity counts over rolling windows."""
+
+    dau: int = Field(default=0, description="Distinct non-anonymous usernames, last 1 day")
+    wau: int = Field(default=0, description="Distinct non-anonymous usernames, last 7 days")
+    mau: int = Field(default=0, description="Distinct non-anonymous usernames, last 30 days")
+    wau_available: bool = Field(
+        default=True,
+        description="True when retention covers the 7-day window; WAU is honest only then",
+    )
+    mau_available: bool = Field(
+        default=False,
+        description="True when retention covers the 30-day window; MAU is honest only then",
+    )
+
+
+class ActiveAgents(BaseModel):
+    """Active agent (bearer-token caller) counts over rolling windows."""
+
+    daa: int = Field(default=0, description="Distinct agent identities, last 1 day")
+    waa: int = Field(default=0, description="Distinct agent identities, last 7 days")
+    maa: int = Field(default=0, description="Distinct agent identities, last 30 days")
+    waa_available: bool = Field(
+        default=True,
+        description="True when retention covers the 7-day window; WAA is honest only then",
+    )
+    maa_available: bool = Field(
+        default=False,
+        description="True when retention covers the 30-day window; MAA is honest only then",
+    )
+
+
+class TrafficSplit(BaseModel):
+    """Human vs agent traffic split for the current window."""
+
+    human_events: int = Field(default=0, description="Authenticated, non-agent events")
+    agent_events: int = Field(default=0, description="Agent/service-account events (jwt_bearer)")
+    human_pct: float = Field(
+        default=0.0,
+        description="Human share over (human+agent), one decimal, 0 when denominator 0",
+    )
+    agent_pct: float = Field(
+        default=0.0,
+        description="Agent share over (human+agent), one decimal, 0 when denominator 0",
+    )
+
+
+class AdoptionMomentum(BaseModel):
+    """Week-over-week adoption momentum metrics."""
+
+    events_current: int = Field(
+        default=0,
+        description="Non-anonymous events in the current window",
+    )
+    events_prior: int = Field(
+        default=0,
+        description="Non-anonymous events in the prior window",
+    )
+    events_wow_pct: float | None = Field(
+        default=None,
+        description="Week-over-week event change percent, None when prior is zero",
+    )
+    active_identities_current: int = Field(
+        default=0,
+        description="Distinct non-anonymous identities in the current window",
+    )
+    active_identities_prior: int = Field(
+        default=0,
+        description="Distinct non-anonymous identities in the prior window",
+    )
+    active_agents_current: int = Field(
+        default=0,
+        description="Distinct agent identities in the current window",
+    )
+    active_agents_prior: int = Field(
+        default=0,
+        description="Distinct agent identities in the prior window",
+    )
+    has_prior_data: bool = Field(
+        default=False,
+        description="True when the prior window has at least one event",
+    )
+
+
+class ExecutiveSummaryResponse(BaseModel):
+    """Global, cross-stream executive summary of gateway activity."""
+
+    window_days: int = Field(description="Length of the comparison window in days")
+    retention_days: int = Field(
+        default=0,
+        description="Configured audit retention (TTL) in days; gates window-N metric availability",
+    )
+    governance: GovernanceScope = Field(default_factory=GovernanceScope)
+    active_users: ActiveUsers = Field(default_factory=ActiveUsers)
+    active_agents: ActiveAgents = Field(default_factory=ActiveAgents)
+    traffic_split: TrafficSplit = Field(default_factory=TrafficSplit)
+    momentum: AdoptionMomentum = Field(default_factory=AdoptionMomentum)
 
 
 def _build_query(
@@ -345,12 +563,22 @@ async def get_statistics(
         "mcp_access": "mcp_server_access",
     }
     log_type = log_type_map.get(stream, stream)
-    cutoff = datetime.now(UTC) - timedelta(days=days)
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=days)
     base_match: dict[str, Any] = {"log_type": log_type, "timestamp": {"$gte": cutoff}}
+
+    # Prior window of equal length, ending where the current window starts
+    prior_start = now - timedelta(days=days * 2)
+    prior_match: dict[str, Any] = {
+        "log_type": log_type,
+        "timestamp": {"$gte": prior_start, "$lt": cutoff},
+    }
 
     if username:
         escaped_username = re.escape(username)
-        base_match["identity.username"] = {"$regex": f"^{escaped_username}$", "$options": "i"}
+        username_filter = {"$regex": f"^{escaped_username}$", "$options": "i"}
+        base_match["identity.username"] = username_filter
+        prior_match["identity.username"] = username_filter
 
     repository = get_audit_repository()
 
@@ -460,6 +688,19 @@ async def get_statistics(
                 {"$limit": 10},
             ]
         ),
+        # Prior-window daily timeline for week-over-week overlay
+        repository.aggregate(
+            [
+                {"$match": prior_match},
+                {
+                    "$group": {
+                        "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$timestamp"}},
+                        "count": {"$sum": 1},
+                    }
+                },
+                {"$sort": {"_id": 1}},
+            ]
+        ),
     ]
 
     # Conditionally add MCP server aggregation
@@ -484,7 +725,8 @@ async def get_statistics(
     timeline_raw = results[3]
     status_raw = results[4]
     user_activity_raw = results[5]
-    top_servers_raw = results[6] if stream == "mcp_access" else []
+    timeline_prior_raw = results[6]
+    top_servers_raw = results[7] if stream == "mcp_access" else []
 
     # Transform results
     top_users = [
@@ -510,6 +752,10 @@ async def get_statistics(
     ]
 
     activity_timeline = [TimeSeriesBucket(period=r["_id"], count=r["count"]) for r in timeline_raw]
+
+    activity_timeline_prior = [
+        TimeSeriesBucket(period=r["_id"], count=r["count"]) for r in timeline_prior_raw
+    ]
 
     status_dist = StatusDistribution()
     if stream == "mcp_access":
@@ -559,8 +805,195 @@ async def get_statistics(
         top_servers=top_servers,
         top_operations=top_operations,
         activity_timeline=activity_timeline,
+        activity_timeline_prior=activity_timeline_prior,
         status_distribution=status_dist,
         user_activity=user_activity,
+    )
+
+
+def _build_traffic_split(
+    human_events: int,
+    agent_events: int,
+) -> TrafficSplit:
+    """
+    Build the human vs agent traffic split with percentages.
+
+    Args:
+        human_events: Count of authenticated non-agent events
+        agent_events: Count of agent (jwt_bearer) events
+
+    Returns:
+        TrafficSplit with counts and one-decimal percentages
+    """
+    total = human_events + agent_events
+    return TrafficSplit(
+        human_events=human_events,
+        agent_events=agent_events,
+        human_pct=_percentage(human_events, total),
+        agent_pct=_percentage(agent_events, total),
+    )
+
+
+def _build_momentum(
+    events_current: int,
+    events_prior: int,
+    identities_current: int,
+    identities_prior: int,
+    agents_current: int,
+    agents_prior: int,
+    prior_window_retained: bool,
+) -> AdoptionMomentum:
+    """
+    Build the week-over-week adoption momentum block.
+
+    Args:
+        events_current: Non-anonymous events in the current window
+        events_prior: Non-anonymous events in the prior window
+        identities_current: Distinct identities in the current window
+        identities_prior: Distinct identities in the prior window
+        agents_current: Distinct agents in the current window
+        agents_prior: Distinct agents in the prior window
+        prior_window_retained: True when retention covers the full prior window,
+            so a zero prior count means genuinely no traffic rather than expired data
+
+    Returns:
+        AdoptionMomentum with computed week-over-week change
+    """
+    # Only trust the prior window when retention covers it AND it has events.
+    # Without retention coverage a zero prior count is expired data, not real zero.
+    has_prior_data = prior_window_retained and events_prior > 0
+    wow_pct = None
+    if has_prior_data:
+        wow_pct = round((events_current - events_prior) / events_prior * 100, 1)
+    return AdoptionMomentum(
+        events_current=events_current,
+        events_prior=events_prior,
+        events_wow_pct=wow_pct,
+        active_identities_current=identities_current,
+        active_identities_prior=identities_prior,
+        active_agents_current=agents_current,
+        active_agents_prior=agents_prior,
+        has_prior_data=has_prior_data,
+    )
+
+
+@router.get("/executive-summary", response_model=ExecutiveSummaryResponse)
+async def get_executive_summary(
+    user_context: Annotated[dict[str, Any], Depends(require_admin)],
+    days: int = Query(
+        7,
+        ge=1,
+        le=30,
+        description="Length of the comparison window in days",
+    ),
+) -> ExecutiveSummaryResponse:
+    """Get a global, cross-stream executive summary. Requires admin access."""
+    start_time = time.time()
+    repository = get_audit_repository()
+
+    # Retention (TTL) gates which rolling-window metrics are honest. A window of
+    # N days is only meaningful when audit events are retained for at least N days.
+    retention_days = settings.audit_log_mongodb_ttl_days
+
+    now = datetime.now(UTC)
+    cur_start = now - timedelta(days=days)
+    prior_start = now - timedelta(days=days * 2)
+    mcp_match = {"log_type": "mcp_server_access"}
+    # Agents are non-anonymous callers using a bearer token (non-interactive).
+    agent_filter = {
+        "identity.username": {"$nin": [ANONYMOUS_USERNAME, None, ""]},
+        "identity.credential_type": AGENT_CREDENTIAL_TYPE,
+    }
+
+    # Current window matches scoped to MCP-only metrics
+    cur_window = _window_match(cur_start, now)
+    cur_mcp = _window_match(cur_start, now, mcp_match)
+    cur_non_anon = _non_anonymous_match(cur_start, now)
+    prior_non_anon = _non_anonymous_match(prior_start, cur_start)
+
+    # Split by credential_type: humans use session cookies (interactive web UI),
+    # agents use bearer tokens (programmatic). Both exclude anonymous traffic.
+    cur_agents = _window_match(cur_start, now, agent_filter)
+    cur_humans = _window_match(
+        cur_start,
+        now,
+        {
+            "identity.username": {"$nin": [ANONYMOUS_USERNAME, None, ""]},
+            "identity.credential_type": HUMAN_CREDENTIAL_TYPE,
+        },
+    )
+    prior_agents = _window_match(prior_start, cur_start, agent_filter)
+
+    # Rolling DAA/WAA/MAA windows: distinct agent identities over 1/7/30 days.
+    daa_match = _window_match(now - timedelta(days=1), now, agent_filter)
+    waa_match = _window_match(now - timedelta(days=7), now, agent_filter)
+    maa_match = _window_match(now - timedelta(days=30), now, agent_filter)
+
+    # Run all independent queries concurrently
+    results = await asyncio.gather(
+        _count_distinct_usernames(repository, cur_window),
+        repository.distinct("mcp_server.name", cur_mcp),
+        repository.distinct("mcp_request.tool_name", cur_mcp),
+        _count_distinct_usernames(repository, _window_match(now - timedelta(days=1), now)),
+        _count_distinct_usernames(repository, _window_match(now - timedelta(days=7), now)),
+        _count_distinct_usernames(repository, _window_match(now - timedelta(days=30), now)),
+        repository.count(cur_humans),
+        repository.count(cur_agents),
+        repository.count(cur_non_anon),
+        repository.count(prior_non_anon),
+        _count_distinct_usernames(repository, cur_non_anon),
+        _count_distinct_usernames(repository, prior_non_anon),
+        _count_distinct_usernames(repository, cur_agents),
+        _count_distinct_usernames(repository, prior_agents),
+        _count_distinct_usernames(repository, daa_match),
+        _count_distinct_usernames(repository, waa_match),
+        _count_distinct_usernames(repository, maa_match),
+    )
+
+    governance = GovernanceScope(
+        mcp_servers_governed=len([s for s in results[1] if s]),
+        tools_under_policy=len([t for t in results[2] if t]),
+        identities_active=results[0],
+    )
+    active_users = ActiveUsers(
+        dau=results[3],
+        wau=results[4],
+        mau=results[5],
+        wau_available=retention_days >= 7,
+        mau_available=retention_days >= 30,
+    )
+    active_agents = ActiveAgents(
+        daa=results[14],
+        waa=results[15],
+        maa=results[16],
+        waa_available=retention_days >= 7,
+        maa_available=retention_days >= 30,
+    )
+    traffic_split = _build_traffic_split(human_events=results[6], agent_events=results[7])
+    momentum = _build_momentum(
+        events_current=results[8],
+        events_prior=results[9],
+        identities_current=results[10],
+        identities_prior=results[11],
+        agents_current=results[12],
+        agents_prior=results[13],
+        prior_window_retained=retention_days >= days * 2,
+    )
+
+    elapsed = time.time() - start_time
+    logger.info(
+        f"Executive summary computed in {elapsed:.2f}s "
+        f"(days={days}, retention_days={retention_days})"
+    )
+
+    return ExecutiveSummaryResponse(
+        window_days=days,
+        retention_days=retention_days,
+        governance=governance,
+        active_users=active_users,
+        active_agents=active_agents,
+        traffic_split=traffic_split,
+        momentum=momentum,
     )
 
 

--- a/registry/audit/routes.py
+++ b/registry/audit/routes.py
@@ -44,6 +44,12 @@ HUMAN_CREDENTIAL_TYPE: str = "session_cookie"
 # Username assigned to unauthenticated traffic
 ANONYMOUS_USERNAME: str = "anonymous"
 
+# Executive summary cache: this endpoint runs many aggregations per call, so a
+# short TTL cache (keyed by the days window) shields the database from repeated
+# page loads / refreshes. Mirrors the /api/stats caching precedent.
+EXEC_SUMMARY_CACHE_TTL_SECONDS: int = 30
+_exec_summary_cache: dict[int, tuple[datetime, ExecutiveSummaryResponse]] = {}
+
 
 def _window_match(
     start: datetime,
@@ -913,7 +919,7 @@ async def _get_registered_assets() -> RegisteredAssets:
 
     try:
         servers, tools, agents, skills, custom_entities = await asyncio.gather(
-            server_repo.count(),
+            server_repo.count(exclude_versions=True),
             server_repo.count_tools(),
             agent_repo.count(),
             skill_repo.count(),
@@ -932,17 +938,21 @@ async def _get_registered_assets() -> RegisteredAssets:
     )
 
 
-@router.get("/executive-summary", response_model=ExecutiveSummaryResponse)
-async def get_executive_summary(
-    user_context: Annotated[dict[str, Any], Depends(require_admin)],
-    days: int = Query(
-        7,
-        ge=1,
-        le=30,
-        description="Length of the comparison window in days",
-    ),
+async def _compute_executive_summary(
+    days: int,
 ) -> ExecutiveSummaryResponse:
-    """Get a global, cross-stream executive summary. Requires admin access."""
+    """
+    Compute the global, cross-stream executive summary.
+
+    Runs all audit aggregations and inventory counts. Caching is handled by the
+    route wrapper, so this always computes fresh.
+
+    Args:
+        days: Length of the comparison window in days
+
+    Returns:
+        The computed ExecutiveSummaryResponse
+    """
     start_time = time.time()
     repository = get_audit_repository()
 
@@ -1053,6 +1063,49 @@ async def get_executive_summary(
         traffic_split=traffic_split,
         momentum=momentum,
     )
+
+
+async def _get_cached_executive_summary(
+    days: int,
+) -> ExecutiveSummaryResponse:
+    """
+    Return the executive summary for a window, using a short-TTL cache.
+
+    The summary runs many aggregations, so results are cached per ``days`` for
+    EXEC_SUMMARY_CACHE_TTL_SECONDS to shield the database from repeated page
+    loads and manual refreshes.
+
+    Args:
+        days: Length of the comparison window in days
+
+    Returns:
+        Cached or freshly computed ExecutiveSummaryResponse
+    """
+    now = datetime.now(UTC)
+    cached = _exec_summary_cache.get(days)
+    if cached is not None:
+        cached_at, cached_value = cached
+        if (now - cached_at).total_seconds() < EXEC_SUMMARY_CACHE_TTL_SECONDS:
+            logger.debug(f"Executive summary cache hit (days={days})")
+            return cached_value
+
+    summary = await _compute_executive_summary(days)
+    _exec_summary_cache[days] = (now, summary)
+    return summary
+
+
+@router.get("/executive-summary", response_model=ExecutiveSummaryResponse)
+async def get_executive_summary(
+    user_context: Annotated[dict[str, Any], Depends(require_admin)],
+    days: int = Query(
+        7,
+        ge=1,
+        le=30,
+        description="Length of the comparison window in days",
+    ),
+) -> ExecutiveSummaryResponse:
+    """Get a global, cross-stream executive summary. Requires admin access."""
+    return await _get_cached_executive_summary(days)
 
 
 @router.get("/events", response_model=AuditEventsResponse)

--- a/registry/audit/routes.py
+++ b/registry/audit/routes.py
@@ -295,6 +295,16 @@ class GovernanceScope(BaseModel):
     )
 
 
+class RegisteredAssets(BaseModel):
+    """Total registered inventory in the registry catalog (not activity-scoped)."""
+
+    servers: int = Field(default=0, description="Total registered MCP servers")
+    tools: int = Field(default=0, description="Total tools exposed across all servers")
+    agents: int = Field(default=0, description="Total registered agents")
+    skills: int = Field(default=0, description="Total registered skills")
+    custom_entities: int = Field(default=0, description="Total custom entity records")
+
+
 class ActiveUsers(BaseModel):
     """Active identity counts over rolling windows."""
 
@@ -388,6 +398,7 @@ class ExecutiveSummaryResponse(BaseModel):
         description="Configured audit retention (TTL) in days; gates window-N metric availability",
     )
     governance: GovernanceScope = Field(default_factory=GovernanceScope)
+    registered_assets: RegisteredAssets = Field(default_factory=RegisteredAssets)
     active_users: ActiveUsers = Field(default_factory=ActiveUsers)
     active_agents: ActiveAgents = Field(default_factory=ActiveAgents)
     traffic_split: TrafficSplit = Field(default_factory=TrafficSplit)
@@ -877,6 +888,50 @@ def _build_momentum(
     )
 
 
+async def _get_registered_assets() -> RegisteredAssets:
+    """
+    Gather total registered inventory counts from the asset repositories.
+
+    All counts run concurrently and each uses an efficient count/aggregation
+    (no per-document loads), so this stays O(1) round-trips rather than N+1.
+
+    Returns:
+        RegisteredAssets with servers, tools, agents, skills, and custom
+        entity totals; zeros for any asset type whose count fails.
+    """
+    from registry.repositories.factory import (
+        get_agent_repository,
+        get_custom_entity_repository,
+        get_server_repository,
+        get_skill_repository,
+    )
+
+    server_repo = get_server_repository()
+    agent_repo = get_agent_repository()
+    skill_repo = get_skill_repository()
+    custom_entity_repo = get_custom_entity_repository()
+
+    try:
+        servers, tools, agents, skills, custom_entities = await asyncio.gather(
+            server_repo.count(),
+            server_repo.count_tools(),
+            agent_repo.count(),
+            skill_repo.count(),
+            custom_entity_repo.count_all(),
+        )
+    except Exception:
+        logger.exception("Failed to gather registered asset counts")
+        return RegisteredAssets()
+
+    return RegisteredAssets(
+        servers=servers,
+        tools=tools,
+        agents=agents,
+        skills=skills,
+        custom_entities=custom_entities,
+    )
+
+
 @router.get("/executive-summary", response_model=ExecutiveSummaryResponse)
 async def get_executive_summary(
     user_context: Annotated[dict[str, Any], Depends(require_admin)],
@@ -948,6 +1003,7 @@ async def get_executive_summary(
         _count_distinct_usernames(repository, daa_match),
         _count_distinct_usernames(repository, waa_match),
         _count_distinct_usernames(repository, maa_match),
+        _get_registered_assets(),
     )
 
     governance = GovernanceScope(
@@ -955,6 +1011,7 @@ async def get_executive_summary(
         tools_under_policy=len([t for t in results[2] if t]),
         identities_active=results[0],
     )
+    registered_assets = results[17]
     active_users = ActiveUsers(
         dau=results[3],
         wau=results[4],
@@ -990,6 +1047,7 @@ async def get_executive_summary(
         window_days=days,
         retention_days=retention_days,
         governance=governance,
+        registered_assets=registered_assets,
         active_users=active_users,
         active_agents=active_agents,
         traffic_split=traffic_split,

--- a/registry/repositories/documentdb/custom_entity_repository.py
+++ b/registry/repositories/documentdb/custom_entity_repository.py
@@ -184,3 +184,12 @@ class DocumentDBCustomEntityRepository(CustomEntityRepositoryBase):
         if visibility_filter:
             query.update(visibility_filter)
         return await coll.count_documents(query)
+
+    async def count_all(self) -> int:
+        """Count custom entity records across every type in one query.
+
+        Returns:
+            Total number of custom entity records, all types combined.
+        """
+        coll = await self._get_collection()
+        return await coll.count_documents({})

--- a/registry/repositories/documentdb/server_repository.py
+++ b/registry/repositories/documentdb/server_repository.py
@@ -501,6 +501,35 @@ class DocumentDBServerRepository(ServerRepositoryBase):
             logger.error(f"Error counting servers in DocumentDB: {e}", exc_info=True)
             return 0
 
+    async def count_tools(self) -> int:
+        """Get the total number of tools exposed across all servers.
+
+        Tools are embedded in each server document under ``tool_list``; there is
+        no separate tools collection. This sums the list sizes in a single
+        aggregation (no N+1 loads). Version documents (``_id`` containing ":")
+        are excluded so tools are not double-counted across versions.
+
+        Returns:
+            Total number of tools across all current servers.
+        """
+        logger.debug(f"DocumentDB COUNT: Counting tools in collection '{self._collection_name}'")
+        collection = await self._get_collection()
+
+        pipeline = [
+            {"$match": {"_id": {"$not": {"$regex": ":"}}}},
+            {"$group": {"_id": None, "total": {"$sum": {"$size": {"$ifNull": ["$tool_list", []]}}}}},
+        ]
+
+        try:
+            cursor = collection.aggregate(pipeline)
+            docs = await cursor.to_list(length=1)
+            total = docs[0]["total"] if docs else 0
+            logger.debug(f"DocumentDB COUNT: Found {total} tools")
+            return total
+        except Exception as e:
+            logger.error(f"Error counting tools in DocumentDB: {e}", exc_info=True)
+            return 0
+
     async def update_field(
         self,
         path: str,

--- a/registry/repositories/documentdb/server_repository.py
+++ b/registry/repositories/documentdb/server_repository.py
@@ -484,8 +484,17 @@ class DocumentDBServerRepository(ServerRepositoryBase):
             logger.error(f"Failed to update server state in DocumentDB: {e}", exc_info=True)
             return False
 
-    async def count(self) -> int:
+    async def count(
+        self,
+        exclude_versions: bool = False,
+    ) -> int:
         """Get total count of servers.
+
+        Args:
+            exclude_versions: When True, exclude version documents (``_id``
+                containing ":") so the count reflects distinct servers only,
+                matching the basis used by ``count_tools()``. Defaults to False
+                to preserve the historical count of all documents.
 
         Returns:
             Total number of servers in the repository.
@@ -493,8 +502,10 @@ class DocumentDBServerRepository(ServerRepositoryBase):
         logger.debug(f"DocumentDB COUNT: Counting servers in collection '{self._collection_name}'")
         collection = await self._get_collection()
 
+        query: dict[str, Any] = {"_id": {"$not": {"$regex": ":"}}} if exclude_versions else {}
+
         try:
-            count = await collection.count_documents({})
+            count = await collection.count_documents(query)
             logger.debug(f"DocumentDB COUNT: Found {count} servers")
             return count
         except Exception as e:

--- a/registry/repositories/file/server_repository.py
+++ b/registry/repositories/file/server_repository.py
@@ -414,12 +414,22 @@ class FileServerRepository(ServerRepositoryBase):
 
         return True
 
-    async def count(self) -> int:
+    async def count(
+        self,
+        exclude_versions: bool = False,
+    ) -> int:
         """Get total count of servers.
+
+        Args:
+            exclude_versions: When True, exclude version documents (keys
+                containing ":") so the count reflects distinct servers only.
+                Defaults to False to preserve the historical count.
 
         Returns:
             Total number of servers in the repository.
         """
+        if exclude_versions:
+            return len([path for path in self._servers if ":" not in path])
         return len(self._servers)
 
     async def update_field(

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -186,8 +186,16 @@ class ServerRepositoryBase(ABC):
         pass
 
     @abstractmethod
-    async def count(self) -> int:
+    async def count(
+        self,
+        exclude_versions: bool = False,
+    ) -> int:
         """Get total count of servers.
+
+        Args:
+            exclude_versions: When True, exclude version documents so the count
+                reflects distinct servers only. Defaults to False to preserve
+                the historical count of all documents.
 
         Returns:
             Total number of servers in the repository.

--- a/tests/unit/audit/test_filter_statistics.py
+++ b/tests/unit/audit/test_filter_statistics.py
@@ -9,6 +9,8 @@ Validates: Issue #572
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from registry.core.config import settings
 from registry.repositories.audit_repository import DocumentDBAuditRepository
 
@@ -431,6 +433,15 @@ def _is_human_query(query: dict) -> bool:
 class TestExecutiveSummaryEndpoint:
     """Tests for GET /api/audit/executive-summary endpoint."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_summary_cache(self):
+        """Clear the module-level summary cache so tests do not see stale data."""
+        import registry.audit.routes as routes
+
+        routes._exec_summary_cache.clear()
+        yield
+        routes._exec_summary_cache.clear()
+
     async def test_happy_path_computes_metrics(self):
         """Computes governance, active users, traffic split, and momentum."""
         mock_repo = MagicMock()
@@ -703,3 +714,29 @@ class TestExecutiveSummaryEndpoint:
             assert assets.agents == 4
             assert assets.skills == 7
             assert assets.custom_entities == 2
+
+    async def test_summary_is_cached_within_ttl(self):
+        """A second call within the TTL returns the cache without recomputing."""
+        from registry.audit.routes import (
+            ExecutiveSummaryResponse,
+            RegisteredAssets,
+            get_executive_summary,
+        )
+
+        compute = AsyncMock(
+            return_value=ExecutiveSummaryResponse(
+                window_days=7,
+                registered_assets=RegisteredAssets(),
+            )
+        )
+
+        with patch(
+            "registry.audit.routes._compute_executive_summary",
+            new=compute,
+        ):
+            user_context = {"is_admin": True, "username": "admin"}
+            await get_executive_summary(user_context=user_context, days=7)
+            await get_executive_summary(user_context=user_context, days=7)
+
+        # Two requests, but the expensive computation ran only once
+        assert compute.await_count == 1

--- a/tests/unit/audit/test_filter_statistics.py
+++ b/tests/unit/audit/test_filter_statistics.py
@@ -9,6 +9,7 @@ Validates: Issue #572
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from registry.core.config import settings
 from registry.repositories.audit_repository import DocumentDBAuditRepository
 
 # =============================================================================
@@ -278,9 +279,15 @@ class TestStatisticsEndpoint:
             },
         ]
 
-        # aggregate() is called 5 times for registry_api (no server aggregation)
+        # Prior-window timeline
+        timeline_prior = [
+            {"_id": "2026-02-20", "count": 100},
+            {"_id": "2026-02-21", "count": 120},
+        ]
+
+        # aggregate() is called 6 times for registry_api (no server aggregation)
         mock_repo.aggregate = AsyncMock(
-            side_effect=[top_users, top_ops, timeline, status_dist, user_activity]
+            side_effect=[top_users, top_ops, timeline, status_dist, user_activity, timeline_prior]
         )
 
         with patch(
@@ -310,6 +317,9 @@ class TestStatisticsEndpoint:
             assert result.user_activity[0].username == "admin"
             assert result.user_activity[0].total == 300
             assert len(result.user_activity[0].operations) == 2
+            assert len(result.activity_timeline_prior) == 2
+            assert result.activity_timeline_prior[0].period == "2026-02-20"
+            assert result.activity_timeline_prior[0].count == 100
 
     async def test_returns_statistics_for_mcp_stream(self):
         """Returns aggregated statistics for mcp_access stream including servers."""
@@ -331,14 +341,24 @@ class TestStatisticsEndpoint:
                 "operations": [{"name": "tools/call", "count": 100}],
             },
         ]
+        timeline_prior = [{"_id": "2026-02-21", "count": 150}]
         top_servers = [
             {"_id": "fininfo-server", "count": 89},
             {"_id": "currenttime-server", "count": 67},
         ]
 
-        # aggregate() is called 6 times for mcp_access (includes user_activity + server aggregation)
+        # aggregate() is called 7 times for mcp_access
+        # (user_activity + prior timeline + server aggregation)
         mock_repo.aggregate = AsyncMock(
-            side_effect=[top_users, top_ops, timeline, status_dist, user_activity, top_servers]
+            side_effect=[
+                top_users,
+                top_ops,
+                timeline,
+                status_dist,
+                user_activity,
+                timeline_prior,
+                top_servers,
+            ]
         )
 
         with patch(
@@ -391,3 +411,223 @@ class TestStatisticsEndpoint:
             assert result.status_distribution.status_4xx == 0
             assert result.status_distribution.status_5xx == 0
             assert result.user_activity == []
+
+
+# =============================================================================
+# API Endpoint: GET /audit/executive-summary
+# =============================================================================
+
+
+def _is_agent_query(query: dict) -> bool:
+    """Return True when the query filters for agent (bearer-token) traffic."""
+    return query.get("identity.credential_type") == "bearer_token"
+
+
+def _is_human_query(query: dict) -> bool:
+    """Return True when the query filters for human (session-cookie) traffic."""
+    return query.get("identity.credential_type") == "session_cookie"
+
+
+class TestExecutiveSummaryEndpoint:
+    """Tests for GET /api/audit/executive-summary endpoint."""
+
+    async def test_happy_path_computes_metrics(self):
+        """Computes governance, active users, traffic split, and momentum."""
+        mock_repo = MagicMock()
+
+        async def mock_distinct(field, query):
+            # MCP-only metrics
+            if field == "mcp_server.name":
+                return ["fininfo-server", "currenttime-server", ""]
+            if field == "mcp_request.tool_name":
+                return ["get_quote", "get_time", None]
+            # Username distinct counts: agents have only one identity
+            if _is_agent_query(query):
+                return ["agent-bot"]
+            return ["alice", "bob", "anonymous", ""]
+
+        async def mock_count(query):
+            # Human events vs agent events for traffic split
+            if _is_human_query(query):
+                return 60
+            if _is_agent_query(query):
+                return 40
+            # Non-anonymous event counts (current vs prior window)
+            ts = query.get("timestamp", {})
+            gte = ts.get("$gte")
+            # Prior window has the older start; current has the newer start
+            return 100 if gte is not None else 0
+
+        mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
+        mock_repo.count = AsyncMock(side_effect=mock_count)
+
+        with patch(
+            "registry.audit.routes.get_audit_repository",
+            return_value=mock_repo,
+        ):
+            from registry.audit.routes import get_executive_summary
+
+            result = await get_executive_summary(
+                user_context={"is_admin": True, "username": "admin"},
+                days=7,
+            )
+
+            # Governance: falsy values dropped
+            assert result.governance.mcp_servers_governed == 2
+            assert result.governance.tools_under_policy == 2
+            # identities_active drops anonymous/empty -> alice, bob
+            assert result.governance.identities_active == 2
+
+            # Active users: same non-agent distinct -> 2 each
+            assert result.active_users.dau == 2
+            assert result.active_users.wau == 2
+            assert result.active_users.mau == 2
+
+            # Active agents: agent-filtered distinct returns one identity
+            assert result.active_agents.daa == 1
+            assert result.active_agents.waa == 1
+            assert result.active_agents.maa == 1
+            assert result.active_agents.waa_available is True
+            assert result.active_agents.maa_available is False
+
+            # Traffic split: 60 human, 40 agent -> 60.0 / 40.0
+            assert result.traffic_split.human_events == 60
+            assert result.traffic_split.agent_events == 40
+            assert result.traffic_split.human_pct == 60.0
+            assert result.traffic_split.agent_pct == 40.0
+
+            assert result.window_days == 7
+            # Default retention (7d) covers WAU but not the 30d MAU window
+            assert result.retention_days == 7
+            assert result.active_users.wau_available is True
+            assert result.active_users.mau_available is False
+
+    async def test_no_prior_data_sets_wow_none(self):
+        """events_wow_pct is None and has_prior_data False when prior window is empty."""
+        mock_repo = MagicMock()
+
+        async def mock_distinct(field, query):
+            if field in ("mcp_server.name", "mcp_request.tool_name"):
+                return []
+            return ["alice"]
+
+        # Distinguish current vs prior non-anonymous event counts by window start.
+        # The prior window starts further in the past (days*2) than the current
+        # window (days). We return 0 for the older start to simulate no prior data.
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        cur_start_threshold = now - timedelta(days=10)
+
+        async def mock_count(query):
+            if _is_agent_query(query):
+                return 5
+            gte = query.get("timestamp", {}).get("$gte")
+            if gte is not None and gte < cur_start_threshold:
+                return 0  # prior window
+            return 50  # current window
+
+        mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
+        mock_repo.count = AsyncMock(side_effect=mock_count)
+
+        with patch(
+            "registry.audit.routes.get_audit_repository",
+            return_value=mock_repo,
+        ):
+            from registry.audit.routes import get_executive_summary
+
+            result = await get_executive_summary(
+                user_context={"is_admin": True, "username": "admin"},
+                days=7,
+            )
+
+            assert result.momentum.events_prior == 0
+            assert result.momentum.events_wow_pct is None
+            assert result.momentum.has_prior_data is False
+            assert result.momentum.events_current == 50
+
+    async def test_wow_pct_rounding(self):
+        """events_wow_pct rounds to one decimal when prior data exists."""
+        mock_repo = MagicMock()
+
+        async def mock_distinct(field, query):
+            if field in ("mcp_server.name", "mcp_request.tool_name"):
+                return []
+            return ["alice"]
+
+        from datetime import UTC, datetime, timedelta
+
+        now = datetime.now(UTC)
+        cur_start_threshold = now - timedelta(days=10)
+
+        async def mock_count(query):
+            if _is_agent_query(query):
+                return 1
+            gte = query.get("timestamp", {}).get("$gte")
+            if gte is not None and gte < cur_start_threshold:
+                return 30  # prior window
+            return 40  # current window -> (40-30)/30*100 = 33.333...
+
+        mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
+        mock_repo.count = AsyncMock(side_effect=mock_count)
+
+        # Retention must cover the prior window (days*2 = 14) for WoW to be honest.
+        with (
+            patch(
+                "registry.audit.routes.get_audit_repository",
+                return_value=mock_repo,
+            ),
+            patch.object(settings, "audit_log_mongodb_ttl_days", 30),
+        ):
+            from registry.audit.routes import get_executive_summary
+
+            result = await get_executive_summary(
+                user_context={"is_admin": True, "username": "admin"},
+                days=7,
+            )
+
+            assert result.momentum.events_prior == 30
+            assert result.momentum.events_current == 40
+            assert result.momentum.events_wow_pct == 33.3
+            assert result.momentum.has_prior_data is True
+            # Retention now covers the 30d window too
+            assert result.active_users.mau_available is True
+
+    async def test_short_retention_hides_wow(self):
+        """has_prior_data is False when retention does not cover the prior window."""
+        mock_repo = MagicMock()
+
+        async def mock_distinct(field, query):
+            if field in ("mcp_server.name", "mcp_request.tool_name"):
+                return []
+            return ["alice"]
+
+        # Prior window reports events, but retention is too short to trust them.
+        async def mock_count(query):
+            if _is_agent_query(query):
+                return 1
+            return 30
+
+        mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
+        mock_repo.count = AsyncMock(side_effect=mock_count)
+
+        # days=7 needs 14d retention for the prior window; 7d is not enough.
+        with (
+            patch(
+                "registry.audit.routes.get_audit_repository",
+                return_value=mock_repo,
+            ),
+            patch.object(settings, "audit_log_mongodb_ttl_days", 7),
+        ):
+            from registry.audit.routes import get_executive_summary
+
+            result = await get_executive_summary(
+                user_context={"is_admin": True, "username": "admin"},
+                days=7,
+            )
+
+            # Prior count is non-zero, but retention gating still hides WoW.
+            assert result.momentum.events_prior == 30
+            assert result.momentum.has_prior_data is False
+            assert result.momentum.events_wow_pct is None
+            assert result.active_users.mau_available is False

--- a/tests/unit/audit/test_filter_statistics.py
+++ b/tests/unit/audit/test_filter_statistics.py
@@ -461,9 +461,17 @@ class TestExecutiveSummaryEndpoint:
         mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
         mock_repo.count = AsyncMock(side_effect=mock_count)
 
-        with patch(
-            "registry.audit.routes.get_audit_repository",
-            return_value=mock_repo,
+        from registry.audit.routes import RegisteredAssets
+
+        with (
+            patch(
+                "registry.audit.routes.get_audit_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "registry.audit.routes._get_registered_assets",
+                new=AsyncMock(return_value=RegisteredAssets()),
+            ),
         ):
             from registry.audit.routes import get_executive_summary
 
@@ -489,6 +497,10 @@ class TestExecutiveSummaryEndpoint:
             assert result.active_agents.maa == 1
             assert result.active_agents.waa_available is True
             assert result.active_agents.maa_available is False
+
+            # Registered assets come from the patched helper (zeros here)
+            assert result.registered_assets.servers == 0
+            assert result.registered_assets.tools == 0
 
             # Traffic split: 60 human, 40 agent -> 60.0 / 40.0
             assert result.traffic_split.human_events == 60
@@ -530,9 +542,17 @@ class TestExecutiveSummaryEndpoint:
         mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
         mock_repo.count = AsyncMock(side_effect=mock_count)
 
-        with patch(
-            "registry.audit.routes.get_audit_repository",
-            return_value=mock_repo,
+        from registry.audit.routes import RegisteredAssets
+
+        with (
+            patch(
+                "registry.audit.routes.get_audit_repository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "registry.audit.routes._get_registered_assets",
+                new=AsyncMock(return_value=RegisteredAssets()),
+            ),
         ):
             from registry.audit.routes import get_executive_summary
 
@@ -571,11 +591,17 @@ class TestExecutiveSummaryEndpoint:
         mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
         mock_repo.count = AsyncMock(side_effect=mock_count)
 
+        from registry.audit.routes import RegisteredAssets
+
         # Retention must cover the prior window (days*2 = 14) for WoW to be honest.
         with (
             patch(
                 "registry.audit.routes.get_audit_repository",
                 return_value=mock_repo,
+            ),
+            patch(
+                "registry.audit.routes._get_registered_assets",
+                new=AsyncMock(return_value=RegisteredAssets()),
             ),
             patch.object(settings, "audit_log_mongodb_ttl_days", 30),
         ):
@@ -611,11 +637,17 @@ class TestExecutiveSummaryEndpoint:
         mock_repo.distinct = AsyncMock(side_effect=mock_distinct)
         mock_repo.count = AsyncMock(side_effect=mock_count)
 
+        from registry.audit.routes import RegisteredAssets
+
         # days=7 needs 14d retention for the prior window; 7d is not enough.
         with (
             patch(
                 "registry.audit.routes.get_audit_repository",
                 return_value=mock_repo,
+            ),
+            patch(
+                "registry.audit.routes._get_registered_assets",
+                new=AsyncMock(return_value=RegisteredAssets()),
             ),
             patch.object(settings, "audit_log_mongodb_ttl_days", 7),
         ):
@@ -631,3 +663,43 @@ class TestExecutiveSummaryEndpoint:
             assert result.momentum.has_prior_data is False
             assert result.momentum.events_wow_pct is None
             assert result.active_users.mau_available is False
+
+    async def test_registered_assets_counts(self):
+        """_get_registered_assets gathers counts from each asset repository."""
+        server_repo = MagicMock()
+        server_repo.count = AsyncMock(return_value=5)
+        server_repo.count_tools = AsyncMock(return_value=13)
+        agent_repo = MagicMock()
+        agent_repo.count = AsyncMock(return_value=4)
+        skill_repo = MagicMock()
+        skill_repo.count = AsyncMock(return_value=7)
+        custom_entity_repo = MagicMock()
+        custom_entity_repo.count_all = AsyncMock(return_value=2)
+
+        with (
+            patch(
+                "registry.repositories.factory.get_server_repository",
+                return_value=server_repo,
+            ),
+            patch(
+                "registry.repositories.factory.get_agent_repository",
+                return_value=agent_repo,
+            ),
+            patch(
+                "registry.repositories.factory.get_skill_repository",
+                return_value=skill_repo,
+            ),
+            patch(
+                "registry.repositories.factory.get_custom_entity_repository",
+                return_value=custom_entity_repo,
+            ),
+        ):
+            from registry.audit.routes import _get_registered_assets
+
+            assets = await _get_registered_assets()
+
+            assert assets.servers == 5
+            assert assets.tools == 13
+            assert assets.agents == 4
+            assert assets.skills == 7
+            assert assets.custom_entities == 2

--- a/tests/unit/repositories/test_documentdb_server_repository.py
+++ b/tests/unit/repositories/test_documentdb_server_repository.py
@@ -25,6 +25,11 @@ def _make_cursor(items: list[dict]) -> MagicMock:
         return item
 
     cursor.__anext__ = anext_impl
+
+    async def to_list_impl(length=None):
+        return list(items) if length is None else list(items)[:length]
+
+    cursor.to_list = to_list_impl
     return cursor
 
 
@@ -274,9 +279,43 @@ class TestCount:
         mock_collection.count_documents.return_value = 42
         assert await repo.count() == 42
 
+    async def test_counts_all_documents_by_default(self, repo, mock_collection):
+        mock_collection.count_documents.return_value = 42
+        await repo.count()
+        mock_collection.count_documents.assert_called_once_with({})
+
+    async def test_exclude_versions_filters_version_docs(self, repo, mock_collection):
+        mock_collection.count_documents.return_value = 5
+        result = await repo.count(exclude_versions=True)
+        assert result == 5
+        # Version documents (_id containing ":") are excluded from the count
+        mock_collection.count_documents.assert_called_once_with(
+            {"_id": {"$not": {"$regex": ":"}}}
+        )
+
     async def test_error_returns_zero(self, repo, mock_collection):
         mock_collection.count_documents.side_effect = Exception("db error")
         assert await repo.count() == 0
+
+
+class TestCountTools:
+    async def test_sums_tool_list_sizes(self, repo, mock_collection):
+        mock_collection.aggregate = MagicMock(return_value=_make_cursor([{"_id": None, "total": 13}]))
+
+        result = await repo.count_tools()
+
+        assert result == 13
+        # Version documents are excluded so tools are not double-counted
+        pipeline = mock_collection.aggregate.call_args[0][0]
+        assert pipeline[0] == {"$match": {"_id": {"$not": {"$regex": ":"}}}}
+
+    async def test_empty_collection_returns_zero(self, repo, mock_collection):
+        mock_collection.aggregate = MagicMock(return_value=_make_cursor([]))
+        assert await repo.count_tools() == 0
+
+    async def test_error_returns_zero(self, repo, mock_collection):
+        mock_collection.aggregate = MagicMock(side_effect=Exception("db error"))
+        assert await repo.count_tools() == 0
 
 
 class TestUpdateField:


### PR DESCRIPTION
## Summary

Adds an always-visible **Executive Summary** band at the top of the Settings > Audit page, aimed at platform leads and execs reviewing the gateway's value. The existing charts answer "what happened operationally"; this band answers "what are we controlling, and what adoption is it driving."

All metrics are aggregations over data already in the audit collection. No new instrumentation, no new logging.

## What's shown

- **Governance Scope** - distinct MCP servers governed, tools under policy, and active identities ("the blast radius we control").
- **Weekly Active (People | Agents)** - a combined tile with DAU/WAU/MAU for people alongside DAA/WAA/MAA for agents, separated by a divider.
- **Events (7d)** - non-anonymous governed call volume with a week-over-week delta chip.
- **Agent vs Human split** - share of governed calls from token-based agents vs interactive web-UI sessions.
- A plain-English narrative line and a legend tie the band together.
- The activity timeline now has a faint prior-week comparison line.
- The statistics panel is expanded by default (prior explicit collapse choices are still respected).

## Definitions and honesty guarantees

- **Agent vs human** is classified by `identity.credential_type`: `bearer_token` = non-interactive / API / token callers (incl. CLI, scripts, and all MCP tool calls), `session_cookie` = interactive web UI. Anonymous traffic (health checks, probes) is excluded. The split is over **calls**, not identities, and the UI states this explicitly. A human using curl with a bearer token is counted as an agent by this definition; the legend makes that clear.
- **Retention-aware gating**: a window-N metric is only reported when the configured audit TTL (`audit_log_mongodb_ttl_days`) covers the window. MAU/MAA require >= 30-day retention; the week-over-week delta requires retention to cover the prior window (2x the comparison window). On the default 7-day retention, MAU/MAA show "needs 30d retention" and the WoW chip is hidden rather than showing a misleading -100%. Raising retention to 30+ days lights these up automatically with no code change.

## DocumentDB compatibility

Every aggregation operator used by the new endpoint is already in use against DocumentDB elsewhere in this same file. Distinct-count and window-count metrics use `distinct()` + `count()` with simple range matches (no date-bucketing pipelines on the executive-summary path), and anonymous filtering for distinct counts is done in Python.

## API

- New: `GET /api/audit/executive-summary?days=7` (admin-only), returns governance, active_users, active_agents, traffic_split, momentum, plus `retention_days` and per-metric availability flags.
- Changed: `GET /api/audit/statistics` now also returns `activity_timeline_prior` for the prior-week overlay.

## Testing

- `tests/unit/audit/test_filter_statistics.py` extended to cover the new endpoint: metric computation, traffic split percentages, week-over-week rounding, the no-prior-data branch, retention gating (MAU/MAA availability and WoW suppression), active agents, and the prior-week timeline.
- 97 audit tests pass (`uv run pytest tests/ -k audit -n 8`).
- `ruff check` clean on changed Python files; frontend `tsc --noEmit` clean.

## Notes

- On a default deployment, DAU 1 with ~9,934 events/week indicates almost all volume comes from a single identity (likely admin or a service token). Raising retention will produce a more meaningful MAU/WoW story.
