### PR TITLE
fix(security): enforce authorization on External API management endpoints

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -377,9 +377,7 @@ def _compute_card_diff(
                     key=lambda s: (s.get("id") if isinstance(s, dict) else "") or "",
                 )
             if isinstance(remote_value, list):
-                remote_value = [
-                    _drop_nulls(s) if isinstance(s, dict) else s for s in remote_value
-                ]
+                remote_value = [_drop_nulls(s) if isinstance(s, dict) else s for s in remote_value]
                 remote_value = sorted(
                     remote_value,
                     key=lambda s: (s.get("id") if isinstance(s, dict) else "") or "",
@@ -387,13 +385,11 @@ def _compute_card_diff(
 
         if field_name == "security_schemes" and isinstance(current_value, dict):
             current_value = {
-                k: _drop_nulls(v) if isinstance(v, dict) else v
-                for k, v in current_value.items()
+                k: _drop_nulls(v) if isinstance(v, dict) else v for k, v in current_value.items()
             }
             if isinstance(remote_value, dict):
                 remote_value = {
-                    k: _drop_nulls(v) if isinstance(v, dict) else v
-                    for k, v in remote_value.items()
+                    k: _drop_nulls(v) if isinstance(v, dict) else v for k, v in remote_value.items()
                 }
 
         if current_value != remote_value:
@@ -1373,6 +1369,23 @@ async def toggle_agent(
         )
 
     _check_agent_permission("toggle_service", agent_card.name, user_context)
+
+    # Per-resource access check for non-admins, mirroring the server toggle
+    # (POST /api/servers/toggle). Having toggle_service permission is not
+    # enough; the caller must also have access to this specific agent (in
+    # accessible_agents, or be its owner).
+    if not user_context.get("is_admin", False):
+        accessible_agents = user_context.get("accessible_agents", [])
+        owns_agent = agent_card.registered_by == user_context.get("username")
+        if "all" not in accessible_agents and path not in accessible_agents and not owns_agent:
+            logger.warning(
+                f"User {user_context.get('username')} attempted to toggle agent "
+                f"{path} without access"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this agent",
+            )
 
     success = await agent_service.toggle_agent(path, enabled)
 

--- a/registry/api/federation_routes.py
+++ b/registry/api/federation_routes.py
@@ -27,6 +27,45 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+
+def _check_federation_management_scope(
+    user_context: dict[str, Any] | None,
+) -> None:
+    """Check if the caller may manage federation configuration.
+
+    Federation config controls which external sources / peer registries this
+    registry pulls from and syncs with, so it is a privileged operation.
+    Mirrors _check_peer_management_scope in peer_management_routes.py. Allows:
+    - Admin users (is_admin or mcp-registry-admin group)
+    - Federation-static-token users (federation/peers scope)
+
+    Args:
+        user_context: User context from the auth dependency.
+
+    Raises:
+        HTTPException: 403 if the caller lacks federation management permission.
+    """
+    if user_context and user_context.get("is_admin", False):
+        return
+
+    scopes = (user_context or {}).get("scopes", [])
+    if "federation/peers" in scopes:
+        return
+
+    groups = (user_context or {}).get("groups", [])
+    if "mcp-registry-admin" in groups:
+        return
+
+    logger.warning(
+        f"User {(user_context or {}).get('username')} attempted federation "
+        f"management without required scope. Scopes: {scopes}, Groups: {groups}"
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Federation management requires admin privileges or federation/peers scope",
+    )
+
+
 router = APIRouter()
 
 
@@ -125,6 +164,8 @@ async def save_federation_config(
         }
         ```
     """
+    _check_federation_management_scope(user_context)
+
     # Set audit action for federation config create/update
     set_audit_action(
         request,
@@ -209,6 +250,8 @@ async def update_federation_config(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     # Set audit action for federation config update
     set_audit_action(
         request,
@@ -288,6 +331,8 @@ async def delete_federation_config(
     Raises:
         404: Configuration not found
     """
+    _check_federation_management_scope(user_context)
+
     logger.info(f"User {user_context['username']} deleting federation config: {config_id}")
 
     deleted = await repo.delete_config(config_id)
@@ -352,6 +397,8 @@ async def add_anthropic_server(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     logger.info(f"User {user_context['username']} adding Anthropic server: {server_name}")
 
     config = await repo.get_config(config_id)
@@ -409,6 +456,8 @@ async def remove_anthropic_server(
     Returns:
         Updated configuration with removal details
     """
+    _check_federation_management_scope(user_context)
+
     logger.info(f"User {user_context['username']} removing Anthropic server: {server_name}")
 
     config = await repo.get_config(config_id)
@@ -484,6 +533,8 @@ async def add_asor_agent(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     logger.info(f"User {user_context['username']} adding ASOR agent: {agent_id}")
 
     config = await repo.get_config(config_id)
@@ -538,6 +589,8 @@ async def remove_asor_agent(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     logger.info(f"User {user_context['username']} removing ASOR agent: {agent_id}")
 
     config = await repo.get_config(config_id)
@@ -590,6 +643,8 @@ async def add_aws_registry(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     set_audit_action(
         request,
         "create",
@@ -653,6 +708,8 @@ async def remove_aws_registry(
     Returns:
         Updated configuration
     """
+    _check_federation_management_scope(user_context)
+
     set_audit_action(
         request,
         "delete",
@@ -902,6 +959,8 @@ async def sync_federation(
         POST /api/federation/sync?source=anthropic
         ```
     """
+    _check_federation_management_scope(user_context)
+
     # Set audit action for federation sync
     set_audit_action(
         request,

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -211,7 +211,9 @@ async def management_list_users(
             )
             added += 1
 
-        logger.debug(f"[LIST_USERS] Added {added} M2M clients from MongoDB (skipped {len(m2m_docs) - added} duplicates)")
+        logger.debug(
+            f"[LIST_USERS] Added {added} M2M clients from MongoDB (skipped {len(m2m_docs) - added} duplicates)"
+        )
     except Exception as e:
         logger.warning(f"Failed to retrieve M2M clients from MongoDB: {e}")
         # Don't fail the entire operation if MongoDB query fails
@@ -651,6 +653,9 @@ async def management_create_group(
             ui_permissions=ui_permissions,
             agent_access=agent_access,
             is_idp_managed=create_in_idp,
+            # Admin-gated route (_require_admin above): allowed to write
+            # admin-conferring ui_permissions.
+            allow_privileged=True,
         )
 
         if not import_success:
@@ -747,10 +752,7 @@ async def management_delete_group(
                 operation="delete",
                 resource_type="group",
                 resource_id=group_name,
-                description=(
-                    f"Delete group '{group_name}' - IdP call skipped "
-                    f"({skip_reason})"
-                ),
+                description=(f"Delete group '{group_name}' - IdP call skipped ({skip_reason})"),
                 idp_skip_reason=skip_reason,
             )
 
@@ -905,10 +907,7 @@ async def management_update_group(
                 operation="update",
                 resource_type="group",
                 resource_id=group_name,
-                description=(
-                    f"Update group '{group_name}' - IdP call skipped "
-                    f"({skip_reason})"
-                ),
+                description=(f"Update group '{group_name}' - IdP call skipped ({skip_reason})"),
                 idp_skip_reason=skip_reason,
             )
 
@@ -951,6 +950,9 @@ async def management_update_group(
             ui_permissions=ui_permissions,
             agent_access=agent_access,
             is_idp_managed=is_idp_managed,
+            # Admin-gated route (_require_admin above): allowed to write
+            # admin-conferring ui_permissions.
+            allow_privileged=True,
         )
 
         if not import_success:

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -64,6 +64,29 @@ class RatingRequest(BaseModel):
 templates = Jinja2Templates(directory=settings.templates_dir)
 
 
+def _require_admin(
+    user_context: dict | None,
+) -> None:
+    """Verify the caller has admin permissions.
+
+    Mirrors the gate used across the IAM management routes (see
+    registry/api/management_routes.py:_require_admin). Used by the External API
+    group-management endpoints, which are JWT mirrors of the admin-only
+    /api/internal/* routes and must enforce the same admin requirement.
+
+    Args:
+        user_context: User context from authentication.
+
+    Raises:
+        HTTPException: 403 if the caller is not an admin.
+    """
+    if not (user_context and user_context.get("is_admin")):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator permissions are required for this operation",
+        )
+
+
 def _build_scan_headers_from_credentials(
     server_info: dict,
 ) -> str | None:
@@ -1678,9 +1701,7 @@ async def internal_register_service(
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(path)
 
-    logger.warning(
-        "INTERNAL REGISTER: Updating scopes for new server"
-    )  # TODO: replace with debug
+    logger.warning("INTERNAL REGISTER: Updating scopes for new server")  # TODO: replace with debug
 
     # Update scopes with the new server's tools
     from ..services.scope_service import update_server_scopes
@@ -2721,9 +2742,7 @@ async def get_service_tools(
                     from ..repositories.factory import get_search_repository
 
                     search_repo = get_search_repository()
-                    await search_repo.index_server(
-                        service_path, updated_server_info, is_enabled
-                    )
+                    await search_repo.index_server(service_path, updated_server_info, is_enabled)
                 except Exception as e:
                     logger.warning(f"Failed to update search index for {service_path}: {e}")
                 logger.info(f"Updated search index for {service_path}")
@@ -3668,12 +3687,25 @@ async def register_service_api(
 
     is_local = deployment == DeploymentType.LOCAL
 
-    # Admin check for local registration
+    # Authorization: local registration requires admin (distributes executable
+    # launch recipes); remote registration requires the register_service UI
+    # permission, matching the legacy session/UI route POST /register.
     if is_local:
         if not user_context.get("is_admin"):
             raise HTTPException(
                 status_code=fastapi_status.HTTP_403_FORBIDDEN,
                 detail="Local server registration requires admin privileges",
+            )
+    else:
+        ui_permissions = user_context.get("ui_permissions", {})
+        if not ui_permissions.get("register_service"):
+            logger.warning(
+                f"User '{user_context.get('username')}' attempted API register "
+                f"without register_service permission"
+            )
+            raise HTTPException(
+                status_code=fastapi_status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to register new services",
             )
 
     logger.info(
@@ -4058,6 +4090,15 @@ async def update_server_auth_credential(
             },
         )
 
+    # Authorization: updating a server's stored backend credential is a server
+    # modification. Require modify_service permission, matching PUT/PATCH
+    # /servers/{path}.
+    _check_server_permission(
+        "modify_service",
+        existing_server.get("server_name", server_path),
+        user_context,
+    )
+
     # Build update dict
     existing_server["auth_scheme"] = body.auth_scheme
 
@@ -4162,6 +4203,37 @@ async def toggle_service_api(
     server_info = await server_service.get_server_info(path)
     if not server_info:
         raise HTTPException(status_code=404, detail="Service path not registered")
+
+    # Authorization: mirror the legacy UI toggle route (toggle_service_route).
+    # Require the toggle_service UI permission for this service, then a
+    # per-server access check for non-admin callers.
+    from ..auth.dependencies import user_has_ui_permission_for_service
+
+    service_name = server_info["server_name"]
+
+    if not user_has_ui_permission_for_service(
+        "toggle_service", service_name, user_context.get("ui_permissions", {})
+    ):
+        logger.warning(
+            f"User '{user_context.get('username')}' attempted to toggle "
+            f"'{service_name}' without toggle_service permission"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"You do not have permission to toggle {service_name}",
+        )
+
+    if not user_context.get("is_admin"):
+        if not await server_service.user_can_access_server_path(
+            path, user_context.get("accessible_servers", [])
+        ):
+            logger.warning(
+                f"User '{user_context.get('username')}' attempted to toggle '{path}' without access"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this server",
+            )
 
     # Toggle the service
     success = await server_service.toggle_service(path, new_state)
@@ -4444,6 +4516,8 @@ async def add_server_to_groups_api(
       -F "group_names=admin,developers"
     ```
     """
+    _require_admin(user_context)
+
     logger.info(
         f"API add to groups request from user '{user_context.get('username')}' for server '{server_name}'"
     )
@@ -4483,6 +4557,8 @@ async def remove_server_from_groups_api(
       -F "group_names=developers"
     ```
     """
+    _require_admin(user_context)
+
     logger.info(
         f"API remove from groups request from user '{user_context.get('username')}' for server '{server_name}'"
     )
@@ -4598,6 +4674,8 @@ async def create_group_api(
       -F "create_in_idp=true"
     ```
     """
+    _require_admin(user_context)
+
     logger.info(
         f"API create group request from user '{user_context.get('username')}' for group '{group_name}'"
     )
@@ -4726,6 +4804,8 @@ async def delete_group_api(
       -F "force=false"
     ```
     """
+    _require_admin(user_context)
+
     logger.info(
         f"API delete group request from user '{user_context.get('username')}' for group '{group_name}'"
     )
@@ -4888,6 +4968,8 @@ async def import_group_definition(
       -d @group-definition.json
     ```
     """
+    _require_admin(user_context)
+
     from ..services.scope_service import import_group
     from ..utils.iam_manager import get_iam_manager
 
@@ -5325,6 +5407,17 @@ async def remove_server_version(
     """
     decoded_path = "/" + service_path if not service_path.startswith("/") else service_path
 
+    # Authorization: removing a version mutates the server. Require
+    # modify_service permission, matching PUT/PATCH /servers/{path}.
+    existing_server = await server_service.get_server_info(decoded_path)
+    if not existing_server:
+        raise HTTPException(status_code=404, detail="Service path not registered")
+    _check_server_permission(
+        "modify_service",
+        existing_server.get("server_name", decoded_path),
+        user_context,
+    )
+
     try:
         result = await server_service.remove_server_version(path=decoded_path, version=version)
 
@@ -5359,6 +5452,17 @@ async def set_default_version(
         Success message
     """
     decoded_path = "/" + service_path if not service_path.startswith("/") else service_path
+
+    # Authorization: changing the default version mutates the server. Require
+    # modify_service permission, matching PUT/PATCH /servers/{path}.
+    existing_server = await server_service.get_server_info(decoded_path)
+    if not existing_server:
+        raise HTTPException(status_code=404, detail="Service path not registered")
+    _check_server_permission(
+        "modify_service",
+        existing_server.get("server_name", decoded_path),
+        user_context,
+    )
 
     try:
         result = await server_service.set_default_version(

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -24,6 +24,51 @@ def _looks_like_guid(
     return bool(_GUID_RE.match(value or ""))
 
 
+# Mutating UI actions that confer registry-wide admin when granted "all".
+# Mirrors _ADMIN_ACTION_PREFIXES / _user_is_admin in
+# registry/auth/dependencies.py -- keep the two lists in sync.
+#
+# IMPORTANT: admin is conferred only by the literal "all" grant, NOT "*".
+# "*" on a mutating action grants access to every server WITHOUT admin (see
+# issue #663), so it must not be treated as admin-conferring here or this guard
+# would block a legitimate non-admin permission.
+_PRIVILEGED_ACTION_PREFIXES = (
+    "register_",
+    "modify_",
+    "toggle_",
+    "delete_",
+    "publish_",
+    "create_",
+)
+_PRIVILEGED_GRANTS = {"all"}
+
+
+def _grants_admin(
+    ui_permissions: dict | None,
+) -> bool:
+    """Return True if ui_permissions would confer admin privileges.
+
+    Admin is conferred by any mutating UI action (see
+    _PRIVILEGED_ACTION_PREFIXES) granted with "all" access. This is the same
+    rule _user_is_admin uses to derive admin status per request, so a group
+    carrying such permissions promotes its members to admin.
+
+    Args:
+        ui_permissions: Dict mapping UI actions to lists of allowed resources.
+
+    Returns:
+        True if the permissions would confer admin, False otherwise.
+    """
+    if not ui_permissions:
+        return False
+    for action, resources in ui_permissions.items():
+        if action.startswith(_PRIVILEGED_ACTION_PREFIXES) and (
+            _PRIVILEGED_GRANTS & set(resources or [])
+        ):
+            return True
+    return False
+
+
 def _flatten_server_access(
     server_access: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -95,7 +140,9 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             self._indexes_created = True
             logger.info(f"Created group_mappings index for {self._collection_name}")
         except Exception as e:
-            logger.warning(f"Could not create group_mappings index for {self._collection_name}: {e}")
+            logger.warning(
+                f"Could not create group_mappings index for {self._collection_name}: {e}"
+            )
 
     async def load_all(self) -> None:
         """Load all scopes from DocumentDB."""
@@ -771,6 +818,7 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
         ui_permissions: dict = None,
         agent_access: list = None,
         is_idp_managed: bool = True,
+        allow_privileged: bool = False,
     ) -> bool:
         """
         Import a complete group definition.
@@ -785,11 +833,25 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             is_idp_managed: Whether PATCH/DELETE should call the upstream IdP.
                 Defaults to True to preserve pre-#946 behavior for callers
                 that do not explicitly pass the flag.
+            allow_privileged: Whether to permit writing admin-conferring
+                ui_permissions (mutating action with "all"/"*"). Defaults to
+                False so untrusted/public callers cannot mint admin groups.
+                Admin-gated callers (IAM management routes, IdP sync) pass True.
 
         Returns:
             True if successful, False otherwise
         """
         try:
+            # Defense in depth: refuse to write admin-conferring permissions
+            # unless the caller has explicitly enforced an admin check. The
+            # public External API import path never passes allow_privileged=True.
+            if _grants_admin(ui_permissions) and not allow_privileged:
+                logger.error(
+                    f"Refusing to import group '{group_name}' with "
+                    f"admin-conferring ui_permissions without allow_privileged=True"
+                )
+                return False
+
             collection = await self._get_collection()
 
             # Set defaults

--- a/registry/services/scope_service.py
+++ b/registry/services/scope_service.py
@@ -368,6 +368,7 @@ async def import_group(
     ui_permissions: dict = None,
     agent_access: list = None,
     is_idp_managed: bool = True,
+    allow_privileged: bool = False,
 ) -> bool:
     """
     Import a complete group definition with all document types.
@@ -385,6 +386,9 @@ async def import_group(
         agent_access: Optional list of agent paths this group can access
         is_idp_managed: Whether PATCH/DELETE should call the upstream IdP.
             See issue #946. Defaults to True to preserve pre-#946 behavior.
+        allow_privileged: Whether to permit writing admin-conferring
+            ui_permissions. Defaults to False; only admin-gated callers pass
+            True. See ScopeRepository.import_group for details.
 
     Returns:
         True if successful, False otherwise
@@ -404,6 +408,7 @@ async def import_group(
             ui_permissions=ui_permissions,
             agent_access=agent_access,
             is_idp_managed=is_idp_managed,
+            allow_privileged=allow_privileged,
         )
 
         if success:

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -643,7 +643,9 @@ class TestListAgents:
             mock_agent_service.get_all_agents = AsyncMock(
                 return_value=[enabled_agent, disabled_agent]
             )
-            mock_agent_service.is_agent_enabled = AsyncMock(side_effect=lambda path: path == "/agents/enabled")
+            mock_agent_service.is_agent_enabled = AsyncMock(
+                side_effect=lambda path: path == "/agents/enabled"
+            )
 
             # Act
             response = test_app.get("/agents?enabled_only=true")
@@ -855,7 +857,9 @@ class TestListAgents:
     # --- Pagination: Fast path tests (unrestricted user, no field filters) ---
 
     @pytest.mark.asyncio
-    async def test_list_agents_fast_path_with_limit_offset(self, test_app_admin, mock_admin_context):
+    async def test_list_agents_fast_path_with_limit_offset(
+        self, test_app_admin, mock_admin_context
+    ):
         """Admin user with limit/offset uses DB-level pagination."""
         agents = [AgentCardFactory(path=f"/agents/agent-{i}") for i in range(5)]
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
@@ -890,7 +894,9 @@ class TestListAgents:
             assert data["has_next"] is False
 
     @pytest.mark.asyncio
-    async def test_list_agents_fast_path_offset_beyond_total(self, test_app_admin, mock_admin_context):
+    async def test_list_agents_fast_path_offset_beyond_total(
+        self, test_app_admin, mock_admin_context
+    ):
         """Fast path: offset beyond total returns empty list."""
         with patch("registry.api.agent_routes.agent_service") as mock_agent_service:
             mock_agent_service.get_agents_paginated = AsyncMock(return_value=([], 3))
@@ -1268,6 +1274,102 @@ class TestToggleAgent:
 
             # Assert
             assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_toggle_agent_rejects_without_access(self, mock_search_repo, sample_agent_card):
+        """Permission alone is not enough: non-admin needs per-agent access.
+
+        Mirrors the per-server access check on POST /api/servers/toggle. The
+        caller has toggle_service for "all" (so the permission check passes)
+        but the target agent is not in accessible_agents and they are not the
+        owner, so the toggle must be rejected.
+        """
+        from fastapi import FastAPI
+
+        from registry.api.agent_routes import nginx_proxied_auth, router
+        from registry.auth.csrf import verify_csrf_token_flexible
+
+        ctx = {
+            "username": "outsider",
+            "groups": ["other-group"],
+            "scopes": ["read:agents"],
+            "accessible_agents": ["/agents/some-other-agent"],
+            "ui_permissions": {"toggle_service": ["all"]},
+            "is_admin": False,
+        }
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[nginx_proxied_auth] = lambda: ctx
+        app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+
+        with (
+            patch("registry.api.agent_routes.agent_service") as mock_agent_service,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.agent_routes.get_search_repository",
+                return_value=mock_search_repo,
+            ),
+        ):
+            mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
+            mock_agent_service.toggle_agent = AsyncMock(return_value=True)
+
+            client = TestClient(app)
+            response = client.post("/agents/test-agent/toggle?enabled=true")
+
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            mock_agent_service.toggle_agent.assert_not_called()
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_toggle_agent_allows_owner_without_accessible_list(
+        self, mock_search_repo, sample_agent_card
+    ):
+        """Owner with permission can toggle even if not in accessible_agents."""
+        from fastapi import FastAPI
+
+        from registry.api.agent_routes import nginx_proxied_auth, router
+        from registry.auth.csrf import verify_csrf_token_flexible
+
+        # sample_agent_card.registered_by == "testuser"
+        ctx = {
+            "username": "testuser",
+            "groups": ["test-group"],
+            "scopes": ["write:agents"],
+            "accessible_agents": ["/agents/some-other-agent"],
+            "ui_permissions": {"toggle_service": ["all"]},
+            "is_admin": False,
+        }
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[nginx_proxied_auth] = lambda: ctx
+        app.dependency_overrides[verify_csrf_token_flexible] = lambda: None
+
+        with (
+            patch("registry.api.agent_routes.agent_service") as mock_agent_service,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.agent_routes.get_search_repository",
+                return_value=mock_search_repo,
+            ),
+        ):
+            mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
+            mock_agent_service.toggle_agent = AsyncMock(return_value=True)
+
+            client = TestClient(app)
+            response = client.post("/agents/test-agent/toggle?enabled=true")
+
+            assert response.status_code == status.HTTP_200_OK
+
+        app.dependency_overrides.clear()
 
 
 @pytest.mark.unit
@@ -1739,9 +1841,12 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
             toggle_agent=AsyncMock(),
         )
 
-        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
-            "registry.services.agent_scanner.agent_scanner_service",
-            new=scanner_mock,
+        with (
+            patch("registry.api.agent_routes.agent_service", new=service_mock),
+            patch(
+                "registry.services.agent_scanner.agent_scanner_service",
+                new=scanner_mock,
+            ),
         ):
             # Act
             still_enabled = await _perform_agent_security_scan_on_registration(
@@ -1815,12 +1920,16 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
         search_repo_mock = MagicMock()
         search_repo_mock.index_agent = AsyncMock()
 
-        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
-            "registry.services.agent_scanner.agent_scanner_service",
-            new=scanner_mock,
-        ), patch(
-            "registry.api.agent_routes.get_search_repository",
-            return_value=search_repo_mock,
+        with (
+            patch("registry.api.agent_routes.agent_service", new=service_mock),
+            patch(
+                "registry.services.agent_scanner.agent_scanner_service",
+                new=scanner_mock,
+            ),
+            patch(
+                "registry.api.agent_routes.get_search_repository",
+                return_value=search_repo_mock,
+            ),
         ):
             # Act
             still_enabled = await _perform_agent_security_scan_on_registration(
@@ -1881,9 +1990,12 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
             toggle_agent=AsyncMock(),
         )
 
-        with patch("registry.api.agent_routes.agent_service", new=service_mock), patch(
-            "registry.services.agent_scanner.agent_scanner_service",
-            new=scanner_mock,
+        with (
+            patch("registry.api.agent_routes.agent_service", new=service_mock),
+            patch(
+                "registry.services.agent_scanner.agent_scanner_service",
+                new=scanner_mock,
+            ),
         ):
             # Act
             still_enabled = await _perform_agent_security_scan_on_registration(

--- a/tests/unit/api/test_federation_routes_authz.py
+++ b/tests/unit/api/test_federation_routes_authz.py
@@ -1,0 +1,109 @@
+"""Authorization tests for federation_routes management endpoints.
+
+The /api/federation/* mutating routes are JWT mirrors of admin-gated
+operations that previously enforced no authorization. These tests verify the
+_check_federation_management_scope gate added in fix/servers-api-authz:
+admin OR federation/peers scope may manage federation config; everyone else
+gets 403. Mirrors the sibling gate in peer_management_routes.py.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from registry.api.federation_routes import _get_federation_repo
+from registry.auth.dependencies import nginx_proxied_auth
+from registry.main import app
+
+
+def _non_admin_ctx():
+    return {
+        "username": "ctuser",
+        "groups": ["currenttime-users"],
+        "scopes": ["currenttime-users"],
+        "is_admin": False,
+    }
+
+
+def _admin_ctx():
+    return {
+        "username": "admin",
+        "groups": ["mcp-registry-admin"],
+        "scopes": ["mcp-registry-admin"],
+        "is_admin": True,
+    }
+
+
+def _federation_scope_ctx():
+    return {
+        "username": "peer-1",
+        "groups": [],
+        "scopes": ["federation/peers"],
+        "is_admin": False,
+    }
+
+
+@pytest.fixture
+def _mock_repo():
+    """A repo whose methods are AsyncMocks so we can assert no-write on 403."""
+    repo = AsyncMock()
+    repo.delete_config = AsyncMock(return_value=True)
+    repo.get_config = AsyncMock(return_value={"id": "default"})
+    return repo
+
+
+def _override(auth_ctx, repo):
+    app.dependency_overrides[nginx_proxied_auth] = lambda: auth_ctx
+    app.dependency_overrides[_get_federation_repo] = lambda: repo
+
+
+def _clear():
+    app.dependency_overrides.clear()
+
+
+class TestFederationManagementAuthz:
+    """All federation management routes require admin or federation/peers."""
+
+    def test_delete_config_rejects_non_admin(self, _mock_repo):
+        _override(_non_admin_ctx(), _mock_repo)
+        try:
+            client = TestClient(app)
+            resp = client.delete("/api/federation/config/default")
+        finally:
+            _clear()
+
+        assert resp.status_code == 403
+        _mock_repo.delete_config.assert_not_called()
+
+    def test_sync_rejects_non_admin(self, _mock_repo):
+        _override(_non_admin_ctx(), _mock_repo)
+        try:
+            client = TestClient(app)
+            resp = client.post("/api/federation/sync")
+        finally:
+            _clear()
+
+        assert resp.status_code == 403
+
+    def test_delete_config_allows_admin(self, _mock_repo):
+        _override(_admin_ctx(), _mock_repo)
+        try:
+            client = TestClient(app)
+            resp = client.delete("/api/federation/config/default")
+        finally:
+            _clear()
+
+        # Admin passes the gate; the route proceeds (not 403).
+        assert resp.status_code != 403
+
+    def test_delete_config_allows_federation_scope(self, _mock_repo):
+        _override(_federation_scope_ctx(), _mock_repo)
+        try:
+            client = TestClient(app)
+            resp = client.delete("/api/federation/config/default")
+        finally:
+            _clear()
+
+        # federation/peers scope passes the gate (matches peer management).
+        assert resp.status_code != 403

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -623,6 +623,7 @@ class TestManagementCreateGroup:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=True,
+                allow_privileged=True,
             )
 
     def test_create_group_success_entra(self, test_client_admin):
@@ -674,6 +675,7 @@ class TestManagementCreateGroup:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=True,
+                allow_privileged=True,
             )
 
     def test_create_group_requires_admin(self, test_client_regular):
@@ -803,6 +805,7 @@ class TestManagementCreateGroup:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=True,
+                allow_privileged=True,
             )
 
 
@@ -858,6 +861,7 @@ class TestManagementCreateGroupCreateInIdp:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=False,
+                allow_privileged=True,
             )
 
     def test_create_group_with_create_in_idp_true(self, test_client_admin):
@@ -910,6 +914,7 @@ class TestManagementCreateGroupCreateInIdp:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=True,
+                allow_privileged=True,
             )
 
     def test_create_group_default_does_not_create_in_idp(self, test_client_admin):
@@ -949,6 +954,7 @@ class TestManagementCreateGroupCreateInIdp:
                 ui_permissions={},
                 agent_access=[],
                 is_idp_managed=False,
+                allow_privileged=True,
             )
 
 

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -938,7 +938,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -974,7 +973,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -1011,7 +1009,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -1048,7 +1045,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -1088,7 +1084,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -1125,7 +1120,6 @@ class TestRegisterService:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_nginx_reload_scheduler,
         mock_health_service,
@@ -1174,7 +1168,6 @@ class TestInternalRegister:
         self,
         test_client_no_auth,
         mock_server_service,
-
         mock_nginx_service,
         mock_health_service,
     ):
@@ -1525,7 +1518,6 @@ class TestRegisterLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
         mock_security_scanner_service,
     ):
@@ -1614,7 +1606,6 @@ class TestRegisterLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Unpinned npx package gets the 'unpinned-version' soft warning tag."""
@@ -1660,7 +1651,6 @@ class TestRegisterLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Remote registration without explicit deployment still works (default)."""
@@ -1720,7 +1710,6 @@ class TestEditLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Admin can edit a local server's launch recipe."""
@@ -1826,7 +1815,6 @@ class TestEditLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Remote edit still works when deployment field is omitted (preserves existing)."""
@@ -1856,7 +1844,6 @@ class TestEditLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Per-server oauth_client_id + append_mcp_path are persisted on edit."""
@@ -2035,7 +2022,6 @@ class TestEditLocalSecurityReviewReset:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Identical recipe → tag stays cleared (review preserved)."""
@@ -2070,7 +2056,6 @@ class TestEditLocalSecurityReviewReset:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """Different recipe (version bump) → tag re-added even though it had
@@ -2105,7 +2090,6 @@ class TestEditLocalSecurityReviewReset:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         """args list change (e.g. swapping a flag) is also a material change."""
@@ -2153,7 +2137,6 @@ class TestRefreshLocalServer:
         self,
         test_client_admin,
         mock_server_service,
-
         mock_nginx_service,
     ):
         mock_server_service.get_server_info.return_value = {
@@ -2202,7 +2185,6 @@ class TestClearSecurityPendingLocal:
         self,
         test_client_admin,
         mock_server_service,
-
     ):
         mock_server_service.get_server_info.return_value = self.LOCAL_PENDING
         mock_server_service.is_service_enabled.return_value = True
@@ -2279,9 +2261,7 @@ class TestServerRegisterVisibility:
         "proxy_pass_url": "http://localhost:9000",
     }
 
-    def test_register_persists_visibility_public(
-        self, test_client_admin, mock_server_service
-    ):
+    def test_register_persists_visibility_public(self, test_client_admin, mock_server_service):
         response = test_client_admin.post(
             "/api/servers/register",
             data={**self._BASE_FORM, "visibility": "public"},
@@ -2311,9 +2291,7 @@ class TestServerRegisterVisibility:
         assert server_entry["oauth_client_id"] == "mcp-gateway"
         assert server_entry["append_mcp_path"] is False
 
-    def test_register_rejects_invalid_visibility(
-        self, test_client_admin, mock_server_service
-    ):
+    def test_register_rejects_invalid_visibility(self, test_client_admin, mock_server_service):
         response = test_client_admin.post(
             "/api/servers/register",
             data={**self._BASE_FORM, "visibility": "garbage"},
@@ -2695,3 +2673,255 @@ class TestGetGroupApi:
 
         assert response.status_code == 200
         assert response.json()["scope_name"] == "file-group"
+
+
+# =============================================================================
+# TESTS — Authorization on /api/servers/* (privilege-escalation fix)
+#
+# Verifies the guards added in fix/servers-api-authz:
+#   - All five /api/servers/groups/* routes require admin.
+#   - POST /api/servers/toggle requires toggle_service permission + access.
+#   - POST /api/servers/register (remote) requires register_service permission.
+#   - PATCH /servers/{path}/auth-credential + version routes require
+#     modify_service permission.
+# See .scratchpad/cve/design-privesc-fix-servers-api.md.
+# =============================================================================
+
+
+class TestServersGroupsAdminGate:
+    """All /api/servers/groups/* routes must reject non-admin callers."""
+
+    def test_import_group_rejects_non_admin(
+        self,
+        test_client_regular,
+    ):
+        """Non-admin import is blocked BEFORE import_group is called."""
+        with patch(
+            "registry.services.scope_service.import_group", new_callable=AsyncMock
+        ) as mock_import:
+            response = test_client_regular.post(
+                "/api/servers/groups/import",
+                json={
+                    "scope_name": "attacker-group",
+                    "ui_permissions": {"register_service": ["all"]},
+                },
+            )
+
+        assert response.status_code == 403
+        mock_import.assert_not_called()
+
+    def test_create_group_rejects_non_admin(
+        self,
+        test_client_regular,
+    ):
+        """Non-admin group create is blocked before the service is called."""
+        with patch(
+            "registry.services.scope_service.create_group", new_callable=AsyncMock
+        ) as mock_create:
+            response = test_client_regular.post(
+                "/api/servers/groups/create",
+                data={"group_name": "attacker-group"},
+            )
+
+        assert response.status_code == 403
+        mock_create.assert_not_called()
+
+    def test_add_to_groups_rejects_non_admin(
+        self,
+        test_client_regular,
+    ):
+        """Non-admin add-to-groups is blocked."""
+        response = test_client_regular.post(
+            "/api/servers/groups/add",
+            data={"server_name": "test-server", "group_names": "mcp-registry-admin"},
+        )
+        assert response.status_code == 403
+
+    def test_remove_from_groups_rejects_non_admin(
+        self,
+        test_client_regular,
+    ):
+        """Non-admin remove-from-groups is blocked."""
+        response = test_client_regular.post(
+            "/api/servers/groups/remove",
+            data={"server_name": "test-server", "group_names": "some-group"},
+        )
+        assert response.status_code == 403
+
+    def test_delete_group_rejects_non_admin(
+        self,
+        test_client_regular,
+    ):
+        """Non-admin group delete is blocked."""
+        response = test_client_regular.post(
+            "/api/servers/groups/delete",
+            data={"group_name": "some-group"},
+        )
+        assert response.status_code == 403
+
+    def test_import_group_allows_admin(
+        self,
+        test_client_admin,
+    ):
+        """Admin import reaches the service layer (no 403)."""
+        with patch(
+            "registry.services.scope_service.import_group",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_import:
+            response = test_client_admin.post(
+                "/api/servers/groups/import",
+                json={"scope_name": "legit-group", "create_in_idp": False},
+            )
+
+        assert response.status_code != 403
+        mock_import.assert_called_once()
+
+
+class TestToggleApiAuthorization:
+    """POST /api/servers/toggle must enforce permission + per-server access."""
+
+    def test_toggle_api_rejects_without_permission(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Caller lacking toggle_service permission gets 403, no toggle."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=False,
+        ):
+            response = test_client_regular.post(
+                "/api/servers/toggle",
+                data={"path": "/test-server", "new_state": "true"},
+            )
+
+        assert response.status_code == 403
+        mock_server_service.toggle_service.assert_not_called()
+
+    def test_toggle_api_rejects_without_server_access(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Non-admin with permission but no access to the server gets 403."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        mock_server_service.user_can_access_server_path = AsyncMock(return_value=False)
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=True,
+        ):
+            response = test_client_regular.post(
+                "/api/servers/toggle",
+                data={"path": "/test-server", "new_state": "true"},
+            )
+
+        assert response.status_code == 403
+        mock_server_service.toggle_service.assert_not_called()
+
+    def test_toggle_api_allows_with_permission_and_access(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Permission + access lets the toggle through."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        mock_server_service.user_can_access_server_path = AsyncMock(return_value=True)
+        mock_server_service.toggle_service.return_value = True
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=True,
+        ):
+            response = test_client_regular.post(
+                "/api/servers/toggle",
+                data={"path": "/test-server", "new_state": "true"},
+            )
+
+        assert response.status_code != 403
+        mock_server_service.toggle_service.assert_called_once()
+
+
+class TestRegisterApiAuthorization:
+    """POST /api/servers/register (remote) must require register_service."""
+
+    _FORM = {
+        "name": "My Service",
+        "description": "desc",
+        "path": "/my-service",
+        "proxy_pass_url": "http://localhost:8080",
+    }
+
+    def test_register_api_rejects_without_permission(
+        self,
+        test_client_regular,
+    ):
+        """Regular user without register_service permission gets 403.
+
+        The regular_user_context fixture has no register_service permission.
+        """
+        response = test_client_regular.post("/api/servers/register", data=self._FORM)
+        assert response.status_code == 403
+
+
+class TestServerModifyApiAuthorization:
+    """auth-credential + version routes must require modify_service."""
+
+    def test_auth_credential_rejects_without_permission(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Non-admin without modify_service cannot rewrite a credential."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=False,
+        ):
+            response = test_client_regular.patch(
+                "/api/servers/test-server/auth-credential",
+                json={"auth_scheme": "bearer", "auth_credential": "stolen"},
+            )
+
+        assert response.status_code == 403
+
+    def test_set_default_version_rejects_without_permission(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Non-admin without modify_service cannot change default version."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=False,
+        ):
+            response = test_client_regular.put(
+                "/api/servers/test-server/versions/default",
+                json={"version": "v2.0.0"},
+            )
+
+        assert response.status_code == 403
+
+    def test_remove_version_rejects_without_permission(
+        self,
+        test_client_regular,
+        mock_server_service,
+        sample_server_info,
+    ):
+        """Non-admin without modify_service cannot remove a version."""
+        mock_server_service.get_server_info.return_value = sample_server_info
+        with patch(
+            "registry.auth.dependencies.user_has_ui_permission_for_service",
+            return_value=False,
+        ):
+            response = test_client_regular.delete(
+                "/api/servers/test-server/versions/v1.0.0",
+            )
+
+        assert response.status_code == 403

--- a/tests/unit/repositories/test_scope_repo_privileged_guard.py
+++ b/tests/unit/repositories/test_scope_repo_privileged_guard.py
@@ -1,0 +1,121 @@
+"""Unit tests for the admin-conferring ui_permissions guard in scope_repository.
+
+Covers _grants_admin (the content check) and the allow_privileged gate on
+DocumentDBScopeRepository.import_group, which is the defense-in-depth layer of
+the /api/servers/* privilege-escalation fix (see
+.scratchpad/cve/design-privesc-fix-servers-api.md, section 3.4).
+
+_grants_admin must agree with _user_is_admin in registry/auth/dependencies.py:
+both decide admin status from the same mutating-action-with-all/* rule.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from registry.auth.dependencies import _user_is_admin
+from registry.repositories.documentdb.scope_repository import (
+    DocumentDBScopeRepository,
+    _grants_admin,
+)
+
+
+class TestGrantsAdmin:
+    """Direct tests for the _grants_admin content check."""
+
+    def test_register_service_all_grants_admin(self):
+        assert _grants_admin({"register_service": ["all"]}) is True
+
+    def test_register_service_star_does_not_grant_admin(self):
+        # "*" grants all-server access WITHOUT admin (issue #663); it must not
+        # be treated as admin-conferring, or this guard would block a
+        # legitimate non-admin permission.
+        assert _grants_admin({"register_service": ["*"]}) is False
+
+    def test_other_mutating_actions_grant_admin(self):
+        assert _grants_admin({"modify_service": ["all"]}) is True
+        assert _grants_admin({"toggle_service": ["all"]}) is True
+        assert _grants_admin({"delete_service": ["all"]}) is True
+
+    def test_read_only_action_with_all_does_not_grant_admin(self):
+        assert _grants_admin({"list_service": ["all"]}) is False
+
+    def test_scoped_mutating_action_does_not_grant_admin(self):
+        # Scoped to a specific server, not "all"/"*".
+        assert _grants_admin({"register_service": ["currenttime"]}) is False
+
+    def test_empty_and_none(self):
+        assert _grants_admin({}) is False
+        assert _grants_admin(None) is False
+
+    def test_agrees_with_user_is_admin(self):
+        """The repo guard and the live admin check must agree.
+
+        If they drift, an attacker could write permissions the guard allows but
+        that still promote to admin (or vice-versa).
+        """
+        cases = [
+            {"register_service": ["all"]},
+            {"register_service": ["*"]},
+            {"modify_service": ["all"]},
+            {"list_service": ["all"]},
+            {"register_service": ["currenttime"]},
+            {},
+        ]
+        for ui_permissions in cases:
+            assert _grants_admin(ui_permissions) == _user_is_admin(ui_permissions), (
+                f"disagreement on {ui_permissions}"
+            )
+
+
+def _make_repo() -> DocumentDBScopeRepository:
+    """Build a repo whose _get_collection returns a mock collection."""
+    repo = DocumentDBScopeRepository()
+    mock_collection = MagicMock()
+    mock_collection.replace_one = AsyncMock(
+        return_value=MagicMock(upserted_id="x", matched_count=1)
+    )
+    repo._get_collection = AsyncMock(return_value=mock_collection)
+    repo._scopes_cache = {}
+    return repo, mock_collection
+
+
+class TestImportGroupPrivilegedGuard:
+    """allow_privileged gate on DocumentDBScopeRepository.import_group."""
+
+    @pytest.mark.asyncio
+    async def test_blocks_admin_permissions_by_default(self):
+        repo, collection = _make_repo()
+
+        result = await repo.import_group(
+            group_name="attacker-group",
+            ui_permissions={"register_service": ["all"]},
+        )
+
+        assert result is False
+        collection.replace_one.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allows_admin_permissions_when_flagged(self):
+        repo, collection = _make_repo()
+
+        result = await repo.import_group(
+            group_name="legit-admin-group",
+            ui_permissions={"register_service": ["all"]},
+            allow_privileged=True,
+        )
+
+        assert result is True
+        collection.replace_one.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_allows_non_privileged_permissions_by_default(self):
+        repo, collection = _make_repo()
+
+        result = await repo.import_group(
+            group_name="normal-group",
+            ui_permissions={"list_service": ["all"]},
+        )
+
+        assert result is True
+        collection.replace_one.assert_called_once()


### PR DESCRIPTION
## Summary

The External API endpoints under `/api/servers/*` (and several sibling resource families) authenticate the caller via `nginx_proxied_auth` but skip the authorization checks their `/internal/*` and legacy/UI counterparts enforce. Any authenticated low-privileged user could escalate to admin or perform privileged operations.

The headline issue: `POST /api/servers/groups/import` accepted an arbitrary `ui_permissions` payload with no authorization. A low-privileged user could map their own IdP group to a mutating action with `"all"` access (e.g. `register_service: ["all"]`); because admin status is derived live from `ui_permissions` on every request (issue #663), the caller is promoted to admin on their next request.

A cross-family audit showed this is a class of bug ("JWT mirror routes that never re-applied the gate"), not a single endpoint. This PR fixes every confirmed instance.

## What was fixed

**Servers (`server_routes.py`)**
- All five `/api/servers/groups/*` routes (import, create, add, remove, delete) now require admin via a shared `_require_admin` helper (mirrors `management_routes.py`).
- `POST /api/servers/toggle` now requires `toggle_service` permission plus a per-server access check for non-admins, matching the legacy toggle route.
- `POST /api/servers/register` (remote) now requires `register_service` permission, matching the legacy register route.
- `PATCH /servers/{path}/auth-credential`, `PUT /servers/{path}/versions/default`, and `DELETE /servers/{path}/versions/{version}` now require `modify_service` (found during enumeration).

**Federation (`federation_routes.py`)**
- All 10 mutating routes had only `nginx_proxied_auth` and no authz at any layer. A low-privileged user could point the registry at an attacker-controlled federation source / peer registry and trigger a sync (data-exfil + content-injection). Added `_check_federation_management_scope` (admin OR `federation/peers` scope, mirroring `peer_management_routes.py`) to all of them.

**Agents (`agent_routes.py`)**
- `POST /agents/{path}/toggle` had a permission check but skipped the per-resource access check the server toggle has. Added it.

**Defense in depth (`scope_repository.py`, `scope_service.py`)**
- `import_group` refuses to persist admin-conferring `ui_permissions` (a mutating action granted `"all"`) unless the caller passes `allow_privileged=True`. The public import path never does; admin-gated IAM management callers do. `_grants_admin` mirrors `_user_is_admin` exactly: `"all"` confers admin, `"*"` does not (issue #663), so the legitimate non-admin all-servers grant is not blocked.

## Explicitly not changed
- Legacy `/register` and `/toggle/{path}` (already correct), peers / IAM / M2M / ANS routes (already gated), `_user_is_admin` live-derivation (intended).
- Skills and custom-entity inconsistencies are tracked as follow-ups, not part of this security fix.

## Testing

- New unit tests: server group/toggle/register/modify authz, repository content guard (including agreement with `_user_is_admin`), federation management authz, and the agent toggle access check.
- Existing suites in all touched modules pass (228 in the affected API/repository tests).
- Live verification against a running registry with a real low-privileged token confirmed every server and federation route returns 403 for non-admins, while admin and `federation/peers`-scope callers proceed; the defense-in-depth guard refused an admin-conferring import even for an admin via the public path, and the group was never persisted.

## Notes
- Affected confirmed build per the report: `mcpgateway/registry:1.24.4`. Recommend shipping as a new patch image tag and reviewing access logs for prior non-admin POSTs to the group/federation endpoints.
