### PR TITLE
Separate internal service tokens from user tokens

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -80,14 +80,23 @@ _auth_log_file = _setup_logging(service_name="auth-server")
 logger = logging.getLogger(__name__)
 logger.info(f"Auth-server logging configured. Writing to file: {_auth_log_file}")
 
-# Import JWT constants from shared internal auth module
-from registry.auth.internal import (
-    _INTERNAL_JWT_AUDIENCE as JWT_AUDIENCE,
-)
+# Import JWT constants from shared internal auth module.
+#
+# The issuer is shared (the same auth server issues both user and internal
+# tokens). The AUDIENCE is deliberately NOT shared: user tokens use
+# ``_USER_JWT_AUDIENCE`` ("mcp-registry") below, while internal service tokens
+# use ``_INTERNAL_JWT_AUDIENCE`` ("mcp-internal"). Historically this file
+# borrowed ``_INTERNAL_JWT_AUDIENCE`` for user tokens too, which collapsed the
+# trust boundary between user and internal tokens (Security Finding 1). Keep
+# these two audiences distinct.
 from registry.auth.internal import (
     _INTERNAL_JWT_ISSUER as JWT_ISSUER,
 )
 from registry.auth.internal import validate_internal_auth
+
+# Audience for end-user access tokens. MUST stay distinct from
+# registry.auth.internal._INTERNAL_JWT_AUDIENCE ("mcp-internal").
+_USER_JWT_AUDIENCE: str = "mcp-registry"
 
 MAX_TOKEN_LIFETIME_HOURS = 24
 DEFAULT_TOKEN_LIFETIME_HOURS = 8
@@ -1736,7 +1745,7 @@ class SimplifiedCognitoValidator:
                 SECRET_KEY,
                 algorithms=["HS256"],
                 issuer=JWT_ISSUER,
