### PR TITLE
fix(ecs): registry/mcpgw metric labels (#1326) + Grafana password to Secrets Manager (#1325)

### DIFF
--- a/infra/lib/registry/constructs/observability-pipeline.ts
+++ b/infra/lib/registry/constructs/observability-pipeline.ts
@@ -50,6 +50,8 @@ export interface ObservabilityPipelineProps {
   readonly metricsApiKeySecret?: secretsmanager.ISecret;
   /** Secrets Manager secret holding the OTLP exporter headers */
   readonly otlpExporterHeadersSecret?: secretsmanager.ISecret;
+  /** Secrets Manager secret holding the Grafana admin password (issue #1325) */
+  readonly grafanaAdminPasswordSecret?: secretsmanager.ISecret;
   /** Additional IAM policy statements for Secrets Manager + KMS access */
   readonly secretsAccessStatements: iam.PolicyStatement[];
   /** Security group of the registry ECS service (for metrics ingress) */
@@ -409,7 +411,9 @@ export class ObservabilityPipeline extends Construct {
       'GrafanaExecRole',
       `${namePrefix}-grafana-task-exec-${region}`,
       grafanaLogGroup,
-      [],
+      // Issue #1325: the execution role must read the Grafana admin password
+      // secret (and KMS-decrypt it) for the container `secrets` valueFrom.
+      props.secretsAccessStatements,
     );
 
     const grafanaTaskRole = _createTaskRole(
@@ -458,11 +462,23 @@ export class ObservabilityPipeline extends Construct {
       GF_AUTH_ANONYMOUS_ENABLED: 'false',
       GF_AUTH_ANONYMOUS_ORG_ROLE: 'Viewer',
       GF_AUTH_DISABLE_LOGIN_FORM: 'false',
-      GF_SECURITY_ADMIN_PASSWORD: config.grafanaAdminPassword,
       GF_LOG_MODE: 'console',
       GF_LOG_LEVEL: 'info',
       GF_DASHBOARDS_MIN_REFRESH_INTERVAL: '10s',
     };
+
+    // Issue #1325: source GF_SECURITY_ADMIN_PASSWORD from Secrets Manager via
+    // the container `secrets` map instead of a plaintext env value, so it does
+    // not appear in the rendered task definition. Falls back to the plaintext
+    // env only if the secret was not provided (observability disabled paths).
+    const grafanaSecrets: Record<string, ecs.Secret> = {};
+    if (props.grafanaAdminPasswordSecret) {
+      grafanaSecrets['GF_SECURITY_ADMIN_PASSWORD'] = ecs.Secret.fromSecretsManager(
+        props.grafanaAdminPasswordSecret,
+      );
+    } else {
+      grafanaEnv['GF_SECURITY_ADMIN_PASSWORD'] = config.grafanaAdminPassword;
+    }
 
     const grafanaContainer = grafanaTaskDef.addContainer('grafana', {
       containerName: 'grafana',
@@ -470,6 +486,7 @@ export class ObservabilityPipeline extends Construct {
       essential: true,
       cpu: 512,
       memoryLimitMiB: 1024,
+      secrets: grafanaSecrets,
       environment: grafanaEnv,
       logging: ecs.LogDrivers.awsLogs({
         logGroup: grafanaLogGroup,

--- a/infra/lib/registry/constructs/registry-secrets.ts
+++ b/infra/lib/registry/constructs/registry-secrets.ts
@@ -33,6 +33,7 @@ export class RegistrySecrets extends Construct {
   public readonly auth0M2mClientSecret?: secretsmanager.Secret;
   public readonly metricsApiKey?: secretsmanager.Secret;
   public readonly otlpExporterHeaders?: secretsmanager.Secret;
+  public readonly grafanaAdminPassword?: secretsmanager.Secret;
 
   /** IAM statements granting GetSecretValue + KMS decrypt for all secrets above */
   public readonly accessStatements: iam.PolicyStatement[];
@@ -153,6 +154,13 @@ export class RegistrySecrets extends Construct {
         kmsKey: this.kmsKey,
         generateString: { passwordLength: 48, excludePunctuation: true },
       });
+      // Issue #1325: store the Grafana admin password in Secrets Manager instead
+      // of injecting it as a plaintext container env value.
+      this.grafanaAdminPassword = _createSecret(this, 'GrafanaAdminPassword', {
+        description: 'Grafana admin password',
+        kmsKey: this.kmsKey,
+        stringValue: config.grafanaAdminPassword,
+      });
     }
 
     if (config.enableObservability && config.otel.otlpEndpoint !== '') {
@@ -175,7 +183,7 @@ export class RegistrySecrets extends Construct {
     for (const s of [
       this.entraClientSecret, this.oktaClientSecret, this.oktaM2mClientSecret,
       this.oktaApiToken, this.auth0ClientSecret, this.auth0M2mClientSecret,
-      this.metricsApiKey, this.otlpExporterHeaders,
+      this.metricsApiKey, this.otlpExporterHeaders, this.grafanaAdminPassword,
     ]) if (s) arns.push(s.secretArn);
 
     this.accessStatements = [

--- a/infra/lib/registry/registry-service-stack.ts
+++ b/infra/lib/registry/registry-service-stack.ts
@@ -501,6 +501,7 @@ export class RegistryServiceStack extends cdk.Stack {
       appSecretsKmsKey: this.appSecretsKmsKey,
       metricsApiKeySecret: secretsBundle.metricsApiKey,
       otlpExporterHeadersSecret: secretsBundle.otlpExporterHeaders,
+      grafanaAdminPasswordSecret: secretsBundle.grafanaAdminPassword,
       secretsAccessStatements,
       registryServiceSg: registryService.securityGroup,
       authServiceSg: authService.securityGroup,

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -1428,6 +1428,21 @@ module "ecs_service_registry" {
           name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
           value = "grpc"
         },
+        {
+          # Without an explicit service.name, the OTLP push path lands in AMP as
+          # job="unknown_service" and the Grafana panels/job filters miss it
+          # (issue #1326). Match the name used on Compose/Helm so all surfaces
+          # agree.
+          name  = "OTEL_SERVICE_NAME"
+          value = "mcp-gateway-registry"
+        },
+        {
+          # The ADOT sidecar pipeline is metrics-only, so exported traces are
+          # rejected with UNIMPLEMENTED (hundreds of errors/run). Disable the
+          # traces exporter; metrics still flow. Issue #1326.
+          name  = "OTEL_TRACES_EXPORTER"
+          value = "none"
+        },
         # Service Connect namespace for FQDN alias injection in entrypoint.
         # Enables Python health checker to resolve both short names and FQDNs.
         {
@@ -1981,6 +1996,19 @@ module "ecs_service_mcpgw" {
         {
           name  = "OTEL_EXPORTER_OTLP_PROTOCOL"
           value = "grpc"
+        },
+        {
+          # Without an explicit service.name, the OTLP push path lands in AMP as
+          # job="unknown_service" (issue #1326). Match the name used on
+          # Compose/Helm so all surfaces agree.
+          name  = "OTEL_SERVICE_NAME"
+          value = "mcp-mcpgw"
+        },
+        {
+          # The ADOT sidecar pipeline is metrics-only; exported traces are
+          # rejected with UNIMPLEMENTED. Disable the traces exporter. Issue #1326.
+          name  = "OTEL_TRACES_EXPORTER"
+          value = "none"
         }
         ],
         # Extra environment variables from user (Issue #1000)

--- a/terraform/aws-ecs/modules/mcp-gateway/iam.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/iam.tf
@@ -37,7 +37,10 @@ resource "aws_iam_policy" "ecs_secrets_access" {
             aws_secretsmanager_secret.pingfederate_m2m_client_secret[0].arn,
             aws_secretsmanager_secret.pf_admin_pass[0].arn,
           ] : [],
-          var.enable_observability ? [aws_secretsmanager_secret.metrics_api_key[0].arn] : [],
+          var.enable_observability ? [
+            aws_secretsmanager_secret.metrics_api_key[0].arn,
+            aws_secretsmanager_secret.grafana_admin_password[0].arn
+          ] : [],
           var.enable_observability && var.otel_otlp_endpoint != "" ? [aws_secretsmanager_secret.otlp_exporter_headers[0].arn] : []
         )
       },

--- a/terraform/aws-ecs/modules/mcp-gateway/observability.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/observability.tf
@@ -505,6 +505,9 @@ module "ecs_service_grafana" {
   create_task_exec_iam_role = true
   task_exec_iam_role_policies = {
     EcsExecTaskExecution = aws_iam_policy.ecs_exec_task_execution.arn
+    # Issue #1325: lets the execution role pull the Grafana admin password from
+    # Secrets Manager (and KMS-decrypt it) for the container `secrets` valueFrom.
+    SecretsManagerAccess = aws_iam_policy.ecs_secrets_access.arn
   }
   create_tasks_iam_role = true
   tasks_iam_role_policies = {
@@ -579,10 +582,6 @@ module "ecs_service_grafana" {
           value = "false"
         },
         {
-          name  = "GF_SECURITY_ADMIN_PASSWORD"
-          value = var.grafana_admin_password
-        },
-        {
           name  = "GF_LOG_MODE"
           value = "console"
         },
@@ -593,6 +592,16 @@ module "ecs_service_grafana" {
         {
           name  = "GF_DASHBOARDS_MIN_REFRESH_INTERVAL"
           value = "10s"
+        }
+      ]
+
+      # Issue #1325: GF_SECURITY_ADMIN_PASSWORD comes from Secrets Manager via
+      # valueFrom (not a plaintext env value) so it does not appear in the
+      # rendered task definition.
+      secrets = [
+        {
+          name      = "GF_SECURITY_ADMIN_PASSWORD"
+          valueFrom = aws_secretsmanager_secret.grafana_admin_password[0].arn
         }
       ]
 
@@ -642,8 +651,17 @@ module "ecs_service_grafana" {
       environment = [
         { name = "AWS_REGION", value = data.aws_region.current.id },
         { name = "AMP_ENDPOINT", value = local.amp_query_endpoint },
-        { name = "GF_SECURITY_ADMIN_PASSWORD", value = var.grafana_admin_password },
         { name = "DASHBOARD_JSON", value = file("${path.module}/../../grafana/dashboards/mcp-analytics-comprehensive.json") },
+      ]
+
+      # Issue #1325: the post-install sidecar needs the admin password to build
+      # the Grafana API URL; pull it from Secrets Manager via valueFrom rather
+      # than a plaintext env value.
+      secrets = [
+        {
+          name      = "GF_SECURITY_ADMIN_PASSWORD"
+          valueFrom = aws_secretsmanager_secret.grafana_admin_password[0].arn
+        }
       ]
 
       # Log into the grafana container's log group (do NOT create a second group

--- a/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
@@ -452,6 +452,29 @@ resource "aws_secretsmanager_secret_version" "metrics_api_key" {
   secret_string = random_password.metrics_api_key[0].result
 }
 
+# Grafana admin password (issue #1325). Previously injected as a plaintext
+# container env value, exposing it via `aws ecs describe-task-definition` and in
+# Terraform state. Now stored in Secrets Manager and referenced via valueFrom so
+# it no longer appears in the rendered task definition. Sourced from the
+# operator-supplied var.grafana_admin_password.
+#checkov:skip=CKV2_AWS_57:Operator-supplied Grafana admin password - rotation requires coordinated service restart
+resource "aws_secretsmanager_secret" "grafana_admin_password" {
+  count = var.enable_observability ? 1 : 0
+
+  name_prefix             = "${local.name_prefix}-grafana-admin-"
+  description             = "Grafana admin password (issue #1325)"
+  recovery_window_in_days = 0
+  kms_key_id              = aws_kms_key.secrets.id
+  tags                    = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "grafana_admin_password" {
+  count = var.enable_observability ? 1 : 0
+
+  secret_id     = aws_secretsmanager_secret.grafana_admin_password[0].id
+  secret_string = var.grafana_admin_password
+}
+
 
 # OTLP exporter headers (e.g., dd-api-key=xxx for Datadog)
 # Only created when observability is enabled AND an OTLP endpoint is configured


### PR DESCRIPTION
## Overview
Two pre-existing ECS observability fixes surfaced while investigating issue #1316 (the free-threading experiment, since closed). Both are infrastructure-only and verified by `terraform validate` + CDK `tsc` build.

Fixes #1326
Fixes #1325

## #1326 — registry/mcpgw metrics land in AMP as `job=unknown_service`
On the live ECS (Terraform) deployment, registry and mcpgw push metrics to the ADOT sidecar over OTLP, but never set `service.name`. AMP's `prometheusremotewrite` therefore labels every series `job="unknown_service"`, so dashboard/`job` filters miss them, and the apps also spam `Failed to export traces ... UNIMPLEMENTED` (the ADOT pipeline is metrics-only).

Fix (registry + mcpgw task defs):
- `OTEL_SERVICE_NAME` = `mcp-gateway-registry` / `mcp-mcpgw` — matches the names already used on Docker Compose and Helm, so all surfaces agree and AMP gets the correct `job` label.
- `OTEL_TRACES_EXPORTER=none` — stops the metrics-only collector rejecting exported traces with UNIMPLEMENTED.

**CDK note:** not applicable to the CDK stack. Its ADOT sidecar uses a Prometheus *scrape* receiver on metrics-service only and never sets `OTEL_EXPORTER_OTLP_ENDPOINT` on the app containers, so there is no OTLP push to mislabel.

## #1325 — Grafana admin password plaintext in task-def env
The Grafana admin password was injected as a plaintext container `environment` value (visible via `aws ecs describe-task-definition` and in Terraform/CDK state), unlike every other secret in the stack.

Fix (both Terraform and CDK, for parity):
- Store the password in Secrets Manager (KMS-encrypted), reference via `valueFrom` (Terraform) / `ecs.Secret.fromSecretsManager` (CDK).
- Applied to **both** the Grafana container and the post-install config sidecar that builds the Grafana API URL.
- Grant the Grafana execution role `GetSecretValue` + `kms:Decrypt` on the new secret.

**Operational note:** rotate the currently-exposed Grafana password as part of applying this change (it was previously readable in plaintext).

## Testing
- `terraform validate`: Success (pre-existing `data.aws_region.name` deprecation warnings only).
- `terraform fmt`: clean.
- CDK `npm run build` (tsc): passes.
- Both changes are infra-only; verification of the live effect (correct `job` label in AMP, password no longer in task-def env) happens on the next ECS deploy.
