### PR TITLE
Fix TemplateResponse calls for current Starlette signature

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -568,9 +568,9 @@ async def read_root(
             )
 
     return templates.TemplateResponse(
+        request,
         "index.html",
         {
-            "request": request,
             "services": service_data,
             "username": user_context["username"],
             "user_context": user_context,  # Pass full user context to template
@@ -2223,9 +2223,9 @@ async def edit_server_form(
             )
 
     return templates.TemplateResponse(
+        request,
         "edit_server.html",
         {
-            "request": request,
             "server": server_info,
             "username": user_context["username"],
             "user_context": user_context,
@@ -2595,9 +2595,9 @@ async def token_generation_page(
 ):
     """Show token generation page for authenticated users."""
     return templates.TemplateResponse(
+        request,
         "token_generation.html",
         {
-            "request": request,
             "username": user_context["username"],
             "user_context": user_context,
             "user_scopes": user_context["scopes"],

--- a/registry/auth/routes.py
+++ b/registry/auth/routes.py
@@ -118,7 +118,7 @@ async def login_form(request: Request, error: str | None = None):
     """Show login form with OAuth2 providers"""
     oauth_providers = await get_oauth2_providers()
     return templates.TemplateResponse(
-        "login.html", {"request": request, "error": error, "oauth_providers": oauth_providers}
+        request, "login.html", {"error": error, "oauth_providers": oauth_providers}
     )
 
 

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -3112,3 +3112,33 @@ class TestServerModifyApiAuthorization:
             )
 
         assert response.status_code == 403
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestTemplateRenderingRoutes:
+    """Regression tests for server-rendered HTML routes.
+
+    These routes call ``templates.TemplateResponse`` and render a real Jinja2
+    template (auth/services are mocked, but the template engine is not). They
+    guard the Starlette TemplateResponse signature: Starlette removed the
+    legacy ``TemplateResponse(name, context)`` form, so the request must be the
+    first positional argument (``TemplateResponse(request, name, context)``).
+    The old form made Jinja try to load the context dict as a template name and
+    returned HTTP 500 (unhashable dict key).
+    """
+
+    def test_token_generation_page_renders(self, test_client_regular) -> None:
+        """GET /api/tokens renders the token page (200), not a 500."""
+        response = test_client_regular.get("/api/tokens")
+
+        assert response.status_code == 200
+        assert "Generate API Token" in response.text
+
+    def test_token_generation_page_lists_user_scopes(self, test_client_regular) -> None:
+        """The rendered page includes the user's scopes."""
+        response = test_client_regular.get("/api/tokens")
+
+        assert response.status_code == 200
+        # regular_user_context grants "test-server/read"
+        assert "test-server/read" in response.text


### PR DESCRIPTION
## Summary

`GET /api/tokens` and `GET /login` returned HTTP 500. Starlette removed the legacy `TemplateResponse(name, context)` form and now requires the request as the first positional argument. The old calls passed the template name where the request was expected and the context dict where the name was expected, so Jinja tried to load the context dict as a template and raised `cannot use 'tuple' as a dict key (unhashable type: 'dict')`.

## Changes

- Update all four `templates.TemplateResponse(...)` call sites to `TemplateResponse(request, name, context)`: token generation page, index, edit server, and login form.
- Add a regression test that renders the token generation page and asserts 200 plus expected content.

## Tests

- New `TestTemplateRenderingRoutes` in `tests/unit/api/test_server_routes.py`.
- Full suite: `uv run pytest tests/ -n 8` — 4832 passed, 62 skipped.
- Verified live: `GET /api/tokens` and `GET /login` now return 200.