### PR TITLE
fix: Grafana dashboard label case, CLI toggle/rate payloads, and /validate logging cleanup

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -1712,6 +1712,9 @@ class RegistryClient:
             or endpoint == "/api/servers/groups/import"
             or "/auth-credential" in endpoint
             or "/versions" in endpoint
+            # The server rate endpoint (POST /api/servers/{path}/rate) takes a
+            # JSON RatingRequest body, not form data.
+            or endpoint.endswith("/rate")
             or (method in ("PUT", "PATCH") and endpoint.startswith("/api/servers/"))
         ):
             # Send as JSON for agent, management, search, federation, and import endpoints
@@ -1816,6 +1819,10 @@ class RegistryClient:
         """
         Toggle service enabled/disabled status.
 
+        The POST /api/servers/toggle endpoint requires an explicit ``new_state``
+        rather than flipping the current state itself, so this reads the current
+        enabled state first and sends the opposite.
+
         Args:
             service_path: Path of service to toggle
 
@@ -1827,11 +1834,24 @@ class RegistryClient:
         """
         logger.info(f"Toggling service: {service_path}")
 
+        # Read current state so we can send the opposite as new_state.
+        current = self.get_server(service_path)
+        new_state = not current.is_enabled
+
         response = self._make_request(
-            method="POST", endpoint="/api/servers/toggle", data={"service_path": service_path}
+            method="POST",
+            endpoint="/api/servers/toggle",
+            data={"path": service_path, "new_state": str(new_state).lower()},
         )
 
-        result = ToggleResponse(**response.json())
+        # The endpoint returns {service_path, new_enabled_state, message, ...};
+        # map it onto ToggleResponse rather than passing the raw keys.
+        body = response.json()
+        result = ToggleResponse(
+            path=body.get("service_path", service_path),
+            is_enabled=body.get("new_enabled_state", new_state),
+            message=body.get("message", ""),
+        )
         logger.info(f"Service toggled: {service_path} -> enabled={result.is_enabled}")
         return result
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1927,8 +1927,11 @@ async def validate_request(request: Request):
                         server_name_from_url = "/".join(path_parts)
                         endpoint_from_url = None
 
