### PR TITLE
fix(connect-config): omit server auth header under OAuth login for all IDEs (gateway injects egress)

### DIFF
--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -322,11 +322,14 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     // Build headers object: custom first, then auth_scheme, then gateway auth.
     // When the IDE handles login via OAuth (useOAuthLogin), the static gateway
     // token is omitted - the IDE obtains it through the OAuth/PKCE flow.
-    // includeServerAuth is also dropped in that mode: the gateway injects the
-    // server's stored egress credential upstream, so the client must not send a
-    // server Authorization/API-key header (the [YOUR_SERVER_AUTH_TOKEN]
-    // placeholder would be forwarded as-is and break the connection).
-    const buildHeaders = (includeGatewayToken = true, includeServerAuth = true) => {
+    // The server-auth header is dropped in that mode too (default
+    // includeServerAuth = !useOAuthLogin), for every IDE that emits it: the
+    // gateway injects the server's stored egress credential upstream, so the
+    // client must not send a server Authorization/API-key header (the
+    // [YOUR_SERVER_AUTH_TOKEN] placeholder would be forwarded as-is and break
+    // the connection). IDEs that can't run OAuth login (Roo Code / Kiro / VS
+    // Code default) still keep the static gateway token, just not server auth.
+    const buildHeaders = (includeGatewayToken = true, includeServerAuth = !useOAuthLogin) => {
       const headers: Record<string, string> = {};
 
       // Custom headers go first so auth_scheme and gateway auth overwrite collisions
@@ -528,7 +531,10 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     for (const h of customHeaders) {
       headerLines.push(`      ${h.name}: ${h.value}`);
     }
-    if (server.auth_scheme && server.auth_scheme !== 'none') {
+    // Server auth header. Skipped in OAuth-login mode: the gateway injects the
+    // server's stored egress credential upstream, so the client must not send a
+    // server Authorization/API-key header (the placeholder would break it).
+    if (!useOAuthLogin && server.auth_scheme && server.auth_scheme !== 'none') {
       if (server.auth_scheme === 'bearer') {
         headerLines.push(`      Authorization: Bearer [YOUR_SERVER_AUTH_TOKEN]`);
       } else if (server.auth_scheme === 'api_key') {
@@ -556,7 +562,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     lines.push('    timeout: 300');
 
     return lines.join('\n');
-  }, [server.name, server.auth_scheme, server.description, server.auth_header_name, isRegistryOnly, jwtToken, customHeaders, buildConnectUrl]);
+  }, [server.name, server.auth_scheme, server.description, server.auth_header_name, isRegistryOnly, useOAuthLogin, jwtToken, customHeaders, buildConnectUrl]);
 
   const generateClaudeCodeCommand = useCallback(() => {
     const serverName = server.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -322,7 +322,11 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     // Build headers object: custom first, then auth_scheme, then gateway auth.
     // When the IDE handles login via OAuth (useOAuthLogin), the static gateway
     // token is omitted - the IDE obtains it through the OAuth/PKCE flow.
-    const buildHeaders = (includeGatewayToken = true) => {
+    // includeServerAuth is also dropped in that mode: the gateway injects the
+    // server's stored egress credential upstream, so the client must not send a
+    // server Authorization/API-key header (the [YOUR_SERVER_AUTH_TOKEN]
+    // placeholder would be forwarded as-is and break the connection).
+    const buildHeaders = (includeGatewayToken = true, includeServerAuth = true) => {
       const headers: Record<string, string> = {};
 
       // Custom headers go first so auth_scheme and gateway auth overwrite collisions
@@ -331,7 +335,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
       }
 
       // Add server authentication headers if server requires auth
-      if (server.auth_scheme && server.auth_scheme !== 'none') {
+      if (includeServerAuth && server.auth_scheme && server.auth_scheme !== 'none') {
         if (server.auth_scheme === 'bearer') {
           headers['Authorization'] = 'Bearer [YOUR_SERVER_AUTH_TOKEN]';
         } else if (server.auth_scheme === 'api_key') {
@@ -355,7 +359,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
         // key (upper-snake) is Cursor's documented MCP OAuth config shape; it
         // intentionally differs from the lowercase keys elsewhere in this file.
         if (useOAuthLogin) {
-          const oauthHeaders = buildHeaders(false);
+          const oauthHeaders = buildHeaders(false, false);
           return {
             mcpServers: {
               [serverName]: {
@@ -598,8 +602,10 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
       command += ` \\\n  --header "${h.name}: ${h.value}"`;
     }
 
-    // Server auth header
-    if (server.auth_scheme && server.auth_scheme !== 'none') {
+    // Server auth header. Skipped in OAuth-login mode: the gateway injects the
+    // server's stored egress credential upstream, so the client must not send a
+    // server Authorization/API-key header (the placeholder would break it).
+    if (!useOAuthLogin && server.auth_scheme && server.auth_scheme !== 'none') {
       if (server.auth_scheme === 'bearer') {
         command += ` \\\n  --header "Authorization: Bearer [YOUR_SERVER_AUTH_TOKEN]"`;
       } else if (server.auth_scheme === 'api_key') {

--- a/frontend/src/components/__tests__/ServerConfigModal.test.tsx
+++ b/frontend/src/components/__tests__/ServerConfigModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import axios from 'axios';
 import ServerConfigModal from '../ServerConfigModal';
 import type { Server } from '../ServerCard';
@@ -183,6 +183,43 @@ describe('ServerConfigModal IDE OAuth login (oauth_client_id)', () => {
     // No headers block at all: gateway token omitted (OAuth) and server auth
     // header suppressed.
     expect(serverConfig.headers).toBeUndefined();
+  });
+
+  test('Roo Code: drops server Authorization but keeps the static gateway token under OAuth login', async () => {
+    // Roo Code can't run the IDE OAuth-login config, so it keeps the static
+    // X-Authorization gateway token — but the gateway still injects the egress
+    // credential, so the server Authorization header must be omitted.
+    connectConfig = { custom_headers: [], oauth_client_id: 'mcp-gateway' };
+
+    renderModal({ auth_scheme: 'bearer' } as Partial<Server>);
+
+    await waitFor(() => screen.getByRole('button', { name: 'Roo Code' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Roo Code' }));
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.type).toBe('streamable-http');
+    });
+    const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+    expect(serverConfig.headers['X-Authorization']).toContain('Bearer');
+    expect(serverConfig.headers.Authorization).toBeUndefined();
+  });
+
+  test('Kiro: drops server Authorization but keeps the static gateway token under OAuth login', async () => {
+    connectConfig = { custom_headers: [], oauth_client_id: 'mcp-gateway' };
+
+    renderModal({ auth_scheme: 'bearer' } as Partial<Server>);
+
+    await waitFor(() => screen.getByRole('button', { name: 'Kiro' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Kiro' }));
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.autoApprove).toBeDefined();
+    });
+    const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+    expect(serverConfig.headers['X-Authorization']).toContain('Bearer');
+    expect(serverConfig.headers.Authorization).toBeUndefined();
   });
 
   test('Cursor: keeps the static gateway token when oauth_client_id is absent', async () => {

--- a/frontend/src/components/__tests__/ServerConfigModal.test.tsx
+++ b/frontend/src/components/__tests__/ServerConfigModal.test.tsx
@@ -168,6 +168,23 @@ describe('ServerConfigModal IDE OAuth login (oauth_client_id)', () => {
     expect(serverConfig.headers).toBeUndefined();
   });
 
+  test('Cursor: omits the server Authorization header for a bearer server under OAuth login', async () => {
+    // The gateway injects the stored egress credential upstream, so the client
+    // config must not carry the [YOUR_SERVER_AUTH_TOKEN] placeholder.
+    connectConfig = { custom_headers: [], oauth_client_id: 'mcp-gateway' };
+
+    renderModal({ auth_scheme: 'bearer' } as Partial<Server>);
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.auth).toEqual({ CLIENT_ID: 'mcp-gateway' });
+    });
+    const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+    // No headers block at all: gateway token omitted (OAuth) and server auth
+    // header suppressed.
+    expect(serverConfig.headers).toBeUndefined();
+  });
+
   test('Cursor: keeps the static gateway token when oauth_client_id is absent', async () => {
     connectConfig = { custom_headers: [] };
 


### PR DESCRIPTION
## Summary

Follow-up to #1224 (per-server OAuth `client_id` login). When a server resolves an OAuth client id (`useOAuthLogin`), the gateway does two things: it runs the IDE OAuth/PKCE login **and** injects the server's stored egress credential upstream server-side. The client should therefore only authenticate to the gateway — it must not send the upstream server's `Authorization`/API-key header.

But the Connect dialog still emitted a client-side server-auth header for any `auth_scheme` server, even in OAuth-login mode:

```jsonc
{
  "mcpServers": {
    "my-server": {
      "url": "https://gw/my-server/mcp",
      "headers": { "Authorization": "Bearer [YOUR_SERVER_AUTH_TOKEN]" },  // ← wrong in OAuth-login mode
      "auth": { "CLIENT_ID": "mcp-gateway" }
    }
  }
}
```

The client forwards that placeholder verbatim, which collides with the gateway-injected egress credential and breaks the connection. Users have to manually delete the header.

## Fix

Drop the server-auth header **whenever an OAuth client id is configured (`useOAuthLogin`)**, across every IDE surface that emits it — not just Cursor:

| IDE | Before (OAuth-login deployment) | After |
|-----|----------------------|-------|
| Cursor (JSON) | `headers.Authorization` + `auth.CLIENT_ID` | `auth.CLIENT_ID` only, no `headers` |
| Roo Code (JSON) | `headers: { X-Authorization, Authorization }` | `headers: { X-Authorization }` (keeps gateway token) |
| Kiro (JSON) | `headers: { X-Authorization, Authorization }` | `headers: { X-Authorization }` |
| Claude Code (CLI) | `--client-id <id>` + `--header "Authorization: ..."` | `--client-id <id>` only |
| Goose (YAML) | `Authorization: Bearer [...]` + `X-Authorization` | `X-Authorization` only |
| VS Code default (JSON) | `headers.Authorization` | dropped |

Codex already omitted the server-auth header. IDEs that can't run the OAuth-login config (Roo Code / Kiro / VS Code default / Goose) **keep** the static `X-Authorization` gateway token — only the upstream server-auth header is removed. All **non-OAuth (static-token)** paths are byte-for-byte unchanged.

Implementation: `buildHeaders()`'s `includeServerAuth` now defaults to `!useOAuthLogin` (one place covers all the JSON IDEs); the Claude Code CLI and Goose builders get the same `!useOAuthLogin` guard.

## Changes

- `frontend/src/components/ServerConfigModal.tsx`
  - `buildHeaders()` `includeServerAuth` defaults to `!useOAuthLogin` (covers Cursor / Roo Code / Claude Code JSON / Kiro / default).
  - `generateClaudeCodeCommand()` and `generateGooseConfig()` skip the server-auth header when `useOAuthLogin` (Goose deps updated).
- `frontend/src/components/__tests__/ServerConfigModal.test.tsx`
  - Regression tests: Cursor (no `headers`), Roo Code & Kiro (server `Authorization` omitted, `X-Authorization` gateway token kept) under OAuth login.

## Notes

Backward compatible: with no resolved OAuth client id, output is unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Frontend `jest` ServerConfigModal suite (11/11), incl. Cursor / Roo Code / Kiro under OAuth login