### PR TITLE
fix(ecs): remove dangling call to deleted run-scopes-init-task.sh

### DIFF
--- a/terraform/aws-ecs/scripts/post-deployment-setup.sh
+++ b/terraform/aws-ecs/scripts/post-deployment-setup.sh
@@ -546,25 +546,21 @@ _initialize_scopes() {
             return 1
         fi
     else
-        # EFS mode (default)
-        log_info "Using EFS storage backend"
+        # The legacy EFS/file scopes-init delivery was removed: scopes.yml is no
+        # longer shipped to EFS, and DocumentDB is the only supported scopes
+        # backend. Reaching this branch means no DocumentDB endpoint was found in
+        # the terraform outputs, which is a deployment misconfiguration.
+        log_error "No DocumentDB endpoint found in terraform outputs ($OUTPUTS_FILE)."
+        log_error "Scopes initialization requires the DocumentDB backend; the legacy EFS scopes-init task has been removed."
+        log_error "Set storage_backend = \"documentdb\" and re-run 'terraform apply' before post-deployment setup."
 
         if [[ "$DRY_RUN" == "true" ]]; then
-            log_info "[DRY RUN] Would run: $SCRIPT_DIR/run-scopes-init-task.sh --skip-build"
             STEPS_SKIPPED=$((STEPS_SKIPPED + 1))
             return 0
         fi
 
-        log_info "Running scopes initialization task on EFS..."
-
-        if "$SCRIPT_DIR/run-scopes-init-task.sh" --skip-build; then
-            log_success "MCP scopes initialized on EFS!"
-            STEPS_PASSED=$((STEPS_PASSED + 1))
-        else
-            log_error "Scopes initialization failed."
-            STEPS_FAILED=$((STEPS_FAILED + 1))
-            return 1
-        fi
+        STEPS_FAILED=$((STEPS_FAILED + 1))
+        return 1
     fi
 }
 


### PR DESCRIPTION
## Summary

The scopes.yml EFS-delivery cleanup ([#1292](https://github.com/agentic-community/mcp-gateway-registry/pull/1292)) deleted `terraform/aws-ecs/scripts/run-scopes-init-task.sh` but left its caller in `post-deployment-setup.sh`. The `_initialize_scopes()` function still invoked the deleted script in its EFS-mode `else` branch, so any deploy that hit that path (no DocumentDB endpoint in the terraform outputs) would exec a missing script and fail.

## Change

DocumentDB is now the only supported scopes backend (the file backend and the EFS scopes.yml delivery were removed). The dead EFS-mode branch is replaced with an actionable error that directs operators to set `storage_backend = "documentdb"` and re-apply, instead of calling a script that no longer exists.

No EFS infrastructure is touched — this is the minimal cleanup of the dangling reference only.

## Testing

- `bash -n terraform/aws-ecs/scripts/post-deployment-setup.sh` passes.
- `grep -rn "run-scopes-init-task" terraform/` returns nothing.

## Context

The larger EFS-infrastructure removal (the EFS module, mounts, vars/outputs, and the CDK scopes-loader Lambda retirement) tracked in #1286 is **not** included here and is being parked — see the status comment on #1286.

Refs #1286
