### PR TITLE
fix(charts): stop release tag-bump from clobbering keycloak image tag

### DIFF
--- a/.github/workflows/helm-chart-update.yml
+++ b/.github/workflows/helm-chart-update.yml
@@ -46,15 +46,20 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          # Only update global.image.tag (4-space indent under `global.image:`).
-          # The per-service image.tag (2-space indent) is intentionally left
-          # empty so it falls back to global.image.tag — do not overwrite it.
+          # Only update global.image.tag (the shared app image tag). The
+          # per-service image.tag is intentionally left empty so it falls back
+          # to global.image.tag — do not overwrite it.
+          #
+          # We target the exact YAML path with yq instead of a sed indent
+          # match. The stack chart's keycloak.image.tag is also 4-space
+          # indented, so an indent-based sed would clobber it (it pins the
+          # Bitnami image, e.g. 26.3.3-debian-12-r0, not the app version).
           for VALUES_FILE in \
             charts/mcp-gateway-registry-stack/values.yaml \
             charts/auth-server/values.yaml \
             charts/registry/values.yaml \
             charts/mcpgw/values.yaml; do
-            sed -i "s/^\(    tag:\s*\).*/\1${VERSION}/" "$VALUES_FILE"
+            VERSION="$VERSION" yq -i '.global.image.tag = strenv(VERSION)' "$VALUES_FILE"
             echo "Updated $VALUES_FILE"
           done
 

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -114,7 +114,7 @@ keycloak:
   image:
     registry: docker.io
     repository: bitnamilegacy/keycloak
-    tag: 1.24.7
+    tag: 26.3.3-debian-12-r0
 
   global:
     security:


### PR DESCRIPTION
## Problem

The automated tag-bump PR #1288 set `keycloak.image.tag` to `1.24.7` in `charts/mcp-gateway-registry-stack/values.yaml`. That image is `docker.io/bitnamilegacy/keycloak`, which has **no `1.24.7` tag** (verified: HTTP 404). A fresh EKS deploy off the 1.24.7 chart would fail with `ImagePullBackOff` on Keycloak, silently undoing the Bitnami image fix from #1287.

## Root cause

The `helm-chart-update.yml` workflow bumped tags with an indent-based sed:

```
sed -i "s/^\(    tag:\s*\).*/\1${VERSION}/"
```

The intent was to hit only `global.image.tag`, but the stack chart's `keycloak.image.tag` is **also** 4-space indented (`keycloak: -> image: -> tag:`), so it was clobbered too. PostgreSQL survived only because its tag is 6-space indented. This would recur on every release.

## Fix

1. Restore `keycloak.image.tag` to `26.3.3-debian-12-r0`.
2. Replace the indent-based sed with a path-targeted `yq` update of `.global.image.tag` (yq is preinstalled on `ubuntu-latest`), so Bitnami-pinned tags are never touched.

## Verification

- `global.image.tag` = `1.24.7` (preserved)
- `keycloak.image.tag` = `26.3.3-debian-12-r0` (restored, returns HTTP 200)
- `postgres.image.tag` = `17.6.0-debian-12-r0` (unchanged)
- Both YAML files parse cleanly.