### PR TITLE
feat(a2a): add reverse-proxy gateway support for A2A agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1078,6 +1078,18 @@ AGENT_SECURITY_ADD_PENDING_TAG=true
 A2A_SCANNER_LLM_API_KEY=your_azure_openai_api_key_here
 
 # =============================================================================
+# A2A REVERSE-PROXY MODE
+# =============================================================================
+
+# Enable reverse-proxy mode for A2A agents (opt-in, default: false)
+# When true, each enabled agent gets nginx location blocks that proxy its A2A
+# traffic (agent card + JSON-RPC) through the gateway for centralized auth and
+# metrics, instead of clients connecting directly to the agent backend.
+# When false, /agent/* paths keep the registry-only discovery behavior.
+# Also requires with-gateway deployment mode.
+A2A_REVERSE_PROXY_ENABLED=false
+
+# =============================================================================
 # CONTAINER REGISTRY CREDENTIALS (for CI/CD and local builds)
 # =============================================================================
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1981,6 +1981,97 @@ def _is_registry_api_request(
     return False
 
 
+def _get_a2a_agent_path(
+    original_url: str | None,
+) -> str | None:
+    """Return the agent path for an A2A reverse-proxy request, or None.
+
+    Recognizes URLs of the form ``{root}/agent/{agent_path}/...``
+    and returns the agent path with a leading slash (e.g. "/flight-booking-agent"),
+    matching the agent's registered path and the ``invoke_agent`` scope
+    resources. Agent paths may be multi-segment (e.g. "/lob1/travel"); the trailing
+    agent-card discovery suffix is stripped so the card and JSON-RPC requests
+    resolve to the same agent path. Returns None for any non-agent request so the
+    caller falls back to MCP handling.
+
+    Args:
+        original_url: The X-Original-URL header value from nginx.
+
+    Returns:
+        The agent path (leading slash, one or more segments) or None.
+    """
+    if not original_url:
+        return None
+
+    parsed = urlparse(original_url)
+    path = parsed.path.strip("/")
+
+    registry_prefix = REGISTRY_ROOT_PATH.strip("/")
+    if registry_prefix and path.startswith(registry_prefix):
+        path = path[len(registry_prefix) :].lstrip("/")
+
+    parts = path.split("/") if path else []
+    if len(parts) < 2 or parts[0] != "agent":
+        return None
+
+    agent_segments = parts[1:]
+    # Drop the agent-card discovery suffix so /agent/x/.well-known/agent-card.json
+    # and /agent/x/ both resolve to the same agent path.
+    if agent_segments[-2:] == [".well-known", "agent-card.json"]:
+        agent_segments = agent_segments[:-2]
+
+    if not agent_segments or not all(agent_segments):
+        return None
+
+    return "/" + "/".join(agent_segments)
+
+
+async def validate_a2a_agent_access(
+    agent_path: str,
+    user_scopes: list[str],
+) -> bool:
+    """Check per-agent A2A invocation access against structured agent scopes.
+
+    Enforced at the ``/validate`` auth subrequest: it answers "may this caller
+    invoke this agent?". Mirrors :func:`validate_server_tool_access`: each of the
+    caller's scopes is resolved via the scope repository, then we look for an
+    ``invoke_agent`` action under the scope's ``agents`` block whose resources
+    cover this agent. Resources support ``all``/``*`` wildcards or an exact agent
+    path (e.g. ``/travel``).
+
+    Args:
+        agent_path: Agent path with leading slash (e.g. "/travel").
+        user_scopes: Scope names resolved for the caller (from group mappings).
+
+    Returns:
+        True if any scope grants ``invoke_agent`` on this agent, else False.
+    """
+    if not user_scopes:
+        return False
+
+    scope_repo = get_scope_repository()
+    for scope in user_scopes:
+        try:
+            scope_config = await scope_repo.get_server_scopes(scope)
+        except Exception as exc:
+            logger.warning(f"A2A access: failed to resolve scope '{scope}': {exc}")
+            continue
+        if not scope_config:
+            continue
+
+        for entry in scope_config:
+            agents_block = entry.get("agents")
+            if not isinstance(agents_block, dict):
+                continue
+            for action in agents_block.get("actions", []):
+                if action.get("action") != "invoke_agent":
+                    continue
+                resources = action.get("resources", [])
+                if "all" in resources or "*" in resources or agent_path in resources:
+                    return True
+    return False
+
+
 def _check_registry_static_token(
     bearer_token: str,
 ) -> dict | None:
@@ -2676,6 +2767,28 @@ async def validate_request(request: Request):
             )
         else:
             user_scopes = validation_result.get("scopes", [])
+
+        # A2A agent proxy requests: enforce per-agent invoke FGAC here at the
+        # auth subrequest, resolving the caller's scopes to an invoke_agent
+        # action that covers this agent (see validate_a2a_agent_access).
+        a2a_agent_path = _get_a2a_agent_path(original_url)
+        if a2a_agent_path is not None:
+            if not await validate_a2a_agent_access(a2a_agent_path, user_scopes):
+                logger.warning(
+                    f"Access denied for user "
+                    f"{hash_username(validation_result.get('username', ''))} "
+                    f"to A2A agent {a2a_agent_path} - missing invoke scope"
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Access denied to agent {a2a_agent_path} - no invoke scope",
+                    headers={"Connection": "close"},
+                )
+            logger.info(f"A2A per-agent scope validation passed for {a2a_agent_path}")
+            # This is an agent proxy request, not an MCP server; skip the MCP
+            # server/tool scope validation below.
+            server_name = None
+
         if server_name:
             # For ANY server access, enforce scope validation (fail closed principle)
             # This includes MCP initialization methods that may not have a specific tool

