### PR TITLE
feat(compose): add OpenBao dev-mode container to Docker Compose stacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1476,3 +1476,14 @@ UPDATE_CHECK_ENABLED=true
 # Polling interval in hours for the update-check background task. Minimum 1.
 # Default: 24
 UPDATE_CHECK_INTERVAL_HOURS=24
+
+# =============================================================================
+# OPENBAO (per-user egress credential vault, local Docker Compose)
+# =============================================================================
+# Docker Compose runs OpenBao in DEV mode (in-memory, auto-unsealed) with this
+# fixed root token. The registry authenticates to OpenBao using token auth, so
+# OPENBAO_TOKEN here doubles as the dev root token and the registry's token.
+# DEV ONLY: data is not persisted across restarts. The production secret store
+# is Helm standalone OpenBao (EKS) or AWS Secrets Manager (ECS).
+# Default: dev-root-token
+OPENBAO_TOKEN=dev-root-token

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,6 +1,34 @@
 version: '3.8'
 
 services:
+  # OpenBao - per-user egress credential vault (third-party OBO support).
+  # Runs in DEV mode: in-memory storage, auto-unsealed, with a fixed root
+  # token. This is the local-dev equivalent of the Helm standalone OpenBao
+  # (charts/mcp-gateway-registry-stack); the Helm path is sealed + file-backed
+  # and bootstraps via an init Job, none of which is needed for local compose.
+  # Data is NOT persisted across restarts (dev mode is in-memory by design).
+  # The registry reaches it via token auth using OPENBAO_TOKEN. Port 8200 is
+  # non-privileged, so this works under rootless podman without changes.
+  openbao:
+    image: openbao/openbao:2.5.5
+    container_name: mcp-openbao
+    command: ["server", "-dev"]
+    environment:
+      # Dev mode auto-mounts KV v2 at secret/ and auto-unseals with this token.
+      - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
+      - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+    ports:
+      - "8200:8200"
+    healthcheck:
+      # Health endpoint reports 200 once the API is listening (dev mode is
+      # always unsealed + initialized, so the default codes are fine).
+      test: ["CMD", "bao", "status", "-address=http://127.0.0.1:8200"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
   # Registry service (includes nginx, SSL, FAISS, models)
   # PODMAN VERSION: Uses non-privileged ports for rootless operation
   registry:

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -11,6 +11,33 @@ version: '3.8'
 # Note: DocumentDB is a managed AWS service and runs outside of Docker.
 
 services:
+  # OpenBao - per-user egress credential vault (third-party OBO support).
+  # Runs in DEV mode: in-memory storage, auto-unsealed, with a fixed root
+  # token. This is the local-dev equivalent of the Helm standalone OpenBao
+  # (charts/mcp-gateway-registry-stack); the Helm path is sealed + file-backed
+  # and bootstraps via an init Job, none of which is needed for local compose.
+  # Data is NOT persisted across restarts (dev mode is in-memory by design).
+  # The registry reaches it via token auth using OPENBAO_TOKEN.
+  openbao:
+    image: openbao/openbao:2.5.5
+    container_name: mcp-openbao
+    command: ["server", "-dev"]
+    environment:
+      # Dev mode auto-mounts KV v2 at secret/ and auto-unseals with this token.
+      - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
+      - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+    ports:
+      - "8200:8200"
+    healthcheck:
+      # Health endpoint reports 200 once the API is listening (dev mode is
+      # always unsealed + initialized, so the default codes are fine).
+      test: ["CMD", "bao", "status", "-address=http://127.0.0.1:8200"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
   # Registry service (includes nginx, SSL, FAISS, models) - using pre-built image
   registry:
     image: ${DOCKERHUB_ORG:-mcpgateway}/registry:${REGISTRY_VERSION:-latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,33 @@ services:
       "
     restart: "no"
 
+  # OpenBao - per-user egress credential vault (third-party OBO support).
+  # Runs in DEV mode: in-memory storage, auto-unsealed, with a fixed root
+  # token. This is the local-dev equivalent of the Helm standalone OpenBao
+  # (charts/mcp-gateway-registry-stack); the Helm path is sealed + file-backed
+  # and bootstraps via an init Job, none of which is needed for local compose.
+  # Data is NOT persisted across restarts (dev mode is in-memory by design).
+  # The registry reaches it via token auth using OPENBAO_TOKEN.
+  openbao:
+    image: openbao/openbao:2.5.5
+    container_name: mcp-openbao
+    command: ["server", "-dev"]
+    environment:
+      # Dev mode auto-mounts KV v2 at secret/ and auto-unseals with this token.
+      - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
+      - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+    ports:
+      - "8200:8200"
+    healthcheck:
+      # Health endpoint reports 200 once the API is listening (dev mode is
+      # always unsealed + initialized, so the default codes are fine).
+      test: ["CMD", "bao", "status", "-address=http://127.0.0.1:8200"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
   # Registry service (includes nginx, SSL, FAISS, models)
   registry:
     build:


### PR DESCRIPTION
## Summary

Adds an OpenBao service (dev mode) to the Docker Compose stacks so the per-user egress credential vault comes up on startup for local development. This is the Docker Compose counterpart to the Helm standalone OpenBao infrastructure in #1305.

## What this adds

- `openbao` service in `docker-compose.yml`, `docker-compose.prebuilt.yml`, and `docker-compose.podman.yml`.
  - Image `openbao/openbao:2.5.5`, `command: server -dev`.
  - Dev mode: in-memory storage, auto-unsealed, KV v2 auto-mounted at `secret/`, fixed root token from `OPENBAO_TOKEN`.
  - Exposed on `:8200`, healthcheck via `bao status`, `restart: unless-stopped`.
- `OPENBAO_TOKEN` documented in `.env.example` (default `dev-root-token`).

## Design notes

- Dev mode (not sealed + file-backed) is intentional for local Compose. The Helm path (#1305) is sealed, file-backed, and bootstraps via an init Job with Kubernetes auth, token-reviewer JWT, and RBAC. None of that machinery applies to Compose, where the registry authenticates via token auth using `OPENBAO_TOKEN`. Data is not persisted across restarts by design.
- The DHI overlay (`docker-compose.dhi.yml`) is an override-only file applied on top of the base. It inherits the `openbao` service automatically; there is no `dhi.io/openbao` hardened image to override with, so no change is needed there.
- Registry and auth-server egress environment wiring is intentionally left out of this PR. The egress consumer code (#1312) is not yet on `main`, so wiring those variables now would be dead config that the running image ignores. That wiring will be added alongside #1312.

## Testing

- All four Compose files validated with `docker compose config` (including the base + DHI overlay).
- Brought the container up standalone: healthy within 8 seconds.
- Verified unsealed and initialized, KV v2 mounted at `secret/`, and a token-auth write/read round-trip at `secret/data/mcp/egress/...` (the operation the egress store performs).

## Related

- #1305 (Helm standalone OpenBao infrastructure)
- #1312 (egress 3LO backend/frontend; consumer of OpenBao)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
