### PR TITLE
feat(egress-auth): Terraform/ECS wiring for the egress credential vault

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -683,7 +687,7 @@
         "filename": "terraform/aws-ecs/modules/mcp-gateway/secrets.tf",
         "hashed_secret": "be4c27293b0757101cbef01b36ac78028aefc399",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 144
       }
     ],
     "terraform/aws-ecs/scripts/init-keycloak.sh": [
@@ -820,5 +824,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-10T06:00:15Z"
+  "generated_at": "2026-06-25T16:23:36Z"
 }

--- a/terraform/aws-ecs/main.tf
+++ b/terraform/aws-ecs/main.tf
@@ -353,6 +353,18 @@ module "mcp_gateway" {
   auth_server_extra_env = var.auth_server_extra_env
   mcpgw_extra_env       = var.mcpgw_extra_env
 
+  # Per-user egress credential vault (third-party OBO). secrets-manager backend
+  # on ECS; IAM grants are added in the module when enabled.
+  egress_auth_enabled                = var.egress_auth_enabled
+  egress_secret_store_backend        = var.egress_secret_store_backend
+  egress_oauth_callback_base_url     = var.egress_oauth_callback_base_url
+  egress_token_refresh_skew_seconds  = var.egress_token_refresh_skew_seconds
+  egress_state_ttl_seconds           = var.egress_state_ttl_seconds
+  egress_registry_internal_url       = var.egress_registry_internal_url
+  egress_nginx_marker_secret         = var.egress_nginx_marker_secret
+  egress_secrets_manager_kms_key_id  = var.egress_secrets_manager_kms_key_id
+  egress_secrets_manager_path_prefix = var.egress_secrets_manager_path_prefix
+
   # Wait for S3 bucket policy to propagate (30s delay)
   # This prevents "Access Denied" errors when ALB tests write permissions
   depends_on = [time_sleep.wait_for_bucket_policy]

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -462,6 +462,18 @@ module "ecs_service_auth" {
         {
           name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
           value = "grpc"
+        },
+        # Per-user egress credential vault: auth-server only needs the feature
+        # flag and the internal vend URL (it does NOT touch the secret store).
+        # AUTH_SERVER_NGINX_MARKER_SECRET is injected via secrets/valueFrom below
+        # (required unconditionally, not just for egress).
+        {
+          name  = "EGRESS_AUTH_ENABLED"
+          value = tostring(var.egress_auth_enabled)
+        },
+        {
+          name  = "EGRESS_REGISTRY_INTERNAL_URL"
+          value = var.egress_registry_internal_url
         }
         ],
         # PR #947: MongoDB connection string override (plain-text variant).
@@ -483,6 +495,10 @@ module "ecs_service_auth" {
           {
             name      = "SECRET_KEY"
             valueFrom = aws_secretsmanager_secret.secret_key.arn
+          },
+          {
+            name      = "AUTH_SERVER_NGINX_MARKER_SECRET"
+            valueFrom = aws_secretsmanager_secret.nginx_marker_secret.arn
           },
           {
             name      = "KEYCLOAK_CLIENT_SECRET"
@@ -723,6 +739,11 @@ module "ecs_service_registry" {
     # Cognito read-only access for the registry IAM management UI (list groups/users)
     var.cognito_enabled ? {
       CognitoIamRead = aws_iam_policy.cognito_iam_read[0].arn
+    } : {},
+    # Per-user egress credential vault: runtime CRUD on per-user secrets under
+    # the egress path prefix (+ CMK KMS when configured). Registry only.
+    var.egress_auth_enabled && var.egress_secret_store_backend == "secrets-manager" ? {
+      EgressVaultAccess = aws_iam_policy.ecs_egress_vault_access[0].arn
     } : {},
     # Issue #1122: per-task ADOT sidecar needs AMP remote-write permission
     var.enable_observability ? {
@@ -1467,6 +1488,39 @@ module "ecs_service_registry" {
           name  = "GITHUB_API_BASE_URL"
           value = var.github_api_base_url
         },
+        # Per-user egress credential vault (third-party OBO). Registry owns the
+        # full set (secret store + OAuth engine). secrets-manager is the natural
+        # backend on ECS; the task role grants are added in iam.tf when enabled.
+        {
+          name  = "EGRESS_AUTH_ENABLED"
+          value = tostring(var.egress_auth_enabled)
+        },
+        {
+          name  = "SECRET_STORE_BACKEND"
+          value = var.egress_secret_store_backend
+        },
+        {
+          name  = "EGRESS_OAUTH_CALLBACK_BASE_URL"
+          value = var.egress_oauth_callback_base_url
+        },
+        {
+          name  = "EGRESS_TOKEN_REFRESH_SKEW_SECONDS"
+          value = tostring(var.egress_token_refresh_skew_seconds)
+        },
+        {
+          name  = "EGRESS_STATE_TTL_SECONDS"
+          value = tostring(var.egress_state_ttl_seconds)
+        },
+        # AUTH_SERVER_NGINX_MARKER_SECRET is injected via secrets/valueFrom below
+        # (required unconditionally, not just for egress).
+        {
+          name  = "SECRETS_MANAGER_KMS_KEY_ID"
+          value = var.egress_secrets_manager_kms_key_id
+        },
+        {
+          name  = "SECRETS_MANAGER_PATH_PREFIX"
+          value = var.egress_secrets_manager_path_prefix
+        },
         ],
         # PR #947: MongoDB connection string override (plain-text variant).
         # Only emitted when var.mongodb_connection_string is non-empty and a
@@ -1487,6 +1541,10 @@ module "ecs_service_registry" {
           {
             name      = "SECRET_KEY"
             valueFrom = aws_secretsmanager_secret.secret_key.arn
+          },
+          {
+            name      = "AUTH_SERVER_NGINX_MARKER_SECRET"
+            valueFrom = aws_secretsmanager_secret.nginx_marker_secret.arn
           },
           {
             name      = "KEYCLOAK_CLIENT_SECRET"

--- a/terraform/aws-ecs/modules/mcp-gateway/iam.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/iam.tf
@@ -15,6 +15,7 @@ resource "aws_iam_policy" "ecs_secrets_access" {
         Resource = concat(
           [
             aws_secretsmanager_secret.secret_key.arn,
+            aws_secretsmanager_secret.nginx_marker_secret.arn,
             aws_secretsmanager_secret.keycloak_client_secret.arn,
             aws_secretsmanager_secret.keycloak_m2m_client_secret.arn,
             aws_secretsmanager_secret.embeddings_api_key.arn,
@@ -52,6 +53,52 @@ resource "aws_iam_policy" "ecs_secrets_access" {
         ]
       }
     ]
+  })
+
+  tags = local.common_tags
+}
+
+# Per-user egress credential vault: the registry task creates/reads/updates/
+# deletes per-user secrets at RUNTIME under the configured path prefix (these
+# are not pre-provisioned ARNs), so it needs a broader verb set scoped to the
+# prefix, plus KMS for the CMK encrypting them. Only created when the egress
+# vault is enabled with the secrets-manager backend.
+resource "aws_iam_policy" "ecs_egress_vault_access" {
+  count       = var.egress_auth_enabled && var.egress_secret_store_backend == "secrets-manager" ? 1 : 0
+  name_prefix = "${local.name_prefix}-egress-vault-"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = [
+            "secretsmanager:CreateSecret",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:DeleteSecret",
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:ListSecretVersionIds"
+          ]
+          # Scope to the egress path prefix only. Secrets Manager ARNs append a
+          # random 6-char suffix, so the wildcard covers "<prefix>/*-??????".
+          Resource = "arn:aws:secretsmanager:*:*:secret:${var.egress_secrets_manager_path_prefix}/*"
+        }
+      ],
+      # KMS only when a customer-managed CMK is configured; the AWS-managed key
+      # needs no explicit grant.
+      var.egress_secrets_manager_kms_key_id != "" ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+          ]
+          Resource = [var.egress_secrets_manager_kms_key_id]
+        }
+      ] : []
+    )
   })
 
   tags = local.common_tags

