### PR TITLE
perf(auth): collapse per-group scope lookup into one bulk query (+ group_mappings index)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -784,18 +784,14 @@ async def map_groups_to_scopes(groups: list[str]) -> list[str]:
     """
     scopes = []
 
-    # Query DocumentDB directly for group mappings
+    # Resolve all groups to scopes in a single query. Issuing one query per
+    # group serialized a DB round-trip per group on every authenticated
+    # request, which dominated latency for users with many groups on a remote
+    # cluster. get_group_mappings_bulk collapses that into one $in query.
     try:
         scope_repo = get_scope_repository()
-
-        for group in groups:
-            # Query DocumentDB for this group's scope mappings
-            group_scopes = await scope_repo.get_group_mappings(group)
-            if group_scopes:
-                scopes.extend(group_scopes)
-                logger.debug(f"Mapped group '{group}' to scopes: {group_scopes}")
-            else:
-                logger.debug(f"No scope mapping found for group: {group}")
+        scopes = await scope_repo.get_group_mappings_bulk(groups)
+        logger.debug(f"Mapped {len(groups)} groups to scopes: {scopes}")
     except Exception as e:
         logger.error(f"Error querying group mappings from DocumentDB: {e}", exc_info=True)
         # Fall back to in-memory config if DocumentDB query fails

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -69,13 +69,33 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         self._collection: AsyncIOMotorCollection | None = None
         self._collection_name = get_collection_name("mcp_scopes")
         self._scopes_cache: dict[str, Any] = {}
+        self._indexes_created = False
 
     async def _get_collection(self) -> AsyncIOMotorCollection:
-        """Get DocumentDB collection."""
+        """Get DocumentDB collection, creating indexes on first access."""
         if self._collection is None:
             db = await get_documentdb_client()
             self._collection = db[self._collection_name]
+            await self._ensure_indexes()
         return self._collection
+
+    async def _ensure_indexes(self) -> None:
+        """Create the multikey index on group_mappings if not present.
+
+        ``get_group_mappings`` / ``get_group_mappings_bulk`` filter on
+        ``group_mappings`` (``find({"group_mappings": ...})`` and the bulk
+        ``$in``). Without an index on that array field each query is a full
+        collection scan; the multikey index turns it into an index seek and
+        is what makes the bulk ``$in`` actually cheap.
+        """
+        if self._indexes_created or self._collection is None:
+            return
+        try:
+            await self._collection.create_index("group_mappings")
+            self._indexes_created = True
+            logger.info(f"Created group_mappings index for {self._collection_name}")
+        except Exception as e:
+            logger.warning(f"Could not create group_mappings index for {self._collection_name}: {e}")
 
     async def load_all(self) -> None:
         """Load all scopes from DocumentDB."""
@@ -161,6 +181,39 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             return scope_names
         except Exception as e:
             logger.error(f"Error getting group mappings for '{keycloak_group}': {e}", exc_info=True)
+            return []
+
+    async def get_group_mappings_bulk(
+        self,
+        groups: list[str],
+    ) -> list[str]:
+        """Union of scope names mapped to any of the given groups in one query.
+
+        Collapses the per-group ``find`` fan-out into a single ``$in`` query,
+        backed by the ``group_mappings`` index. Returns a de-duplicated,
+        order-stable list of scope names.
+        """
+        unique = sorted({g for g in groups if g})
+        if not unique:
+            return []
+
+        collection = await self._get_collection()
+        try:
+            cursor = collection.find({"group_mappings": {"$in": unique}})
+            seen: set[str] = set()
+            scope_names: list[str] = []
+            async for doc in cursor:
+                scope_id = doc["_id"]
+                if scope_id not in seen:
+                    seen.add(scope_id)
+                    scope_names.append(scope_id)
+            logger.debug(
+                f"DocumentDB READ: bulk group mappings for {len(unique)} groups "
+                f"-> {len(scope_names)} scopes"
+            )
+            return scope_names
+        except Exception as e:
+            logger.error(f"Error getting bulk group mappings: {e}", exc_info=True)
             return []
 
     async def get_all_mapped_group_names(self) -> set[str]:

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -489,6 +489,38 @@ class ScopeRepositoryBase(ABC):
         """
         pass
 
