### PR TITLE
fix(telemetry): UI cloud display honors MCP_CLOUD_PROVIDER override

### DIFF
--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -278,6 +278,13 @@ updates = {
     'KEYCLOAK_ADMIN_PASSWORD': os.environ.get('KEYCLOAK_ADMIN_PASSWORD', ''),
     'KEYCLOAK_DB_PASSWORD': os.environ.get('KEYCLOAK_DB_PASSWORD', ''),
     'SECRET_KEY': os.environ.get('SECRET_KEY', ''),
+    # Declare this as a local/on-prem install. The telemetry cloud-detection
+    # cascade checks AWS_REGION first and would otherwise classify this Mac as
+    # "aws" purely because .env.example ships AWS_REGION=us-east-1. This explicit
+    # operator override (allowed: aws|azure|gcp|on_premises|other) takes
+    # precedence over auto-detection, so it reports on_premises regardless of
+    # whatever AWS_REGION is set to.
+    'MCP_CLOUD_PROVIDER': 'on_premises',
 }
 
 for key, value in updates.items():
@@ -296,7 +303,7 @@ PYEOF
 Verify (without exposing values):
 ```bash
 cd "${INSTALL_DIR}"
-for KEY in AUTH_PROVIDER AUTH_SERVER_EXTERNAL_URL KEYCLOAK_ADMIN_PASSWORD KEYCLOAK_DB_PASSWORD SECRET_KEY; do
+for KEY in AUTH_PROVIDER AUTH_SERVER_EXTERNAL_URL KEYCLOAK_ADMIN_PASSWORD KEYCLOAK_DB_PASSWORD SECRET_KEY MCP_CLOUD_PROVIDER; do
     VALUE=$(grep "^${KEY}=" .env | cut -d'=' -f2)
     if [ -n "$VALUE" ]; then
         echo "${KEY}=[set]"

--- a/.gitignore
+++ b/.gitignore
@@ -447,3 +447,6 @@ tests/fixtures/search_dataset/benchmark_results.md
 # Benchmark search results (generated, not committed)
 results*.json
 pingfederate/setup/pingfederate-ca-bundle.pem
+
+# Local Docker Compose override (machine-specific paths, e.g. macOS log-dir redirect)
+docker-compose.override.yml

--- a/registry/api/system_routes.py
+++ b/registry/api/system_routes.py
@@ -348,9 +348,14 @@ async def get_telemetry_detection_info(
         - cloud: aws/gcp/azure/unknown
         - cloud_detection_method: env/dmi/ecs_meta/k8s_heuristic/imds/unknown
     """
-    from ..core.telemetry import _detect_cloud_provider_with_method
+    from ..core.telemetry import _resolve_cloud
 
-    cloud, method = _detect_cloud_provider_with_method()
+    # Use the resolved value so the displayed cloud honors operator overrides
+    # (MCP_CLOUD_PROVIDER env var and the registry-card cloud-provider hint),
+    # matching what is actually reported in telemetry events. The raw
+    # auto-detection cascade alone would, for example, report "aws" purely
+    # because AWS_REGION is set, even on an on-premises/local install.
+    cloud, method = await _resolve_cloud()
     return {"cloud": cloud, "cloud_detection_method": method}
 
 

--- a/tests/unit/services/test_ard_service.py
+++ b/tests/unit/services/test_ard_service.py
@@ -75,6 +75,11 @@ class TestBuildCatalog:
             patch.object(ard_service, "get_skill_repository", return_value=skill_repo),
             patch.object(ard_service.settings, "ard_publisher_domain", "registry.example.com"),
             patch.object(ard_service.settings, "registry_name", "Test Registry"),
+            # Pin an HTTPS registry_url so the host trust-manifest identity is
+            # deterministic. Without this the test inherits the ambient default
+            # (http://localhost:8000), which fails the Phase-1 https identity
+            # assertion in environments that do not override REGISTRY_URL.
+            patch.object(ard_service.settings, "registry_url", "https://registry.example.com"),
         ):
             manifest = await ard_service.build_catalog(_fake_request())
         return manifest, server_repo, agent_repo, skill_repo


### PR DESCRIPTION
## Summary

Fixes the registry UI reporting the deployment cloud as **AWS** on a local/on-prem install (discovered during a macOS `/macos-setup` run with no AWS present).

The telemetry cloud-detection cascade returns `aws` whenever `AWS_REGION` / `AWS_DEFAULT_REGION` is set, and `.env.example` ships `AWS_REGION=us-east-1`. The code already provides the `MCP_CLOUD_PROVIDER` operator override (resolved by `_resolve_cloud()`), which correctly makes telemetry **events** report `on_premises`. But the UI tooltip endpoint `GET /api/system/telemetry-detection` called the raw cascade (`_detect_cloud_provider_with_method()`) instead of `_resolve_cloud()`, so it never honored the override.

## Changes

- **`registry/api/system_routes.py`** — `GET /api/system/telemetry-detection` now returns `await _resolve_cloud()`, so the displayed cloud honors `MCP_CLOUD_PROVIDER` and the registry-card cloud hint, matching telemetry events.
- **`.claude/skills/macos-setup/SKILL.md`** — Phase 4 writes `MCP_CLOUD_PROVIDER=on_premises` into `.env` by default for macOS installs; verification loop updated.
- **`.gitignore`** — ignore `docker-compose.override.yml` (machine-specific local override used on macOS to redirect container log bind-mounts off the root-owned `/var/log/containers/ai-registry`).

## Verification

- Before: `GET /api/system/telemetry-detection` -> `{"cloud":"aws","cloud_detection_method":"env"}`
- After: `{"cloud":"on_premises","cloud_detection_method":"explicit"}`
- Telemetry events log `cloud=on_premises, method=explicit`.
- `AWS_REGION=us-east-1` remains set; AWS SDK / Bedrock features unaffected.

## Backward compatibility

When `MCP_CLOUD_PROVIDER` is unset and no registry-card hint exists, `_resolve_cloud()` falls through to the existing auto-detection cascade. No behavior change for existing cloud deployments.

Closes #1306