-                logger.info(
-                    f"Extracted server_name '{server_name_from_url}' and endpoint '{endpoint_from_url}' from original_url: {original_url}"
+                logger.debug(
+                    "Extracted server_name '%s' and endpoint '%s' from original_url: %s",
+                    server_name_from_url,
+                    endpoint_from_url,
+                    original_url,
                 )
             except Exception as e:
                 logger.warning(
@@ -1940,13 +1943,16 @@ async def validate_request(request: Request):
         try:
             if body:
                 payload_text = body  # .decode('utf-8')
-                logger.info(
-                    f"Raw Request Payload ({len(payload_text)} chars): {payload_text[:1000]}..."
+                logger.debug(
+                    "Raw Request Payload (%d chars): %s...",
+                    len(payload_text),
+                    payload_text[:1000],
                 )
                 request_payload = json.loads(payload_text)
-                logger.info(f"JSON RPC Request Payload: {json.dumps(request_payload, indent=2)}")
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug("JSON RPC Request Payload: %s", json.dumps(request_payload))
             else:
-                logger.info("No request body provided, skipping payload parsing")
+                logger.debug("No request body provided, skipping payload parsing")
         except UnicodeDecodeError as e:
             logger.warning(f"Could not decode body as UTF-8: {e}")
         except json.JSONDecodeError as e:
@@ -1956,23 +1962,29 @@ async def validate_request(request: Request):
 
         # Log request for debugging with anonymized IP
         client_ip = get_client_ip(request)
-        logger.info(f"Validation request from {anonymize_ip(client_ip)}")
-        logger.info(f"Request Method: {request.method}")
+        logger.debug("Validation request from %s", anonymize_ip(client_ip))
+        logger.debug("Request Method: %s", request.method)
 
         # Log masked HTTP headers for GDPR/SOX compliance
         all_headers = dict(request.headers)
         masked_headers = mask_headers(all_headers)
-        logger.debug(f"HTTP Headers (masked): {json.dumps(masked_headers, indent=2)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug("HTTP Headers (masked): %s", json.dumps(masked_headers))
 
         # Log specific headers for debugging with masked sensitive data
-        logger.info(
-            f"Key Headers: Authorization={bool(authorization)}, Cookie={bool(cookie_header)}, "
-            f"User-Pool-Id={mask_sensitive_id(user_pool_id) if user_pool_id else 'None'}, "
-            f"Client-Id={mask_sensitive_id(client_id) if client_id else 'None'}, "
-            f"Region={region}, Original-URL={original_url}"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Key Headers: Authorization=%s, Cookie=%s, "
+                "User-Pool-Id=%s, Client-Id=%s, Region=%s, Original-URL=%s",
+                bool(authorization),
+                bool(cookie_header),
+                mask_sensitive_id(user_pool_id) if user_pool_id else "None",
+                mask_sensitive_id(client_id) if client_id else "None",
+                region,
+                original_url,
+            )
 
-        logger.info(f"Server Name from URL: {server_name_from_url}")
+        logger.debug("Server Name from URL: %s", server_name_from_url)
 
         # Only activate static token auth when there is no session cookie
         # (UI uses cookies, CLI uses Bearer)
@@ -2278,7 +2290,7 @@ async def validate_request(request: Request):
                     headers={"Connection": "close"},
                 )
 
-        logger.info(f"Token validation successful using method: {validation_result['method']}")
+        logger.debug("Token validation successful using method: %s", validation_result["method"])
 
         # Enrich groups from MongoDB if empty (for M2M clients)
         try:
@@ -2399,7 +2411,7 @@ async def validate_request(request: Request):
         if user_groups and auth_method in ["keycloak", "entra", "cognito", "okta", "auth0"]:
             # Map IdP groups to scopes using the group mappings (query DocumentDB)
             user_scopes = await map_groups_to_scopes(user_groups)
-            logger.info(f"Mapped {auth_method} groups {user_groups} to scopes: {user_scopes}")
+            logger.debug("Mapped %s groups %s to scopes: %s", auth_method, user_groups, user_scopes)
         elif (
             user_groups
             and not existing_scopes
@@ -2414,9 +2426,12 @@ async def validate_request(request: Request):
             # "pingfederate" — keeps Keycloak/Okta/etc. completely
             # unchanged.
             user_scopes = await map_groups_to_scopes(user_groups)
-            logger.info(
-                f"Re-mapped pingfederate groups {user_groups} to scopes: {user_scopes} "
-                f"after fallback enrichment (transport={auth_method})"
+            logger.debug(
+                "Re-mapped pingfederate groups %s to scopes: %s "
+                "after fallback enrichment (transport=%s)",
+                user_groups,
+                user_scopes,
+                auth_method,
             )
         else:
             user_scopes = validation_result.get("scopes", [])
@@ -2433,8 +2448,11 @@ async def validate_request(request: Request):
                 if tool_name
                 else (endpoint_from_url if endpoint_from_url else "initialize")
             )
-            logger.info(
-                f"Method determined for validation: '{method}' (tool_name={tool_name}, endpoint_from_url={endpoint_from_url})"
+            logger.debug(
+                "Method determined for validation: '%s' (tool_name=%s, endpoint_from_url=%s)",
+                method,
+                tool_name,
+                endpoint_from_url,
             )
             actual_tool_name = None
 
@@ -2443,7 +2461,9 @@ async def validate_request(request: Request):
                 params = request_payload.get("params", {})
                 if isinstance(params, dict):
                     actual_tool_name = params.get("name")
-                    logger.info(f"Extracted actual tool name for tools/call: '{actual_tool_name}'")
+                    logger.debug(
+                        "Extracted actual tool name for tools/call: '%s'", actual_tool_name
+                    )
 
             # Check if user has any scopes - if not, deny access (fail closed)
             if not user_scopes:
@@ -2467,8 +2487,11 @@ async def validate_request(request: Request):
                     detail=f"Access denied to {server_name}.{method}",
                     headers={"Connection": "close"},
                 )
-            logger.info(
-                f"Scope validation passed for {server_name}.{method} (tool: {actual_tool_name})"
+            logger.debug(
+                "Scope validation passed for %s.%s (tool: %s)",
+                server_name,
+                method,
+                actual_tool_name,
             )
         else:
             logger.debug("No server information available, skipping scope validation")
@@ -2649,10 +2672,12 @@ async def validate_request(request: Request):
             "server_name": server_name,
             "tool_name": tool_name,
         }
-        logger.info(
-            f"Full validation result: {json.dumps(_mask_sensitive_dict(validation_result), indent=2)}"
-        )
-        logger.info(f"Response data being sent: {json.dumps(response_data, indent=2)}")
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Full validation result: %s",
+                json.dumps(_mask_sensitive_dict(validation_result)),
+            )
+            logger.debug("Response data being sent: %s", json.dumps(response_data))
 
         # Log MCP server access event if this is an MCP request (has server_name)
         if server_name:

--- a/config/grafana/dashboards/mcp-analytics-comprehensive.json
+++ b/config/grafana/dashboards/mcp-analytics-comprehensive.json
@@ -21,19 +21,19 @@
       "targets": [
         {
           "legendFormat": "Initialize Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Tools List Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Tool Call Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Auth Success Rate",
-          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"True\"}[1m]))"
         }
       ],
       "gridPos": {
@@ -64,11 +64,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"true\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"True\"}[5m]))",
           "legendFormat": "Successful Auth"
         },
         {
-          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"false\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"False\"}[5m]))",
           "legendFormat": "Failed Auth"
         }
       ],
@@ -100,7 +100,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(mcpgw_registry_auth_request_total{success=\"true\"}) / sum(mcpgw_registry_auth_request_total) * 100",
+          "expr": "sum(mcpgw_registry_auth_request_total{success=\"True\"}) / sum(mcpgw_registry_auth_request_total) * 100",
           "legendFormat": "Success Rate %"
         }
       ],
@@ -337,11 +337,11 @@
       "targets": [
         {
           "legendFormat": "Auth Error Rate",
-          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"False\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
         },
         {
           "legendFormat": "Tool Execution Error Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"False\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -713,7 +713,7 @@
       "targets": [
         {
           "legendFormat": "Success Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"true\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"True\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {

--- a/terraform/aws-ecs/grafana/dashboards/mcp-analytics-comprehensive.json
+++ b/terraform/aws-ecs/grafana/dashboards/mcp-analytics-comprehensive.json
@@ -21,19 +21,19 @@
       "targets": [
         {
           "legendFormat": "Initialize Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"initialize\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Tools List Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/list\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Tool Call Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{method=\"tools/call\", success=\"True\"}[1m]))"
         },
         {
           "legendFormat": "Auth Success Rate",
-          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"true\"}[1m]))"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"True\"}[1m]))"
         }
       ],
       "gridPos": {
@@ -64,11 +64,11 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"true\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"True\"}[5m]))",
           "legendFormat": "Successful Auth"
         },
         {
-          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"false\"}[5m]))",
+          "expr": "sum(rate(mcpgw_registry_auth_request_total{success=\"False\"}[5m]))",
           "legendFormat": "Failed Auth"
         }
       ],
@@ -100,7 +100,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(mcpgw_registry_auth_request_total{success=\"true\"}) / sum(mcpgw_registry_auth_request_total) * 100",
+          "expr": "sum(mcpgw_registry_auth_request_total{success=\"True\"}) / sum(mcpgw_registry_auth_request_total) * 100",
           "legendFormat": "Success Rate %"
         }
       ],
@@ -337,11 +337,11 @@
       "targets": [
         {
           "legendFormat": "Auth Error Rate",
-          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_auth_request_total{success=\"False\"}[5m])) / sum(increase(mcpgw_registry_auth_request_total[5m])) * 100"
         },
         {
           "legendFormat": "Tool Execution Error Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"false\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"False\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {
@@ -713,7 +713,7 @@
       "targets": [
         {
           "legendFormat": "Success Rate",
-          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"true\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
+          "expr": "sum(increase(mcpgw_registry_tool_execution_total{success=\"True\"}[5m])) / sum(increase(mcpgw_registry_tool_execution_total[5m])) * 100"
         }
       ],
       "gridPos": {

--- a/tests/unit/api/test_registry_client_toggle_rate.py
+++ b/tests/unit/api/test_registry_client_toggle_rate.py
@@ -1,0 +1,126 @@
+"""Unit tests for RegistryClient.toggle_service and rate_server payloads.
+
+These lock in the request shapes the registry API expects, guarding against the
+CLI/API contract mismatches fixed alongside issue #1316:
+
+- POST /api/servers/toggle wants form fields ``path`` + ``new_state`` (an
+  explicit boolean), not a ``service_path`` field, and returns
+  ``service_path`` / ``new_enabled_state`` rather than ``path`` / ``is_enabled``.
+- POST /api/servers/{path}/rate wants a JSON RatingRequest body, not form data.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.registry_client import RegistryClient
+
+
+@pytest.fixture
+def client() -> RegistryClient:
+    """A RegistryClient pointed at a dummy URL with a dummy token."""
+    return RegistryClient(registry_url="http://localhost", token="dummy-token-1234567890")
+
+
+class TestToggleServicePayload:
+    """Tests for toggle_service request/response handling."""
+
+    def test_toggle_reads_state_then_sends_opposite(
+        self,
+        client: RegistryClient,
+    ) -> None:
+        """toggle_service reads the current state and sends new_state as its opposite."""
+        # Arrange: server is currently enabled, so new_state must be "false".
+        current = MagicMock(is_enabled=True)
+        toggle_response = MagicMock()
+        toggle_response.json.return_value = {
+            "message": "Toggle request for /currenttime/ processed.",
+            "service_path": "/currenttime/",
+            "new_enabled_state": False,
+        }
+
+        with (
+            patch.object(client, "get_server", return_value=current) as mock_get,
+            patch.object(client, "_make_request", return_value=toggle_response) as mock_req,
+        ):
+            # Act
+            result = client.toggle_service("/currenttime/")
+
+        # Assert: read happened, and the write used the correct form payload.
+        mock_get.assert_called_once_with("/currenttime/")
+        mock_req.assert_called_once_with(
+            method="POST",
+            endpoint="/api/servers/toggle",
+            data={"path": "/currenttime/", "new_state": "false"},
+        )
+        # Response mapped from service_path / new_enabled_state.
+        assert result.path == "/currenttime/"
+        assert result.is_enabled is False
+        assert result.message == "Toggle request for /currenttime/ processed."
+
+    def test_toggle_enables_a_disabled_server(
+        self,
+        client: RegistryClient,
+    ) -> None:
+        """A disabled server is sent new_state="true"."""
+        current = MagicMock(is_enabled=False)
+        toggle_response = MagicMock()
+        toggle_response.json.return_value = {
+            "message": "Toggle request for /foo/ processed.",
+            "service_path": "/foo/",
+            "new_enabled_state": True,
+        }
+
+        with (
+            patch.object(client, "get_server", return_value=current),
+            patch.object(client, "_make_request", return_value=toggle_response) as mock_req,
+        ):
+            result = client.toggle_service("/foo/")
+
+        assert mock_req.call_args.kwargs["data"]["new_state"] == "true"
+        assert result.is_enabled is True
+
+
+class TestRateServerPayload:
+    """Tests for rate_server request encoding."""
+
+    def test_rate_sends_json_body(
+        self,
+        client: RegistryClient,
+    ) -> None:
+        """rate_server posts to the /rate endpoint with the rating in the body."""
+        rate_response = MagicMock()
+        rate_response.json.return_value = {
+            "message": "Rating added successfully",
+            "average_rating": 4.5,
+        }
+
+        with patch.object(client, "_make_request", return_value=rate_response) as mock_req:
+            client.rate_server("/currenttime/", 4)
+
+        mock_req.assert_called_once()
+        kwargs = mock_req.call_args.kwargs
+        assert kwargs["method"] == "POST"
+        assert kwargs["endpoint"] == "/api/servers/currenttime//rate"
+        assert kwargs["data"] == {"rating": 4}
+
+    def test_rate_endpoint_routes_to_json_branch(
+        self,
+        client: RegistryClient,
+    ) -> None:
+        """_make_request sends a JSON (not form) body for the /rate endpoint."""
+        # The endpoint expects a JSON RatingRequest; confirm requests.request is
+        # called with json= (not data=) for paths ending in /rate.
+        fake_response = MagicMock(status_code=200)
+        fake_response.raise_for_status.return_value = None
+
+        with patch("api.registry_client.requests.request", return_value=fake_response) as mock_req:
+            client._make_request(
+                method="POST",
+                endpoint="/api/servers/currenttime//rate",
+                data={"rating": 3},
+            )
+
+        kwargs = mock_req.call_args.kwargs
+        assert kwargs["json"] == {"rating": 3}
+        assert kwargs.get("data") is None


### PR DESCRIPTION
## Overview
Three independent, pre-existing fixes surfaced while investigating issue #1316. The free-threading experiment from that investigation was rejected (see closed PR #1324 for the benchmark + rationale); these fixes stand on their own and are split out here on a clean branch off `main` with no free-threading machinery.

## Fixes

### 1. `/validate` hot-path logging cleanup (perf hygiene)
Demote the per-request INFO log statements on the `/validate` happy path to DEBUG, and gate the structured `json.dumps` dumps behind `logger.isEnabledFor(DEBUG)` with lazy `%s` args. `/validate` is the nginx `auth_request` subrequest that runs on every proxied request, so this removes three `json.dumps(indent=2)` serializations plus ~10 string-formats per request at the default INFO level. JWT/scope/tool-access semantics unchanged.

### 2. Grafana analytics dashboard "No data" — fixes #1322
Dashboard panels filtered on `success="true"`/`"false"` (lowercase), but the metrics emit `success="True"`/`"False"` (capital, from Python `str(bool)`). The mismatch made Authentication Success Rate, Authentication Flow Analysis, Real-time Protocol Activity, and the error-rate panels render "No data". Fixed both the compose (`config/grafana`) and terraform (`aws-ecs/grafana`) dashboard copies. Verified the corrected queries return data against a running stack.

### 3. `registry_management.py` toggle/rate HTTP 422 — fixes #1323
- `toggle_service` sent a single form field `service_path`, but `POST /api/servers/toggle` requires `path` + an explicit boolean `new_state`. Now reads current state via `get_server` and sends the opposite, mapping the response keys onto `ToggleResponse`.
- `rate_server` posted to `/api/servers/{path}/rate` (a JSON endpoint) through the form-encoded branch. Added `/rate` to the JSON allowlist.
- Adds unit tests pinning both request shapes.

## Testing
- `tests/unit/api/`: 692 passed, 8 skipped.
- `tests/auth_server/`: 348 passed.
- New CLI tests: 4 passed.
- Both Grafana dashboard JSONs validated.
- `auth_server/server.py`: py_compile + ruff clean.

## Not included (tracked separately)
- #1326 — ECS registry/mcpgw metrics land in AMP as `job=unknown_service` (own PR).
- #1325 — ECS Grafana admin password in plaintext → Secrets Manager (own PR).
- Free-threading / grpcio removal / OTLP HTTP swap — rejected, see closed PR #1324.

Closes #1322
Closes #1323