+    async def get_group_mappings_bulk(
+        self,
+        groups: list[str],
+    ) -> list[str]:
+        """Get the union of scope names mapped to any of the given groups.
+
+        Batch equivalent of ``get_group_mappings``. ``map_groups_to_scopes``
+        on the auth hot path resolves a user's groups to scopes on every
+        authenticated request; issuing one query per group serializes a
+        round-trip per group — cheap on a local Mongo, seconds on a remote
+        cluster for a user with many groups (same fan-out that
+        ``get_server_scopes_bulk`` was added to fix). Backends that can fetch
+        all mappings in a single query (DocumentDB ``$in``) override this; the
+        default loops over the per-group method so in-memory backends (file)
+        stay correct with no extra cost.
+
+        Args:
+            groups: Group names/IDs to resolve.
+
+        Returns:
+            De-duplicated list of scope names, order-preserving across the
+            input groups. Empty list if none map.
+        """
+        seen: set[str] = set()
+        result: list[str] = []
+        for group in groups:
+            for scope in await self.get_group_mappings(group):
+                if scope not in seen:
+                    seen.add(scope)
+                    result.append(scope)
+        return result
+
     @abstractmethod
     async def get_all_mapped_group_names(self) -> set[str]:
         """

--- a/tests/auth_server/conftest.py
+++ b/tests/auth_server/conftest.py
@@ -616,8 +616,22 @@ def mock_scope_repository_with_data(mock_scopes_config):
         group_mappings = mock_scopes_config.get("group_mappings", {})
         return group_mappings.get(group_name, [])
 
+    # get_group_mappings_bulk returns the de-duplicated union across groups
+    # (mirrors the base-class default). map_groups_to_scopes calls this now.
+    async def get_group_mappings_bulk_side_effect(groups: list[str]):
+        group_mappings = mock_scopes_config.get("group_mappings", {})
+        seen: set[str] = set()
+        out: list[str] = []
+        for group in groups:
+            for scope in group_mappings.get(group, []):
+                if scope not in seen:
+                    seen.add(scope)
+                    out.append(scope)
+        return out
+
     mock_repo.get_server_scopes.side_effect = get_server_scopes_side_effect
     mock_repo.get_group_mappings.side_effect = get_group_mappings_side_effect
+    mock_repo.get_group_mappings_bulk.side_effect = get_group_mappings_bulk_side_effect
     mock_repo.load_all = AsyncMock()
     mock_repo.list_groups.return_value = {}
     mock_repo.get_group.return_value = None

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -176,12 +176,14 @@ class TestGroupToScopeMapping:
         """Test basic group to scope mapping."""
         from auth_server.server import map_groups_to_scopes
 
-        # Arrange - Mock the repository to return scopes for groups
+        # Arrange - Mock the repository to return the union of scopes in one
+        # bulk call (map_groups_to_scopes resolves all groups in a single query).
         mock_repo = AsyncMock()
-        mock_repo.get_group_mappings.side_effect = lambda group: {
-            "users": ["read:servers", "read:tools"],
-            "developers": ["write:servers"],
-        }.get(group, [])
+        mock_repo.get_group_mappings_bulk.return_value = [
+            "read:servers",
+            "read:tools",
+            "write:servers",
+        ]
 
         with patch("auth_server.server.get_scope_repository", return_value=mock_repo):
             groups = ["users", "developers"]
@@ -193,19 +195,21 @@ class TestGroupToScopeMapping:
             assert "read:servers" in scopes
             assert "write:servers" in scopes
             assert "read:tools" in scopes
+            mock_repo.get_group_mappings_bulk.assert_awaited_once_with(groups)
 
     @pytest.mark.asyncio
     async def test_map_groups_to_scopes_no_duplicates(self, mock_scopes_config):
         """Test that duplicate scopes are removed."""
         from auth_server.server import map_groups_to_scopes
 
-        # Arrange - Mock the repository to return scopes for groups
+        # Arrange - the bulk query returns the de-duplicated union; verify
+        # map_groups_to_scopes preserves that (no duplicate re-introduced).
         mock_repo = AsyncMock()
-        # Both groups return "read:servers" to test deduplication
-        mock_repo.get_group_mappings.side_effect = lambda group: {
-            "users": ["read:servers", "read:tools"],
-            "developers": ["read:servers", "write:servers"],
-        }.get(group, [])
+        mock_repo.get_group_mappings_bulk.return_value = [
+            "read:servers",
+            "read:tools",
+            "write:servers",
+        ]
 
         with patch("auth_server.server.get_scope_repository", return_value=mock_repo):
             # Both groups have "read:servers"
@@ -227,7 +231,7 @@ class TestGroupToScopeMapping:
 
         # Arrange - Mock repository to return empty list for unknown groups
         mock_repo = AsyncMock()
-        mock_repo.get_group_mappings.return_value = []
+        mock_repo.get_group_mappings_bulk.return_value = []
 
         with patch("auth_server.server.get_scope_repository", return_value=mock_repo):
             groups = ["unknown-group"]
@@ -2236,6 +2240,7 @@ class TestBuildStaticTokenMap:
 
         mock_repo = AsyncMock()
         mock_repo.get_group_mappings.return_value = ["mcp-readonly/read"]
+        mock_repo.get_group_mappings_bulk.return_value = ["mcp-readonly/read"]
 
         with (
             patch.object(server_module, "REGISTRY_STATIC_TOKEN_AUTH_ENABLED", True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -315,6 +315,7 @@ def mock_scope_repository():
     mock = AsyncMock()
     mock.load_all = AsyncMock()
     mock.get_group_mappings.return_value = []
+    mock.get_group_mappings_bulk.return_value = []
     mock.get_all_mapped_group_names.return_value = set()
     mock.list_groups.return_value = {}  # Return empty dict, not list
     mock.get_group.return_value = None

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -287,7 +287,21 @@ def mock_scopes_config(sample_scopes_config: dict[str, Any], monkeypatch):
                 out[name] = scopes
         return out
 
+    # get_group_mappings_bulk returns the de-duplicated union of scopes across
+    # the given groups (mirrors the base-class default that loops the single
+    # getter). Production map_groups_to_scopes now calls this instead of looping.
+    async def mock_get_group_mappings_bulk(groups: list[str]):
+        seen: set[str] = set()
+        out: list[str] = []
+        for group in groups:
+            for scope in await mock_get_group_mappings(group):
+                if scope not in seen:
+                    seen.add(scope)
+                    out.append(scope)
+        return out
+
     mock_repo.get_group_mappings.side_effect = mock_get_group_mappings
+    mock_repo.get_group_mappings_bulk.side_effect = mock_get_group_mappings_bulk
     mock_repo.get_all_group_mappings.side_effect = mock_get_all_group_mappings
     mock_repo.get_ui_scopes.side_effect = mock_get_ui_scopes
     mock_repo.get_server_scopes.side_effect = mock_get_server_scopes

--- a/tests/unit/repositories/test_scope_repository_bulk.py
+++ b/tests/unit/repositories/test_scope_repository_bulk.py
@@ -187,3 +187,56 @@ class TestFileBackendBulkDefault:
     async def test_ui_scopes_bulk_loops_singles(self, file_repo):
         result = await file_repo.get_ui_scopes_bulk(["admin", "noperm", "missing"])
         assert result == {"admin": {"list_service": ["all"]}}
+
+
+class TestGetGroupMappingsBulk:
+    """DocumentDB overrides get_group_mappings_bulk with a single $in query
+    returning the de-duplicated union of scope names across the groups."""
+
+    async def test_empty_input_skips_query(self, repo, mock_collection):
+        assert await repo.get_group_mappings_bulk([]) == []
+        mock_collection.find.assert_not_called()
+
+    async def test_only_falsy_input_skips_query(self, repo, mock_collection):
+        assert await repo.get_group_mappings_bulk(["", None]) == []
+        mock_collection.find.assert_not_called()
+
+    async def test_uses_in_query_with_deduped_sorted_groups(self, repo, mock_collection):
+        mock_collection.find.return_value = _make_cursor([])
+        await repo.get_group_mappings_bulk(["g-b", "g-a", "g-b", ""])
+        mock_collection.find.assert_called_once_with({"group_mappings": {"$in": ["g-a", "g-b"]}})
+
+    async def test_returns_deduped_union_of_scope_ids(self, repo, mock_collection):
+        # Two groups map to overlapping scopes; the scope _id appears once each.
+        mock_collection.find.return_value = _make_cursor(
+            [{"_id": "registry-admins"}, {"_id": "public-mcp-users"}]
+        )
+        result = await repo.get_group_mappings_bulk(["g-a", "g-b"])
+        assert result == ["registry-admins", "public-mcp-users"]
+
+    async def test_error_returns_empty(self, repo, mock_collection):
+        mock_collection.find.side_effect = Exception("db error")
+        assert await repo.get_group_mappings_bulk(["g-a"]) == []
+
+
+class TestFileBackendGroupMappingsBulkDefault:
+    """File backend inherits the base-class default: loops the single getter
+    and unions the results, de-duplicated and order-stable."""
+
+    @pytest.fixture
+    def file_repo(self):
+        r = FileScopeRepository.__new__(FileScopeRepository)
+        r._scopes_data = {
+            "group_mappings": {
+                "g-a": ["read:servers", "read:tools"],
+                "g-b": ["read:servers", "write:servers"],
+            },
+        }
+        return r
+
+    async def test_unions_and_dedupes(self, file_repo):
+        result = await file_repo.get_group_mappings_bulk(["g-a", "g-b", "missing"])
+        assert result == ["read:servers", "read:tools", "write:servers"]
+
+    async def test_empty_returns_empty(self, file_repo):
+        assert await file_repo.get_group_mappings_bulk([]) == []


### PR DESCRIPTION
## Problem

`map_groups_to_scopes` resolved a user's groups to scopes by awaiting **one DocumentDB query per group, serially** ([server.py](../blob/main/auth_server/server.py) loop over `get_group_mappings`). It runs inside `validate_session_cookie` and the nginx `/validate` subrequest, and scopes are not cached on the session — so **every authenticated request** re-paid the full per-group fan-out. For a user with many groups on a remote cluster, that's N back-to-back round-trips and is the dominant request latency (the "slow but working" cohort from the TIAA report).

Two compounding factors:
- The fan-out is per-request, not just at login.
- `mcp_scopes_default` had **no index on `group_mappings`** (only `{_id:1}`), so each of the N `find({"group_mappings": ...})` calls was a full collection scan.

This is a gateway-side DB issue — no Entra/IdP configuration change addresses it.

## Fix (smallest correct change)

1. **`get_group_mappings_bulk`** — single `$in` query returning the de-duplicated, order-stable union of scope names. Mirrors the existing `get_server_scopes_bulk` precedent: non-abstract default on the interface loops the single getter (file backend inherits it for free), DocumentDB overrides with one query.
2. **Swap `map_groups_to_scopes`** to call it once. N round-trips → 1.
3. **Add the multikey index** on `mcp_scopes_default.group_mappings` via an ensure-index hook, so the `$in` is an index seek rather than a scan.

No session-caching, no new config, no API change — deliberately minimal.

## Relationship to #1279

#1279 (group filter at login) shrank N from thousands to tens and fixed the hard failure (X-Groups header overflow → 500s). This PR makes the residual per-request lookup O(1) queries regardless of group count. Complementary, not overlapping.

## Tests

- `get_group_mappings_bulk`: DocumentDB `$in` (dedup/sorted/empty/error) and file-backend default (union/dedup) in `tests/unit/repositories/test_scope_repository_bulk.py`.
- Updated `map_groups_to_scopes` and `/validate` tests + shared fixtures to mock the bulk method.
- Affected suites: 982 passed, 5 skipped, 0 failures. ruff + bandit clean.

## Note

The index is created at runtime via the ensure-index hook on first collection access (same pattern as `security_scan_repository`). Existing deployments pick it up automatically on next auth-server start; no manual migration required.