--- a/docker/lua/agent_card_rewrite.lua
+++ b/docker/lua/agent_card_rewrite.lua
@@ -1,0 +1,65 @@
+-- agent_card_rewrite.lua: rewrite A2A agent-card endpoint URLs from the backend
+-- to the gateway so clients route JSON-RPC calls back through this proxy
+-- Runs in the body_filter phase on the agent-card discovery route.
+-- The companion header_filter clears Content-Length because the body size changes.
+local ok, cjson = pcall(require, "cjson")
+if not ok then return end
+
+local chunk = ngx.arg[1]
+local eof = ngx.arg[2]
+
+-- Buffer the upstream body across chunks; emit nothing until the final chunk.
+local buf = ngx.ctx.agent_card_buf
+if buf == nil then
+    buf = {}
+    ngx.ctx.agent_card_buf = buf
+end
+if chunk and chunk ~= "" then
+    buf[#buf + 1] = chunk
+end
+if not eof then
+    ngx.arg[1] = nil
+    return
+end
+
+local body = table.concat(buf)
+ngx.ctx.agent_card_buf = nil
+
+local dok, card = pcall(cjson.decode, body)
+if not dok or type(card) ~= "table" then
+    -- Not an agent card we understand; pass the original body through unchanged.
+    ngx.arg[1] = body
+    return
+end
+
+-- Gateway base for this agent is the request URI minus the agent-card suffix,
+-- e.g. /agent/travel/.well-known/agent-card.json -> /agent/travel
+local base = ngx.var.uri:gsub("/%.well%-known/agent%-card%.json$", "")
+-- http_host preserves a non-default port (e.g. :8443); ngx.var.host strips it.
+-- Trailing slash so the advertised URL matches the JSON-RPC endpoint, which is
+-- the prefix location {ROOT_PATH}/agent/<path>/ (a no-slash URL would not match).
+local gateway_url = ngx.var.scheme .. "://" .. ngx.var.http_host .. base .. "/"
+
+if card.url then
+    card.url = gateway_url
+end
+-- A2A advertises extra transports under different keys across versions:
+-- "additionalInterfaces" (0.2.x) and "supportedInterfaces" (proto/1.0).
+-- Point every advertised interface URL at the gateway.
+local function rewrite_interfaces(list)
+    if type(list) ~= "table" then return end
+    for _, iface in ipairs(list) do
+        if type(iface) == "table" and iface.url then
+            iface.url = gateway_url
+        end
+    end
+end
+rewrite_interfaces(card.additionalInterfaces)
+rewrite_interfaces(card.supportedInterfaces)
+
+local eok, encoded = pcall(cjson.encode, card)
+if eok then
+    ngx.arg[1] = encoded
+else
+    ngx.arg[1] = body
+end

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -106,6 +106,9 @@ server {
     # Registered MCP server locations (generated dynamically)
 {{LOCATION_BLOCKS}}
 
+    # Registered A2A agent reverse-proxy locations (generated dynamically)
+{{AGENT_LOCATION_BLOCKS}}
+
 {{REGISTRY_ONLY_BLOCK}}
 
     # Internal session management for virtual MCP server router.
@@ -1643,6 +1646,9 @@ server {
 
     # Registered MCP server locations (generated dynamically)
 {{LOCATION_BLOCKS}}
+
+    # Registered A2A agent reverse-proxy locations (generated dynamically)
+{{AGENT_LOCATION_BLOCKS}}
 
 {{REGISTRY_ONLY_BLOCK}}
 

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -315,6 +315,9 @@ server {
     # Registered MCP server locations (generated dynamically)
 {{LOCATION_BLOCKS}}
 
+    # Registered A2A agent reverse-proxy locations (generated dynamically)
+{{AGENT_LOCATION_BLOCKS}}
+
 {{REGISTRY_ONLY_BLOCK}}
 
     # Internal session management for virtual MCP server router.

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -185,6 +185,9 @@ cp "$LUA_SOURCE_DIR/virtual_router.lua" "$LUA_SCRIPTS_DIR/virtual_router.lua"
 cp "$LUA_SOURCE_DIR/emit_metrics.lua" "$LUA_SCRIPTS_DIR/emit_metrics.lua"
 cp "$LUA_SOURCE_DIR/flush_metrics.lua" "$LUA_SCRIPTS_DIR/flush_metrics.lua"
 
+# A2A reverse-proxy filter
+cp "$LUA_SOURCE_DIR/agent_card_rewrite.lua" "$LUA_SCRIPTS_DIR/agent_card_rewrite.lua"
+
 echo "Lua scripts copied from $LUA_SOURCE_DIR to $LUA_SCRIPTS_DIR."
 
 # --- Nginx Configuration ---

--- a/docs/design/a2a-protocol-integration.md
+++ b/docs/design/a2a-protocol-integration.md
@@ -12,6 +12,7 @@ This guide documents the Agent-to-Agent (A2A) protocol implementation in the MCP
 6. [Discovery: How Agents Find Other Agents](#discovery-how-agents-find-other-agents)
 7. [Access Control: Three-Tier Permission System](#access-control-three-tier-permission-system)
 8. [The Code: Where Everything Lives](#the-code-where-everything-lives)
+9. [Reverse-Proxy Mode: Proxying A2A Traffic](#reverse-proxy-mode-proxying-a2a-traffic)
 
 ---
 
@@ -25,6 +26,8 @@ The MCP Gateway Registry now supports Agent-to-Agent (A2A) communication through
 - **The registry itself is NOT involved in agent-to-agent communication**
 
 This is fundamentally different from how the MCP Gateway works. The gateway proxies MCP server requests, but for A2A agents, it simply acts as a discovery and validation service. Once agents find each other through the registry, they communicate peer-to-peer with no registry intermediation.
+
+> **Note:** An optional **reverse-proxy mode** extends this design so the gateway *can* proxy A2A traffic (agent-card discovery and JSON-RPC) the same way it proxies MCP, with per-agent access control. Registry-only discovery (everything above) is unchanged and remains the default; reverse-proxy mode adds proxied routes for registered agents. See [Reverse-Proxy Mode: Proxying A2A Traffic](#reverse-proxy-mode-proxying-a2a-traffic).
 
 ### Why This Matters
 
@@ -1097,6 +1100,87 @@ curl -X POST http://localhost/api/agents/code-reviewer/toggle?enabled=true \
 ```
 
 Now the agent is discoverable by other agents and will appear in semantic searches.
+
+---
+
+## Reverse-Proxy Mode: Proxying A2A Traffic
+
+By default the registry returns an agent's *direct* URL and steps aside (registry-only discovery, above). **Reverse-proxy mode** instead puts the gateway in the A2A data path — the same way it proxies MCP servers — so the agent backend stays private and clients reach it through a gateway path with auth on every call. It is opt-in and does not change registry-only discovery; when enabled, each **enabled** agent gets a proxied route under `/agent/{path}`.
+
+### Enabling
+
+Off by default. Set `A2A_REVERSE_PROXY_ENABLED=true` (settings field `a2a_reverse_proxy_enabled`). It also requires `with-gateway` deployment mode (`nginx_updates_enabled`); in registry-only mode no proxy routes are generated.
+
+### Routes Per Agent
+
+For an agent at path `flight-booking-agent`, the config generator emits two nginx locations, both guarded by the `auth_request /validate` subrequest (like MCP routes):
+
+| Route | Purpose |
+| --- | --- |
+| `= /agent/flight-booking-agent/.well-known/agent-card.json` | Agent-card discovery (exact match) |
+| `/agent/flight-booking-agent/` | A2A JSON-RPC endpoint (and SSE streaming) |
+
+### Discovery Flow (Card Rewrite)
+
+```
+A2A Client
+    ↓ GET /agent/{path}/.well-known/agent-card.json + Bearer JWT
+[Gateway - Nginx]
+    ↓ auth_request (X-Original-URL, Authorization)
+[Auth Server - /validate]
+_get_a2a_agent_path → /{path}
+validate_a2a_agent_access(scopes)
+    ↓ 200 + X-Scopes  (or 401 / 403)
+[Gateway] proxy_pass /.well-known/agent-card.json
+    ↓
+[Agent Backend]
+Returns card { url: backend, supportedInterfaces: [...] }
+    ↓
+[Gateway] agent_card_rewrite.lua rewrites url + interfaces → gateway URL
+    ↓
+A2A Client receives card advertising https://<gateway>/agent/{path}
+```
+
+`agent_card_rewrite.lua` (a `body_filter`) makes the proxy transparent: it rewrites the card's top-level `url` and advertised interface URLs (`additionalInterfaces` for A2A 0.2.x, `supportedInterfaces` for proto/1.0 SDKs) from the backend origin to the gateway, so the client's JSON-RPC calls return through the proxy. A companion `header_filter` clears `Content-Length` since the body changes.
+
+### Invocation Flow (Per-Agent FGAC)
+
+```
+A2A Client
+    ↓ POST /agent/{path}/ {method: "SendMessage", ...} + Bearer JWT
+[Gateway - Nginx]
+capture_body.lua → X-Body (rewrite phase, for metrics)
+    ↓ auth_request (X-Original-URL, Authorization)
+[Auth Server - /validate]
+Per-agent gate: does any caller scope grant invoke_agent on {path}?
+    ↓
+    ├─ Yes → 200 + X-Scopes → $auth_scopes
+    │        [Gateway] proxy_pass /  (SSE-safe: proxy_buffering off, long read timeout)
+    │        [Agent Backend] returns JSON-RPC result → client
+    └─ No  → 403 → client
+```
+
+### Access Control
+
+Invocation is gated per-agent at `/validate` by `validate_a2a_agent_access`, mirroring MCP tool access (`validate_server_tool_access`): a caller may invoke an agent if any of its scopes grants an `invoke_agent` action covering the agent path.
+
+Scopes are structured documents in the `mcp_scopes` collection (seeded from `scripts/*.json`):
+
+```json
+{
+  "agents": {
+    "actions": [
+      {"action": "invoke_agent", "resources": ["all"]}
+    ]
+  }
+}
+```
+
+`resources` takes `all`/`*` or exact paths (e.g. `["/travel"]`). The `registry-admins` scope grants `invoke_agent` on `all`; finer grants are added as scope documents via the scope-management API. Per-method/per-skill FGAC is out of scope — the gateway can't resolve structured permissions in the request path.
+
+### Streaming (SSE)
+
+The JSON-RPC location sets `proxy_buffering off` and a long `proxy_read_timeout` so `message/stream` Server-Sent Events are delivered incrementally and long-lived connections are not killed mid-flight.
 
 ---
 

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -778,6 +778,14 @@ These have no `.env` equivalent because they describe the infrastructure, not th
 
 ---
 
+## Group 31 — A2A Reverse-Proxy Mode
+
+| Parameter | Docker (`.env`) | Terraform (`.tfvars`) | Helm (`values.yaml`) | Purpose |
+|-----------|-----------------|-----------------------|----------------------|---------|
+| Enable reverse-proxy | `A2A_REVERSE_PROXY_ENABLED` | — | — | Opt-in. When `true`, each enabled agent gets nginx blocks that proxy its A2A traffic (agent card + JSON-RPC) through the gateway for centralized auth and metrics. Default `false` = registry-only discovery, no proxy blocks. Also gated by `with-gateway` deployment mode. See [A2A reverse-proxy mode](design/a2a-protocol-integration.md#reverse-proxy-mode-proxying-a2a-traffic). |
+
+---
+
 ## Checklist for new parameters
 
 When you add a new configuration parameter:

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -412,6 +412,13 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("openbao_role", "OpenBao Role", False),
         ],
     },
+    "a2a_reverse_proxy": {
+        "title": "A2A Reverse-Proxy Mode",
+        "order": 26,
+        "fields": [
+            ("a2a_reverse_proxy_enabled", "Enabled", False),
+        ],
+    },
 }
 
 

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -488,6 +488,19 @@ class Settings(BaseSettings):
     agent_security_add_pending_tag: bool = True
     a2a_scanner_llm_api_key: str = ""  # Optional Azure OpenAI API key for LLM-based analysis
 
+    # A2A reverse-proxy mode (opt-in)
+    a2a_reverse_proxy_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable A2A agent reverse-proxy generation. When true, each enabled agent "
+            "gets nginx location blocks that proxy its A2A traffic (agent card + "
+            "JSON-RPC) through the gateway for centralized auth and metrics, instead of "
+            "clients connecting directly to the agent backend. When false (default), no "
+            "agent proxy blocks are emitted and /agent/* paths fall through to the "
+            "existing behavior."
+        ),
+    )
+
     # Skill security scanning settings (AI Agent Skills)
     skill_security_scan_enabled: bool = True
     skill_security_scan_on_registration: bool = True

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -25,6 +25,17 @@ logger = logging.getLogger(__name__)
 # currently has so an operator's chmod isn't silently reverted.
 DEFAULT_NGINX_CONFIG_MODE: int = 0o644
 
+# Route prefix under which enabled A2A agents are reverse-proxied through the
+# gateway. An agent registered at path "/flight-booking-agent" is
+# reachable at "{ROOT_PATH}/agent/flight-booking-agent/".
+AGENT_ROUTE_PREFIX: str = "/agent"
+
+# Agent path and backend url come from registry data and are interpolated into
+# nginx directive positions, so they must be validated to prevent config
+# injection (e.g. "}", ";", newlines breaking out of the location block).
+_NGINX_AGENT_PATH_SAFE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
+_NGINX_AGENT_URL_SAFE = re.compile(r"^https?://[A-Za-z0-9.\-]+(?::\d+)?(?:/[A-Za-z0-9._~\-/]*)?$")
+
 
 # Headroom added on top of the auth-server mcp-proxy hop's own upstream timeout
 # (MCP_PROXY_TIMEOUT) when deriving nginx's proxy_read_timeout for the
@@ -971,6 +982,16 @@ class NginxConfigService:
                 logger.error(f"Failed to generate virtual server config: {e}", exc_info=True)
                 config_content = config_content.replace("{{VIRTUAL_SERVER_BLOCKS}}", "")
 
+            # Generate A2A agent reverse-proxy blocks. Opt-in via
+            # A2A_REVERSE_PROXY_ENABLED. In registry-only mode they are also
+            # skipped: the registry-only 503 block already returns 503 for any
+            # /agent/* path that is not an API route.
+            if settings.nginx_updates_enabled and settings.a2a_reverse_proxy_enabled:
+                agent_blocks = await self._generate_agent_location_blocks()
+            else:
+                agent_blocks = ""
+            config_content = config_content.replace("{{AGENT_LOCATION_BLOCKS}}", agent_blocks)
+
             root_path = os.environ.get("ROOT_PATH", "").rstrip("/")
             config_content = config_content.replace("{{ROOT_PATH}}", root_path)
 
@@ -1601,6 +1622,193 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
 
         except Exception as e:
             logger.error(f"Failed to write virtual server mappings: {e}", exc_info=True)
+
+    async def _generate_agent_location_blocks(self) -> str:
+        """Generate nginx reverse-proxy location blocks for enabled A2A agents.
+
+        Mirrors the MCP-server and virtual-server generators: each enabled
+        agent gets location blocks that proxy A2A traffic through the gateway
+        (centralized auth, metrics, network isolation) instead of clients
+        connecting directly to the agent backend.
+
+        Returns:
+            Nginx configuration string, or an empty string when there are no
+            enabled agents.
+        """
+        try:
+            from registry.services.agent_service import agent_service
+
+            enabled_paths = await agent_service.get_enabled_agents()
+            if not enabled_paths:
+                logger.debug("No enabled A2A agents found")
+                return ""
+
+            location_blocks = []
+            for path in enabled_paths:
+                agent = await agent_service.get_agent_info(path)
+                if agent is None:
+                    logger.warning(f"Enabled agent '{path}' has no card; skipping nginx block")
+                    continue
+
+                backend_url = (agent.url or "").rstrip("/")
+                if not backend_url:
+                    logger.warning(f"Agent '{path}' has no url; skipping nginx block")
+                    continue
+
+                # Only proxy true A2A agents. A non-A2A agent that happens to
+                # carry a URL must not get a JSON-RPC proxy route.
+                if (agent.supported_protocol or "").lower() != "a2a":
+                    logger.debug(
+                        f"Agent '{path}' protocol is {agent.supported_protocol!r} "
+                        "(not 'a2a'); skipping nginx block"
+                    )
+                    continue
+
+                # Never advertise a proxy path to a backend that is not
+                # known-healthy, so the gateway does not route to a dead agent.
+                if not HealthStatus.is_healthy(agent.health_status):
+                    logger.debug(
+                        f"Agent '{path}' health is {agent.health_status!r} "
+                        "(not healthy); skipping nginx block"
+                    )
+                    continue
+
+                agent_path = (agent.path or path).strip("/")
+                try:
+                    block = self._create_agent_location_block(
+                        agent_path,
+                        backend_url,
+                        agent.name,
+                    )
+                except ValueError as exc:
+                    logger.warning(f"Skipping agent '{path}' with unsafe nginx input: {exc}")
+                    continue
+                location_blocks.append(block)
+                logger.debug(f"Generated A2A agent location block for {agent_path}")
+
+            logger.info(f"Generated {len(location_blocks)} A2A agent location blocks")
+            return "\n".join(location_blocks)
+
+        except Exception as e:
+            logger.error(f"Failed to generate agent location blocks: {e}", exc_info=True)
+            return ""
+
+    def _create_agent_location_block(
+        self,
+        agent_path: str,
+        backend_url: str,
+        agent_name: str,
+    ) -> str:
+        """Create nginx location blocks for a single A2A agent.
+
+        Emits two prefix locations under ``{ROOT_PATH}/agent/{agent_path}/``:
+          1. The agent card (``.well-known/agent-card.json``) for discovery.
+          2. The JSON-RPC endpoint for ``message/send`` / ``message/stream``.
+
+        Both are protected by the ``/validate`` auth subrequest (the same hop
+        used for MCP servers) and proxy straight to the agent backend. A2A is
+        JSON-RPC over HTTP, so no protocol translation is required.
+
+        Args:
+            agent_path: Agent path without surrounding slashes
+                (e.g. ``flight-booking-agent``).
+            backend_url: Agent backend base URL without a trailing slash.
+            agent_name: Human-readable agent name (used in a comment only).
+
+        Returns:
+            Nginx configuration string with the two location blocks.
+
+        Raises:
+            ValueError: If ``agent_path`` or ``backend_url`` contains characters
+                that are unsafe to interpolate into an nginx config.
+        """
+        if not _NGINX_AGENT_PATH_SAFE.match(agent_path):
+            raise ValueError(f"unsafe agent path: {agent_path!r}")
+        if not _NGINX_AGENT_URL_SAFE.match(backend_url):
+            raise ValueError(f"unsafe agent url: {backend_url!r}")
+
+        parsed_url = urlparse(backend_url)
+        upstream_host = parsed_url.netloc
+        # External services (https or FQDN) use the upstream hostname; bare
+        # internal hostnames preserve the original Host header.
+        if parsed_url.scheme == "https" or "." in upstream_host:
+            host_header = upstream_host
+        else:
+            host_header = "$host"
+
+        dns_resolver = os.environ.get("NGINX_DNS_RESOLVER", "8.8.8.8 8.8.4.4")
+        dns_resolver_timeout = os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")
+        safe_name = self._sanitize_for_nginx_comment(agent_name)
+        route = f"{AGENT_ROUTE_PREFIX}/{agent_path}"
+
+        return f"""
+    # A2A agent card (discovery): {safe_name}
+    # Exact match so suffixes (e.g. /.well-known/agent-card.json/../secret)
+    # cannot be smuggled through this proxy.
+    location = {{{{ROOT_PATH}}}}{route}/.well-known/agent-card.json {{
+        resolver {dns_resolver} valid=10s;
+        resolver_timeout {dns_resolver_timeout}s;
+        auth_request /validate;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+        proxy_pass {backend_url}/.well-known/agent-card.json;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        proxy_set_header Host {host_header};
+        proxy_set_header Authorization $http_authorization;
+        # Rewrite the card's endpoint URLs from the backend to this gateway so
+        # clients send JSON-RPC back through the proxy. Body size changes, so
+        # Content-Length must be cleared before the rewrite runs.
+        header_filter_by_lua_block {{ ngx.header.content_length = nil }}
+        body_filter_by_lua_file /etc/nginx/lua/agent_card_rewrite.lua;
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }}
+
+    # A2A agent JSON-RPC endpoint: {safe_name}
+    location {{{{ROOT_PATH}}}}{route}/ {{
+        resolver {dns_resolver} valid=10s;
+        resolver_timeout {dns_resolver_timeout}s;
+        auth_request /validate;
+        auth_request_set $auth_user $upstream_http_x_user;
+        auth_request_set $auth_username $upstream_http_x_username;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+        auth_request_set $auth_method $upstream_http_x_auth_method;
+
+        # Capture the JSON-RPC body (rewrite phase) so emit_metrics can record
+        # the A2A method; per-agent invoke is enforced by the auth server via
+        # the /validate subrequest above.
+        rewrite_by_lua_file /etc/nginx/lua/capture_body.lua;
+        log_by_lua_file /etc/nginx/lua/emit_metrics.lua;
+
+        proxy_pass {backend_url}/;
+        proxy_http_version 1.1;
+        proxy_ssl_server_name on;
+        # message/stream (SSE) can stay open for minutes; override nginx's 60s
+        # default so streaming responses are not killed mid-flight.
+        proxy_connect_timeout 10s;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_set_header Host {host_header};
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Original-URL $scheme://$host$request_uri;
+        proxy_set_header Authorization $http_authorization;
+
+        # Forward validated auth context to the agent backend
+        proxy_set_header X-User $auth_user;
+        proxy_set_header X-Username $auth_username;
+        proxy_set_header X-Scopes $auth_scopes;
+        proxy_set_header X-Auth-Method $auth_method;
+        proxy_pass_request_headers on;
+
+        # message/stream uses SSE; disable buffering for incremental delivery
+        proxy_buffering off;
+        proxy_set_header Accept $http_accept;
+
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }}"""
 
     def _generate_transport_location_blocks(self, path: str, server_info: dict[str, Any]) -> list:
         """Generate nginx location blocks for different transport types."""

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -220,6 +220,14 @@ class AgentService:
             logger.error(f"Failed to re-index agent {path}: {e}")
 
         logger.info(f"Agent '{updated_agent.name}' ({path}) updated")
+
+        # Regenerate nginx config if the agent is enabled, since its backend
+        # url may have changed.
+        if await self.is_agent_enabled(path):
+            from ..core.nginx_service import nginx_reload_scheduler
+
+            nginx_reload_scheduler.mark_dirty()
+
         return updated_agent
 
     async def delete_agent(
@@ -245,6 +253,9 @@ class AgentService:
 
         try:
             agent_name = existing_agent.name
+            # Capture enabled state before deletion removes the state record, so
+            # we only regenerate nginx config when a proxied block actually existed.
+            was_enabled = await self.is_agent_enabled(path)
 
             from .search_index_cleanup import remove_from_search_index_with_retry
 
@@ -260,6 +271,13 @@ class AgentService:
             await self._repo.delete(path)
 
             logger.info(f"Successfully deleted agent '{agent_name}' from path '{path}'")
+
+            # Regenerate nginx config so the agent's reverse-proxy block is
+            # removed, but only if it was enabled.
+            if was_enabled:
+                from ..core.nginx_service import nginx_reload_scheduler
+
+                nginx_reload_scheduler.mark_dirty()
             return True
 
         except ValueError:
@@ -292,6 +310,11 @@ class AgentService:
         await self._repo.set_state(path, True)
         logger.info(f"Enabled agent '{agent.name}' ({path})")
 
+        # Regenerate nginx config so the agent's reverse-proxy block is added.
+        from ..core.nginx_service import nginx_reload_scheduler
+
+        nginx_reload_scheduler.mark_dirty()
+
     async def disable_agent(
         self,
         path: str,
@@ -315,6 +338,11 @@ class AgentService:
 
         await self._repo.set_state(path, False)
         logger.info(f"Disabled agent '{agent.name}' ({path})")
+
+        # Regenerate nginx config so the agent's reverse-proxy block is removed.
+        from ..core.nginx_service import nginx_reload_scheduler
+
+        nginx_reload_scheduler.mark_dirty()
 
     async def is_agent_enabled(
         self,

--- a/scripts/registry-admins.json
+++ b/scripts/registry-admins.json
@@ -16,7 +16,8 @@
           {"action": "get_agent", "resources": ["all"]},
           {"action": "publish_agent", "resources": ["all"]},
           {"action": "modify_agent", "resources": ["all"]},
-          {"action": "delete_agent", "resources": ["all"]}
+          {"action": "delete_agent", "resources": ["all"]},
+          {"action": "invoke_agent", "resources": ["all"]}
         ]
       }
     }

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -734,6 +734,75 @@ class TestValidateEndpoint:
             assert data["username"] == "testuser"
 
     @patch("auth_server.server.get_auth_provider")
+    def test_validate_a2a_agent_request_allowed(
+        self,
+        mock_get_provider,
+        mock_cognito_provider,
+        auth_env_vars,
+        mock_scope_repository_with_data,
+    ):
+        """An A2A agent proxy request with invoke access passes and skips MCP checks."""
+        mock_get_provider.return_value = mock_cognito_provider
+
+        import auth_server.server as server_module
+
+        with (
+            patch(
+                "auth_server.server.get_scope_repository",
+                return_value=mock_scope_repository_with_data,
+            ),
+            patch(
+                "auth_server.server.validate_a2a_agent_access",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            client = TestClient(server_module.app)
+            response = client.get(
+                "/validate",
+                headers={
+                    "Authorization": "Bearer test-token",
+                    "X-Original-URL": "https://example.com/agent/travel/",
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json()["valid"] is True
+
+    @patch("auth_server.server.get_auth_provider")
+    def test_validate_a2a_agent_request_denied(
+        self,
+        mock_get_provider,
+        mock_cognito_provider,
+        auth_env_vars,
+        mock_scope_repository_with_data,
+    ):
+        """An A2A agent proxy request without invoke access is rejected with 403."""
+        mock_get_provider.return_value = mock_cognito_provider
+
+        import auth_server.server as server_module
+
+        with (
+            patch(
+                "auth_server.server.get_scope_repository",
+                return_value=mock_scope_repository_with_data,
+            ),
+            patch(
+                "auth_server.server.validate_a2a_agent_access",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            client = TestClient(server_module.app)
+            response = client.get(
+                "/validate",
+                headers={
+                    "Authorization": "Bearer test-token",
+                    "X-Original-URL": "https://example.com/agent/travel/",
+                },
+            )
+
+        assert response.status_code == 403
+
+    @patch("auth_server.server.get_auth_provider")
     def test_validate_uninspectable_body_fails_closed(
         self,
         mock_get_provider,
@@ -3308,6 +3377,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
             )
 
         assert response.status_code == 403
+
     def test_egress_consent_emits_iserror_baseline_with_connect_url(self):
         """DEFAULT consent delivery: when egress is on and the user has no token,
         a tools/call gets a SUCCESSFUL JSON-RPC result with isError=true whose
@@ -3930,6 +4000,8 @@ class TestAuthorizeForwardedMcpBody:
                     ["read:servers"],
                 )
         assert exc_info.value.status_code == 403
+
+
 class TestSessionCookieSecureDefault:
     """Verify the session cookie Secure flag resolves fail-closed.
 
@@ -3959,6 +4031,7 @@ class TestSessionCookieSecureDefault:
         """Even secure-by-default must not emit Secure over plain HTTP."""
         assert self._resolve_cookie_secure({}, is_https=False) is False
         assert self._resolve_cookie_secure({"secure": True}, is_https=False) is False
+
 
 class TestForwardHeadersIngressStrip:
     """Egress ingress-auth policy (issue #1266): client auth headers are ingress
@@ -4105,3 +4178,175 @@ class TestInternalRelayDecision:
         """A federated copy (e.g. server claim 'ai-registry' from /ai-registry/...)
         is a different first path segment and must NOT relay."""
         assert self._decides_relay("ai-registry") is False
+
+
+# =============================================================================
+# A2A AGENT PROXY ACCESS TESTS
+# =============================================================================
+
+
+class TestGetA2AAgentPath:
+    """Tests for _get_a2a_agent_path URL parsing."""
+
+    def test_none_url_returns_none(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path(None) is None
+
+    def test_agent_jsonrpc_url(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/agent/travel/") == "/travel"
+
+    def test_agent_card_url(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        url = "https://mcp.example.com/agent/flight-booking-agent/.well-known/agent-card.json"
+        assert _get_a2a_agent_path(url) == "/flight-booking-agent"
+
+    def test_non_agent_url_returns_none(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/currenttime/mcp") is None
+
+    def test_api_url_returns_none(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/api/agents") is None
+
+    def test_bare_agent_prefix_without_segment_returns_none(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/agent/") is None
+
+    def test_multi_segment_agent_path(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/agent/lob1/travel/") == "/lob1/travel"
+
+    def test_multi_segment_agent_card_url(self):
+        from auth_server.server import _get_a2a_agent_path
+
+        url = "https://mcp.example.com/agent/lob1/travel/.well-known/agent-card.json"
+        assert _get_a2a_agent_path(url) == "/lob1/travel"
+
+    def test_registry_root_path_prefix_is_stripped(self):
+        """When the registry is hosted on a sub-path, the prefix is stripped."""
+        import auth_server.server as server_module
+
+        with patch.object(server_module, "REGISTRY_ROOT_PATH", "/registry"):
+            assert (
+                server_module._get_a2a_agent_path("https://mcp.example.com/registry/agent/travel/")
+                == "/travel"
+            )
+
+    def test_agent_card_at_root_returns_none(self):
+        """A card discovery URL with no agent segment resolves to None."""
+        from auth_server.server import _get_a2a_agent_path
+
+        url = "https://mcp.example.com/agent/.well-known/agent-card.json"
+        assert _get_a2a_agent_path(url) is None
+
+    def test_empty_agent_segment_returns_none(self):
+        """An empty path segment (…/agent/lob1//travel/) is rejected."""
+        from auth_server.server import _get_a2a_agent_path
+
+        assert _get_a2a_agent_path("https://mcp.example.com/agent/lob1//travel/") is None
+
+
+class TestValidateA2AAgentAccess:
+    """Tests for validate_a2a_agent_access structured per-agent gating.
+
+    The function resolves each caller scope via the scope repository and looks
+    for an ``invoke_agent`` action whose resources cover the agent path. The
+    repository is mocked to return scope -> server_access config, mirroring the
+    fixtures used by the MCP validate_server_tool_access tests.
+    """
+
+    @staticmethod
+    def _repo(scope_config: dict[str, list]):
+        """Build a mock scope repository returning the given scope -> config map."""
+        repo = AsyncMock()
+
+        async def get_server_scopes(scope_name: str):
+            return scope_config.get(scope_name, [])
+
+        repo.get_server_scopes.side_effect = get_server_scopes
+        return repo
+
+    @staticmethod
+    def _invoke_scope(resources: list[str]) -> list:
+        """A server_access list granting invoke_agent on the given resources."""
+        return [{"agents": {"actions": [{"action": "invoke_agent", "resources": resources}]}}]
+
+    async def test_invoke_all_resources_allows(self):
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = self._repo({"a2a-invoker": self._invoke_scope(["all"])})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-invoker"]) is True
+
+    async def test_invoke_exact_path_allows(self):
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = self._repo({"a2a-travel": self._invoke_scope(["/travel"])})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-travel"]) is True
+
+    async def test_invoke_different_path_denied(self):
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = self._repo({"a2a-hr": self._invoke_scope(["/hr"])})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-hr"]) is False
+
+    async def test_sibling_path_not_matched(self):
+        """An exact-path resource for /travel-extended must NOT grant /travel."""
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = self._repo({"a2a-ext": self._invoke_scope(["/travel-extended"])})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-ext"]) is False
+
+    async def test_non_invoke_action_denied(self):
+        """A scope granting only agent CRUD (no invoke_agent) is denied."""
+        from auth_server.server import validate_a2a_agent_access
+
+        crud = [{"agents": {"actions": [{"action": "get_agent", "resources": ["all"]}]}}]
+        repo = self._repo({"a2a-reader": crud})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-reader"]) is False
+
+    async def test_mcp_only_scope_denied(self):
+        """A pure MCP server scope (no agents block) is denied."""
+        from auth_server.server import validate_a2a_agent_access
+
+        mcp = [{"server": "*", "methods": ["all"], "tools": ["all"]}]
+        repo = self._repo({"mcp-servers-unrestricted/read": mcp})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert (
+                await validate_a2a_agent_access("/travel", ["mcp-servers-unrestricted/read"])
+                is False
+            )
+
+    async def test_empty_scopes_denied(self):
+        from auth_server.server import validate_a2a_agent_access
+
+        assert await validate_a2a_agent_access("/travel", []) is False
+
+    async def test_scope_resolution_error_is_skipped_and_denied(self):
+        """A scope whose repository lookup raises is skipped, not fatal; access denied."""
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = AsyncMock()
+        repo.get_server_scopes.side_effect = RuntimeError("scope backend down")
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["a2a-invoker"]) is False
+
+    async def test_unknown_scope_with_empty_config_denied(self):
+        """A scope that resolves to an empty config is skipped (denied)."""
+        from auth_server.server import validate_a2a_agent_access
+
+        repo = self._repo({})
+        with patch("auth_server.server.get_scope_repository", return_value=repo):
+            assert await validate_a2a_agent_access("/travel", ["missing-scope"]) is False

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -363,6 +363,132 @@ server {
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_a2a_blocks_emitted_when_flag_enabled(
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write
+):
+    """A2A location blocks are rendered when the reverse-proxy flag is on."""
+    template_content = "server {\n    listen 80;\n{{AGENT_LOCATION_BLOCKS}}\n}\n"
+
+    with patch("registry.core.nginx_service.settings") as mock_settings:
+        mock_settings.nginx_updates_enabled = True
+        mock_settings.a2a_reverse_proxy_enabled = True
+        mock_settings.nginx_config_path = "/etc/nginx/conf.d/nginx_rev_proxy.conf"
+        mock_settings.auth_server_url = "http://auth-server:8888"
+        with patch.object(nginx_service.nginx_template_path, "exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=template_content)):
+                with patch("registry.health.service.health_service", mock_health_service):
+                    with patch.object(
+                        nginx_service, "get_additional_server_names", return_value=""
+                    ):
+                        with patch.object(nginx_service, "reload_nginx", return_value=True):
+                            with patch.object(
+                                nginx_service,
+                                "_generate_agent_location_blocks",
+                                new=AsyncMock(return_value="# A2A_BLOCK_SENTINEL"),
+                            ) as gen:
+                                result = await nginx_service.generate_config_async(sample_servers)
+
+    assert result is True
+    gen.assert_awaited_once()
+    written = mock_atomic_write.call_args_list[-1][0][1]
+    assert "# A2A_BLOCK_SENTINEL" in written
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_a2a_blocks_skipped_when_flag_disabled(
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write
+):
+    """No A2A blocks are generated when the reverse-proxy flag is off (default)."""
+    template_content = "server {\n    listen 80;\n{{AGENT_LOCATION_BLOCKS}}\n}\n"
+
+    with patch("registry.core.nginx_service.settings") as mock_settings:
+        mock_settings.nginx_updates_enabled = True
+        mock_settings.a2a_reverse_proxy_enabled = False
+        mock_settings.nginx_config_path = "/etc/nginx/conf.d/nginx_rev_proxy.conf"
+        mock_settings.auth_server_url = "http://auth-server:8888"
+        with patch.object(nginx_service.nginx_template_path, "exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=template_content)):
+                with patch("registry.health.service.health_service", mock_health_service):
+                    with patch.object(
+                        nginx_service, "get_additional_server_names", return_value=""
+                    ):
+                        with patch.object(nginx_service, "reload_nginx", return_value=True):
+                            with patch.object(
+                                nginx_service,
+                                "_generate_agent_location_blocks",
+                                new=AsyncMock(return_value="# A2A_BLOCK_SENTINEL"),
+                            ) as gen:
+                                result = await nginx_service.generate_config_async(sample_servers)
+
+    assert result is True
+    gen.assert_not_awaited()
+    written = mock_atomic_write.call_args_list[-1][0][1]
+    assert "# A2A_BLOCK_SENTINEL" not in written
+    assert "{{AGENT_LOCATION_BLOCKS}}" not in written
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_enabling_agent_changes_rendered_config_hash(
+    nginx_service, sample_servers, mock_health_service, mock_atomic_write
+):
+    """Enabling a healthy A2A agent changes the rendered config and its hash.
+
+    Exercises the real render-to-hash path: the agent generator is NOT mocked,
+    so the scheduler's hash-based change detection would see a new hash and
+    trigger an nginx reload once an agent becomes eligible for proxying.
+    """
+    import hashlib
+    from types import SimpleNamespace
+
+    template_content = "server {\n    listen 80;\n{{AGENT_LOCATION_BLOCKS}}\n}\n"
+    healthy_agent = SimpleNamespace(
+        path="/flight-booking-agent",
+        url="https://flight-booking.dev.example.com",
+        name="Flight Booking Agent",
+        supported_protocol="a2a",
+        health_status="healthy",
+    )
+
+    async def _render(enabled_paths, agent_info):
+        with patch("registry.core.nginx_service.settings") as mock_settings:
+            mock_settings.nginx_updates_enabled = True
+            mock_settings.a2a_reverse_proxy_enabled = True
+            mock_settings.nginx_config_path = "/etc/nginx/conf.d/nginx_rev_proxy.conf"
+            mock_settings.auth_server_url = "http://auth-server:8888"
+            with patch.object(nginx_service.nginx_template_path, "exists", return_value=True):
+                with patch("builtins.open", mock_open(read_data=template_content)):
+                    with patch("registry.health.service.health_service", mock_health_service):
+                        with patch.object(
+                            nginx_service, "get_additional_server_names", return_value=""
+                        ):
+                            with patch.object(nginx_service, "reload_nginx", return_value=True):
+                                with patch(
+                                    "registry.services.agent_service.agent_service"
+                                ) as mock_agent_svc:
+                                    mock_agent_svc.get_enabled_agents = AsyncMock(
+                                        return_value=enabled_paths
+                                    )
+                                    mock_agent_svc.get_agent_info = AsyncMock(
+                                        return_value=agent_info
+                                    )
+                                    await nginx_service.generate_config_async(sample_servers)
+        return mock_atomic_write.call_args_list[-1][0][1]
+
+    without_agent = await _render([], None)
+    with_agent = await _render(["/flight-booking-agent"], healthy_agent)
+
+    assert "/agent/flight-booking-agent/" not in without_agent
+    assert "/agent/flight-booking-agent/" in with_agent
+    assert (
+        hashlib.sha256(without_agent.encode()).hexdigest()
+        != hashlib.sha256(with_agent.encode()).hexdigest()
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_generate_config_async_template_not_found(nginx_service, sample_servers):
     """Test configuration generation when template is not found."""
     with patch.object(nginx_service.nginx_template_path, "exists", return_value=False):

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -9,7 +9,7 @@ than MagicMock behavior.
 import logging
 from datetime import UTC, datetime
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -470,6 +470,35 @@ class TestUpdateAgent:
         with pytest.raises(ValueError, match="Invalid"):
             await agent_service.update_agent("/test-agent", {"num_stars": 10.0})
 
+    @pytest.mark.asyncio
+    async def test_update_enabled_agent_marks_nginx_dirty(
+        self,
+        agent_service: AgentService,
+        fake_repo: InMemoryAgentRepository,
+    ):
+        """Updating an enabled agent regenerates nginx config (backend url may change)."""
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
+
+        with patch("registry.core.nginx_service.nginx_reload_scheduler") as scheduler:
+            await agent_service.update_agent("/test-agent", {"description": "Updated"})
+
+        scheduler.mark_dirty.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_disabled_agent_does_not_mark_nginx_dirty(
+        self,
+        agent_service: AgentService,
+        fake_repo: InMemoryAgentRepository,
+    ):
+        """A disabled agent has no proxy block, so update skips nginx regeneration."""
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+
+        with patch("registry.core.nginx_service.nginx_reload_scheduler") as scheduler:
+            await agent_service.update_agent("/test-agent", {"description": "Updated"})
+
+        scheduler.mark_dirty.assert_not_called()
+
 
 # =============================================================================
 # TEST: Delete Agent
@@ -532,6 +561,37 @@ class TestDeleteAgent:
         result = await agent_service.remove_agent("/nonexistent")
 
         assert result is False
+
+    @pytest.mark.asyncio
+    async def test_delete_enabled_agent_marks_nginx_dirty(
+        self,
+        agent_service: AgentService,
+        fake_repo: InMemoryAgentRepository,
+    ):
+        """Deleting an enabled agent removes its proxy block, triggering nginx reload."""
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+        await fake_repo.set_state("/test-agent", True)
+
+        with patch("registry.core.nginx_service.nginx_reload_scheduler") as scheduler:
+            result = await agent_service.delete_agent("/test-agent")
+
+        assert result is True
+        scheduler.mark_dirty.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_disabled_agent_does_not_mark_nginx_dirty(
+        self,
+        agent_service: AgentService,
+        fake_repo: InMemoryAgentRepository,
+    ):
+        """A disabled agent had no proxy block, so delete skips nginx regeneration."""
+        await fake_repo.create(AgentCardFactory(path="/test-agent"))
+
+        with patch("registry.core.nginx_service.nginx_reload_scheduler") as scheduler:
+            result = await agent_service.delete_agent("/test-agent")
+
+        assert result is True
+        scheduler.mark_dirty.assert_not_called()
 
 
 # =============================================================================

--- a/tests/unit/test_agent_nginx.py
+++ b/tests/unit/test_agent_nginx.py
@@ -1,0 +1,417 @@
+"""Unit tests for A2A agent nginx reverse-proxy config generation."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from registry.core.nginx_service import NginxConfigService
+
+
+def _agent(
+    path="/flight-booking-agent",
+    url="https://flight-booking.dev.example.com",
+    name="Flight Booking Agent",
+    supported_protocol="a2a",
+    health_status="healthy",
+):
+    """Build a lightweight agent-card stand-in for the generator.
+
+    The generator reads ``path``, ``url``, ``name``, ``supported_protocol``
+    and ``health_status``, so a namespace avoids coupling the test to the full
+    AgentCard pydantic model. Defaults describe a healthy A2A agent (the case
+    that produces a proxy block).
+    """
+    return SimpleNamespace(
+        path=path,
+        url=url,
+        name=name,
+        supported_protocol=supported_protocol,
+        health_status=health_status,
+    )
+
+
+@pytest.fixture
+def patched_agent_service():
+    """Patch the agent_service singleton imported lazily by the generator."""
+    with patch("registry.services.agent_service.agent_service") as mock_svc:
+        mock_svc.get_enabled_agents = AsyncMock(return_value=[])
+        mock_svc.get_agent_info = AsyncMock(return_value=None)
+        yield mock_svc
+
+
+class TestGenerateAgentLocationBlocks:
+    """Tests for _generate_agent_location_blocks."""
+
+    @pytest.mark.asyncio
+    async def test_no_enabled_agents_returns_empty(self, patched_agent_service):
+        """Empty string returned when there are no enabled agents."""
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_generates_blocks_for_enabled_agent(self, patched_agent_service):
+        """An enabled agent produces a location block at /agent/{path}/."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent())
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "{{ROOT_PATH}}/agent/flight-booking-agent/" in result
+
+    @pytest.mark.asyncio
+    async def test_includes_agent_card_discovery_location(self, patched_agent_service):
+        """The agent-card discovery location is emitted."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent())
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "{{ROOT_PATH}}/agent/flight-booking-agent/.well-known/agent-card.json" in result
+
+    @pytest.mark.asyncio
+    async def test_block_enforces_auth_request(self, patched_agent_service):
+        """Generated blocks are protected by the /validate auth subrequest."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent())
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "auth_request /validate;" in result
+
+    @pytest.mark.asyncio
+    async def test_jsonrpc_block_disables_buffering_for_sse(self, patched_agent_service):
+        """The JSON-RPC block disables proxy buffering for message/stream SSE."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent())
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "proxy_buffering off;" in result
+
+    @pytest.mark.asyncio
+    async def test_proxies_to_backend_url(self, patched_agent_service):
+        """The block proxies to the agent backend url."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent())
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "proxy_pass https://flight-booking.dev.example.com/;" in result
+
+    @pytest.mark.asyncio
+    async def test_skips_agent_without_url(self, patched_agent_service):
+        """An enabled agent with no backend url is skipped."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent(url=""))
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_missing_agent_card(self, patched_agent_service):
+        """An enabled path with no resolvable card is skipped."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=None)
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_agent_with_unsafe_path(self, patched_agent_service):
+        """An agent whose path would inject nginx directives is skipped."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/evil"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="evil}\n location / { return 200; }\n #")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_agent_with_unsafe_url(self, patched_agent_service):
+        """An agent whose backend url is not a safe http(s) url is skipped."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/evil"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(url="https://host/ { return 200; }")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_unhealthy_agent(self, patched_agent_service):
+        """An unhealthy agent is skipped so no route points at a dead backend."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(health_status="unhealthy")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_agent_with_unknown_health(self, patched_agent_service):
+        """An agent whose health is not yet verified (unknown) is skipped."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(health_status="unknown")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_non_a2a_protocol_agent(self, patched_agent_service):
+        """A non-A2A agent with a URL does not get a JSON-RPC proxy block."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(supported_protocol="other")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_agent_missing_protocol(self, patched_agent_service):
+        """An agent with no supported_protocol is skipped (not treated as A2A)."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(supported_protocol=None)
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_generates_blocks_for_multiple_agents(self, patched_agent_service):
+        """Each enabled agent gets its own route."""
+        patched_agent_service.get_enabled_agents = AsyncMock(
+            return_value=["/flight-booking-agent", "/travel-assistant-agent"]
+        )
+
+        async def _info(path):
+            return _agent(path=path, url=f"https://flight-booking{path}.example.com")
+
+        patched_agent_service.get_agent_info = AsyncMock(side_effect=_info)
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "{{ROOT_PATH}}/agent/flight-booking-agent/" in result
+        assert "{{ROOT_PATH}}/agent/travel-assistant-agent/" in result
+
+    @pytest.mark.asyncio
+    async def test_generation_failure_returns_empty(self, patched_agent_service):
+        """A failure while resolving agents must not break config rendering.
+
+        The generator fails closed to an empty string so nginx still reloads
+        (without any agent proxy blocks) instead of raising.
+        """
+        patched_agent_service.get_enabled_agents = AsyncMock(
+            side_effect=RuntimeError("agent store unavailable")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+
+class TestReverseProxyFlagDefault:
+    """The reverse-proxy mode must be opt-in."""
+
+    def test_flag_defaults_to_disabled(self):
+        """A2A_REVERSE_PROXY_ENABLED defaults to False (opt-in)."""
+        from registry.core.config import Settings
+
+        assert Settings.model_fields["a2a_reverse_proxy_enabled"].default is False
+
+
+class TestCreateAgentLocationBlock:
+    """Tests for _create_agent_location_block."""
+
+    def test_external_host_uses_upstream_hostname(self):
+        """An https backend sets the Host header to the upstream hostname."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "proxy_set_header Host flight-booking.dev.example.com;" in block
+
+    def test_internal_host_preserves_original_host(self):
+        """A bare internal hostname preserves the original Host header."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "http://flight-booking-agent",
+            "Flight Booking Agent",
+        )
+
+        assert "proxy_set_header Host $host;" in block
+
+    def test_captures_body_for_metrics(self):
+        """The JSON-RPC block captures the request body so metrics can record the method."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "rewrite_by_lua_file /etc/nginx/lua/capture_body.lua;" in block
+
+    def test_card_location_is_exact_match(self):
+        """The agent-card location uses an exact match to block suffix smuggling."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert (
+            "location = {{ROOT_PATH}}/agent/flight-booking-agent/.well-known/agent-card.json"
+            in block
+        )
+
+    def test_card_proxy_pass_has_no_double_slash(self):
+        """The agent-card proxy_pass targets the backend without a double slash."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert (
+            "proxy_pass https://flight-booking.dev.example.com/.well-known/agent-card.json;"
+            in block
+        )
+
+    def test_streaming_read_timeout_present(self):
+        """The JSON-RPC block sets a long read timeout for SSE streaming."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "proxy_read_timeout 86400s;" in block
+
+    def test_dotted_internal_hostname_uses_upstream_netloc(self):
+        """A dotted internal hostname (with port) sets Host to the upstream netloc."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "http://svc.namespace.svc.cluster.local:8080",
+            "Flight Booking Agent",
+        )
+
+        assert "proxy_set_header Host svc.namespace.svc.cluster.local:8080;" in block
+
+    def test_unsafe_path_raises(self):
+        """An agent path with nginx metacharacters raises ValueError."""
+        service = NginxConfigService()
+
+        with pytest.raises(ValueError, match="unsafe agent path"):
+            service._create_agent_location_block(
+                "evil}\n location / {}",
+                "https://flight-booking.dev.example.com",
+                "Evil",
+            )
+
+    def test_unsafe_url_raises(self):
+        """A backend url with nginx metacharacters raises ValueError."""
+        service = NginxConfigService()
+
+        with pytest.raises(ValueError, match="unsafe agent url"):
+            service._create_agent_location_block(
+                "flight-booking-agent",
+                "https://host/ { return 200; }",
+                "Evil",
+            )
+
+    def test_card_location_rewrites_card_urls(self):
+        """The agent-card location runs the card-rewrite body filter."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "body_filter_by_lua_file /etc/nginx/lua/agent_card_rewrite.lua;" in block
+
+    def test_card_location_clears_content_length(self):
+        """Content-Length is cleared so the rewritten card body is not truncated."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "ngx.header.content_length = nil" in block
+
+    def test_jsonrpc_block_forwards_scopes_to_backend(self):
+        """Validated scopes are captured from /validate and forwarded to the agent."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "flight-booking-agent",
+            "https://flight-booking.dev.example.com",
+            "Flight Booking Agent",
+        )
+
+        assert "auth_request_set $auth_scopes $upstream_http_x_scopes;" in block
+        assert "proxy_set_header X-Scopes $auth_scopes;" in block
+
+    def test_multi_segment_agent_path_in_route(self):
+        """A multi-segment agent path renders verbatim in the location route."""
+        service = NginxConfigService()
+
+        block = service._create_agent_location_block(
+            "lob1/travel",
+            "https://flight-booking.dev.example.com",
+            "Travel",
+        )
+
+        assert "{{ROOT_PATH}}/agent/lob1/travel/" in block


### PR DESCRIPTION
## Summary

Adds reverse-proxy gateway support for A2A agents, so A2A **agent-card discovery** and **JSON-RPC traffic** are proxied through the nginx gateway (not just discovered). Implements the feature requested upstream in [agentic-community/mcp-gateway-registry#847](https://github.com/agentic-community/mcp-gateway-registry/issues/847).

The mode is **opt-in** via `A2A_REVERSE_PROXY_ENABLED` (default `false`) — registry-only discovery is unchanged for existing deployments.

## What changed

- **Opt-in feature flag** (`registry/core/config.py`, `registry/core/nginx_service.py`): new `a2a_reverse_proxy_enabled` setting (env `A2A_REVERSE_PROXY_ENABLED`, default `false`). Agent location blocks are only generated when it is enabled (and in `with-gateway` deployment mode). When off, `/agent/*` keeps the existing registry-only behavior.
- **nginx config generation** (`registry/core/nginx_service.py`): generate per-agent `location` blocks — one for the agent card (`/agent/<path>/.well-known/agent-card.json`) and one for the JSON-RPC endpoint (`/agent/<path>/`) — wired through the `auth_request /validate` subrequest (same hop as MCP servers). `path`/`url` are input-validated before interpolation. Templates gain a `{{AGENT_LOCATION_BLOCKS}}` placeholder.
- **Agent lifecycle → nginx refresh** (`registry/services/agent_service.py`): mark nginx dirty on enable/disable/update/delete so proxy routes track agent state.
- **Per-agent FGAC** (`auth_server/server.py`): `/validate` enforces invocation access via `validate_a2a_agent_access()`, which mirrors `validate_server_tool_access` — it resolves each caller scope through the scope repository and matches an `invoke_agent` action whose `resources` cover the agent path (`all`/`*` or exact path). Adds `_get_a2a_agent_path()`.
- **Scope seed** (`scripts/registry-admins.json`): adds an `invoke_agent` action (`resources: ["all"]`) to the admin scope; finer-grained per-agent grants are created as additional scope documents via the scope-management API.
- **Agent-card rewrite** (`docker/lua/agent_card_rewrite.lua`): rewrites agent-card URLs from the backend origin to the gateway origin (top-level `url` plus `additionalInterfaces`/`supportedInterfaces`) so clients route JSON-RPC back through the proxy.
- **Settings surface**: flag wired into `.env.example`, the Settings → System Config UI (`registry/api/config_routes.py` `CONFIG_GROUPS`), and `docs/unified-parameter-reference.md`.
- **Docs** (`docs/design/a2a-protocol-integration.md`): "Reverse-Proxy Mode" section, incl. how to enable the mode.

Per-method / per-skill FGAC is intentionally out of scope for this iteration: the structured model is action + resources, and the gateway can't resolve structured permissions in the request path.

## Tests

- `tests/unit/test_agent_nginx.py` (new): 25 tests for agent location-block generation, incl. the opt-in default (`A2A_REVERSE_PROXY_ENABLED=false`) — **all pass**.
- `tests/unit/core/test_nginx_service.py` (extended): render-level gate tests — blocks emitted when the flag is on, skipped when off — **all pass**.
- `tests/auth_server/unit/test_server.py` (extended): 16 A2A tests (`TestGetA2AAgentPath`, `TestValidateA2AAgentAccess`, structured/async) — **all pass**.
- `ruff check` clean on the added code.

## Notes

- No new Python dependencies.
- Changes are additive and opt-in (feature off by default; only `invoke_agent` appended to an existing scope seed).