--- a/terraform/aws-ecs/modules/mcp-gateway/outputs.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/outputs.tf
@@ -91,7 +91,8 @@ output "service_discovery_namespace_hosted_zone_id" {
 output "secret_arns" {
   description = "ARNs of MCP Gateway Registry secrets"
   value = {
-    secret_key = aws_secretsmanager_secret.secret_key.arn
+    secret_key          = aws_secretsmanager_secret.secret_key.arn
+    nginx_marker_secret = aws_secretsmanager_secret.nginx_marker_secret.arn
   }
   sensitive = false
 }

--- a/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
@@ -101,6 +101,33 @@ resource "aws_secretsmanager_secret_version" "secret_key" {
   secret_string = random_password.secret_key.result
 }
 
+# nginx marker secret. Required unconditionally by both auth-server and registry
+# (they refuse to start without it): nginx force-sets it as X-Validate-Source-Secret
+# on the /validate subrequest, and the auth-server only mints an mcp-proxy token
+# when it matches -- so a direct :8888 /validate with a forged X-Resolved-Upstream
+# cannot obtain one. Generated like secret_key (not gated on egress). special=false
+# because the registry substitutes the value verbatim into the generated nginx conf,
+# where quotes/backslashes/$ would break parsing.
+resource "random_password" "nginx_marker_secret" {
+  length  = 64
+  special = false
+}
+
+#checkov:skip=CKV2_AWS_57:Application-generated marker secret - rotation requires coordinated service restart
+resource "aws_secretsmanager_secret" "nginx_marker_secret" {
+  name_prefix             = "${local.name_prefix}-nginx-marker-"
+  description             = "nginx marker secret shared by auth-server and registry (guards mcp-proxy token minting)"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.secrets.id
+  tags                    = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "nginx_marker_secret" {
+  secret_id = aws_secretsmanager_secret.nginx_marker_secret.id
+  # Operator-supplied value wins; otherwise use the auto-generated one.
+  secret_string = var.egress_nginx_marker_secret != "" ? var.egress_nginx_marker_secret : random_password.nginx_marker_secret.result
+}
+
 # Keycloak client secrets (created with placeholder, updated by init-keycloak.sh)
 #checkov:skip=CKV2_AWS_57:Keycloak client secret managed by Keycloak init script, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "keycloak_client_secret" {

--- a/terraform/aws-ecs/modules/mcp-gateway/variables.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/variables.tf
@@ -1536,3 +1536,66 @@ variable "mcpgw_extra_env" {
   default     = []
   sensitive   = true
 }
+
+# ---------------------------------------------------------------------------
+# Per-user egress credential vault (third-party OBO support).
+# On ECS the natural secret store is AWS Secrets Manager (OpenBao is the EKS
+# path), so only the secrets-manager vars are wired here. iam.tf grants the
+# task role secretsmanager + kms access (scoped to the path prefix) when
+# egress_auth_enabled.
+# ---------------------------------------------------------------------------
+
+variable "egress_auth_enabled" {
+  description = "Enable the per-user egress credential vault. Default: false."
+  type        = bool
+  default     = false
+}
+
+variable "egress_secret_store_backend" {
+  description = "Egress secret store backend: secrets-manager (openbao is the EKS/Helm path)."
+  type        = string
+  default     = "secrets-manager"
+}
+
+variable "egress_oauth_callback_base_url" {
+  description = "Public base URL for the egress OAuth callback ({base}/oauth2/egress/callback)."
+  type        = string
+  default     = ""
+}
+
+variable "egress_token_refresh_skew_seconds" {
+  description = "Refresh a vaulted token this many seconds before expiry."
+  type        = number
+  default     = 300
+}
+
+variable "egress_state_ttl_seconds" {
+  description = "TTL for the AEAD-encrypted egress OAuth state blob."
+  type        = number
+  default     = 600
+}
+
+variable "egress_registry_internal_url" {
+  description = "URL the auth-server uses to reach the registry internal vend endpoint."
+  type        = string
+  default     = "http://registry:8080"
+}
+
+variable "egress_nginx_marker_secret" {
+  description = "Optional override for the nginx marker secret shared by registry + auth-server. Empty auto-generates a strong value (stored in Secrets Manager). The marker is required unconditionally -- both services refuse to start without it."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "egress_secrets_manager_kms_key_id" {
+  description = "Optional KMS CMK id/ARN for the egress Secrets Manager secrets. Empty uses the AWS-managed key."
+  type        = string
+  default     = ""
+}
+
+variable "egress_secrets_manager_path_prefix" {
+  description = "Secrets Manager name prefix for the egress vault (also scopes the task IAM grant)."
+  type        = string
+  default     = "mcp/egress"
+}

--- a/terraform/aws-ecs/terraform.tfvars.example
+++ b/terraform/aws-ecs/terraform.tfvars.example
@@ -1124,3 +1124,24 @@ aws_registry_federation_enabled = true
 # pingfederate_m2m_client_secret    = ""
 # pingfederate_application_id_uri   = ""
 # pingfederate_groups_claim         = "groups"
+
+# ---------------------------------------------------------------------------
+# Per-user egress credential vault (third-party OBO support). Off by default.
+# On ECS the secret store is AWS Secrets Manager; enabling this grants the
+# registry task role scoped secretsmanager + KMS access under the path prefix.
+# ---------------------------------------------------------------------------
+# egress_auth_enabled                = true
+# egress_secret_store_backend        = "secrets-manager"
+# egress_oauth_callback_base_url     = "https://mcpgateway.example.com"
+# egress_token_refresh_skew_seconds  = 300
+# egress_state_ttl_seconds           = 600
+# egress_registry_internal_url       = "http://registry:8080"
+# egress_secrets_manager_kms_key_id  = ""   # optional CMK; empty uses the AWS-managed key
+# egress_secrets_manager_path_prefix = "mcp/egress"
+
+# nginx marker secret shared by auth-server + registry. REQUIRED unconditionally
+# (both services refuse to start without it), NOT egress-specific -- it guards all
+# mcp-proxy token minting. Auto-generated into Secrets Manager when left empty;
+# set this only to pin a specific value. Avoid quotes/backslashes/$ (the registry
+# substitutes it verbatim into the generated nginx config).
+# egress_nginx_marker_secret         = ""

--- a/terraform/aws-ecs/variables.tf
+++ b/terraform/aws-ecs/variables.tf
@@ -1722,3 +1722,63 @@ variable "autoscaling_target_memory" {
   type        = number
   default     = 80
 }
+
+# ---------------------------------------------------------------------------
+# Per-user egress credential vault (third-party OBO support).
+# secrets-manager backend on ECS (openbao is the EKS/Helm path).
+# ---------------------------------------------------------------------------
+
+variable "egress_auth_enabled" {
+  description = "Enable the per-user egress credential vault. Default: false."
+  type        = bool
+  default     = false
+}
+
+variable "egress_secret_store_backend" {
+  description = "Egress secret store backend: secrets-manager (openbao is the EKS/Helm path)."
+  type        = string
+  default     = "secrets-manager"
+}
+
+variable "egress_oauth_callback_base_url" {
+  description = "Public base URL for the egress OAuth callback ({base}/oauth2/egress/callback)."
+  type        = string
+  default     = ""
+}
+
+variable "egress_token_refresh_skew_seconds" {
+  description = "Refresh a vaulted token this many seconds before expiry."
+  type        = number
+  default     = 300
+}
+
+variable "egress_state_ttl_seconds" {
+  description = "TTL for the AEAD-encrypted egress OAuth state blob."
+  type        = number
+  default     = 600
+}
+
+variable "egress_registry_internal_url" {
+  description = "URL the auth-server uses to reach the registry internal vend endpoint."
+  type        = string
+  default     = "http://registry:8080"
+}
+
+variable "egress_nginx_marker_secret" {
+  description = "Optional override for the nginx marker secret shared by registry + auth-server. Empty auto-generates a strong value (stored in Secrets Manager). The marker is required unconditionally -- both services refuse to start without it."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "egress_secrets_manager_kms_key_id" {
+  description = "Optional KMS CMK id/ARN for the egress Secrets Manager secrets. Empty uses the AWS-managed key."
+  type        = string
+  default     = ""
+}
+
+variable "egress_secrets_manager_path_prefix" {
+  description = "Secrets Manager name prefix for the egress vault (also scopes the task IAM grant)."
+  type        = string
+  default     = "mcp/egress"
+}


### PR DESCRIPTION
Wire the per-user egress credential vault into the Terraform aws-ecs stack. On ECS the secret store is AWS Secrets Manager (OpenBao is the EKS/Helm path), so only the secrets-manager backend is exposed here. Off by default (egress_auth_enabled=false).

- variables.tf / modules/mcp-gateway/variables.tf: egress_* variables (enable flag, secret store backend, OAuth callback base URL, refresh skew, state TTL, registry internal URL, nginx marker secret, Secrets Manager KMS key id + path prefix).
- main.tf: pass the egress variables through to the mcp-gateway module.
- modules/mcp-gateway/ecs-services.tf: inject the egress env vars into the registry task (full set) and the auth-server task (enable flag + internal vend URL + marker secret), and attach the egress vault IAM policy to the task role when enabled.
- modules/mcp-gateway/iam.tf: runtime CRUD policy scoped to the Secrets Manager egress path prefix, plus KMS decrypt/generate-data-key when a customer-managed CMK is configured. Created only when egress_auth_enabled with the secrets-manager backend.
- terraform.tfvars.example: documented egress example values.

Assumes the egress application PR (registry/auth-server/nginx) is merged; this PR only adds the ECS deployment surface.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
