### PR TITLE
(fix) mcp session id hardening

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -65,6 +65,28 @@ local SUPPORTED_PROTOCOL_VERSIONS = {
 local LATEST_PROTOCOL_VERSION = "2025-11-25"
 
 
+-- Resolve the authenticated user identity for the current request.
+-- Used both when creating sessions (_handle_initialize) and when enforcing
+-- session ownership, so the values compared are always the same.
+-- Returns nil when no real identity is present: nginx auth_request_set yields
+-- an EMPTY STRING (not nil) for an absent upstream X-User header, and in Lua
+-- "" is truthy, so a plain `a or b or "anonymous"` chain would lock onto the
+-- empty string and never fall through. We normalize "" to nil at each step so
+-- callers can fail closed instead of treating an unauthenticated/identity-less
+-- request as a shared "anonymous" owner whose sessions everyone could hijack.
+local function _auth_user_id()
+    local u = ngx.var.auth_user
+    if u and u ~= "" then
+        return u
+    end
+    u = ngx.var.auth_username
+    if u and u ~= "" then
+        return u
+    end
+    return nil
+end
+
+
 -- Ensure inputSchema has "type": "object" as required by MCP spec
 local function _ensure_mcp_schema(schema)
     if not schema or type(schema) ~= "table" then
@@ -211,6 +233,10 @@ end
 
 -- Get or create a backend session for a given client session + backend location.
 -- Two-tier cache: L1 shared dict (30s) -> L2 MongoDB -> initialize backend
+-- client_session_id is always a gate-validated ^vs-[0-9a-f]+$ id here (route()
+-- allowlists it before any method that reaches this function), and
+-- backend_location comes from the trusted mapping file -- so session_key has no
+-- attacker-injectable query/path metacharacters.
 local function _get_backend_session(client_session_id, backend_location, server_id)
     local session_key = client_session_id .. ":" .. backend_location
     local cache_key = "bsess:" .. session_key
@@ -221,10 +247,18 @@ local function _get_backend_session(client_session_id, backend_location, server_
         return session_id
     end
 
-    -- L2: MongoDB via internal FastAPI API
-    local res = ngx.location.capture("/_internal/sessions/backend/" .. session_key, {
-        method = ngx.HTTP_GET,
-    })
+    -- L2: MongoDB via internal FastAPI API, bound to the authenticated owner
+    -- so a backend session belonging to a different user is never returned
+    -- (defense in depth behind the client-session gate). Escape the session-id
+    -- segment as well -- a no-op for valid vs-<hex> ids, but it keeps the
+    -- subrequest URI safe regardless of how the key was built.
+    local owner = _auth_user_id()
+    local owner_qs = owner and ("?user_id=" .. ngx.escape_uri(owner)) or ""
+    local backend_path = ngx.escape_uri(client_session_id) .. ":" .. backend_location
+    local res = ngx.location.capture(
+        "/_internal/sessions/backend/" .. backend_path .. owner_qs, {
+            method = ngx.HTTP_GET,
+        })
     if res and res.status == 200 then
         local ok, data = pcall(cjson.decode, res.body)
         if ok and data.backend_session_id then
@@ -239,15 +273,17 @@ local function _get_backend_session(client_session_id, backend_location, server_
     session_id = _initialize_backend(backend_location)
 
     if session_id then
-        -- Store in L2 (MongoDB)
-        local user_id = ngx.var.auth_user or ngx.var.auth_username or "anonymous"
+        -- Store in L2 (MongoDB). Store the resolved owner ("anonymous" only as
+        -- a last-resort audit label; the gate rejects identity-less requests
+        -- before any backend session is created).
+        local user_id = owner or "anonymous"
         local store_body = cjson.encode({
             backend_session_id = session_id,
             client_session_id = client_session_id,
             user_id = user_id,
             virtual_server_path = "/virtual/" .. server_id,
         })
-        ngx.location.capture("/_internal/sessions/backend/" .. session_key, {
+        ngx.location.capture("/_internal/sessions/backend/" .. backend_path, {
             method = ngx.HTTP_PUT,
             body = store_body,
         })
@@ -264,11 +300,18 @@ local function _invalidate_backend_session(client_session_id, backend_location)
     local session_key = client_session_id .. ":" .. backend_location
     local cache_key = "bsess:" .. session_key
 
-    -- Remove from L1
+    -- Remove from L1 (uses the raw key, matching how _get_backend_session
+    -- populated the shared dict)
     session_cache:delete(cache_key)
 
-    -- Remove from L2
-    ngx.location.capture("/_internal/sessions/backend/" .. session_key, {
+    -- Remove from L2, scoped to the authenticated owner (symmetric with the GET
+    -- lookup). Escape the session-id segment in the subrequest URI for the same
+    -- defense-in-depth reason as the GET/PUT paths (a no-op for valid vs-<hex>
+    -- ids, which is all that reaches here past the route() allowlist).
+    local backend_path = ngx.escape_uri(client_session_id) .. ":" .. backend_location
+    local owner = _auth_user_id()
+    local owner_qs = owner and ("?user_id=" .. ngx.escape_uri(owner)) or ""
+    ngx.location.capture("/_internal/sessions/backend/" .. backend_path .. owner_qs, {
         method = ngx.HTTP_DELETE,
     })
 end
@@ -647,24 +690,44 @@ local function _proxy_to_backend(request_id, method_name, proxied_params,
 end
 
 
--- Validate a client session ID against MongoDB (L2).
--- Uses L1 cache to avoid repeated DB lookups.
--- Returns true if valid, false otherwise.
-local function _validate_client_session(client_session_id)
+-- Validate a client session ID against MongoDB (L2), bound to the caller's
+-- authenticated identity AND the virtual server the session was minted for.
+-- A session that exists but belongs to a different user is rejected (returns
+-- false), preventing session hijacking via a guessed or stolen Mcp-Session-Id
+-- header; a session minted for a different virtual server is likewise rejected,
+-- so it cannot be replayed across virtual servers.
+-- Uses L1 cache to avoid repeated DB lookups; the cache key includes both the
+-- user and the virtual server path so a cached "valid" result can never
+-- authorize a different user or a different virtual server.
+-- Returns true if valid AND owned by the caller for this server, false otherwise.
+local function _validate_client_session(client_session_id, user_id, virtual_server_path)
     if not client_session_id or client_session_id == "" then
         return false
     end
 
-    -- L1: fast path check (cache valid sessions for SESSION_CACHE_TTL)
-    local cache_key = "csess_valid:" .. client_session_id
+    -- L1: fast path check (cache valid sessions for SESSION_CACHE_TTL).
+    -- Key on user_id and virtual_server_path so a session validated for one
+    -- user/server is never reused to authorize a different one from the shared
+    -- per-worker cache.
+    local cache_key = "csess_valid:" .. user_id .. ":"
+        .. (virtual_server_path or "") .. ":" .. client_session_id
     local cached = session_cache:get(cache_key)
     if cached == "1" then
         return true
     end
 
-    -- L2: validate via internal FastAPI endpoint
+    -- L2: validate via internal FastAPI endpoint, passing the authenticated
+    -- user and virtual server path so the registry enforces both bindings in
+    -- the DB query.
+    -- Escape the session ID into the path segment as defense in depth -- the
+    -- caller (route()) already allowlists it to ^vs-[0-9a-f]+$, but escaping
+    -- here means this function is safe even if a future caller forgets to.
+    local query = "?user_id=" .. ngx.escape_uri(user_id)
+    if virtual_server_path then
+        query = query .. "&virtual_server_path=" .. ngx.escape_uri(virtual_server_path)
+    end
     local res = ngx.location.capture(
-        "/_internal/sessions/client/" .. client_session_id,
+        "/_internal/sessions/client/" .. ngx.escape_uri(client_session_id) .. query,
         { method = ngx.HTTP_GET }
     )
 
@@ -687,9 +750,19 @@ local function _negotiate_protocol_version(client_version)
 end
 
 
--- Handle initialize method - create client session, return MCP capabilities
+-- Handle initialize method - create client session, return MCP capabilities.
+-- Returns (response_string, err) where err is nil on success, or one of:
+--   "unauthenticated" -- no authenticated identity; route() emits 401 (a
+--       session must be owned by a concrete user, so we refuse to mint one).
+--   "create_failed"   -- the client session could not be created; route()
+--       emits an error instead of a misleading 200 with no Mcp-Session-Id
+--       (which would make the client 400 on its very next request).
 local function _handle_initialize(request_id, server_id, params)
-    local user_id = ngx.var.auth_user or ngx.var.auth_username or "anonymous"
+    local user_id = _auth_user_id()
+    if not user_id then
+        ngx.log(ngx.WARN, "initialize rejected: no authenticated user for server=", server_id)
+        return nil, "unauthenticated"
+    end
     local virtual_path = "/virtual/" .. server_id
 
     -- Create client session in MongoDB via internal API
@@ -710,14 +783,19 @@ local function _handle_initialize(request_id, server_id, params)
         end
     end
 
-    -- Set Mcp-Session-Id response header so client includes it in future requests
-    if client_session_id then
-        ngx.header["Mcp-Session-Id"] = client_session_id
-        ngx.log(ngx.INFO, "Created client session ", client_session_id,
-            " for user=", user_id, " server=", server_id)
-    else
-        ngx.log(ngx.WARN, "Failed to create client session for server=", server_id)
+    -- Fail loudly if the session could not be created: returning a successful
+    -- initialize with no Mcp-Session-Id just defers the failure to the client's
+    -- next request (which 400s on the missing session).
+    if not client_session_id then
+        ngx.log(ngx.ERR, "Failed to create client session for server=", server_id,
+            " status=", res and res.status or "nil")
+        return nil, "create_failed"
     end
+
+    -- Set Mcp-Session-Id response header so client includes it in future requests
+    ngx.header["Mcp-Session-Id"] = client_session_id
+    ngx.log(ngx.INFO, "Created client session ", client_session_id,
+        " for user=", user_id, " server=", server_id)
 
     -- Negotiate protocol version with client
     local client_version = params and params.protocolVersion
@@ -948,11 +1026,26 @@ function _M.route()
         return
     end
 
-    -- Handle initialize: generate a client session and return capabilities
+    -- Handle initialize: generate a client session and return capabilities.
+    -- A session must be owned by a concrete user; refuse to mint one for a
+    -- request with no authenticated identity, and surface a session-creation
+    -- failure as an error rather than a misleading 200 with no Mcp-Session-Id.
     if method == "initialize" then
-        ngx.status = 200
+        local init_response, init_err = _handle_initialize(request_id, server_id, params)
         ngx.header["Content-Type"] = "application/json"
-        ngx.say(_handle_initialize(request_id, server_id, params))
+        if init_err == "unauthenticated" then
+            ngx.status = 401
+            ngx.say(_jsonrpc_error(request_id, -32600,
+                "Authenticated user identity required."))
+            return
+        elseif init_err or not init_response then
+            ngx.status = 503
+            ngx.say(_jsonrpc_error(request_id, -32603,
+                "Failed to create session. Please retry."))
+            return
+        end
+        ngx.status = 200
+        ngx.say(init_response)
         return
     end
 
@@ -967,10 +1060,46 @@ function _M.route()
     -- Get client session ID from request header (set during initialize)
     local client_session_id = ngx.var.http_mcp_session_id
 
+    -- Resolve the authenticated identity. Fail closed if absent: every session
+    -- is owned by a concrete user, so an identity-less request can never own
+    -- one. This also avoids treating a missing identity as a shared
+    -- "anonymous" owner whose sessions any other identity-less caller could
+    -- reach (auth_request normally blocks unauthenticated callers upstream,
+    -- but we do not depend on that single layer for session ownership).
+    local auth_user = _auth_user_id()
+    if not auth_user then
+        ngx.status = 401
+        ngx.header["Content-Type"] = "application/json"
+        ngx.say(_jsonrpc_error(request_id, -32600,
+            "Authenticated user identity required."))
+        return
+    end
+
+    -- Reject any session ID that is not in the server-minted format before it
+    -- reaches an internal subrequest. The ID is attacker-controlled (it comes
+    -- straight from the Mcp-Session-Id header) and is interpolated into the
+    -- /_internal/sessions/ subrequest URI; without this allowlist a crafted
+    -- value like "vs-x?user_id=victim&" could inject an earlier user_id query
+    -- param and shadow the owner check that the ownership binding relies on.
+    -- Server-minted IDs are always "vs-" + uuid4 hex (see create_client_session),
+    -- so this strict pattern rejects every injection vector with no escaping
+    -- reasoning required.
+    if not client_session_id or not string.match(client_session_id, "^vs%-[0-9a-f]+$") then
+        ngx.status = 400
+        ngx.header["Content-Type"] = "application/json"
+        ngx.say(_jsonrpc_error(request_id, -32600,
+            "Missing or invalid Mcp-Session-Id. Send an initialize request first."))
+        return
+    end
+
     -- Validate client session: per MCP spec, servers that require a session ID
     -- SHOULD respond with 400 Bad Request to requests without a valid Mcp-Session-Id.
     -- Initialize and ping are exempt; notifications already handled above with 202.
-    if not _validate_client_session(client_session_id) then
+    -- The session must also belong to the authenticated caller AND have been
+    -- minted for this virtual server -- presenting another user's session ID,
+    -- or replaying a session from a different virtual server, is rejected here
+    -- before any session context is loaded or routed.
+    if not _validate_client_session(client_session_id, auth_user, "/virtual/" .. server_id) then
         ngx.status = 400
         ngx.header["Content-Type"] = "application/json"
         ngx.say(_jsonrpc_error(request_id, -32600,

--- a/registry/api/internal_routes.py
+++ b/registry/api/internal_routes.py
@@ -91,15 +91,31 @@ async def create_client_session(
 )
 async def validate_client_session(
     client_session_id: str,
+    user_id: str | None = None,
+    virtual_server_path: str | None = None,
 ):
-    """Validate that a client session exists.
+    """Validate that a client session exists and belongs to the caller.
 
-    Returns 200 if valid, 404 if not found or expired.
-    Also bumps last_used_at to keep the session alive.
+    Returns 200 if valid, 404 if not found, expired, owned by a different user,
+    or minted for a different virtual server. Also bumps last_used_at to keep
+    the session alive.
+
+    The Lua router passes the authenticated user identity via the ``user_id``
+    query param and the virtual server path via ``virtual_server_path``. Binding
+    validation to the owner prevents session hijacking: an authenticated client
+    that presents another user's Mcp-Session-Id receives a 404 instead of
+    operating on the victim's session context. Binding to the virtual server
+    path stops a session minted for one virtual server being replayed against
+    another. When either is omitted, that check is not enforced (preserves
+    legacy callers).
     """
     repo = _get_repo()
 
-    is_valid = await repo.validate_client_session(client_session_id)
+    is_valid = await repo.validate_client_session(
+        client_session_id,
+        user_id=user_id,
+        virtual_server_path=virtual_server_path,
+    )
     if not is_valid:
         raise HTTPException(status_code=404, detail="Client session not found")
 
@@ -112,12 +128,19 @@ async def validate_client_session(
 )
 async def get_backend_session(
     session_key: str,
+    user_id: str | None = None,
 ):
-    """Look up a backend session by compound key.
+    """Look up a backend session by compound key, bound to the caller.
 
     The session_key is '<client_session_id>:<backend_key>'.
     Returns the backend_session_id if found, 404 otherwise.
     Also bumps last_used_at atomically.
+
+    The Lua router passes the authenticated user via the ``user_id`` query
+    param. Binding the lookup to the owner is defense in depth (the
+    client-session gate already enforces ownership upstream): a backend session
+    belonging to a different user is treated as not found. When ``user_id`` is
+    omitted, ownership is not enforced (preserves legacy callers).
     """
     repo = _get_repo()
 
@@ -134,6 +157,7 @@ async def get_backend_session(
     backend_session_id = await repo.get_backend_session(
         client_session_id=client_session_id,
         backend_key=backend_key,
+        user_id=user_id,
     )
 
     if backend_session_id is None:
@@ -184,11 +208,16 @@ async def store_backend_session(
 )
 async def delete_backend_session(
     session_key: str,
+    user_id: str | None = None,
 ):
     """Delete a stale backend session.
 
     Called by Lua router when a backend rejects a cached session ID
     (e.g., after backend restart). The router will then re-initialize.
+
+    The router passes the authenticated user via the ``user_id`` query param so
+    the delete is scoped to the owner (defense in depth, symmetric with the GET
+    lookup). When omitted, ownership is not enforced (preserves legacy callers).
     """
     repo = _get_repo()
 
@@ -205,6 +234,7 @@ async def delete_backend_session(
     await repo.delete_backend_session(
         client_session_id=client_session_id,
         backend_key=backend_key,
+        user_id=user_id,
     )
 
     return {"status": "deleted"}

--- a/registry/api/internal_routes.py
+++ b/registry/api/internal_routes.py
@@ -91,7 +91,7 @@ async def create_client_session(
 )
 async def validate_client_session(
     client_session_id: str,
-    user_id: str | None = None,
+    user_id: str,
     virtual_server_path: str | None = None,
 ):
     """Validate that a client session exists and belongs to the caller.
@@ -106,8 +106,12 @@ async def validate_client_session(
     that presents another user's Mcp-Session-Id receives a 404 instead of
     operating on the victim's session context. Binding to the virtual server
     path stops a session minted for one virtual server being replayed against
-    another. When either is omitted, that check is not enforced (preserves
-    legacy callers).
+    another.
+
+    ``user_id`` is REQUIRED: ownership binding is the session-hijacking control,
+    so a request without it must fail loudly (422) rather than silently fall
+    back to existence-only validation. ``virtual_server_path`` stays optional
+    (a missing path widens the match but does not drop the owner check).
     """
     repo = _get_repo()
 
@@ -128,7 +132,7 @@ async def validate_client_session(
 )
 async def get_backend_session(
     session_key: str,
-    user_id: str | None = None,
+    user_id: str,
 ):
     """Look up a backend session by compound key, bound to the caller.
 
@@ -139,8 +143,9 @@ async def get_backend_session(
     The Lua router passes the authenticated user via the ``user_id`` query
     param. Binding the lookup to the owner is defense in depth (the
     client-session gate already enforces ownership upstream): a backend session
-    belonging to a different user is treated as not found. When ``user_id`` is
-    omitted, ownership is not enforced (preserves legacy callers).
+    belonging to a different user is treated as not found. ``user_id`` is
+    REQUIRED so the owner check cannot be silently skipped; a request without it
+    fails with 422.
     """
     repo = _get_repo()
 
@@ -208,7 +213,7 @@ async def store_backend_session(
 )
 async def delete_backend_session(
     session_key: str,
-    user_id: str | None = None,
+    user_id: str,
 ):
     """Delete a stale backend session.
 
@@ -217,7 +222,8 @@ async def delete_backend_session(
 
     The router passes the authenticated user via the ``user_id`` query param so
     the delete is scoped to the owner (defense in depth, symmetric with the GET
-    lookup). When omitted, ownership is not enforced (preserves legacy callers).
+    lookup). ``user_id`` is REQUIRED so the scope cannot be silently dropped; a
+    request without it fails with 422.
     """
     repo = _get_repo()
 

--- a/registry/repositories/documentdb/backend_session_repository.py
+++ b/registry/repositories/documentdb/backend_session_repository.py
@@ -125,6 +125,10 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
         doc_id = _make_backend_session_id(client_session_id, backend_key)
 
         query: dict[str, str] = {"_id": doc_id}
+        # `is not None` is load-bearing: only None means "no owner filter". An
+        # empty-string user_id must add an (always-non-matching) filter, NOT skip
+        # it -- do not "simplify" this to `if user_id:` or an empty owner would
+        # reopen the existence-only hijack gap.
         if user_id is not None:
             query["user_id"] = user_id
 
@@ -211,6 +215,8 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
         doc_id = _make_backend_session_id(client_session_id, backend_key)
 
         query: dict[str, str] = {"_id": doc_id}
+        # `is not None` is load-bearing -- see get_backend_session: only None
+        # means "no owner filter"; an empty string must filter, not skip.
         if user_id is not None:
             query["user_id"] = user_id
 
@@ -286,6 +292,8 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
         doc_id = _make_client_session_id(client_session_id)
 
         query: dict[str, str] = {"_id": doc_id}
+        # `is not None` is load-bearing -- see get_backend_session: only None
+        # means "no owner filter"; an empty string must filter, not skip.
         if user_id is not None:
             query["user_id"] = user_id
         if virtual_server_path is not None:

--- a/registry/repositories/documentdb/backend_session_repository.py
+++ b/registry/repositories/documentdb/backend_session_repository.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ASCENDING
+from pymongo.errors import DuplicateKeyError
 
 from ..interfaces import BackendSessionRepositoryBase
 from .client import get_collection_name, get_documentdb_client
@@ -96,24 +97,39 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
         self,
         client_session_id: str,
         backend_key: str,
+        user_id: str | None = None,
     ) -> str | None:
         """Get backend session ID and atomically bump last_used_at.
 
         Uses find_one_and_update so the TTL is refreshed on every access,
         keeping active sessions alive.
 
+        When ``user_id`` is provided, the lookup also filters on the stored
+        owner. This is defense in depth: although every in-router path to a
+        backend session already passes the owner-bound client-session gate,
+        binding the backend-session read to the owner too means a single missed
+        gate cannot leak another user's live backend session ID. The owner
+        match is in the same atomic query that refreshes the TTL.
+
         Args:
             client_session_id: Client-facing session ID
             backend_key: Backend location key
+            user_id: Authenticated user identity the session must belong to.
+                When None, ownership is not enforced (legacy behavior).
 
         Returns:
-            Backend session ID if found, None otherwise
+            Backend session ID if found (and owned by ``user_id`` when given),
+            None otherwise
         """
         collection = await self._get_collection()
         doc_id = _make_backend_session_id(client_session_id, backend_key)
 
+        query: dict[str, str] = {"_id": doc_id}
+        if user_id is not None:
+            query["user_id"] = user_id
+
         result = await collection.find_one_and_update(
-            {"_id": doc_id},
+            query,
             {"$set": {"last_used_at": datetime.now(UTC)}},
         )
 
@@ -153,28 +169,52 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
             "last_used_at": now,
         }
 
-        await collection.replace_one(
-            {"_id": doc_id},
-            doc,
-            upsert=True,
-        )
-        logger.debug(f"Stored backend session: {doc_id} -> {backend_session_id}")
+        # Pin the owner in the upsert filter so a document with this _id owned by
+        # a different user is never overwritten. client_session_id is already
+        # owner-namespaced (each initialize mints a fresh vs-<uuid4> for one
+        # user), so a mismatch cannot happen on the legitimate path; if it ever
+        # did, the upsert tries to insert a new doc with a colliding _id and
+        # raises DuplicateKeyError, which we swallow as a safe refusal rather
+        # than clobbering another user's live backend session.
+        try:
+            await collection.replace_one(
+                {"_id": doc_id, "user_id": user_id},
+                doc,
+                upsert=True,
+            )
+            logger.debug(f"Stored backend session: {doc_id} -> {backend_session_id}")
+        except DuplicateKeyError:
+            logger.warning(
+                f"Refused to store backend session {doc_id} for user={user_id}: "
+                f"_id already owned by a different user"
+            )
 
     async def delete_backend_session(
         self,
         client_session_id: str,
         backend_key: str,
+        user_id: str | None = None,
     ) -> None:
         """Delete a stale backend session.
+
+        When ``user_id`` is provided, the delete is scoped to the owner so a
+        caller can only invalidate its own backend session (defense in depth,
+        symmetric with get/store). When None, ownership is not enforced
+        (legacy behavior).
 
         Args:
             client_session_id: Client-facing session ID
             backend_key: Backend location key
+            user_id: Authenticated user identity the session must belong to.
         """
         collection = await self._get_collection()
         doc_id = _make_backend_session_id(client_session_id, backend_key)
 
-        result = await collection.delete_one({"_id": doc_id})
+        query: dict[str, str] = {"_id": doc_id}
+        if user_id is not None:
+            query["user_id"] = user_id
+
+        result = await collection.delete_one(query)
         if result.deleted_count > 0:
             logger.debug(f"Deleted backend session: {doc_id}")
 
@@ -216,20 +256,43 @@ class DocumentDBBackendSessionRepository(BackendSessionRepositoryBase):
     async def validate_client_session(
         self,
         client_session_id: str,
+        user_id: str | None = None,
+        virtual_server_path: str | None = None,
     ) -> bool:
-        """Check if a client session exists and bump last_used_at.
+        """Check if a client session exists, is owned by ``user_id``, and bump last_used_at.
+
+        When ``user_id`` is provided, the lookup filters on the stored owner so a
+        session belonging to a different user is treated as not found. This binds
+        the session to the authenticated identity and prevents session hijacking
+        via a guessed or stolen Mcp-Session-Id header (the match is done in the
+        same atomic query that refreshes the TTL, so there is no check/use gap).
+
+        When ``virtual_server_path`` is provided, the lookup also filters on it so
+        a session minted for one virtual server cannot be replayed against
+        another (issue #2: virtual-server binding).
 
         Args:
             client_session_id: Client-facing session ID
+            user_id: Authenticated user identity the session must belong to.
+                When None, ownership is not enforced (legacy behavior).
+            virtual_server_path: Virtual server path the session was minted for.
+                When None, the path is not enforced (legacy behavior).
 
         Returns:
-            True if session exists, False otherwise
+            True if session exists (and matches ``user_id`` /
+            ``virtual_server_path`` when given), False otherwise
         """
         collection = await self._get_collection()
         doc_id = _make_client_session_id(client_session_id)
 
+        query: dict[str, str] = {"_id": doc_id}
+        if user_id is not None:
+            query["user_id"] = user_id
+        if virtual_server_path is not None:
+            query["virtual_server_path"] = virtual_server_path
+
         result = await collection.find_one_and_update(
-            {"_id": doc_id},
+            query,
             {"$set": {"last_used_at": datetime.now(UTC)}},
         )
 

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -1635,15 +1635,19 @@ class BackendSessionRepositoryBase(ABC):
         self,
         client_session_id: str,
         backend_key: str,
+        user_id: str | None = None,
     ) -> str | None:
         """Get backend session ID and bump last_used_at atomically.
 
         Args:
             client_session_id: Client-facing session ID
             backend_key: Backend location key
+            user_id: Authenticated user identity the session must belong to.
+                When None, ownership is not enforced (legacy behavior).
 
         Returns:
-            Backend session ID if found, None otherwise
+            Backend session ID if found (and owned by ``user_id`` when given),
+            None otherwise
         """
         pass
 
@@ -1672,12 +1676,15 @@ class BackendSessionRepositoryBase(ABC):
         self,
         client_session_id: str,
         backend_key: str,
+        user_id: str | None = None,
     ) -> None:
         """Delete a stale backend session.
 
         Args:
             client_session_id: Client-facing session ID
             backend_key: Backend location key
+            user_id: Authenticated user identity the session must belong to.
+                When None, ownership is not enforced (legacy behavior).
         """
         pass
 
@@ -1701,14 +1708,21 @@ class BackendSessionRepositoryBase(ABC):
     async def validate_client_session(
         self,
         client_session_id: str,
+        user_id: str | None = None,
+        virtual_server_path: str | None = None,
     ) -> bool:
-        """Check if a client session exists and bump last_used_at.
+        """Check if a client session exists, is owned by ``user_id``, and bump last_used_at.
 
         Args:
             client_session_id: Client-facing session ID
+            user_id: Authenticated user identity the session must belong to.
+                When None, ownership is not enforced (legacy behavior).
+            virtual_server_path: Virtual server path the session was minted for.
+                When None, the path is not enforced (legacy behavior).
 
         Returns:
-            True if session exists, False otherwise
+            True if session exists (and matches ``user_id`` /
+            ``virtual_server_path`` when given), False otherwise
         """
         pass
 

--- a/registry/schemas/backend_session_models.py
+++ b/registry/schemas/backend_session_models.py
@@ -94,8 +94,12 @@ class StoreSessionRequest(BaseModel):
         description="Client-facing session ID",
     )
     user_id: str = Field(
-        default="anonymous",
-        description="User identity from auth context",
+        ...,
+        description=(
+            "User identity from auth context (required). A session must have a "
+            "concrete owner; defaulting this would silently store a wrong-owner "
+            "document if a caller omitted it."
+        ),
     )
     virtual_server_path: str = Field(
         default="",
@@ -107,8 +111,11 @@ class CreateClientSessionRequest(BaseModel):
     """Request body for creating a client session via internal API."""
 
     user_id: str = Field(
-        default="anonymous",
-        description="User identity from auth context",
+        ...,
+        description=(
+            "User identity from auth context (required). Refuse to mint a "
+            "session with no concrete owner rather than defaulting it."
+        ),
     )
     virtual_server_path: str = Field(
         default="",

--- a/tests/unit/api/test_internal_session_authz.py
+++ b/tests/unit/api/test_internal_session_authz.py
@@ -91,3 +91,89 @@ class TestInternalSessionSecretGate:
         )
         assert response.status_code != status.HTTP_403_FORBIDDEN
         assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.unit
+class TestOwnershipParamRequired:
+    """The ownership-bound endpoints require user_id so the check cannot be
+    silently skipped.
+
+    Ownership binding is the session-hijacking control. If user_id were an
+    optional query param defaulting to None, any caller that forgot it would
+    silently fall back to existence-only validation (the original vulnerable
+    behavior) with no error. Making it a required param turns that mistake into
+    a loud 422 at request time. The Lua router always supplies it, so this is
+    no behavior change on the live path.
+    """
+
+    _SECRET = {"X-Internal-Secret": "test-internal-secret"}
+
+    @pytest.fixture
+    def mock_repo(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        import registry.api.internal_routes as internal_routes
+
+        repo = AsyncMock()
+        repo.validate_client_session = AsyncMock(return_value=True)
+        repo.get_backend_session = AsyncMock(return_value="be-1")
+        repo.delete_backend_session = AsyncMock(return_value=None)
+        monkeypatch.setattr(internal_routes, "get_backend_session_repository", lambda: repo)
+        return repo
+
+    def test_validate_client_session_missing_user_id_is_422(self, client, mock_repo) -> None:
+        response = client.get(
+            "/api/internal/sessions/client/vs-abc",
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        mock_repo.validate_client_session.assert_not_awaited()
+
+    def test_validate_client_session_with_user_id_passes(self, client, mock_repo) -> None:
+        response = client.get(
+            "/api/internal/sessions/client/vs-abc",
+            params={"user_id": "alice", "virtual_server_path": "/virtual/a"},
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_repo.validate_client_session.assert_awaited_once_with(
+            "vs-abc", user_id="alice", virtual_server_path="/virtual/a"
+        )
+
+    def test_get_backend_session_missing_user_id_is_422(self, client, mock_repo) -> None:
+        response = client.get(
+            "/api/internal/sessions/backend/vs-abc:loc",
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        mock_repo.get_backend_session.assert_not_awaited()
+
+    def test_get_backend_session_with_user_id_passes(self, client, mock_repo) -> None:
+        response = client.get(
+            "/api/internal/sessions/backend/vs-abc:loc",
+            params={"user_id": "alice"},
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_repo.get_backend_session.assert_awaited_once_with(
+            client_session_id="vs-abc", backend_key="loc", user_id="alice"
+        )
+
+    def test_delete_backend_session_missing_user_id_is_422(self, client, mock_repo) -> None:
+        response = client.delete(
+            "/api/internal/sessions/backend/vs-abc:loc",
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        mock_repo.delete_backend_session.assert_not_awaited()
+
+    def test_delete_backend_session_with_user_id_passes(self, client, mock_repo) -> None:
+        response = client.delete(
+            "/api/internal/sessions/backend/vs-abc:loc",
+            params={"user_id": "alice"},
+            headers=self._SECRET,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        mock_repo.delete_backend_session.assert_awaited_once_with(
+            client_session_id="vs-abc", backend_key="loc", user_id="alice"
+        )

--- a/tests/unit/repositories/test_backend_session_documentdb.py
+++ b/tests/unit/repositories/test_backend_session_documentdb.py
@@ -1,0 +1,216 @@
+"""Unit tests for DocumentDBBackendSessionRepository.validate_client_session.
+
+The Mongo collection is mocked (no live DB) so these tests focus on the
+repository's own logic: that client-session validation binds the lookup to the
+authenticated owner so a guessed/stolen Mcp-Session-Id for another user is
+rejected (session-hijacking fix). The owner match must happen inside the same
+atomic find_one_and_update that refreshes the TTL, so there is no check/use gap.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymongo.errors import DuplicateKeyError
+
+from registry.repositories.documentdb.backend_session_repository import (
+    DocumentDBBackendSessionRepository,
+)
+
+
+@pytest.fixture
+def collection() -> MagicMock:
+    coll = MagicMock()
+    coll.find_one_and_update = AsyncMock()
+    coll.replace_one = AsyncMock()
+    coll.delete_one = AsyncMock(return_value=MagicMock(deleted_count=1))
+    return coll
+
+
+@pytest.fixture
+def repo(collection):
+    r = DocumentDBBackendSessionRepository()
+    with patch.object(r, "_get_collection", new=AsyncMock(return_value=collection)):
+        yield r
+
+
+@pytest.mark.unit
+class TestValidateClientSessionOwnership:
+    """validate_client_session must enforce the stored owner when user_id given."""
+
+    async def test_owner_match_includes_user_id_in_query(self, repo, collection):
+        """When user_id is supplied, the lookup filter pins both _id and user_id."""
+        collection.find_one_and_update.return_value = {"_id": "client:vs-abc", "user_id": "alice"}
+
+        result = await repo.validate_client_session("vs-abc", user_id="alice")
+
+        assert result is True
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["_id"] == "client:vs-abc"
+        assert query["user_id"] == "alice"
+
+    async def test_wrong_owner_returns_false(self, repo, collection):
+        """A session owned by another user is treated as not found.
+
+        The atomic filtered query returns None because the document's stored
+        user_id does not match the attacker's identity, so the attacker cannot
+        hijack the victim's session even with the correct session ID.
+        """
+        collection.find_one_and_update.return_value = None
+
+        result = await repo.validate_client_session("vs-victim", user_id="attacker")
+
+        assert result is False
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["user_id"] == "attacker"
+
+    async def test_owner_match_is_atomic_with_ttl_bump(self, repo, collection):
+        """Owner check and last_used_at refresh happen in one find_one_and_update."""
+        collection.find_one_and_update.return_value = {"_id": "client:vs-abc"}
+
+        await repo.validate_client_session("vs-abc", user_id="alice")
+
+        # Exactly one DB round-trip; the $set refreshes the TTL field.
+        collection.find_one_and_update.assert_awaited_once()
+        update = collection.find_one_and_update.call_args[0][1]
+        assert "last_used_at" in update["$set"]
+
+    async def test_no_user_id_does_not_filter_on_owner(self, repo, collection):
+        """Legacy behavior: omitting user_id validates by existence only."""
+        collection.find_one_and_update.return_value = {"_id": "client:vs-abc"}
+
+        result = await repo.validate_client_session("vs-abc")
+
+        assert result is True
+        query = collection.find_one_and_update.call_args[0][0]
+        assert "user_id" not in query
+
+    async def test_virtual_server_path_added_to_filter(self, repo, collection):
+        """When virtual_server_path is supplied, the lookup filters on it too.
+
+        Binds the session to the virtual server it was minted for, so a session
+        for /virtual/a cannot be replayed against /virtual/b (issue #2).
+        """
+        collection.find_one_and_update.return_value = {"_id": "client:vs-abc"}
+
+        result = await repo.validate_client_session(
+            "vs-abc", user_id="alice", virtual_server_path="/virtual/a"
+        )
+
+        assert result is True
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["virtual_server_path"] == "/virtual/a"
+
+    async def test_wrong_virtual_server_path_returns_false(self, repo, collection):
+        """A session minted for a different virtual server is rejected."""
+        collection.find_one_and_update.return_value = None
+
+        result = await repo.validate_client_session(
+            "vs-abc", user_id="alice", virtual_server_path="/virtual/b"
+        )
+
+        assert result is False
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["virtual_server_path"] == "/virtual/b"
+
+
+@pytest.mark.unit
+class TestGetBackendSessionOwnership:
+    """get_backend_session must enforce the stored owner when user_id given.
+
+    Defense in depth: even though every in-router path to a backend session
+    already passes the owner-bound client-session gate, the backend-session
+    read is bound to the owner here too, so a single missed gate (or a future
+    handler reaching the backend lookup early) cannot leak another user's live
+    backend session ID.
+    """
+
+    async def test_owner_match_includes_user_id_in_query(self, repo, collection):
+        collection.find_one_and_update.return_value = {
+            "_id": "vs-abc:/_vs_backend_x_",
+            "backend_session_id": "be-1",
+        }
+
+        result = await repo.get_backend_session("vs-abc", "/_vs_backend_x_", user_id="alice")
+
+        assert result == "be-1"
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["_id"] == "vs-abc:/_vs_backend_x_"
+        assert query["user_id"] == "alice"
+
+    async def test_wrong_owner_returns_none(self, repo, collection):
+        """A backend session owned by another user is treated as not found."""
+        collection.find_one_and_update.return_value = None
+
+        result = await repo.get_backend_session("vs-victim", "/_vs_backend_x_", user_id="attacker")
+
+        assert result is None
+        query = collection.find_one_and_update.call_args[0][0]
+        assert query["user_id"] == "attacker"
+
+    async def test_no_user_id_does_not_filter_on_owner(self, repo, collection):
+        """Legacy behavior: omitting user_id looks up by compound key only."""
+        collection.find_one_and_update.return_value = {
+            "_id": "vs-abc:/_vs_backend_x_",
+            "backend_session_id": "be-1",
+        }
+
+        result = await repo.get_backend_session("vs-abc", "/_vs_backend_x_")
+
+        assert result == "be-1"
+        query = collection.find_one_and_update.call_args[0][0]
+        assert "user_id" not in query
+
+
+@pytest.mark.unit
+class TestStoreBackendSessionOwnership:
+    """store_backend_session must not overwrite another user's session document."""
+
+    async def test_upsert_filter_pins_owner(self, repo, collection):
+        """The upsert filter includes user_id so it only matches the owner's doc."""
+        await repo.store_backend_session(
+            client_session_id="vs-abc",
+            backend_key="/_vs_backend_x_",
+            backend_session_id="be-1",
+            user_id="alice",
+            virtual_server_path="/virtual/a",
+        )
+
+        filt = collection.replace_one.call_args[0][0]
+        assert filt["_id"] == "vs-abc:/_vs_backend_x_"
+        assert filt["user_id"] == "alice"
+
+    async def test_owner_collision_is_refused_not_raised(self, repo, collection):
+        """A duplicate-key from a differently-owned _id is swallowed, not propagated.
+
+        client_session_id is owner-namespaced so this cannot happen on the
+        legitimate path, but if it ever did, refusing to overwrite (rather than
+        crashing or clobbering) is the safe outcome.
+        """
+        collection.replace_one.side_effect = DuplicateKeyError("dup _id, other owner")
+
+        # Must not raise.
+        await repo.store_backend_session(
+            client_session_id="vs-abc",
+            backend_key="/_vs_backend_x_",
+            backend_session_id="be-1",
+            user_id="attacker",
+            virtual_server_path="/virtual/a",
+        )
+
+
+@pytest.mark.unit
+class TestDeleteBackendSessionOwnership:
+    """delete_backend_session must scope deletion to the owner when given."""
+
+    async def test_delete_filter_pins_owner(self, repo, collection):
+        await repo.delete_backend_session("vs-abc", "/_vs_backend_x_", user_id="alice")
+
+        filt = collection.delete_one.call_args[0][0]
+        assert filt["_id"] == "vs-abc:/_vs_backend_x_"
+        assert filt["user_id"] == "alice"
+
+    async def test_delete_without_owner_uses_id_only(self, repo, collection):
+        await repo.delete_backend_session("vs-abc", "/_vs_backend_x_")
+
+        filt = collection.delete_one.call_args[0][0]
+        assert "user_id" not in filt

--- a/tests/unit/test_backend_session_repository.py
+++ b/tests/unit/test_backend_session_repository.py
@@ -297,6 +297,55 @@ class TestBackendSessionInternalAPI:
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_validate_client_session_forwards_owner(self, mock_repo):
+        """The authenticated user identity is forwarded to the repo for ownership check.
+
+        The router supplies the validated user via the user_id query param; the
+        endpoint must pass it through so the repository can reject sessions owned
+        by a different user (session-hijacking fix).
+        """
+        mock_repo.validate_client_session.return_value = True
+
+        with patch(
+            "registry.api.internal_routes.get_backend_session_repository",
+            return_value=mock_repo,
+        ):
+            from registry.api.internal_routes import validate_client_session
+
+            result = await validate_client_session(
+                "vs-abc123", user_id="alice", virtual_server_path="/virtual/a"
+            )
+            assert result == {"status": "valid"}
+            mock_repo.validate_client_session.assert_awaited_once_with(
+                "vs-abc123", user_id="alice", virtual_server_path="/virtual/a"
+            )
+
+    @pytest.mark.asyncio
+    async def test_validate_client_session_wrong_owner_404(self, mock_repo):
+        """A session that does not belong to the caller is rejected with 404.
+
+        The repo returns False when the stored owner does not match the
+        authenticated user, so the attacker presenting a victim's session ID
+        gets the same 404 as a non-existent session.
+        """
+        mock_repo.validate_client_session.return_value = False
+
+        with patch(
+            "registry.api.internal_routes.get_backend_session_repository",
+            return_value=mock_repo,
+        ):
+            from fastapi import HTTPException
+
+            from registry.api.internal_routes import validate_client_session
+
+            with pytest.raises(HTTPException) as exc_info:
+                await validate_client_session("vs-victim", user_id="attacker")
+            assert exc_info.value.status_code == 404
+            mock_repo.validate_client_session.assert_awaited_once_with(
+                "vs-victim", user_id="attacker", virtual_server_path=None
+            )
+
+    @pytest.mark.asyncio
     async def test_get_backend_session_found(self, mock_repo):
         """Test get returns backend session ID."""
         mock_repo.get_backend_session.return_value = "backend-sess-xyz"
@@ -309,6 +358,30 @@ class TestBackendSessionInternalAPI:
 
             result = await get_backend_session("vs-abc123:/_vs_backend_weather_")
             assert result.backend_session_id == "backend-sess-xyz"
+
+    @pytest.mark.asyncio
+    async def test_get_backend_session_forwards_owner(self, mock_repo):
+        """The authenticated user is forwarded to the repo for the owner check.
+
+        Defense in depth: the backend-session lookup is bound to the caller so
+        a single missed client-session gate cannot leak another user's live
+        backend session ID.
+        """
+        mock_repo.get_backend_session.return_value = "backend-sess-xyz"
+
+        with patch(
+            "registry.api.internal_routes.get_backend_session_repository",
+            return_value=mock_repo,
+        ):
+            from registry.api.internal_routes import get_backend_session
+
+            result = await get_backend_session("vs-abc123:/_vs_backend_weather_", user_id="alice")
+            assert result.backend_session_id == "backend-sess-xyz"
+            mock_repo.get_backend_session.assert_awaited_once_with(
+                client_session_id="vs-abc123",
+                backend_key="/_vs_backend_weather_",
+                user_id="alice",
+            )
 
     @pytest.mark.asyncio
     async def test_get_backend_session_not_found(self, mock_repo):
@@ -379,11 +452,14 @@ class TestBackendSessionInternalAPI:
         ):
             from registry.api.internal_routes import delete_backend_session
 
-            result = await delete_backend_session("vs-abc123:/_vs_backend_weather_")
+            result = await delete_backend_session(
+                "vs-abc123:/_vs_backend_weather_", user_id="alice"
+            )
             assert result == {"status": "deleted"}
             mock_repo.delete_backend_session.assert_called_once_with(
                 client_session_id="vs-abc123",
                 backend_key="/_vs_backend_weather_",
+                user_id="alice",
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_backend_session_repository.py
+++ b/tests/unit/test_backend_session_repository.py
@@ -276,7 +276,7 @@ class TestBackendSessionInternalAPI:
         ):
             from registry.api.internal_routes import validate_client_session
 
-            result = await validate_client_session("vs-abc123")
+            result = await validate_client_session("vs-abc123", user_id="admin")
             assert result == {"status": "valid"}
 
     @pytest.mark.asyncio
@@ -293,7 +293,7 @@ class TestBackendSessionInternalAPI:
             from registry.api.internal_routes import validate_client_session
 
             with pytest.raises(HTTPException) as exc_info:
-                await validate_client_session("vs-nonexistent")
+                await validate_client_session("vs-nonexistent", user_id="admin")
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -356,7 +356,7 @@ class TestBackendSessionInternalAPI:
         ):
             from registry.api.internal_routes import get_backend_session
 
-            result = await get_backend_session("vs-abc123:/_vs_backend_weather_")
+            result = await get_backend_session("vs-abc123:/_vs_backend_weather_", user_id="admin")
             assert result.backend_session_id == "backend-sess-xyz"
 
     @pytest.mark.asyncio
@@ -397,7 +397,7 @@ class TestBackendSessionInternalAPI:
             from registry.api.internal_routes import get_backend_session
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_backend_session("vs-abc123:/_vs_backend_weather_")
+                await get_backend_session("vs-abc123:/_vs_backend_weather_", user_id="admin")
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
@@ -412,7 +412,7 @@ class TestBackendSessionInternalAPI:
             from registry.api.internal_routes import get_backend_session
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_backend_session("no-colon-in-key")
+                await get_backend_session("no-colon-in-key", user_id="admin")
             assert exc_info.value.status_code == 400
 
     @pytest.mark.asyncio

--- a/tests/unit/test_backend_session_repository.py
+++ b/tests/unit/test_backend_session_repository.py
@@ -150,19 +150,25 @@ class TestStoreSessionRequest:
         assert req.backend_session_id == "backend-sess-xyz"
         assert req.client_session_id == "vs-abc123"
 
-    def test_default_user_id(self):
-        """Test that user_id defaults to anonymous."""
-        req = StoreSessionRequest(
-            backend_session_id="backend-sess-xyz",
-            client_session_id="vs-abc123",
-        )
-        assert req.user_id == "anonymous"
+    def test_requires_user_id(self):
+        """user_id is required: a session must have a concrete owner.
+
+        Defaulting it (previously "anonymous") would silently store a
+        wrong-owner document if a caller forgot to set it -- the same
+        silent-fallback footgun removed from the ownership-bound endpoints.
+        """
+        with pytest.raises(ValidationError):
+            StoreSessionRequest(
+                backend_session_id="backend-sess-xyz",
+                client_session_id="vs-abc123",
+            )
 
     def test_default_virtual_server_path(self):
         """Test that virtual_server_path defaults to empty string."""
         req = StoreSessionRequest(
             backend_session_id="backend-sess-xyz",
             client_session_id="vs-abc123",
+            user_id="admin",
         )
         assert req.virtual_server_path == ""
 
@@ -171,6 +177,7 @@ class TestStoreSessionRequest:
         with pytest.raises(ValidationError):
             StoreSessionRequest(
                 client_session_id="vs-abc123",
+                user_id="admin",
             )
 
     def test_requires_client_session_id(self):
@@ -178,6 +185,7 @@ class TestStoreSessionRequest:
         with pytest.raises(ValidationError):
             StoreSessionRequest(
                 backend_session_id="backend-sess-xyz",
+                user_id="admin",
             )
 
 
@@ -193,10 +201,14 @@ class TestCreateClientSessionRequest:
         assert req.user_id == "admin"
         assert req.virtual_server_path == "/virtual/my-server"
 
-    def test_defaults(self):
-        """Test default values."""
-        req = CreateClientSessionRequest()
-        assert req.user_id == "anonymous"
+    def test_requires_user_id(self):
+        """user_id is required: refuse to mint a session with no concrete owner."""
+        with pytest.raises(ValidationError):
+            CreateClientSessionRequest()
+
+    def test_default_virtual_server_path(self):
+        """virtual_server_path still defaults to empty string."""
+        req = CreateClientSessionRequest(user_id="admin")
         assert req.virtual_server_path == ""
 
 


### PR DESCRIPTION
fix: bind MCP sessions to the authenticated user to prevent session hijacking

Summary

An authenticated MCP client that presented another user's Mcp-Session-Id (format vs-<uuid4hex>) could hijack that session. The Lua virtual router validated sessions
by existence only — it never checked that the session belonged to the caller. Because backend sessions are keyed solely on client_session_id, a hijacked client
session gave an attacker access to the victim's backend session too.

This PR binds session validation to the authenticated identity end-to-end (router → internal endpoints → repository), enforced before any session context is loaded,
and hardens the surrounding request-body and endpoint contracts so the ownership check can't be silently skipped.

Changes

Virtual router (docker/lua/virtual_router.lua)
- Resolve the authenticated identity once and fail closed with 401 when absent. Normalizes the empty string nginx yields for a missing X-User to nil, so the fallback
chain does not lock onto a truthy "".
- Allowlist the session ID to ^vs-[0-9a-f]+$ before it reaches any internal subrequest, closing a query-param injection that could shadow the owner check; escape it
into subrequest URIs as defense in depth.
- Scope the L1 cache key by user and virtual server path.
- Surface session-creation failure as 503 instead of a misleading 200 with no Mcp-Session-Id.

Repository (backend_session_repository.py)
- validate_client_session and get_backend_session add user_id to the find_one_and_update filter (atomic owner check — no check/use gap). validate_client_session also
binds virtual_server_path so a session minted for one virtual server can't be replayed against another. 
- store_backend_session pins user_id in the upsert filter and refuses a cross-owner collision; delete_backend_session is scoped to the owner.
- Owner filters use is not None guards: only None means "no owner filter"; an empty-string user_id must add an always-non-matching filter, not skip it (a truthiness
check would reopen the existence-only gap).

Internal endpoints (internal_routes.py)
- validate / get / delete session endpoints now require user_id as a query param. Previously it was optional, so a caller that omitted it silently fell back to
existence-only validation — the original hijack behavior — with no error. Omitting it now fails with 422.

Schemas (backend_session_models.py)
- StoreSessionRequest.user_id and CreateClientSessionRequest.user_id are now required (were default="anonymous"). The router always sets them to the authenticated
owner, so no behavior change on the live path; it stops a future caller from silently storing an "anonymous"-owned document no real lookup could read back.
virtual_server_path stays defaulted — it is not the ownership control.

Compatibility

Repository (backend_session_repository.py)
- validate_client_session and get_backend_session add user_id to the find_one_and_update filter (atomic owner check — no check/use gap). validate_client_session also
binds virtual_server_path so a session minted for one virtual server can't be replayed against another.
- store_backend_session pins user_id in the upsert filter and refuses a cross-owner collision; delete_backend_session is scoped to the owner.
- Owner filters use is not None guards: only None means "no owner filter"; an empty-string user_id must add an always-non-matching filter, not skip it (a truthiness
check would reopen the existence-only gap).

Internal endpoints (internal_routes.py)
- validate / get / delete session endpoints now require user_id as a query param. Previously it was optional, so a caller that omitted it silently fell back to
existence-only validation — the original hijack behavior — with no error. Omitting it now fails with 422.

Schemas (backend_session_models.py)
- StoreSessionRequest.user_id and CreateClientSessionRequest.user_id are now required (were default="anonymous"). The router always sets them to the authenticated
owner, so no behavior change on the live path; it stops a future caller from silently storing an "anonymous"-owned document no real lookup could read back.
virtual_server_path stays defaulted — it is not the ownership control.

Compatibility

The Lua router already always supplies user_id and virtual_server_path, so there is no behavior change on the live path — these changes convert latent "forgot the
arg" footguns into loud failures. Ownership remains optional at the repository layer (a generic data-access primitive where None legitimately means "no owner
filter") to preserve legacy callers.

Tests

- Repository: owner binding and virtual-server binding across validate/get/store/delete, including wrong-owner and wrong-path rejection plus the legacy no-owner
paths.
- Endpoints: assert 422 when user_id is omitted (with a valid internal secret, so the failure is the missing param, not the auth gate) and that supplying it forwards
correctly to the repository.
- Models: assert user_id is required rather than defaulting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