-                audience=JWT_AUDIENCE,
+                audience=_USER_JWT_AUDIENCE,
                 options={
                     "verify_exp": True,
                     "verify_iat": True,
@@ -3247,7 +3256,7 @@ async def generate_user_token(
             # Build JWT claims
             jwt_claims = {
                 "iss": JWT_ISSUER,
-                "aud": JWT_AUDIENCE,
+                "aud": _USER_JWT_AUDIENCE,
                 "sub": username,
                 "preferred_username": username,
                 "email": user_email,

--- a/registry/auth/internal.py
+++ b/registry/auth/internal.py
@@ -6,6 +6,7 @@ between services (e.g., mcpgw -> registry, registry -> auth-server)
 using JWTs signed with the shared SECRET_KEY.
 """
 
+import hashlib
 import hmac
 import logging
 import os
@@ -22,10 +23,41 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-# JWT constants (must match auth_server/server.py)
+# JWT constants for internal service-to-service tokens.
+#
+# IMPORTANT (Security Finding 1): the internal audience MUST stay distinct from
+# the user-token audience (``_USER_JWT_AUDIENCE = "mcp-registry"`` in
+# auth_server/server.py). These two token classes were historically minted and
+# validated against the SAME audience/key, which made a low-privilege user token
+# interchangeable with a trusted internal service credential. Do NOT re-merge
+# them: internal tokens use ``mcp-internal`` + a mandatory ``token_kind`` claim +
+# a separate derived signing key so a user token can never satisfy the internal
+# gate. The issuer is legitimately shared (the same auth server issues both).
 _INTERNAL_JWT_ISSUER: str = "mcp-auth-server"
-_INTERNAL_JWT_AUDIENCE: str = "mcp-registry"
+_INTERNAL_JWT_AUDIENCE: str = "mcp-internal"
 _INTERNAL_JWT_TTL_SECONDS: int = 60
+_INTERNAL_TOKEN_KIND: str = "internal-service"
+_INTERNAL_KEY_INFO: bytes = b"mcp-internal-token-v1"
+
+
+def _derive_internal_signing_key(
+    secret_key: str,
+) -> bytes:
+    """Derive a dedicated signing key for internal service tokens.
+
+    Uses HMAC-SHA256 over the shared ``SECRET_KEY`` with a fixed info
+    string so that a user token (signed with the raw ``SECRET_KEY``) can
+    never verify against the internal key, and vice versa. This is a
+    deterministic derivation: both services derive the same key from the
+    same ``SECRET_KEY`` with no additional configuration.
+
+    Args:
+        secret_key: The shared application secret.
+
+    Returns:
+        A 32-byte key suitable for HS256 signing.
+    """
+    return hmac.new(secret_key.encode(), _INTERNAL_KEY_INFO, hashlib.sha256).digest()
 
 
 def generate_internal_token(
@@ -57,11 +89,13 @@ def generate_internal_token(
         "aud": _INTERNAL_JWT_AUDIENCE,
         "sub": subject,
         "purpose": purpose,
+        "token_kind": _INTERNAL_TOKEN_KIND,
         "token_use": "access",
         "iat": now,
         "exp": now + _INTERNAL_JWT_TTL_SECONDS,
     }
-    return pyjwt.encode(claims, secret_key, algorithm="HS256")
+    signing_key = _derive_internal_signing_key(secret_key)
+    return pyjwt.encode(claims, signing_key, algorithm="HS256")
 
 
 async def validate_internal_session_secret(
@@ -158,10 +192,12 @@ def _validate_bearer_token(auth_header: str) -> str:
             detail="Internal server configuration error",
         )
 
+    signing_key = _derive_internal_signing_key(secret_key)
+
     try:
         claims = pyjwt.decode(
             token,
-            secret_key,
+            signing_key,
             algorithms=["HS256"],
             issuer=_INTERNAL_JWT_ISSUER,
             audience=_INTERNAL_JWT_AUDIENCE,
@@ -183,6 +219,13 @@ def _validate_bearer_token(auth_header: str) -> str:
         token_use = claims.get("token_use")
         if token_use != "access":  # nosec B105 - OAuth2 token type validation per RFC 6749, not a password
             raise ValueError(f"Invalid token_use: {token_use}")
+
+        # Defense-in-depth (Security Finding 1): even if the audience/key ever
+        # collide, a token that is not explicitly an internal-service token is
+        # rejected. This also explicitly denies user/resource-kind tokens.
+        token_kind = claims.get("token_kind")
+        if token_kind != _INTERNAL_TOKEN_KIND:
+            raise ValueError(f"Not an internal service token: token_kind={token_kind}")
 
         caller = claims.get("sub", "service")
         logger.debug(f"Internal auth via JWT for: {caller}")

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1006,8 +1006,7 @@ class Settings(BaseSettings):
     secret_store_backend: str = Field(
         default="openbao",
         description=(
-            "Secret store for per-user egress tokens. Accepted values: "
-            "secrets-manager, openbao."
+            "Secret store for per-user egress tokens. Accepted values: secrets-manager, openbao."
         ),
     )
     egress_oauth_callback_base_url: str = Field(
@@ -1323,6 +1322,14 @@ class Settings(BaseSettings):
                 "Set it to a value at least 32 bytes long, identical across all auth_server "
                 "and registry replicas (see chart values.yaml: global.secretKey)."
             )
+        if len(self.secret_key.encode()) < 32:
+            raise RuntimeError(
+                "SECRET_KEY must be at least 32 bytes long. The current value is too short "
+                "to safely sign HS256 tokens and derive the internal service-token signing "
+                "key (a short key can be brute-forced offline from any captured token). "
+                "Set it to a strong random value at least 32 bytes long, identical across "
+                "all auth_server and registry replicas (see chart values.yaml: global.secretKey)."
+            )
         if not self.auth_server_nginx_marker_secret:
             raise RuntimeError(
                 "AUTH_SERVER_NGINX_MARKER_SECRET environment variable is required. "
@@ -1330,6 +1337,12 @@ class Settings(BaseSettings):
                 "auth_server and registry replicas (see chart values.yaml). Without it, the "
                 "auth_server mints mcp-proxy tokens unconditionally, letting a direct :8888 "
                 "/validate call with a forged X-Resolved-Upstream bypass nginx and obtain one."
+            )
+        if len(self.auth_server_nginx_marker_secret.encode()) < 32:
+            raise RuntimeError(
+                "AUTH_SERVER_NGINX_MARKER_SECRET must be at least 32 bytes long. Set it to a "
+                "strong random value at least 32 bytes long, identical across all auth_server "
+                "and registry replicas (see chart values.yaml)."
             )
         self._validate_egress_auth_config()
 

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -748,9 +748,7 @@ class TestValidateEndpoint:
         from unittest.mock import MagicMock
 
         provider = MagicMock()
-        provider.validate_token.side_effect = ValueError(
-            "Token missing 'kid' in header"
-        )
+        provider.validate_token.side_effect = ValueError("Token missing 'kid' in header")
         mock_get_provider.return_value = provider
 
         import auth_server.server as server_module
@@ -1168,13 +1166,20 @@ class TestReloadScopesEndpoint:
     def test_reload_scopes_success_with_jwt(
         self, mock_get_provider, mock_reload_scopes, auth_env_vars
     ):
-        """Test successful scopes reload using self-signed JWT."""
+        """Test successful scopes reload using an internal service JWT.
+
+        The token is minted via ``generate_internal_token`` (not hand-rolled)
+        so it carries the internal-service contract enforced by
+        ``validate_internal_auth``: audience ``mcp-internal``, a
+        ``token_kind=internal-service`` claim, and a signature made with the
+        derived internal key rather than the raw SECRET_KEY (Security Finding 1).
+        A user-shape token (aud=mcp-registry, raw-key signed) is now rejected.
+        """
         # Arrange
         mock_reload_scopes.return_value = {"group_mappings": {}}
 
-        import jwt
-
         import auth_server.server as server_module
+        from registry.auth.internal import generate_internal_token
 
         # Patch module-level SECRET_KEY to match the test env var
         # (it may already be set to a different value from earlier test imports)
@@ -1185,19 +1190,11 @@ class TestReloadScopesEndpoint:
         try:
             client = TestClient(server_module.app)
 
-            now = int(time.time())
-            token = jwt.encode(
-                {
-                    "iss": "mcp-auth-server",
-                    "aud": "mcp-registry",
-                    "sub": "registry-service",
-                    "purpose": "reload-scopes",
-                    "token_use": "access",
-                    "iat": now,
-                    "exp": now + 30,
-                },
-                secret_key,
-                algorithm="HS256",
+            # The auth_env_vars fixture sets SECRET_KEY in os.environ (monkeypatch),
+            # which is what generate_internal_token reads to derive the signing key.
+            token = generate_internal_token(
+                subject="registry-service",
+                purpose="reload-scopes",
             )
 
             # Act
@@ -3111,9 +3108,7 @@ class TestLogScopesLoaded:
         from auth_server import server as server_module
 
         with patch.object(server_module, "logger") as mock_logger:
-            server_module._log_scopes_loaded(
-                {"group_mappings": {"mcp-registry-admin": ["admin"]}}
-            )
+            server_module._log_scopes_loaded({"group_mappings": {"mcp-registry-admin": ["admin"]}})
 
         mock_logger.warning.assert_not_called()
         mock_logger.info.assert_called_once()

--- a/tests/unit/auth/test_internal_token_separation.py
+++ b/tests/unit/auth/test_internal_token_separation.py
@@ -1,0 +1,200 @@
+"""Unit tests for internal/user token separation (Security Finding 1).
+
+Internal service tokens and end-user tokens used to be cryptographically
+interchangeable HS256 JWTs (same SECRET_KEY, same issuer, same audience),
+so a low-privilege user token was accepted by ``validate_internal_auth`` on
+every ``/api/internal/*`` route. These tests pin the three independent
+separation controls that close that hole:
+
+1. Distinct audience: internal tokens use ``mcp-internal``; user tokens use
+   ``mcp-registry``.
+2. Mandatory ``token_kind`` claim: internal tokens carry
+   ``internal-service``; the validator rejects anything else.
+3. Separate signing key: internal tokens are signed with a key derived from
+   ``SECRET_KEY`` via HMAC-SHA256, so a user token signed with the raw
+   ``SECRET_KEY`` fails signature verification on the internal path.
+
+The tests hit ``_validate_authorization_header`` (the header helper behind the
+public ``validate_internal_auth`` dependency) so a regression fails a focused
+unit test rather than an HTTP meta-test.
+"""
+
+import os
+import time
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+from fastapi import HTTPException
+
+from registry.auth.internal import (
+    _INTERNAL_JWT_AUDIENCE,
+    _INTERNAL_JWT_ISSUER,
+    _INTERNAL_TOKEN_KIND,
+    _derive_internal_signing_key,
+    _validate_authorization_header,
+    generate_internal_token,
+)
+
+_SECRET_KEY: str = "x" * 40  # >= 32 bytes so the config-level guard is satisfied
+_USER_AUDIENCE: str = "mcp-registry"
+
+
+def _make_token(
+    secret_key: str,
+    audience: str,
+    token_kind: str | None,
+    use_derived_key: bool,
+) -> str:
+    """Build a JWT for a specific separation scenario.
+
+    Args:
+        secret_key: The shared application secret.
+        audience: The ``aud`` claim to stamp.
+        token_kind: The ``token_kind`` claim, or None to omit it.
+        use_derived_key: When True, sign with the derived internal key;
+            when False, sign with the raw ``secret_key`` (the user-token key).
+
+    Returns:
+        An encoded HS256 JWT.
+    """
+    now = int(time.time())
+    claims = {
+        "iss": _INTERNAL_JWT_ISSUER,
+        "aud": audience,
+        "sub": "test-subject",
+        "token_use": "access",
+        "iat": now,
+        "exp": now + 60,
+    }
+    if token_kind is not None:
+        claims["token_kind"] = token_kind
+
+    signing_key = _derive_internal_signing_key(secret_key) if use_derived_key else secret_key
+    return pyjwt.encode(claims, signing_key, algorithm="HS256")
+
+
+class TestInternalTokenSeparation:
+    """Separation invariants between internal and user tokens."""
+
+    def test_internal_token_accepted(self) -> None:
+        """A token from generate_internal_token passes the gate and returns sub."""
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            token = generate_internal_token(subject="registry-service", purpose="test")
+            caller = _validate_authorization_header(f"Bearer {token}")
+        assert caller == "registry-service"
+
+    def test_user_token_rejected_by_audience(self) -> None:
+        """A user-shape token (aud=mcp-registry, raw-key signed) is rejected."""
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            token = _make_token(
+                secret_key=_SECRET_KEY,
+                audience=_USER_AUDIENCE,
+                token_kind="user",
+                use_derived_key=False,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_authorization_header(f"Bearer {token}")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid token"
+
+    def test_user_token_rejected_by_signature(self) -> None:
+        """Right audience but signed with the raw key (not derived) is rejected.
+
+        This isolates the signing-key control: even if an attacker could set
+        aud=mcp-internal, a token signed with the raw SECRET_KEY fails the
+        signature check against the derived internal key.
+        """
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            token = _make_token(
+                secret_key=_SECRET_KEY,
+                audience=_INTERNAL_JWT_AUDIENCE,
+                token_kind=_INTERNAL_TOKEN_KIND,
+                use_derived_key=False,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_authorization_header(f"Bearer {token}")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid token"
+
+    def test_wrong_token_kind_rejected(self) -> None:
+        """Correct audience and derived key but token_kind=user is rejected.
+
+        This isolates the token_kind control (the derived-key and audience
+        controls are both satisfied here).
+        """
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            token = _make_token(
+                secret_key=_SECRET_KEY,
+                audience=_INTERNAL_JWT_AUDIENCE,
+                token_kind="user",
+                use_derived_key=True,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_authorization_header(f"Bearer {token}")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid token"
+
+    def test_missing_token_kind_rejected(self) -> None:
+        """Correct audience and derived key but no token_kind claim is rejected."""
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            token = _make_token(
+                secret_key=_SECRET_KEY,
+                audience=_INTERNAL_JWT_AUDIENCE,
+                token_kind=None,
+                use_derived_key=True,
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_authorization_header(f"Bearer {token}")
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid token"
+
+    def test_expired_internal_token_rejected(self) -> None:
+        """An otherwise-valid internal token whose exp is in the past is rejected."""
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET_KEY}):
+            now = int(time.time())
+            claims = {
+                "iss": _INTERNAL_JWT_ISSUER,
+                "aud": _INTERNAL_JWT_AUDIENCE,
+                "sub": "registry-service",
+                "token_kind": _INTERNAL_TOKEN_KIND,
+                "token_use": "access",
+                "iat": now - 120,
+                "exp": now - 60,
+            }
+            token = pyjwt.encode(
+                claims, _derive_internal_signing_key(_SECRET_KEY), algorithm="HS256"
+            )
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_authorization_header(f"Bearer {token}")
+        assert exc_info.value.status_code == 401
+
+
+class TestDerivedSigningKey:
+    """Properties of the internal signing-key derivation."""
+
+    def test_derived_key_differs_from_secret(self) -> None:
+        """The derived key is 32 bytes and not equal to the raw secret bytes."""
+        derived = _derive_internal_signing_key(_SECRET_KEY)
+        assert isinstance(derived, bytes)
+        assert len(derived) == 32
+        assert derived != _SECRET_KEY.encode()
+
+    def test_derivation_is_deterministic(self) -> None:
+        """Both services must derive the same key from the same secret."""
+        assert _derive_internal_signing_key(_SECRET_KEY) == _derive_internal_signing_key(
+            _SECRET_KEY
+        )
+
+    def test_different_secret_yields_different_key(self) -> None:
+        """A different SECRET_KEY yields a different derived key."""
+        assert _derive_internal_signing_key("a" * 40) != _derive_internal_signing_key("b" * 40)
+
+
+class TestAudienceInvariant:
+    """The two audiences must never collapse back into one."""
+
+    def test_internal_audience_is_distinct_from_user_audience(self) -> None:
+        """Guard against a future re-merge of the internal and user audiences."""
+        assert _INTERNAL_JWT_AUDIENCE == "mcp-internal"
+        assert _INTERNAL_JWT_AUDIENCE != _USER_AUDIENCE

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -30,7 +30,7 @@ class TestSettingsInstantiation:
         can assert the rest of the defaults.
         """
         monkeypatch.delenv("AUTH_SERVER_URL", raising=False)
-        monkeypatch.setenv("SECRET_KEY", "test-key-for-defaults")
+        monkeypatch.setenv("SECRET_KEY", "test-key-for-defaults-at-least-32-bytes-long")
         monkeypatch.chdir(tmp_path)
 
         settings = Settings()
@@ -120,12 +120,15 @@ class TestSettingsInstantiation:
         monkeypatch.chdir(tmp_path)
 
         with pytest.raises(RuntimeError, match="AUTH_SERVER_NGINX_MARKER_SECRET"):
-            Settings(secret_key="present", auth_server_nginx_marker_secret="")
+            Settings(
+                secret_key="present-and-at-least-32-bytes-long-key",
+                auth_server_nginx_marker_secret="",
+            )
 
     def test_settings_secret_key_not_overridden(self) -> None:
         """Test that provided secret_key is not overridden."""
         # Arrange
-        custom_key = "my-custom-secret-key-12345"
+        custom_key = "my-custom-secret-key-12345-at-least-32-bytes"
 
         # Act
         settings = Settings(secret_key=custom_key)
@@ -137,7 +140,7 @@ class TestSettingsInstantiation:
         """Test Settings instantiation with custom values."""
         # Arrange
         custom_values = {
-            "secret_key": "test-secret",
+            "secret_key": "test-secret-value-at-least-32-bytes-long",
             "session_cookie_name": "test_cookie",
             "session_max_age_seconds": 3600,
             "embeddings_provider": "litellm",
@@ -174,14 +177,14 @@ class TestSettingsEnvironmentVariables:
     def test_settings_load_from_env_auth(self, monkeypatch) -> None:
         """Test loading auth settings from environment variables."""
         # Arrange
-        monkeypatch.setenv("SECRET_KEY", "env-secret-key")
+        monkeypatch.setenv("SECRET_KEY", "env-secret-key-at-least-32-bytes-long-value")
         monkeypatch.setenv("SESSION_COOKIE_NAME", "env_session")
 
         # Act
         settings = Settings()
 
         # Assert
-        assert settings.secret_key == "env-secret-key"
+        assert settings.secret_key == "env-secret-key-at-least-32-bytes-long-value"
         assert settings.session_cookie_name == "env_session"
 
     def test_settings_load_from_env_embeddings(self, monkeypatch) -> None:
@@ -733,6 +736,25 @@ class TestSettingsSecretKey:
         custom = "my-explicit-32-byte-secret-key-aaaa"
         settings = Settings(secret_key=custom)
         assert settings.secret_key == custom
+
+    def test_short_secret_key_rejected(self, monkeypatch, tmp_path) -> None:
+        """A SECRET_KEY shorter than 32 bytes is rejected (Security Finding 28).
+
+        A short key can be brute-forced offline from any captured HS256 token
+        and used to forge tokens or the derived internal service-token key.
+        """
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(RuntimeError, match="at least 32 bytes"):
+            Settings(secret_key="short-key")
+
+    def test_short_marker_secret_rejected(self, monkeypatch, tmp_path) -> None:
+        """An AUTH_SERVER_NGINX_MARKER_SECRET shorter than 32 bytes is rejected."""
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(RuntimeError, match="AUTH_SERVER_NGINX_MARKER_SECRET must be at least"):
+            Settings(
+                secret_key="a-valid-secret-key-of-at-least-32-bytes",
+                auth_server_nginx_marker_secret="short",
+            )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Internal service-to-service JWTs and end-user access tokens previously shared the same audience and signing key, so the two token classes were interchangeable at the internal-auth gate. This change makes them distinct.

## Changes

- Internal service tokens now use a dedicated audience (`mcp-internal`); user tokens keep `mcp-registry` via an explicit `_USER_JWT_AUDIENCE` constant in `auth_server/server.py` (previously it borrowed the internal constant).
- Internal tokens carry a mandatory `token_kind=internal-service` claim, enforced in `_validate_bearer_token`.
- Internal tokens are signed with a key derived from `SECRET_KEY` (HMAC-SHA256 with a fixed info string) rather than `SECRET_KEY` directly.
- Enforce a 32-byte minimum length for `SECRET_KEY` and `AUTH_SERVER_NGINX_MARKER_SECRET` (the derived key inherits `SECRET_KEY` entropy).

Registry and auth-server deploy together, so both sides adopt the new contract in one release; no compatibility window is needed.

## Tests

- New `tests/unit/auth/test_internal_token_separation.py` covers the audience, token-kind, and signing-key controls plus key-derivation properties.
- Updated the reload-scopes success test to mint via `generate_internal_token` so it exercises the real contract.
- Added `SECRET_KEY` / marker minimum-length test cases.
- Full suite: `uv run pytest tests/ -n 8` — 4830 passed, 62 skipped.