### PR TITLE
test(auth): fix authserver test for FastAPI 0.138

### DIFF
--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -980,18 +980,26 @@ class TestInternalRouterGate:
         attribute.
         """
         collected: list[tuple[str, str]] = []
-        for route in server_module.app.routes:
-            path = getattr(route, "path", None)
-            methods = getattr(route, "methods", None)
-            if not path or not methods:
-                continue
-            if not path.startswith("/internal/"):
-                continue
-            for method in methods:
-                # HEAD/OPTIONS are auto-added and not interesting.
-                if method in ("HEAD", "OPTIONS"):
+
+        def _walk(routes) -> None:
+            for route in routes:
+                original_router = getattr(route, "original_router", None)
+                if original_router is not None:
+                    _walk(original_router.routes)
                     continue
-                collected.append((path, method))
+                path = getattr(route, "path", None)
+                methods = getattr(route, "methods", None)
+                if not path or not methods:
+                    continue
+                if not path.startswith("/internal/"):
+                    continue
+                for method in methods:
+                    # HEAD/OPTIONS are auto-added and not interesting.
+                    if method in ("HEAD", "OPTIONS"):
+                        continue
+                    collected.append((path, method))
+
+        _walk(server_module.app.routes)
         return collected
 
     def test_at_least_the_known_endpoints_are_present(self, auth_env_vars):


### PR DESCRIPTION
FastAPI 0.138 stopped flattening an included router's child routes onto app.routes, instead appending a single _IncludedRouter wrapper whose children live on .original_router.routes. The TestInternalRouterGate meta-test walked app.routes flat, so it found zero /internal/* routes and failed once a lockfile bump moved FastAPI 0.136.3 -> 0.138.0.

Recurse into the wrapper via original_router so the test sees the real routes on both the pre- and post-0.138 layouts. Routing and the internal-JWT gate were unaffected; only the test's route enumeration needed updating.

Verified passing on fastapi 0.136.3 and 0.138.0; confirmed failing on 0.138.0 without this change.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
