### PR TITLE
fix(compose): pull prebuilt images from ECR Public instead of Docker Hub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1052,8 +1052,13 @@ DOCKERHUB_TOKEN=your_dockerhub_access_token
 # GITHUB_USERNAME=your_github_username
 # GITHUB_TOKEN=your_github_personal_access_token
 
-# # Container registry organization names
-# DOCKERHUB_ORG=mcpgateway
+# Pre-built image registry (docker-compose.prebuilt.yml / ./build_and_run.sh --prebuilt)
+# Pre-built images are published to Amazon ECR Public and pulled from
+# public.ecr.aws/p3v1o3c6 by default. Override only if you mirror them elsewhere.
+# Images are no longer published to Docker Hub.
+# ECR_REGISTRY=public.ecr.aws/p3v1o3c6
+
+# # Container registry organization names (build/publish workflows only)
 # GITHUB_ORG=agentic-community
 
 # =============================================================================

--- a/README.md
+++ b/README.md
@@ -547,8 +547,7 @@ cp .env.example .env
 # Edit .env with your passwords (KEYCLOAK_ADMIN_PASSWORD, etc.)
 nano .env
 
-# Deploy with pre-built images
-export DOCKERHUB_ORG=mcpgateway
+# Deploy with pre-built images (pulled from Amazon ECR Public by default)
 ./build_and_run.sh --prebuilt
 
 # Access the Registry UI (served by nginx on port 80)

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -435,74 +435,82 @@ validate_predeployment() {
 
 validate_predeployment
 
-# Start metrics service first to generate API keys
-log "Starting metrics service first..."
-$COMPOSE_CMD $COMPOSE_FILES up -d metrics-service || handle_error "Failed to start metrics service"
+# Start metrics service first to generate API keys.
+# Gated: --prebuilt compose no longer ships metrics-service (OTel-native
+# metrics replaced the legacy HTTP POST path). Skip the start, the health
+# wait, and the per-service token generation entirely when the service
+# isn't declared, instead of failing the whole deployment.
+if $COMPOSE_CMD $COMPOSE_FILES config --services 2>/dev/null | grep -q "^metrics-service$"; then
+    log "Starting metrics service first..."
+    $COMPOSE_CMD $COMPOSE_FILES up -d metrics-service || handle_error "Failed to start metrics service"
 
-# Wait for metrics service to be ready
-log "Waiting for metrics service to be ready..."
-max_retries=30
-retry_count=0
-while [ $retry_count -lt $max_retries ]; do
-    if curl -f http://localhost:8890/health &>/dev/null; then
-        log "Metrics service is ready"
-        break
+    # Wait for metrics service to be ready
+    log "Waiting for metrics service to be ready..."
+    max_retries=30
+    retry_count=0
+    while [ $retry_count -lt $max_retries ]; do
+        if curl -f http://localhost:8890/health &>/dev/null; then
+            log "Metrics service is ready"
+            break
+        fi
+        sleep 2
+        retry_count=$((retry_count + 1))
+        log "Waiting for metrics service... ($retry_count/$max_retries)"
+    done
+
+    if [ $retry_count -eq $max_retries ]; then
+        handle_error "Metrics service did not become ready within expected time"
     fi
-    sleep 2
-    retry_count=$((retry_count + 1))
-    log "Waiting for metrics service... ($retry_count/$max_retries)"
-done
 
-if [ $retry_count -eq $max_retries ]; then
-    handle_error "Metrics service did not become ready within expected time"
-fi
+    # Generate dynamic pre-shared tokens for metrics authentication
+    log "Setting up dynamic pre-shared tokens for services..."
 
-# Generate dynamic pre-shared tokens for metrics authentication
-log "Setting up dynamic pre-shared tokens for services..."
+    # Get all services from compose file that might need metrics (exclude monitoring services)
+    METRICS_SERVICES=$($COMPOSE_CMD $COMPOSE_FILES config --services 2>/dev/null | grep -v -E "(prometheus|grafana|metrics-db)" | sort | uniq)
 
-# Get all services from compose file that might need metrics (exclude monitoring services)
-METRICS_SERVICES=$($COMPOSE_CMD $COMPOSE_FILES config --services 2>/dev/null | grep -v -E "(prometheus|grafana|metrics-db)" | sort | uniq)
-
-if [ -z "$METRICS_SERVICES" ]; then
-    log "WARNING: No services found for metrics configuration"
-else
-    log "Found services for metrics: $(echo $METRICS_SERVICES | tr '\n' ' ')"
-fi
-
-# Check if tokens already exist in .env
-source .env 2>/dev/null || true
-
-# Generate tokens for each service dynamically
-for service in $METRICS_SERVICES; do
-    # Convert service name to environment variable format
-    # auth-server -> METRICS_API_KEY_AUTH_SERVER
-    # metrics-service -> METRICS_API_KEY_METRICS_SERVICE (will be skipped as it's the metrics service itself)
-    ENV_VAR_NAME="METRICS_API_KEY_$(echo "$service" | tr '[:lower:]-' '[:upper:]_')"
-    
-    # Skip the metrics service itself and non-metrics services
-    if [ "$service" = "metrics-service" ] || [ "$service" = "prometheus" ] || [ "$service" = "grafana" ]; then
-        continue
-    fi
-    
-    # Get current value
-    CURRENT_VALUE=$(eval echo "\${$ENV_VAR_NAME:-}")
-    
-    # Generate token only if it doesn't exist or is empty
-    if [ -z "$CURRENT_VALUE" ] || [ "$CURRENT_VALUE" = "" ]; then
-        NEW_TOKEN="mcp_metrics_$(openssl rand -hex 16)"
-        
-        # Remove any existing line for this variable
-        sed -i "/^$ENV_VAR_NAME=/d" .env 2>/dev/null || true
-        
-        # Add new token
-        echo "$ENV_VAR_NAME=$NEW_TOKEN" >> .env
-        log "Generated new $service token: ${NEW_TOKEN:0:20}..."
+    if [ -z "$METRICS_SERVICES" ]; then
+        log "WARNING: No services found for metrics configuration"
     else
-        log "Using existing $service token: ${CURRENT_VALUE:0:20}..."
+        log "Found services for metrics: $(echo $METRICS_SERVICES | tr '\n' ' ')"
     fi
-done
 
-log "Dynamic metrics API tokens configured successfully"
+    # Check if tokens already exist in .env
+    source .env 2>/dev/null || true
+
+    # Generate tokens for each service dynamically
+    for service in $METRICS_SERVICES; do
+        # Convert service name to environment variable format
+        # auth-server -> METRICS_API_KEY_AUTH_SERVER
+        # metrics-service -> METRICS_API_KEY_METRICS_SERVICE (will be skipped as it's the metrics service itself)
+        ENV_VAR_NAME="METRICS_API_KEY_$(echo "$service" | tr '[:lower:]-' '[:upper:]_')"
+
+        # Skip the metrics service itself and non-metrics services
+        if [ "$service" = "metrics-service" ] || [ "$service" = "prometheus" ] || [ "$service" = "grafana" ]; then
+            continue
+        fi
+
+        # Get current value
+        CURRENT_VALUE=$(eval echo "\${$ENV_VAR_NAME:-}")
+
+        # Generate token only if it doesn't exist or is empty
+        if [ -z "$CURRENT_VALUE" ] || [ "$CURRENT_VALUE" = "" ]; then
+            NEW_TOKEN="mcp_metrics_$(openssl rand -hex 16)"
+
+            # Remove any existing line for this variable
+            sed -i "/^$ENV_VAR_NAME=/d" .env 2>/dev/null || true
+
+            # Add new token
+            echo "$ENV_VAR_NAME=$NEW_TOKEN" >> .env
+            log "Generated new $service token: ${NEW_TOKEN:0:20}..."
+        else
+            log "Using existing $service token: ${CURRENT_VALUE:0:20}..."
+        fi
+    done
+
+    log "Dynamic metrics API tokens configured successfully"
+else
+    log "metrics-service not declared in compose file (e.g. --prebuilt). Skipping legacy metrics-service start and per-service token generation. Core services emit metrics natively via OpenTelemetry at :9464."
+fi
 
 # Now start all other services with the API keys in environment
 log "Starting remaining services..."

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -39,8 +39,10 @@ services:
     restart: unless-stopped
 
   # Registry service (includes nginx, SSL, FAISS, models) - using pre-built image
+  # Pre-built images are published to Amazon ECR Public (public.ecr.aws/p3v1o3c6).
+  # Override the namespace with ECR_REGISTRY if you mirror them elsewhere.
   registry:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/registry:${REGISTRY_VERSION:-latest}
+    image: ${ECR_REGISTRY:-public.ecr.aws/p3v1o3c6}/registry:${REGISTRY_VERSION:-latest}
     environment:
       # Deployment Mode Configuration
       - DEPLOYMENT_MODE=${DEPLOYMENT_MODE:-with-gateway}
@@ -290,53 +292,21 @@ services:
     depends_on:
       auth-server:
         condition: service_started
-      metrics-service:
-        condition: service_healthy
       mongodb-init:
         condition: service_completed_successfully
     restart: unless-stopped
 
-  # Metrics Collection Service - using pre-built image
-  metrics-service:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/metrics-service:${METRICS_VERSION:-latest}
-    environment:
-      - METRICS_SERVICE_PORT=8890
-      - METRICS_SERVICE_HOST=0.0.0.0
-      - SQLITE_DB_PATH=/var/lib/sqlite/metrics.db
-      - METRICS_RETENTION_DAYS=90
-      - METRICS_API_KEY_AUTH=${METRICS_API_KEY_AUTH_SERVER}
-      - METRICS_API_KEY_REGISTRY=${METRICS_API_KEY_REGISTRY}
-      - METRICS_API_KEY_MCPGW=${METRICS_API_KEY_MCPGW_SERVER}
-      - OTEL_SERVICE_NAME=mcp-metrics-service
-      - OTEL_PROMETHEUS_ENABLED=true
-      - OTEL_PROMETHEUS_PORT=9465
-      - OTEL_OTLP_ENDPOINT=${OTEL_OTLP_ENDPOINT:-}
-      - OTEL_EXPORTER_OTLP_HEADERS=${OTEL_EXPORTER_OTLP_HEADERS:-}
-      - OTEL_OTLP_EXPORT_INTERVAL_MS=${OTEL_OTLP_EXPORT_INTERVAL_MS:-30000}
-      - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
-      - METRICS_RATE_LIMIT=1000
-    ports:
-      - "8890:8890"
-      - "9465:9465"  # Prometheus metrics endpoint
-    volumes:
-      - metrics-db-data:/var/lib/sqlite
-      - ${HOME}/mcp-gateway/logs:/app/logs
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    depends_on:
-      - metrics-db
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8890/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+  # NOTE: The standalone metrics-service (and its SQLite metrics-db) were removed
+  # from the pre-built stack. The core services emit OTel-native metrics directly
+  # (scraped by Prometheus at :9464 on each service); the legacy HTTP POST path
+  # to metrics-service is off by default (METRICS_LEGACY_HTTP_POST=false). This
+  # matches the ECS and Helm deployments, where metrics-service is optional and
+  # is being removed entirely in 1.26.0. The build-mode docker-compose.yml still
+  # builds metrics-service locally if you need it.
 
   # Auth service (separate and scalable) - using pre-built image
   auth-server:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/auth-server:${AUTH_SERVER_VERSION:-latest}
+    image: ${ECR_REGISTRY:-public.ecr.aws/p3v1o3c6}/auth-server:${AUTH_SERVER_VERSION:-latest}
     environment:
       - REGISTRY_URL=${REGISTRY_URL}
       - SECRET_KEY=${SECRET_KEY}
@@ -453,29 +423,19 @@ services:
       # Application log files (bind mount to host for Splunk ingestion, Issue #987)
       - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     depends_on:
-      metrics-service:
-        condition: service_healthy
       mongodb-init:
         condition: service_completed_successfully
     restart: unless-stopped
 
-  # Current Time MCP Server - using pre-built image
-  currenttime-server:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/currenttime-server:${CURRENTTIME_VERSION:-latest}
-    environment:
-      - PORT=8000
-      - MCP_TRANSPORT=streamable-http
-    ports:
-      - "8000:8000"
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    restart: unless-stopped
+  # NOTE: The currenttime-server and realserverfaketools-server demo MCP servers
+  # were removed from the pre-built stack because they are not published to ECR
+  # Public. To run them locally, use the build-mode stack (docker-compose.yml),
+  # which builds them from source.
 
   # MCP Gateway Server - using pre-built image
+  # ECR repository is named "mcpgw" (the published image), service stays mcpgw-server.
   mcpgw-server:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/mcpgw-server:${MCPGW_VERSION:-latest}
+    image: ${ECR_REGISTRY:-public.ecr.aws/p3v1o3c6}/mcpgw:${MCPGW_VERSION:-latest}
     environment:
       - HOST=0.0.0.0
       - PORT=8003
@@ -510,39 +470,9 @@ services:
       - registry
     restart: unless-stopped
 
-  # Real Server Fake Tools MCP Server - using pre-built image
-  realserverfaketools-server:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/realserverfaketools-server:${REALSERVERFAKETOOLS_VERSION:-latest}
-    environment:
-      - PORT=8002
-    ports:
-      - "8002:8002"
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    restart: unless-stopped
-
-  # SQLite container for metrics database - using mirrored pre-built image
-  metrics-db:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/alpine:${ALPINE_VERSION:-latest}
-    volumes:
-      - metrics-db-data:/var/lib/sqlite
-    command: ["sh", "-c", "apk add --no-cache sqlite && mkdir -p /var/lib/sqlite && sqlite3 /var/lib/sqlite/metrics.db 'CREATE TABLE IF NOT EXISTS _health (id INTEGER);' && tail -f /dev/null"]
-    security_opt:
-      - no-new-privileges:true
-    cap_drop:
-      - ALL
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "sqlite3", "/var/lib/sqlite/metrics.db", ".tables"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-
-  # Prometheus for metrics collection - using mirrored pre-built image
+  # Prometheus for metrics collection - using canonical upstream image
   prometheus:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/prometheus:${PROMETHEUS_VERSION:-latest}
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
     ports:
       - "9090:9090"
     volumes:
@@ -561,9 +491,9 @@ services:
       - ALL
     restart: unless-stopped
 
-  # Grafana for metrics visualization - using mirrored pre-built image
+  # Grafana for metrics visualization - using canonical upstream image
   grafana:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/grafana:${GRAFANA_VERSION:-latest}
+    image: grafana/grafana:${GRAFANA_VERSION:-12.3.1}
     ports:
       - "3000:3000"
     environment:
@@ -582,9 +512,9 @@ services:
       - prometheus
     restart: unless-stopped
 
-  # PostgreSQL database for Keycloak - using mirrored pre-built image
+  # PostgreSQL database for Keycloak - using canonical upstream image
   keycloak-db:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/postgres:${POSTGRES_VERSION:-latest}
+    image: postgres:${POSTGRES_VERSION:-16-alpine}
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
@@ -598,9 +528,9 @@ services:
       timeout: 5s
       retries: 5
 
-  # Keycloak Identity Provider - using mirrored pre-built image
+  # Keycloak Identity Provider - using canonical upstream image
   keycloak:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/keycloak:${KEYCLOAK_VERSION:-latest}
+    image: quay.io/keycloak/keycloak:${KEYCLOAK_VERSION:-25.0}
     command: start-dev  # Use 'start' for production with proper SSL
     environment:
       # Database configuration
@@ -699,7 +629,7 @@ services:
   # Vector search is implemented in application code (see search_repository.py)
   # Running with authentication enabled for security
   mongodb:
-    image: ${DOCKERHUB_ORG:-mcpgateway}/mongo:${MONGODB_VERSION:-latest}
+    image: mongo:${MONGODB_VERSION:-8.2}
     container_name: mcp-mongodb
     command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb --auth --keyFile /keyfile/replica.key
     environment:
@@ -765,7 +695,6 @@ services:
 volumes:
   ssl_data:
   keycloak_db_data:
-  metrics-db-data:
   prometheus-data:
   grafana-data:
   mongodb-data:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -133,7 +133,8 @@ Save and exit (Ctrl+X, then Y, then Enter if using nano).
 
 **Set environment variables for deployment:**
 ```bash
-export DOCKERHUB_ORG=mcpgateway
+# Pre-built images are pulled from Amazon ECR Public (public.ecr.aws/p3v1o3c6)
+# by default. No registry login or DOCKERHUB_ORG is required.
 source .env
 export KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-admin}"
 ```


### PR DESCRIPTION
## Summary

Pre-built images are no longer published to Docker Hub (the `mcpgateway` org is stale at 1.24.4). They are now published to **Amazon ECR Public** (`public.ecr.aws/p3v1o3c6`). This updates the pre-built stack so `./build_and_run.sh --prebuilt` works out of the box.

Fixes the root cause behind #1345.

## Changes

`docker-compose.prebuilt.yml`:
- **Core images → ECR Public.** `registry`, `auth-server`, and `mcpgw` now pull from `${ECR_REGISTRY:-public.ecr.aws/p3v1o3c6}` instead of `${DOCKERHUB_ORG:-mcpgateway}`. Note the ECR repository is named `mcpgw` (the service stays `mcpgw-server`).
- **Removed the optional `metrics-service` + `metrics-db`.** Not published to ECR; the legacy HTTP POST path is off by default (`METRICS_LEGACY_HTTP_POST=false`) and the core services emit OTel-native metrics scraped by Prometheus at `:9464`. This matches the ECS and Helm deployments, where metrics-service is optional and is being removed entirely in 1.26.0. The build-mode `docker-compose.yml` still builds it locally.
- **Removed the `currenttime-server` and `realserverfaketools-server` demo servers.** Not published to ECR. They remain available via build-mode `docker-compose.yml`.
- **Base images → canonical upstreams.** `prometheus`, `grafana`, `postgres`, `keycloak`, and `mongo` now point at the same upstream images/tags as `docker-compose.yml`, replacing the `mcpgateway/*` Docker Hub mirrors.

Docs / config:
- `.env.example`, `README.md`, `docs/quickstart.md`: document the new `ECR_REGISTRY` override and drop the `DOCKERHUB_ORG` export (ECR Public requires no login).

## Notes

- Only `docker-compose.prebuilt.yml` referenced `DOCKERHUB_ORG`; the build-mode and podman compose files build locally and were untouched.
- `config/prometheus.yml` is shared with build mode (which still runs metrics-service/otel-collector), so it is left unchanged. The removed targets simply appear as "down" in the prebuilt stack (cosmetic).

## Testing

- `docker compose -f docker-compose.prebuilt.yml config` validates cleanly.