### PR TITLE
feat(terraform): expose AUTH_SERVER_URL as a variable for ECS (#1283)

### DIFF
--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -688,6 +688,7 @@ These have no `.env` equivalent because they describe the infrastructure, not th
 | Terraform variable | Purpose |
 |--------------------|---------|
 | `ingress_cidr_blocks` | CIDRs allowed to reach the main ALB. |
+| `auth_server_url` | Internal URL the registry/nginx use to reach the auth-server. Defaults to `http://auth-server:8888`; set to a Cloud Map / Service Connect FQDN for FQDN-only deployments. (Docker: `AUTH_SERVER_URL`; Helm: derived from the cluster service FQDN.) |
 | `use_regional_domains` | Regional subdomain pattern. |
 | `base_domain` | Root domain for regional pattern. |
 | `keycloak_domain` | Custom Keycloak hostname. |

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -32,6 +32,9 @@ module "mcp_gateway" {
   public_subnet_ids   = local.selected_public_subnet_ids
   ingress_cidr_blocks = var.ingress_cidr_blocks
 
+  # Internal auth-server URL (override for Cloud Map / Service Connect FQDNs)
+  auth_server_url = var.auth_server_url
+
   # ALB logging
   alb_logs_bucket = aws_s3_bucket.alb_logs.id
 
@@ -152,7 +155,7 @@ module "mcp_gateway" {
   entra_login_base_url                      = var.entra_login_base_url
   entra_graph_base_url                      = var.entra_graph_base_url
   idp_group_filter_prefix                   = var.idp_group_filter_prefix
-  allowed_idp_groups                         = var.allowed_idp_groups
+  allowed_idp_groups                        = var.allowed_idp_groups
   idp_user_group_fallback_enabled_providers = var.idp_user_group_fallback_enabled_providers
 
   # Amazon Cognito configuration

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -109,7 +109,7 @@ module "ecs_service_auth" {
         },
         {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:8888"
+          value = var.auth_server_url
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"
@@ -792,7 +792,7 @@ module "ecs_service_registry" {
         },
         {
           name  = "AUTH_SERVER_URL"
-          value = "http://auth-server:8888"
+          value = var.auth_server_url
         },
         {
           name  = "AUTH_SERVER_EXTERNAL_URL"

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -287,6 +287,12 @@ variable "domain_name" {
   default     = ""
 }
 
+variable "auth_server_url" {
+  description = "Internal URL the registry/nginx use to reach the auth-server. Set to a Cloud Map / Service Connect FQDN (e.g. http://auth-server.<namespace>.local:8888) for deployments where only FQDNs resolve. Defaults to the Compose-style service name for backward compatibility."
+  type        = string
+  default     = "http://auth-server:8888"
+}
+
 variable "create_route53_record" {
   description = "Whether to create Route53 DNS record for the domain"
   type        = bool

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -137,6 +137,12 @@ keycloak_database_password = "CHANGE-ME-DB-PASSWORD"
 # Default: "10.0.0.0/16"
 # vpc_cidr = "10.0.0.0/16"
 
+# Internal URL the registry/nginx use to reach the auth-server.
+# Default: "http://auth-server:8888" (works with the bundled auth-server service).
+# Override with a Cloud Map / ECS Service Connect FQDN when only FQDNs resolve,
+# e.g. http://auth-server.<namespace>.local:8888
+# auth_server_url = "http://auth-server:8888"
+
 # Use an existing VPC instead of creating a new VPC and subnets.
 # Default: false
 # use_existing_vpc = false

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -64,6 +64,12 @@ variable "ingress_cidr_blocks" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "auth_server_url" {
+  description = "Internal URL the registry/nginx use to reach the auth-server. Set to a Cloud Map / Service Connect FQDN (e.g. http://auth-server.<namespace>.local:8888) for deployments where only FQDNs resolve. Defaults to the Compose-style service name for backward compatibility."
+  type        = string
+  default     = "http://auth-server:8888"
+}
+
 variable "enable_monitoring" {
   description = "Whether to enable CloudWatch monitoring and alarms"
   type        = bool


### PR DESCRIPTION
## Summary

Closes #1283. Exposes `AUTH_SERVER_URL` as a Terraform variable for the AWS ECS deployment so operators can point the registry/nginx at a Cloud Map / ECS Service Connect FQDN **without editing module code**.

This is the ECS-surface follow-up to #1278 (#553), which made the nginx templates honor `AUTH_SERVER_URL` instead of hardcoding `auth-server:8888`. That fix closed the registry side, but the value was still a hardcoded literal in the ECS task definitions, so FQDN-based auth-server resolution required a code change.

## Changes

- Add `auth_server_url` variable to the root module (`terraform/aws-ecs/variables.tf`) and the `mcp-gateway` module (`modules/mcp-gateway/variables.tf`). Default `http://auth-server:8888` - fully backward compatible.
- Wire it through `main.tf` into the module.
- Replace both hardcoded `AUTH_SERVER_URL` literals in `modules/mcp-gateway/ecs-services.tf` (the `auth-server` and `registry` containers) with `var.auth_server_url`.
- Document it in `terraform.tfvars.example` (commented, with the Cloud Map FQDN example).
- Add the row to `docs/unified-parameter-reference.md` (Group 30 - Infrastructure-Only), per the living-index convention.

## Surface parity

After this change, all three deployment surfaces expose / derive the internal auth-server URL:

| Surface | Mechanism |
|---------|-----------|
| Docker Compose | `AUTH_SERVER_URL` in `.env` (default `http://auth-server:8888`) |
| Helm / EKS | derived cluster service FQDN `http://auth-server.<ns>.svc.cluster.local:8888` |
| Terraform / ECS | **new** `auth_server_url` tfvar (default `http://auth-server:8888`) |

## Validation

- `terraform fmt -check -recursive` - clean
- `terraform validate` - configuration is valid
- Variable resolution confirmed via `terraform console` (override resolves to the supplied FQDN). Note: the task-definition `container_definitions` render as a sensitive/known-after-apply value in `terraform plan`, so the env value is not visible in plan text by design; the wiring chain (root var -> module -> both task defs) is verified statically and via console.
- Backward compatible: unset -> default `http://auth-server:8888`, identical to current behavior.

## Notes

- Depends on #1278 (merged) for the value to take effect in nginx.
- No behavior change for existing deployments that do not set the variable.
