### PR TITLE
fix(a2a): honor lockfile exclude-newer in Docker uv sync

### DIFF
--- a/agents/a2a/src/flight-booking-agent/Dockerfile
+++ b/agents/a2a/src/flight-booking-agent/Dockerfile
@@ -18,7 +18,14 @@ COPY .tmp/pyproject.toml .tmp/uv.lock ./
 
 # Install Python dependencies using uv (as root, before switching users).
 # --locked fails the build if uv.lock is out of sync with pyproject.toml.
-RUN uv sync --locked --no-dev
+# If the lockfile pins an exclude-newer in its [options] block, export it as
+# UV_EXCLUDE_NEWER so `uv sync --locked` re-resolves against the same
+# supply-chain quarantine that produced the lock. Without this, newer uv
+# versions report the lockfile as out of sync because the global exclude-newer
+# is "missing" at sync time. This mirrors .github/workflows/uv-lock-check.yml.
+RUN lock_cutoff=$(awk '/^\[options\]/{o=1;next} /^\[/{o=0} o&&/^exclude-newer[[:space:]]*=/{gsub(/.*=[[:space:]]*"|"[[:space:]]*$/,"");print;exit}' uv.lock) && \
+    if [ -n "$lock_cutoff" ]; then export UV_EXCLUDE_NEWER="$lock_cutoff"; fi && \
+    uv sync --locked --no-dev
 
 # Copy agent code (all files from the context directory)
 COPY . ./

--- a/agents/a2a/src/travel-assistant-agent/Dockerfile
+++ b/agents/a2a/src/travel-assistant-agent/Dockerfile
@@ -18,7 +18,14 @@ COPY .tmp/pyproject.toml .tmp/uv.lock ./
 
 # Install Python dependencies using uv (as root, before switching users).
 # --locked fails the build if uv.lock is out of sync with pyproject.toml.
-RUN uv sync --locked --no-dev
+# If the lockfile pins an exclude-newer in its [options] block, export it as
+# UV_EXCLUDE_NEWER so `uv sync --locked` re-resolves against the same
+# supply-chain quarantine that produced the lock. Without this, newer uv
+# versions report the lockfile as out of sync because the global exclude-newer
+# is "missing" at sync time. This mirrors .github/workflows/uv-lock-check.yml.
+RUN lock_cutoff=$(awk '/^\[options\]/{o=1;next} /^\[/{o=0} o&&/^exclude-newer[[:space:]]*=/{gsub(/.*=[[:space:]]*"|"[[:space:]]*$/,"");print;exit}' uv.lock) && \
+    if [ -n "$lock_cutoff" ]; then export UV_EXCLUDE_NEWER="$lock_cutoff"; fi && \
+    uv sync --locked --no-dev
 
 # Copy agent code (all files from the context directory)
 COPY . ./


### PR DESCRIPTION
## Problem

`make build-push` fails building the two A2A agents (flight-booking-agent, travel-assistant-agent) with:

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Root cause: `agents/a2a/uv.lock` pins `exclude-newer = "2026-06-15T19:37:51Z"` in its `[options]` block (a supply-chain quarantine cutoff). The Dockerfiles ran a bare `uv sync --locked`, and newer uv versions report the lockfile as out of sync because the global `exclude-newer` is "missing" at sync time. The lockfile content is otherwise correct.

This is a pre-existing issue on `main` and affects only the two A2A agent image builds. CI's `uv-lock-check.yml` already handles it (it exports `UV_EXCLUDE_NEWER` from the lock), which is why CI lock-check passes while the Docker build fails.

## Fix

Mirror the CI workflow's approach in both A2A Dockerfiles: read the pinned `exclude-newer` from the lockfile and export it as `UV_EXCLUDE_NEWER` before `uv sync --locked`. The lockfile is **not** modified, so the supply-chain quarantine is preserved.

```dockerfile
RUN lock_cutoff=$(awk '/^\[options\]/{o=1;next} /^\[/{o=0} o&&/^exclude-newer[[:space:]]*=/{gsub(/.*=[[:space:]]*"|"[[:space:]]*$/,"");print;exit}' uv.lock) && \
    if [ -n "$lock_cutoff" ]; then export UV_EXCLUDE_NEWER="$lock_cutoff"; fi && \
    uv sync --locked --no-dev
```

## Testing

- Built both agent images locally with the fix: `uv sync --locked` succeeds (`Resolved 106 packages`, `Installed 76 packages`), images build clean.
- Confirmed the awk one-liner extracts `2026-06-15T19:37:51Z` from the real lockfile.
- Confirmed `exclude-newer` remains present in `agents/a2a/uv.lock` (not stripped).
- `awk` is available in the `python:3.14-slim` base image.

## Notes

The awk program is a single-line, semicolon-separated form on purpose: a multi-line awk script inside a Dockerfile `RUN ... \` continuation collapses onto one line and breaks awk parsing. The single-line form survives line-joining.
