### PR TITLE
ssrf url validation

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -32,6 +32,7 @@ from ..audit import set_audit_action
 from ..auth.csrf import verify_csrf_token_flexible
 from ..auth.dependencies import nginx_proxied_auth
 from ..core.config import settings
+from ..exceptions import UrlValidationError
 from ..repositories.factory import get_search_repository
 from ..repositories.interfaces import SearchRepositoryBase
 from ..schemas.agent_models import (
@@ -66,6 +67,7 @@ from ..services.registration_gate_service import check_registration_gate
 from ..services.webhook_service import send_registration_webhook
 from ..utils.metadata import flatten_metadata_to_text
 from ..utils.request_utils import get_client_ip
+from ..utils.url_guard import PROXY_PROFILE, guarded_async_client, validate_agent_url
 from ._etag_utils import (
     parse_if_match,
     updated_ms,
@@ -293,12 +295,17 @@ async def _fetch_remote_agent_card(
     """
     import json
 
+    # Fail-closed pre-check: reject a caller-supplied base_url that targets a
+    # private/metadata address or bad scheme before any outbound fetch. The
+    # guarded client below additionally re-validates and pins at connect time.
+    validate_agent_url(base_url)
+
     urls = _build_agent_health_urls(base_url)
     agent_card_url = urls[0]
     timeout_seconds = max(1, settings.health_check_timeout_seconds)
 
     try:
-        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        async with guarded_async_client(profile=PROXY_PROFILE, timeout=timeout_seconds) as client:
             response = await client.get(agent_card_url)
 
         if response.status_code != 200:
@@ -327,6 +334,12 @@ async def _fetch_remote_agent_card(
 
     except HTTPException:
         raise
+    except UrlValidationError as exc:
+        logger.warning("Agent card fetch blocked by SSRF guard for %s: %s", agent_card_url, exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent URL failed SSRF validation and cannot be fetched",
+        ) from exc
     except httpx.TimeoutException:
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -1239,7 +1252,9 @@ async def check_agent_health(
         start_time = datetime.now(UTC)
 
         try:
-            async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            async with guarded_async_client(
+                profile=PROXY_PROFILE, timeout=timeout_seconds
+            ) as client:
                 response = await client.get(url)
             status_code = response.status_code
             response_time_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
@@ -1269,7 +1284,9 @@ async def check_agent_health(
         logger.info(f"Agent {path} GET checks failed, falling back to HEAD ping on {base_url}")
         try:
             start_time = datetime.now(UTC)
-            async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+            async with guarded_async_client(
+                profile=PROXY_PROFILE, timeout=timeout_seconds
+            ) as client:
                 response = await client.head(base_url)
             status_code = response.status_code
             response_time_ms = int((datetime.now(UTC) - start_time).total_seconds() * 1000)
@@ -1834,6 +1851,28 @@ async def pull_agent_card(
                 f"'{change.current_value}' to '{change.remote_value}' "
                 f"(requested by '{user_context['username']}')"
             )
+            # Fail closed on a remote card that tries to point the stored agent
+            # URL at an internal/metadata target. Reject in BOTH preview and
+            # apply modes so a poisoned card is surfaced during dry-run and can
+            # never be persisted. update_agent re-validates on the write path;
+            # this earlier check also covers the preview, which does not persist
+            # the URL and therefore would not otherwise validate it.
+            try:
+                validate_agent_url(str(change.remote_value))
+            except UrlValidationError as exc:
+                logger.warning(
+                    "pull-card: rejecting URL change for agent %s -> %s: %s",
+                    path,
+                    change.remote_value,
+                    exc,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "Remote agent card URL failed SSRF validation and was "
+                        "rejected (private/internal addresses are not allowed)"
+                    ),
+                ) from exc
 
     # R4: single structured log line per pull-card op so adoption/outcomes can be
     #     scraped without a dedicated metric. The audit trail also records this.
@@ -1864,6 +1903,17 @@ async def pull_agent_card(
     #    mode it is health + A2A fields in one call.
     try:
         updated_agent = await agent_service.update_agent(path, updates)
+    except UrlValidationError as e:
+        # A poisoned URL that reached the write path is a client-side rejection,
+        # not a server error: surface it as 400 and never persist it.
+        logger.warning(f"pull-card: URL rejected on write for agent {path}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Remote agent card URL failed SSRF validation and was rejected "
+                "(private/internal addresses are not allowed)"
+            ),
+        ) from e
     except Exception as e:
         # In dry-run mode a failed health write should not fail the preview.
         if dry_run or not has_changes:

--- a/registry/constants.py
+++ b/registry/constants.py
@@ -17,6 +17,7 @@ class HealthStatus(str, Enum):
     UNHEALTHY_CONNECTION_ERROR = "unhealthy: connection error"
     UNHEALTHY_ENDPOINT_CHECK_FAILED = "unhealthy: endpoint check failed"
     UNHEALTHY_MISSING_PROXY_URL = "unhealthy: missing proxy URL"
+    UNHEALTHY_URL_BLOCKED = "unhealthy: url blocked by SSRF guard"
     CHECKING = "checking"
     UNKNOWN = "unknown"
     LOCAL = "local"

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -462,6 +462,20 @@ class Settings(BaseSettings):
             "The cloud metadata address 169.254.169.254 is never permitted."
         ),
     )
+    nginx_config_validation_required: bool = Field(
+        default=False,
+        description=(
+            "Fail closed when a generated nginx config cannot be validated with "
+            "'nginx -t' because the nginx binary is absent from this process. "
+            "Leave False for single-container and local-dev deployments where the "
+            "registry and nginx share a process/image (a missing binary means "
+            "there is no nginx to cold-start). Set True for split topologies where "
+            "nginx runs in a separate container/sidecar sharing the config volume: "
+            "the registry cannot run 'nginx -t' itself, so an unvalidated config "
+            "must NOT be promoted (it would poison the sidecar's next cold start). "
+            "When True and the binary is absent, the last-known-good config is kept."
+        ),
+    )
 
     # Update check (GitHub Releases API for newer registry versions)
     update_check_enabled: bool = Field(

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -436,6 +436,33 @@ class Settings(BaseSettings):
         description="GitHub API base URL for App token exchange (for GHES: https://github.mycompany.com/api/v3)",
     )
 
+    # SSRF guard allowlist for server/agent targets that legitimately live on
+    # private networks (e.g. self-hosted MCP servers behind Docker service DNS
+    # or an internal VPC). The URL guard fails closed by default: any host that
+    # resolves to a private/loopback/link-local/metadata address is rejected at
+    # registration and refused at fetch time. Operators who proxy to internal
+    # backends must explicitly opt those targets in here. The cloud metadata
+    # endpoint (169.254.169.254) can never be allowlisted.
+    ssrf_allowed_hosts: str = Field(
+        default="",
+        description=(
+            "Comma-separated hostnames (or literal IPs) that may resolve to "
+            "private addresses and still be accepted by the SSRF guard for "
+            "proxy_pass_url / agent URLs (e.g. 'mcpgw,host.docker.internal,"
+            "localhost'). Keep this list tight. The cloud metadata endpoint is "
+            "never permitted."
+        ),
+    )
+    ssrf_allowed_cidrs: str = Field(
+        default="",
+        description=(
+            "Comma-separated CIDR ranges whose addresses the SSRF guard accepts "
+            "for proxy_pass_url / agent URLs even though they are private (e.g. "
+            "'10.0.0.0/8,192.168.0.0/16'). Use for internal MCP-server subnets. "
+            "The cloud metadata address 169.254.169.254 is never permitted."
+        ),
+    )
+
     # Update check (GitHub Releases API for newer registry versions)
     update_check_enabled: bool = Field(
         default=True,

--- a/registry/core/mcp_client.py
+++ b/registry/core/mcp_client.py
@@ -20,6 +20,41 @@ from mcp.client.streamable_http import streamablehttp_client
 logger = logging.getLogger(__name__)
 
 
+def _assert_mcp_url_fetchable(
+    url: str,
+) -> bool:
+    """Fail-closed SSRF check before an MCP SDK connection is opened.
+
+    The MCP SDK transports (``streamablehttp_client`` / ``sse_client``) build
+    their own httpx client, so they cannot use the pinned guarded transport that
+    protects the registry's direct fetches. This helper re-validates the target
+    against the proxy profile (public-only unless the operator allowlisted the
+    internal target) immediately before a connection is opened, so a
+    ``proxy_pass_url`` that resolves to a private/metadata address is rejected
+    *before* any decrypted credential is built or sent. It resolves DNS at call
+    time, closing the window between registration-time validation and this
+    fetch. Any validation error results in refusal (returns ``False``).
+
+    Args:
+        url: The MCP endpoint / base URL about to be connected to.
+
+    Returns:
+        True if the URL passed validation and may be connected to, else False.
+    """
+    from ..exceptions import UrlValidationError
+    from ..utils.url_guard import PROXY_PROFILE, validate_url
+
+    try:
+        validate_url(url, profile=PROXY_PROFILE)
+        return True
+    except UrlValidationError as e:
+        logger.warning("MCP connection blocked by SSRF guard for %s: %s", url, e)
+        return False
+    except Exception as e:  # pragma: no cover - defensive, fail closed
+        logger.warning("MCP connection blocked (validation error) for %s: %s", url, e)
+        return False
+
+
 class MCPServerInfo(TypedDict, total=False):
     """Server info returned from MCP initialize response."""
 
@@ -227,6 +262,12 @@ async def detect_server_transport(base_url: str) -> str:
         logger.debug(f"Server URL {base_url} already has MCP endpoint")
         return "streamable-http"
 
+    # Fail closed on SSRF before probing the target with the (unpinnable) SDK
+    # client. Both probe endpoints share this host, so validating base_url once
+    # covers them. Default to streamable-http (no connection) when blocked.
+    if not _assert_mcp_url_fetchable(base_url):
+        return "streamable-http"
+
     # Test streamable-http first (default preference)
     try:
         mcp_url = base_url.rstrip("/") + "/mcp/"
@@ -291,11 +332,18 @@ async def get_tools_from_server_with_transport(
 
 async def _get_tools_streamable_http(base_url: str, server_info: dict = None) -> list[dict] | None:
     """Get tools using streamable-http transport"""
-    # Build headers for the server
-    headers = _build_headers_for_server(server_info)
-
     # Check if server_info has explicit mcp_endpoint
     explicit_endpoint = server_info.get("mcp_endpoint") if server_info else None
+
+    # Fail closed on SSRF BEFORE decrypting/building credential headers: a
+    # target that resolves to a private/metadata address must never receive the
+    # server's decrypted backend credentials. Validate the actual endpoint about
+    # to be connected to (explicit endpoint if set, else the base URL).
+    if not _assert_mcp_url_fetchable(explicit_endpoint or base_url):
+        return None
+
+    # Build headers for the server
+    headers = _build_headers_for_server(server_info)
 
     # If explicit endpoint is provided, use it directly (single attempt)
     if explicit_endpoint:
@@ -416,6 +464,10 @@ async def _get_tools_sse(base_url: str, server_info: dict = None) -> list[dict] 
 
     secure_prefix = "s" if sse_url.startswith("https://") else ""
     mcp_server_url = f"http{secure_prefix}://{sse_url[len(f'http{secure_prefix}://') :]}"
+
+    # Fail closed on SSRF BEFORE decrypting/building credential headers.
+    if not _assert_mcp_url_fetchable(mcp_server_url):
+        return None
 
     # Build headers for the server
     headers = _build_headers_for_server(server_info)
@@ -597,6 +649,15 @@ async def get_mcp_connection_result(
         logger.error("MCP Check Error: Base URL is empty.")
         return None
 
+    # Determine the MCP endpoint URL
+    explicit_endpoint = server_info.get("mcp_endpoint") if server_info else None
+
+    # Fail closed on SSRF BEFORE any transport probe or credential build: a
+    # target that resolves to a private/metadata address must never receive the
+    # server's decrypted backend credentials.
+    if not _assert_mcp_url_fetchable(explicit_endpoint or base_url):
+        return None
+
     # Use transport-aware detection
     transport = await detect_server_transport_aware(base_url, server_info)
 
@@ -604,9 +665,6 @@ async def get_mcp_connection_result(
 
     # Build headers for the server
     headers = _build_headers_for_server(server_info)
-
-    # Determine the MCP endpoint URL
-    explicit_endpoint = server_info.get("mcp_endpoint") if server_info else None
 
     if explicit_endpoint:
         mcp_url = explicit_endpoint

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -156,6 +156,182 @@ def _cleanup_stale_temp_files(config_path: Path) -> None:
             logger.warning(f"Failed to remove stale temp file {stale}: {e}")
 
 
+# Suffix for the last-known-good copy kept beside the live config while a
+# candidate is being validated. On a failed validation the live config is
+# restored from this copy so the broken candidate never survives on disk.
+_LAST_GOOD_SUFFIX: str = ".last-good"
+
+
+# Sentinel returned by the config test when the nginx binary is absent. There
+# is no nginx to protect from a bad cold start on such a host (e.g. registry-
+# only mode or local dev), so the caller promotes the candidate without a test
+# rather than rejecting a legitimate render it cannot validate.
+_NGINX_TEST_NO_BINARY: str = "__nginx_binary_missing__"
+
+
+def _run_nginx_config_test() -> tuple[bool, str]:
+    """Run ``nginx -t`` against the live config tree.
+
+    ``nginx -t`` parses the full configuration tree exactly as a cold start
+    (container restart) would - main ``nginx.conf`` plus every ``include``d
+    fragment and the Lua modules they reference. Validating the candidate in
+    place (see :func:`_write_and_validate_config`) is therefore the only
+    faithful predictor of whether a subsequent cold start will boot.
+
+    Returns:
+        A ``(passed, message)`` tuple. ``passed`` is False on a non-zero exit,
+        a timeout, or any other error (fail closed); ``message`` carries
+        nginx's stderr or the failure reason. When the nginx binary is not
+        installed, ``message`` is the ``_NGINX_TEST_NO_BINARY`` sentinel so the
+        caller can distinguish "no nginx to protect" from "config is invalid".
+    """
+    import subprocess  # nosec B404
+
+    try:
+        result = subprocess.run(
+            ["nginx", "-t"],  # nosec B603 B607 - hardcoded command
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError:
+        return False, _NGINX_TEST_NO_BINARY
+    except subprocess.TimeoutExpired:
+        return False, "nginx -t timed out"
+    except Exception as e:  # pragma: no cover - defensive
+        return False, f"nginx -t raised: {e}"
+
+    if result.returncode != 0:
+        return False, result.stderr or "nginx -t returned non-zero"
+    return True, result.stderr or ""
+
+
+def _write_and_validate_config(
+    path: Path,
+    content: str,
+) -> None:
+    """Promote a rendered nginx config only if ``nginx -t`` accepts it.
+
+    A malformed config (whether from a config-injection attempt that still
+    parses partially, an unhealthy-backend edge case, or a template bug) must
+    never persist on disk: even when the running nginx keeps serving its
+    in-memory config, the broken file on disk takes down the *next* cold start
+    (routine on ECS/K8s) and with it the whole gateway.
+
+    This renders the candidate to a temporary file, atomically promotes it into
+    ``path`` after backing up the current live config, then runs ``nginx -t``
+    against the real config tree. If the test passes, the backup is discarded.
+    If it fails, the previous last-known-good config is restored (or, when
+    there was no prior config, the rejected file is removed) so the gateway can
+    still cold-start on the last-good config. Fails closed: any error leaves the
+    last-good config in place and raises.
+
+    Args:
+        path: The live nginx config path.
+        content: The rendered candidate config content.
+
+    Raises:
+        RuntimeError: If ``nginx -t`` rejects the candidate (the live config is
+            restored to the last-known-good state before raising).
+        OSError: If the temp write / rename cannot be performed.
+    """
+    import shutil
+
+    path = Path(path)
+
+    # Pre-flight: decide the missing-binary policy BEFORE the candidate ever
+    # touches the live path, so a split/sidecar deployment cannot pick up an
+    # unvalidated config in the window between write and restore.
+    #
+    # When the nginx binary is absent we cannot run ``nginx -t``. In a
+    # single-container / local-dev deployment that means there is no nginx to
+    # cold-start, so promoting the candidate matches the pre-existing behavior.
+    # In a split topology (nginx in a separate container/sidecar sharing this
+    # config volume) an unvalidated config WOULD poison the sidecar's next cold
+    # start, so operators set ``nginx_config_validation_required=True`` to fail
+    # closed — and here we refuse before writing, leaving the live config
+    # untouched entirely.
+    nginx_available = shutil.which("nginx") is not None
+    if not nginx_available:
+        if settings.nginx_config_validation_required:
+            NGINX_CONFIG_WRITES.labels(status="rejected").inc()
+            raise RuntimeError(
+                "nginx config rejected: nginx binary not found and "
+                "nginx_config_validation_required=True (refusing to promote an "
+                "unvalidated config to the shared config path)"
+            )
+        # No nginx on this host to protect: promote as before. In with-gateway
+        # mode this is surfaced at WARNING so a misconfigured split deployment
+        # is visible without enabling debug logging.
+        if settings.nginx_updates_enabled:
+            logger.warning(
+                "nginx binary not found; promoting config without nginx -t validation. "
+                "If nginx runs in a separate container sharing this path, set "
+                "NGINX_CONFIG_VALIDATION_REQUIRED=true to fail closed."
+            )
+        else:
+            logger.debug("nginx binary not found; promoting config without nginx -t validation")
+        _atomic_write_text(path, content)
+        return
+
+    had_previous = path.exists()
+    backup_path = path.with_name(path.name + _LAST_GOOD_SUFFIX)
+
+    # Back up the current live config so we can restore it on rejection.
+    if had_previous:
+        try:
+            # copy2 preserves mode/timestamps; a plain copy keeps the live file
+            # intact (unlike a rename, which would briefly leave no live file).
+            shutil.copy2(path, backup_path)
+        except OSError as e:
+            logger.error("Could not back up live nginx config before validation: %s", e)
+            raise
+
+    # Promote the candidate into the live path (atomic, preserves mode).
+    _atomic_write_text(path, content)
+
+    passed, message = _run_nginx_config_test()
+
+    if passed:
+        # Candidate accepted: drop the backup.
+        if had_previous:
+            try:
+                backup_path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as e:
+                logger.warning("Could not remove nginx config backup %s: %s", backup_path, e)
+        return
+
+    # Candidate rejected: restore the last-known-good config so a cold start
+    # still boots, then fail closed.
+    logger.error(
+        "Rejected nginx config candidate (nginx -t failed); restoring last-good config: %s",
+        message.strip(),
+    )
+    NGINX_CONFIG_WRITES.labels(status="rejected").inc()
+    if had_previous:
+        try:
+            os.replace(backup_path, path)
+        except OSError as e:
+            logger.error("Failed to restore last-good nginx config from %s: %s", backup_path, e)
+            raise RuntimeError(
+                f"nginx config validation failed and last-good restore failed: {message.strip()}"
+            ) from e
+    else:
+        # No prior config existed: remove the rejected file so nothing invalid
+        # is left for a cold start to load.
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.error("Failed to remove rejected nginx config %s: %s", path, e)
+            raise
+
+    raise RuntimeError(f"nginx config rejected by nginx -t: {message.strip()}")
+
+
 def _ensure_mcp_compliant_schema(input_schema: dict[str, Any]) -> dict[str, Any]:
     """Ensure inputSchema conforms to MCP spec by adding 'type': 'object' if missing.
 
@@ -419,7 +595,13 @@ class NginxConfigService:
             # Write virtual server Lua mapping files (side effect, not part of render)
             await self._commit_virtual_server_mappings()
 
-            _atomic_write_text(settings.nginx_config_path, config_content)
+            # Validate the candidate against the real config tree BEFORE it is
+            # allowed to persist as the live config. A rejected candidate is
+            # never left on disk (the last-known-good config is restored), so a
+            # subsequent nginx cold start cannot be poisoned by a bad render.
+            await asyncio.to_thread(
+                _write_and_validate_config, settings.nginx_config_path, config_content
+            )
 
             logger.info(
                 "Generated Nginx configuration with location blocks and additional server names"
@@ -1773,7 +1955,12 @@ class NginxReloadScheduler:
                 await nginx_service._commit_virtual_server_mappings()
 
                 async with nginx_service.reload_lock:
-                    _atomic_write_text(settings.nginx_config_path, config_text)
+                    # Validate the candidate in-tree before it can persist as
+                    # the live config; a rejected render restores last-good and
+                    # raises, so the cold-start path can never load a bad file.
+                    await asyncio.to_thread(
+                        _write_and_validate_config, settings.nginx_config_path, config_text
+                    )
                     reloaded = await asyncio.to_thread(nginx_service.reload_nginx)
                 if reloaded:
                     self._last_config_hash = new_hash

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -577,12 +577,19 @@ class NginxConfigService:
                             location_blocks.extend(transport_blocks)
                             logger.debug(f"Added location blocks for healthy service: {path}")
                         else:
-                            # Add commented out block for unhealthy services
+                            # Add commented out block for unhealthy services.
+                            # Sanitize both the path and the backend URL: a
+                            # newline in a stored value would otherwise break out
+                            # of the leading '#' and emit a live directive.
+                            # Registration validation now rejects such values;
+                            # this protects legacy data persisted beforehand.
+                            safe_commented_path = self._sanitize_for_nginx_set(path)
+                            safe_commented_url = self._sanitize_for_nginx_set(proxy_pass_url)
                             commented_block = f"""
-#    location {{{{ROOT_PATH}}}}{path}/ {{
+#    location {{{{ROOT_PATH}}}}{safe_commented_path}/ {{
 #        # Service currently unhealthy (status: {health_status})
 #        # Proxy to MCP server
-#        proxy_pass {proxy_pass_url};
+#        proxy_pass {safe_commented_url};
 #        proxy_http_version 1.1;
 #        proxy_set_header Host $host;
 #        proxy_set_header X-Real-IP $remote_addr;
@@ -739,8 +746,7 @@ class NginxConfigService:
                 )
             except Exception as e:
                 logger.warning(
-                    f"Failed to parse AUTH_SERVER_URL '{auth_server_url}': {e}. "
-                    "Using defaults."
+                    f"Failed to parse AUTH_SERVER_URL '{auth_server_url}': {e}. Using defaults."
                 )
                 auth_host = "auth-server"
                 auth_port = "8888"
@@ -1004,19 +1010,29 @@ class NginxConfigService:
             # Handle paths like /context7, /currenttime/, /ai.smithery-xxx
             escaped_path = re.escape(path.rstrip("/"))
 
+            # Defense-in-depth: escape backend URLs before interpolating them
+            # into the quoted nginx map values (belt-and-suspenders with the
+            # registration-time metacharacter rejection).
+            safe_default_backend = self._sanitize_for_nginx_set(default_backend)
+
             # Add map entries for this server
             # Entry for no header (empty string after colon)
-            map_entries.append(f'    "~^{escaped_path}(/.*)?:$"            "{default_backend}";')
+            map_entries.append(
+                f'    "~^{escaped_path}(/.*)?:$"            "{safe_default_backend}";'
+            )
             # Entry for explicit "latest"
-            map_entries.append(f'    "~^{escaped_path}(/.*)?:latest$"      "{default_backend}";')
+            map_entries.append(
+                f'    "~^{escaped_path}(/.*)?:latest$"      "{safe_default_backend}";'
+            )
 
             # Entry for each version
             for v in versions:
                 version_str = v.get("version", "")
                 backend_url = v.get("proxy_pass_url", "")
                 if version_str and backend_url:
+                    safe_backend_url = self._sanitize_for_nginx_set(backend_url)
                     map_entries.append(
-                        f'    "~^{escaped_path}(/.*)?:{re.escape(version_str)}$"  "{backend_url}";'
+                        f'    "~^{escaped_path}(/.*)?:{re.escape(version_str)}$"  "{safe_backend_url}";'
                     )
 
             logger.info(f"Generated version map entries for {path} with {len(versions)} versions")
@@ -1138,10 +1154,14 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 # Sanitize values for safe interpolation into nginx config
                 safe_name = self._sanitize_for_nginx_comment(vs.server_name)
                 safe_id = self._sanitize_for_nginx_set(server_id)
+                # The path is interpolated into a location directive; escape any
+                # nginx-special characters (defense-in-depth over Pydantic path
+                # validation) so it cannot break out of the directive.
+                safe_vs_path = self._sanitize_for_nginx_set(vs.path)
 
                 block = f"""
     # Virtual MCP Server: {safe_name}
-    location {{{{ROOT_PATH}}}}{vs.path} {{
+    location {{{{ROOT_PATH}}}}{safe_vs_path} {{
         set $virtual_server_id "{safe_id}";
         auth_request /validate;
         auth_request_set $auth_scopes $upstream_http_x_scopes;
@@ -1252,8 +1272,18 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                     backend_hostname
                 )
 
+                # Defense-in-depth: escape the backend URL and Host header before
+                # interpolating them into proxy_pass / set / proxy_set_header
+                # directives, matching the escaping applied to the versioned
+                # backend map. Registration-time validation already rejects URLs
+                # with nginx metacharacters; escaping here means legacy data
+                # persisted before validation still cannot break out of the
+                # directive context.
+                safe_mcp_proxy_url = self._sanitize_for_nginx_set(mcp_proxy_url)
+                safe_upstream_host = self._sanitize_for_nginx_set(upstream_host)
+
                 if host_is_resolvable_at_startup:
-                    proxy_directive = f"proxy_pass {mcp_proxy_url};"
+                    proxy_directive = f"proxy_pass {safe_mcp_proxy_url};"
                 else:
                     # sanitized is already underscore-safe (valid nginx var name).
                     backend_var = f"$vs_backend{sanitized}"
@@ -1262,7 +1292,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                     proxy_directive = (
                         f"resolver {dns_resolver} valid=10s;\n"
                         f"        resolver_timeout {dns_resolver_timeout}s;\n"
-                        f'        set {backend_var} "{mcp_proxy_url}";\n'
+                        f'        set {backend_var} "{safe_mcp_proxy_url}";\n'
                         f"        proxy_pass {backend_var};"
                     )
 
@@ -1272,7 +1302,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         {proxy_directive}
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
-        proxy_set_header Host {upstream_host};
+        proxy_set_header Host {safe_upstream_host};
         proxy_set_header Authorization $http_authorization;
         proxy_buffering off;
         proxy_set_header Accept "application/json, text/event-stream";
@@ -1453,6 +1483,14 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
             other_version_ids = server_info.get("other_version_ids", [])
             has_versions = len(other_version_ids) > 0
 
+        # Defense-in-depth: escape the backend URL before it is interpolated
+        # into any nginx directive/string. Registration-time validation already
+        # rejects URLs containing nginx metacharacters, but escaping here means a
+        # value that somehow reaches this point (e.g. legacy data persisted
+        # before validation existed) still cannot break out of the quoted
+        # `set $backend_url "..."` context.
+        safe_proxy_pass_url = self._sanitize_for_nginx_set(proxy_pass_url)
+
         # Extract hostname from proxy_pass_url for external services
         parsed_url = urlparse(proxy_pass_url)
         upstream_host = parsed_url.netloc
@@ -1461,8 +1499,11 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         # For external services (https), use the upstream hostname
         # For internal services (http without dots in hostname), preserve original host
         if parsed_url.scheme == "https" or "." in upstream_host:
-            # External service - use upstream hostname
-            host_header = upstream_host
+            # External service - use upstream hostname. Sanitize before it is
+            # interpolated into `proxy_set_header Host ...` (defense-in-depth: the
+            # netloc comes from a proxy_pass_url whose metacharacters are rejected
+            # at registration, but legacy data must not break out of the directive).
+            host_header = self._sanitize_for_nginx_set(upstream_host)
             logger.info(f"Using upstream hostname for Host header: {host_header}")
         else:
             # Internal service - preserve original host
@@ -1481,11 +1522,11 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         if has_versions:
             # Multi-version server: use map variable with fallback, then proxy the selected
             # upstream URL to auth_server via X-Upstream-Url so it knows where to forward.
-            proxy_directive = f'''
+            proxy_directive = f"""
         # Version routing - use header-based backend selection
         # If X-MCP-Server-Version header matches a version, use that backend
         # Otherwise, use the default backend
-        set $backend_url "{proxy_pass_url}";
+        set $backend_url "{safe_proxy_pass_url}";
         if ($versioned_backend != "") {{
             set $backend_url $versioned_backend;
         }}
@@ -1494,7 +1535,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         proxy_set_header X-Upstream-Url $backend_url;
 
         # Proxy to auth_server mcp-proxy hop (Issue #1026)
-        proxy_pass {mcp_proxy_target};'''
+        proxy_pass {mcp_proxy_target};"""
             version_headers = """
 
         # Add version info to response
@@ -1505,7 +1546,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
             # bind it into the internal token via X-Resolved-Upstream, matching what
             # is forwarded here. Quote the URL so nginx does not interpret braces.
             proxy_directive = f"""
-        set $backend_url "{proxy_pass_url}";
+        set $backend_url "{safe_proxy_pass_url}";
 
         # Tell auth_server which upstream to forward to after filtering
         proxy_set_header X-Upstream-Url $backend_url;

--- a/registry/exceptions.py
+++ b/registry/exceptions.py
@@ -12,6 +12,25 @@ class RegistryError(Exception):
     pass
 
 
+class UrlValidationError(RegistryError):
+    """A URL failed the hardened SSRF/scheme validation guard.
+
+    Raised by :mod:`registry.utils.url_guard` for any URL that uses a
+    disallowed scheme, has no host, resolves to a private/metadata IP, or
+    contains disallowed nginx metacharacters. The guard fails closed, so this
+    is raised on any resolution error or ambiguity as well.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        reason: str,
+    ):
+        self.url = url
+        self.reason = reason
+        super().__init__(f"URL failed validation '{url}': {reason}")
+
+
 # Skill-specific exceptions
 
 
@@ -199,9 +218,7 @@ class SkillContentSSRFError(SkillRegistryError):
         url: str,
     ):
         self.url = url
-        super().__init__(
-            f"URL failed SSRF validation: {url}"
-        )
+        super().__init__(f"URL failed SSRF validation: {url}")
 
 
 class SkillContentTooLargeError(SkillRegistryError):
@@ -212,9 +229,7 @@ class SkillContentTooLargeError(SkillRegistryError):
         max_size: int,
     ):
         self.max_size = max_size
-        super().__init__(
-            f"Content exceeds {max_size // 1024} KB limit"
-        )
+        super().__init__(f"Content exceeds {max_size // 1024} KB limit")
 
 
 # Registration Gate exceptions

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -12,6 +12,8 @@ from registry.constants import DeploymentType, HealthStatus
 
 from ..core.config import settings
 from ..core.endpoint_utils import get_endpoint_url_from_server_info
+from ..exceptions import UrlValidationError
+from ..utils.url_guard import PROXY_PROFILE, guarded_async_client, validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -360,8 +362,9 @@ class HealthMonitoringService:
         HEALTH_CHECK_BATCH_SIZE = 10
         HEALTH_CHECK_BATCH_DELAY_SECONDS = 0.5
 
-        async with httpx.AsyncClient(
-            timeout=httpx.Timeout(settings.health_check_timeout_seconds)
+        async with guarded_async_client(
+            profile=PROXY_PROFILE,
+            timeout=httpx.Timeout(settings.health_check_timeout_seconds),
         ) as client:
             check_tasks = []
             for service_path in enabled_services:
@@ -369,16 +372,13 @@ class HealthMonitoringService:
                     service_path, include_credentials=True
                 )
                 if server_info and server_info.get("proxy_pass_url"):
-                    check_tasks.append(
-                        (service_path, server_info)
-                    )
+                    check_tasks.append((service_path, server_info))
 
             # Execute health checks in staggered batches
             for batch_start in range(0, len(check_tasks), HEALTH_CHECK_BATCH_SIZE):
-                batch = check_tasks[batch_start:batch_start + HEALTH_CHECK_BATCH_SIZE]
+                batch = check_tasks[batch_start : batch_start + HEALTH_CHECK_BATCH_SIZE]
                 batch_coros = [
-                    self._check_single_service(client, path, info)
-                    for path, info in batch
+                    self._check_single_service(client, path, info) for path, info in batch
                 ]
                 results = await asyncio.gather(*batch_coros, return_exceptions=True)
 
@@ -396,16 +396,12 @@ class HealthMonitoringService:
 
             # Regenerate nginx configuration when health status changes
             try:
-                from ..core.nginx_service import nginx_service
-
                 from registry.core.nginx_service import nginx_reload_scheduler
 
                 nginx_reload_scheduler.mark_dirty()
                 logger.info("Nginx config marked dirty due to health status changes")
             except Exception as e:
-                logger.error(
-                    f"Failed to mark nginx config dirty after health status change: {e}"
-                )
+                logger.error(f"Failed to mark nginx config dirty after health status change: {e}")
 
     async def _check_single_service(
         self, client: httpx.AsyncClient, service_path: str, server_info: dict
@@ -681,6 +677,22 @@ class HealthMonitoringService:
         """
         if not proxy_pass_url:
             return False, HealthStatus.UNHEALTHY_MISSING_PROXY_URL
+
+        # Fail closed on SSRF before any credential decryption or header build:
+        # a proxy_pass_url that resolves to a private/metadata target (or uses a
+        # disallowed scheme) must never receive the server's decrypted
+        # credentials. This validates the URL up front; the guarded client used
+        # for the actual request additionally pins the resolved public IP so the
+        # host cannot rebind to a private address after this check.
+        try:
+            validate_url(proxy_pass_url, profile=PROXY_PROFILE)
+        except UrlValidationError as e:
+            logger.warning(
+                "Health check blocked by SSRF guard for %s: %s (credentials NOT sent)",
+                proxy_pass_url,
+                e,
+            )
+            return False, HealthStatus.UNHEALTHY_URL_BLOCKED
 
         # Get transport information from server_info
         supported_transports = server_info.get("supported_transports", ["streamable-http"])
@@ -1234,8 +1246,9 @@ class HealthMonitoringService:
         self.server_health_status[service_path] = HealthStatus.CHECKING
 
         try:
-            async with httpx.AsyncClient(
-                timeout=httpx.Timeout(settings.health_check_timeout_seconds)
+            async with guarded_async_client(
+                profile=PROXY_PROFILE,
+                timeout=httpx.Timeout(settings.health_check_timeout_seconds),
             ) as client:
                 # Use transport-aware endpoint checking
                 is_healthy, status_detail = await self._check_server_endpoint_transport_aware(
@@ -1298,9 +1311,7 @@ class HealthMonitoringService:
                     f"Nginx config marked dirty due to status change for {service_path}: {previous_status} -> {current_status}"
                 )
             except Exception as e:
-                logger.error(
-                    f"Failed to mark nginx config dirty after immediate health check: {e}"
-                )
+                logger.error(f"Failed to mark nginx config dirty after immediate health check: {e}")
 
         return current_status, last_checked_time
 

--- a/registry/main.py
+++ b/registry/main.py
@@ -746,7 +746,9 @@ async def lifespan(app: FastAPI):
         try:
             ard_cfg = await get_ard_ingestion_service().get_config()
             if ard_cfg.enabled and ard_cfg.sync_on_startup and ard_cfg.sources:
-                logger.info("Running ARD ingestion startup pass for %d source(s)", len(ard_cfg.sources))
+                logger.info(
+                    "Running ARD ingestion startup pass for %d source(s)", len(ard_cfg.sources)
+                )
                 await get_ard_ingestion_service().ingest_all()
         except Exception as e:  # noqa: BLE001
             logger.error("ARD ingestion startup pass failed: %s", e, exc_info=True)
@@ -884,6 +886,7 @@ async def lifespan(app: FastAPI):
 
         # Stop ARD ingestion scheduler
         from registry.services.ard_ingestion_scheduler import get_ard_ingestion_scheduler
+
         await get_ard_ingestion_scheduler().stop()
 
         # Stop update-check poller
@@ -1154,6 +1157,33 @@ app.include_router(ard_router, prefix="/api/ard", tags=["ARD Registry"])
 # default behavior is preserved for every other path.
 app.add_exception_handler(StarletteHTTPException, ard_http_exception_handler)
 app.add_exception_handler(RequestValidationError, ard_validation_exception_handler)
+
+
+# SSRF / URL validation: any registration or fetch path that persists or
+# reaches a user/registry-controlled URL raises UrlValidationError when the
+# target is unsafe (bad scheme, private/metadata IP, or nginx metacharacters).
+# Surface it as a clean 400 rather than a 500 so the caller learns the URL was
+# rejected. Fails closed by construction: the request is denied before any
+# outbound connection or persistence.
+from fastapi.responses import JSONResponse  # noqa: E402
+from starlette.requests import Request as _StarletteRequest  # noqa: E402
+
+from registry.exceptions import UrlValidationError  # noqa: E402
+
+
+async def _url_validation_exception_handler(
+    request: _StarletteRequest,
+    exc: Exception,
+) -> JSONResponse:
+    """Return HTTP 400 for a rejected user/registry-controlled URL."""
+    reason = getattr(exc, "reason", "URL failed validation")
+    return JSONResponse(
+        status_code=400,
+        content={"detail": f"URL rejected by security policy: {reason}"},
+    )
+
+
+app.add_exception_handler(UrlValidationError, _url_validation_exception_handler)
 
 # Register public, anonymous per-record endpoints (ARD catalog url targets, issue #1294)
 app.include_router(public_record_router, prefix="/api", tags=["Public Records"])

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -14,6 +14,7 @@ from typing import Any
 from ..repositories.factory import get_agent_repository, get_search_repository
 from ..repositories.interfaces import AgentRepositoryBase, SearchRepositoryBase
 from ..schemas.agent_models import AgentCard
+from ..utils.url_guard import validate_agent_url
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +49,16 @@ class AgentService:
 
         Raises:
             ValueError: If agent path already exists
+            UrlValidationError: If the agent url fails SSRF/scheme validation
         """
         path = agent_card.path
+
+        # Fail-closed URL validation on every agent registration path
+        # (dashboard/API, internal register, federation import) before the
+        # agent card is persisted. Rejects non-http(s) schemes and
+        # private/metadata targets unless the operator allowlisted them.
+        if getattr(agent_card, "url", None):
+            validate_agent_url(str(agent_card.url))
 
         if await self._repo.get(path) is not None:
             logger.error(f"Agent registration failed: path '{path}' already exists")
@@ -178,7 +187,14 @@ class AgentService:
 
         Raises:
             ValueError: If agent not found
+            UrlValidationError: If the update sets a url that fails validation
         """
+        # Fail-closed URL validation on edit paths that change the agent url.
+        # Only runs when the update actually carries a url, so health-status
+        # updates are unaffected.
+        if updates.get("url"):
+            validate_agent_url(str(updates["url"]))
+
         existing_agent = await self._repo.get(path)
         if existing_agent is None:
             logger.error(f"Cannot update agent at path '{path}': not found")

--- a/registry/services/federation/ai_catalog_client.py
+++ b/registry/services/federation/ai_catalog_client.py
@@ -27,7 +27,9 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from pydantic import ValidationError
 
+from ...exceptions import UrlValidationError
 from ...schemas.ard_models import AICatalogManifest
+from ...utils.url_guard import SKILL_PROFILE, guarded_client
 from ..ard_net_guard import assert_fetchable
 from ..ard_search_service import ArdValidationError
 
@@ -51,8 +53,19 @@ class AiCatalogFederationClient:
         self.max_depth = max_depth
         self.polite_interval_ms = polite_interval_ms
         self.same_domain_only = same_domain_only
-        # Auth-less client: NEVER send Authorization to a third-party catalog host.
-        self.client = httpx.Client(timeout=timeout_seconds, follow_redirects=False)
+        # Auth-less, SSRF-pinned client: NEVER send Authorization to a
+        # third-party catalog host, and connect only to an IP that the guard
+        # validated inside this same request. assert_fetchable() enforces the
+        # ARD-specific https-only + same-domain policy up front; the guarded
+        # client then pins the resolved public IP at connect time so the fetch
+        # cannot re-resolve a rebound hostname to a private/metadata address
+        # between validation and connect (SKILL_PROFILE = public-only, no proxy
+        # allowlist — the strictest profile, correct for third-party catalogs).
+        self.client = guarded_client(
+            profile=SKILL_PROFILE,
+            timeout=timeout_seconds,
+            follow_redirects=False,
+        )
 
     def __del__(self):
         if hasattr(self, "client"):
@@ -89,7 +102,15 @@ class AiCatalogFederationClient:
             return
         visited.add(url)
 
-        manifest = self._fetch_one(url, root_domain)
+        # Fail closed per-URL, never per-crawl: a single poisoned entry (e.g. a
+        # URL that httpx rejects with InvalidURL, or any unexpected error) must
+        # skip that node and let the crawl continue with its siblings, so a
+        # hostile catalog cannot DoS the whole ingestion run with one bad link.
+        try:
+            manifest = self._fetch_one(url, root_domain)
+        except Exception as e:
+            logger.warning("ARD ingestion: skipping catalog URL %s after error: %s", url, e)
+            return
         if manifest is None:
             return
         out.append((manifest, url))
@@ -124,11 +145,25 @@ class AiCatalogFederationClient:
         try:
             with self.client.stream("GET", url, headers={"Accept": "application/json"}) as response:
                 response.raise_for_status()
+                # follow_redirects=False means a 3xx is returned as-is and does
+                # NOT raise_for_status() (which only raises on 4xx/5xx); refuse
+                # it explicitly so a hostile host cannot smuggle a fake catalog
+                # body inside a redirect response (the guard pins the original
+                # host, not the unfollowed Location).
+                if 300 <= response.status_code < 400:
+                    logger.warning(
+                        "ARD ingestion: catalog %s returned redirect status %d, skipping",
+                        url,
+                        response.status_code,
+                    )
+                    return None
                 declared = response.headers.get("content-length")
                 if declared and declared.isdigit() and int(declared) > _MAX_BYTES:
                     logger.warning(
                         "ARD ingestion: catalog %s Content-Length %s exceeds %d cap, skipping",
-                        url, declared, _MAX_BYTES,
+                        url,
+                        declared,
+                        _MAX_BYTES,
                     )
                     return None
                 chunks: list[bytes] = []
@@ -138,11 +173,19 @@ class AiCatalogFederationClient:
                     if total > _MAX_BYTES:
                         logger.warning(
                             "ARD ingestion: catalog %s exceeds %d byte cap, aborting",
-                            url, _MAX_BYTES,
+                            url,
+                            _MAX_BYTES,
                         )
                         return None
                     chunks.append(chunk)
                 content = b"".join(chunks)
+        except UrlValidationError as e:
+            # The pinned guarded transport re-resolves and re-validates the host
+            # at connect time (and on every redirect hop). A hostname that
+            # passed assert_fetchable() but rebinds to a private/metadata IP
+            # before the connect is blocked here — skip and log, never fatal.
+            logger.warning("ARD ingestion: refusing rebound/unsafe catalog URL %s: %s", url, e)
+            return None
         except httpx.HTTPError as e:
             logger.warning("ARD ingestion: fetch failed for %s: %s", url, e)
             return None

--- a/registry/services/security_scanner.py
+++ b/registry/services/security_scanner.py
@@ -193,6 +193,17 @@ class SecurityScannerService:
         """
         config = self.get_scan_config()
 
+        # Fail closed on SSRF before spawning the scanner subprocess: the
+        # scanner performs its own outbound requests to server_url, so a
+        # proxy_pass_url that resolves to a private/metadata target must be
+        # rejected here even though registration already validated it (defence
+        # in depth against stored data predating validation, and a live
+        # resolve catches a host that has since been pointed at an internal
+        # address). Raises UrlValidationError -> surfaced by the caller.
+        from ..utils.url_guard import PROXY_PROFILE, validate_url
+
+        validate_url(server_url, profile=PROXY_PROFILE)
+
         # Use config values if not provided
         if analyzers is None:
             analyzers = config.analyzers

--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -8,6 +8,7 @@ from ..utils.credential_encryption import (
     _migrate_auth_type_to_auth_scheme,
     strip_credentials_from_dict,
 )
+from ..utils.url_guard import validate_proxy_pass_url, validate_server_path
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +68,20 @@ class ServerService:
         """
         path = server_info.get("path")
         new_version = server_info.get("version")
+
+        # Fail-closed URL validation on every registration path (dashboard/API,
+        # internal register, CLI, federation import) before anything is
+        # persisted. Rejects non-http(s) schemes, nginx metacharacters, and
+        # private/metadata targets (unless the operator allowlisted the internal
+        # target). Raises UrlValidationError -> HTTP 400.
+        proxy_pass_url = server_info.get("proxy_pass_url")
+        if proxy_pass_url:
+            validate_proxy_pass_url(proxy_pass_url)
+
+        # The path is interpolated into nginx location directives; reject any
+        # nginx metacharacters so a crafted path cannot inject config.
+        if path:
+            validate_server_path(path)
 
         # Check if server with this path already exists
         existing_server = await self._repo.get(path)
@@ -140,7 +155,18 @@ class ServerService:
         }
 
     async def update_server(self, path: str, server_info: dict[str, Any]) -> bool:
-        """Update an existing server."""
+        """Update an existing server.
+
+        Raises:
+            UrlValidationError: If the update sets a proxy_pass_url that fails
+                SSRF/scheme validation. Validation only runs when the update
+                payload actually carries a proxy_pass_url, so health-status and
+                tool-list updates are unaffected.
+        """
+        # Fail-closed URL validation on edit paths that change the backend URL.
+        if server_info.get("proxy_pass_url"):
+            validate_proxy_pass_url(server_info["proxy_pass_url"])
+
         result = await self._repo.update(path, server_info)
 
         if result:
@@ -608,7 +634,12 @@ class ServerService:
 
         Raises:
             ValueError: If server not found or version already exists
+            UrlValidationError: If proxy_pass_url fails SSRF/scheme validation
         """
+        # Fail-closed URL validation before persisting a new version's backend.
+        if proxy_pass_url:
+            validate_proxy_pass_url(proxy_pass_url)
+
         # Get active server document
         active_server = await self._repo.get(path)
         if not active_server:

--- a/registry/services/skill_scanner.py
+++ b/registry/services/skill_scanner.py
@@ -248,16 +248,23 @@ class SkillScannerService:
             Path to temporary directory containing downloaded skill content
 
         Raises:
-            httpx.HTTPError: If download fails
+            UrlValidationError: If the URL fails SSRF validation (private/
+                metadata target, bad scheme, or DNS rebinding at fetch time).
+            httpx.HTTPError: If download fails.
         """
-        import httpx
+        from ..utils.url_guard import guarded_client, validate_url
+
+        # Fail-closed pre-check for a clear early rejection; the guarded client
+        # additionally pins the resolved public IP so the fetch cannot rebind to
+        # a private address between this check and the connect (and re-validates
+        # every redirect hop).
+        validate_url(skill_md_url)
 
         temp_dir = tempfile.mkdtemp(prefix="skill_scan_")
         skill_md_path = Path(temp_dir) / "SKILL.md"
 
-        response = httpx.get(
-            skill_md_url, headers=headers or {}, follow_redirects=True, timeout=30.0
-        )
+        with guarded_client(timeout=30.0) as client:
+            response = client.get(skill_md_url, headers=headers or {}, follow_redirects=True)
         response.raise_for_status()
         skill_md_path.write_text(response.text)
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -8,12 +8,9 @@ Simplified design:
 """
 
 import hashlib
-import ipaddress
 import logging
 import re
-import socket
 from datetime import UTC, datetime
-from functools import lru_cache
 from typing import (
     Any,
 )
@@ -24,6 +21,7 @@ import httpx
 from ..core.config import settings
 from ..exceptions import (
     SkillUrlValidationError,
+    UrlValidationError,
 )
 from ..repositories.factory import (
     get_search_repository,
@@ -45,6 +43,12 @@ from ..schemas.skill_models import (
     VisibilityEnum,
 )
 from ..utils.path_utils import normalize_skill_path
+from ..utils.url_guard import (
+    guarded_async_client,
+)
+from ..utils.url_guard import (
+    validate_url as _validate_url_guard,
+)
 from ..utils.url_utils import (
     extract_repository_url,
     translate_skill_url,
@@ -66,80 +70,22 @@ URL_VALIDATION_TIMEOUT: int = 10
 # server that keeps echoing the x-next-page header cannot loop indefinitely.
 MAX_GITLAB_TREE_PAGES: int = 100
 
-# Built-in trusted domains that skip IP validation (SSRF protection allowlist).
-# Enterprise GitHub hosts are merged in at runtime from settings.github_extra_hosts
-# via _trusted_domains() so GHES instances on private IPs are reachable for
-# SKILL.md fetches (matches the host allowlist used by the GitHub auth provider).
-_DEFAULT_TRUSTED_DOMAINS: frozenset = frozenset(
-    {
-        "github.com",
-        "gitlab.com",
-        "raw.githubusercontent.com",
-        "bitbucket.org",
-    }
-)
-
-
-@lru_cache(maxsize=1)
-def _trusted_domains() -> frozenset[str]:
-    """Return SSRF allowlist: built-in defaults plus configured GHES hosts.
-
-    Reads settings.github_extra_hosts (the same setting that authorises auth
-    header injection) so a single config knob covers both trust decisions.
-    Cached because settings are immutable per-process.
-    """
-    extra_raw = settings.github_extra_hosts or ""
-    extra = frozenset(h.strip().lower() for h in extra_raw.split(",") if h.strip())
-    return _DEFAULT_TRUSTED_DOMAINS | extra
-
-
-def _is_private_ip(
-    ip_str: str,
-) -> bool:
-    """Check if an IP address is private, loopback, or link-local.
-
-    Args:
-        ip_str: IP address string to check
-
-    Returns:
-        True if the IP is private/loopback/link-local, False otherwise
-    """
-    try:
-        ip = ipaddress.ip_address(ip_str)
-
-        # Check for private, loopback, link-local, or reserved addresses
-        if ip.is_private:
-            return True
-        if ip.is_loopback:
-            return True
-        if ip.is_link_local:
-            return True
-        if ip.is_reserved:
-            return True
-
-        # Check for cloud metadata endpoint (169.254.169.254)
-        if ip_str == "169.254.169.254":
-            return True
-
-        return False
-    except ValueError:
-        # Invalid IP address format
-        return True
-
 
 def _is_safe_url(
     url: str,
 ) -> bool:
     """Check if a URL is safe to fetch (SSRF protection).
 
-    This function validates that a URL:
-    1. Uses http or https scheme
-    2. Does not resolve to a private/loopback/link-local IP address
-    3. Does not target cloud metadata endpoints
+    Thin boolean wrapper over the shared hardened guard
+    (:func:`registry.utils.url_guard.validate_url`) so this pre-check gains
+    IPv4-mapped-IPv6 unwrapping, multicast/unspecified blocking, and consistent
+    fail-closed semantics. Only hosts explicitly configured in the operator
+    bypass allowlist (``settings.github_extra_hosts``, e.g. GHES on a private
+    network) skip the private-IP block; built-in public forge domains are
+    IP-validated like any other host.
 
-    Trusted domains (github.com, gitlab.com, etc., plus any host configured
-    via settings.github_extra_hosts) skip the IP check so GHES instances on
-    private networks remain reachable.
+    The actual fetch is additionally protected by the pinned guarded client, so
+    a host that passes here cannot rebind to a private IP before the connect.
 
     Args:
         url: URL to validate
@@ -148,49 +94,13 @@ def _is_safe_url(
         True if the URL is safe to fetch, False otherwise
     """
     try:
-        parsed = urlparse(url)
-
-        # Check scheme - only allow http and https
-        if parsed.scheme not in ("http", "https"):
-            logger.warning(f"SSRF protection: Blocked URL with scheme '{parsed.scheme}'")
-            return False
-
-        hostname = parsed.hostname
-        if not hostname:
-            logger.warning("SSRF protection: URL has no hostname")
-            return False
-
-        # Check if hostname is in trusted domains allowlist
-        hostname_lower = hostname.lower()
-        if hostname_lower in _trusted_domains():
-            logger.debug(f"SSRF protection: Trusted domain '{hostname_lower}'")
-            return True
-
-        # Resolve hostname to IP addresses
-        try:
-            addr_info = socket.getaddrinfo(
-                hostname,
-                parsed.port or (443 if parsed.scheme == "https" else 80),
-                proto=socket.IPPROTO_TCP,
-            )
-        except socket.gaierror as e:
-            logger.warning(f"SSRF protection: Failed to resolve hostname '{hostname}': {e}")
-            return False
-
-        # Check all resolved IP addresses
-        for family, socktype, proto, canonname, sockaddr in addr_info:
-            ip_address = sockaddr[0]
-            if _is_private_ip(ip_address):
-                logger.warning(
-                    f"SSRF protection: Blocked URL resolving to private IP "
-                    f"'{ip_address}' for hostname '{hostname}'"
-                )
-                return False
-
+        _validate_url_guard(url)
         return True
-
-    except Exception as e:
-        logger.warning(f"SSRF protection: Error validating URL: {e}")
+    except UrlValidationError as e:
+        logger.warning("SSRF protection: %s", e)
+        return False
+    except Exception as e:  # pragma: no cover - defensive, fail closed
+        logger.warning("SSRF protection: Error validating URL: %s", e)
         return False
 
 
@@ -455,7 +365,7 @@ async def _discover_skill_resources(
     _, headers = _build_fetch_headers(tree_url, auth_scheme, auth_credential, auth_header_name)
 
     try:
-        async with httpx.AsyncClient(timeout=15.0) as client:
+        async with guarded_async_client(timeout=15.0) as client:
             # Merge global GitHub auth headers (PAT / GitHub App) so private
             # repos and rate-limited public repos work.
             github_headers = await _github_auth.get_auth_headers(tree_url)
@@ -486,8 +396,7 @@ async def _discover_skill_resources(
                     next_page = resp.headers.get("x-next-page", "")
                 if next_page:
                     logger.warning(
-                        "GitLab tree pagination hit %s-page cap for %s; "
-                        "results may be incomplete",
+                        "GitLab tree pagination hit %s-page cap for %s; results may be incomplete",
                         MAX_GITLAB_TREE_PAGES,
                         tree_url,
                     )
@@ -604,7 +513,7 @@ async def _validate_skill_md_url(
     )
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with guarded_async_client() as client:
             github_headers = await _github_auth.get_auth_headers(str(url))
             merged_headers = {**fetch_headers, **github_headers}
             response = await client.get(
@@ -632,6 +541,10 @@ async def _validate_skill_md_url(
                 "content_updated_at": datetime.now(UTC),
             }
 
+    except UrlValidationError as e:
+        raise SkillUrlValidationError(
+            url, "URL failed SSRF validation - private/internal addresses are not allowed"
+        ) from e
     except httpx.RequestError as e:
         raise SkillUrlValidationError(url, str(e)) from e
 
@@ -686,7 +599,7 @@ async def _parse_skill_md_content(
         )
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with guarded_async_client() as client:
             fetch_url, fetch_headers = _build_fetch_headers(
                 raw_url_str,
                 auth_scheme,
@@ -839,6 +752,10 @@ async def _parse_skill_md_content(
             )
             return result
 
+    except UrlValidationError as e:
+        raise SkillUrlValidationError(
+            url, "URL failed SSRF validation - private/internal addresses are not allowed"
+        ) from e
     except httpx.RequestError as e:
         raise SkillUrlValidationError(url, str(e)) from e
 
@@ -883,7 +800,7 @@ async def _check_skill_health(
     fetch_url, fetch_headers = _build_fetch_headers(url, auth_scheme, credential, auth_header_name)
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with guarded_async_client() as client:
             github_headers = await _github_auth.get_auth_headers(str(url))
             merged_headers = {**github_headers, **fetch_headers}
             response = await client.head(
@@ -916,6 +833,15 @@ async def _check_skill_health(
                 "response_time_ms": round(response_time_ms, 2),
             }
 
+    except UrlValidationError as e:
+        logger.warning("Skill health check blocked by SSRF guard for URL %s: %s", url, e)
+        response_time_ms = (time.perf_counter() - start_time) * 1000
+        return {
+            "healthy": False,
+            "status_code": None,
+            "error": "URL failed SSRF validation",
+            "response_time_ms": round(response_time_ms, 2),
+        }
     except httpx.RequestError as e:
         # Log detailed exception on the server, but return a generic message to the client
         logger.error("Error while checking skill health for URL %s: %s", url, e)
@@ -965,11 +891,14 @@ async def _compute_content_integrity(
                 return None
             digest = hashlib.sha256(resp.content).hexdigest()
             return FileHash(path=rel_path, sha256=digest, size_bytes=len(resp.content))
+        except UrlValidationError as e:
+            logger.warning("Integrity fetch blocked by SSRF guard for %s: %s", rel_path, e)
+            return None
         except httpx.RequestError as e:
             logger.warning("Integrity fetch error for %s: %s", rel_path, e)
             return None
 
-    async with httpx.AsyncClient() as client:
+    async with guarded_async_client() as client:
         skill_md_hash = await _hash_url(client, skill_md_url, "SKILL.md")
         if not skill_md_hash:
             return None
@@ -1061,7 +990,7 @@ async def _fetch_authenticated_content(
         merged_headers = {**github_headers, **fetch_headers}
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with guarded_async_client() as client:
             response = await client.get(
                 fetch_url,
                 headers=merged_headers,
@@ -1083,6 +1012,9 @@ async def _fetch_authenticated_content(
                 raise SkillContentTooLargeError(max_size)
 
             return response
+    except UrlValidationError as e:
+        logger.warning("Skill content fetch blocked by SSRF guard for %s: %s", url, e)
+        raise SkillContentSSRFError(url) from e
     except httpx.RequestError as e:
         logger.error("Failed to fetch from %s: %s", url, e)
         raise SkillContentFetchError(url, str(e))

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -208,18 +208,28 @@ def _check_endpoint_reachability(
     Returns:
         Tuple of (is_reachable, error_message)
     """
+    # Use the SSRF/rebinding-safe guarded client: the agent URL is
+    # user-controlled, so this outbound reachability probe must resolve and pin
+    # a validated public IP (proxy profile) rather than fetch an arbitrary
+    # internal target. A blocked URL is reported as unreachable, not raised,
+    # because reachability is advisory and must not become a validation bypass.
+    from ..exceptions import UrlValidationError
+    from .url_guard import PROXY_PROFILE, guarded_client
+
     try:
         well_known_url = f"{url}/.well-known/agent-card.json"
 
-        response = httpx.get(
-            well_known_url,
-            timeout=5.0,
-        )
+        with guarded_client(profile=PROXY_PROFILE, timeout=5.0) as client:
+            response = client.get(well_known_url)
 
         if response.status_code == 200:
             return (True, None)
 
         return (False, f"Endpoint returned status {response.status_code}")
+
+    except UrlValidationError as e:
+        logger.warning(f"Endpoint blocked by SSRF guard for {url}: {e}")
+        return (False, "Endpoint URL failed SSRF validation")
 
     except httpx.TimeoutException:
         logger.warning(f"Endpoint timeout for {url}")

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -1,0 +1,573 @@
+"""Hardened URL validation and rebinding-safe fetch guard (SSRF protection).
+
+This module is the single source of truth for validating user- and
+registry-controlled URLs before the registry stores them or fetches them
+server-side. It consolidates the strengths of the previous partial
+implementations (``skill_service._is_safe_url`` and
+``ard_net_guard.assert_fetchable``) into one fail-closed guard:
+
+- Only ``http`` / ``https`` schemes are accepted.
+- The host must resolve **exclusively** to public IP addresses. Private,
+  loopback, link-local, reserved, multicast, and unspecified ranges are
+  blocked, along with the cloud metadata endpoint (``169.254.169.254``).
+- IPv4-mapped IPv6 addresses (``::ffff:10.0.0.1``) are unwrapped before the
+  range check so a private target cannot be smuggled through an IPv6 literal.
+- DNS-rebinding is defeated by pinning: the fetch connects only to an IP that
+  was validated inside the same transport call, so there is no window between
+  the check and the connect for the hostname to rebind to a private address.
+  Redirects are re-validated on every hop because httpx re-invokes the pinned
+  transport for each redirect.
+
+The guard fails closed: any error, resolution failure, or ambiguity results in
+rejection rather than a permissive fallback.
+
+Two validation profiles exist because the registry has two distinct outbound
+surfaces:
+
+- **Skill fetches** (``SKILL_PROFILE``): public-only, with an operator bypass
+  allowlist read from ``settings.github_extra_hosts`` so GitHub Enterprise
+  Server on an internal network stays reachable. Built-in public forge domains
+  are NOT auto-trusted — they get full IP validation, closing the
+  "internal host masquerading as github.com" bypass.
+
+- **Server / agent targets** (``PROXY_PROFILE``): the same public-only default,
+  but operators who legitimately proxy to internal MCP servers can opt those
+  targets in via ``settings.ssrf_allowed_hosts`` / ``settings.ssrf_allowed_cidrs``.
+  The cloud metadata address is never allowlistable in either profile.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from dataclasses import dataclass, field
+from functools import lru_cache
+from urllib.parse import urlparse
+
+import httpx
+
+from ..core.config import settings
+from ..exceptions import UrlValidationError
+
+logger = logging.getLogger(__name__)
+
+# Default connect/read timeout applied to guarded fetches when a caller does not
+# supply its own. Keeps a hung internal target from tying up a worker.
+_DEFAULT_TIMEOUT_SECONDS: float = 15.0
+
+# The cloud metadata endpoint can never be reached, regardless of allowlists.
+_CLOUD_METADATA_IPS: frozenset[str] = frozenset({"169.254.169.254", "fd00:ec2::254"})
+
+# Nginx metacharacters that must never appear in a proxy_pass_url. A valid URL
+# never legitimately contains these; their presence indicates an attempt to
+# break out of an nginx directive/string context (config injection).
+_NGINX_METACHARACTERS: frozenset[str] = frozenset(
+    {
+        "\r",
+        "\n",
+        ";",
+        "{",
+        "}",
+        "#",
+        '"',
+        "'",
+        "\\",
+        " ",
+        "\t",
+        "$",
+        "\x00",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _Allowlist:
+    """A resolved set of hosts/CIDRs that may bypass the private-IP block."""
+
+    hosts: frozenset[str] = field(default_factory=frozenset)
+    cidrs: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = ()
+
+    def allows_host(
+        self,
+        hostname_lower: str,
+    ) -> bool:
+        """Return True if the hostname is explicitly allowlisted."""
+        return hostname_lower in self.hosts
+
+    def allows_ip(
+        self,
+        ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    ) -> bool:
+        """Return True if the IP falls inside an allowlisted CIDR."""
+        return any(ip in net for net in self.cidrs)
+
+
+def _parse_hosts(
+    raw: str,
+) -> frozenset[str]:
+    """Parse a comma-separated host list into a normalized frozenset."""
+    return frozenset(h.strip().lower() for h in (raw or "").split(",") if h.strip())
+
+
+def _parse_cidrs(
+    raw: str,
+) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    """Parse a comma-separated CIDR list, skipping malformed entries."""
+    nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for chunk in (raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            nets.append(ipaddress.ip_network(chunk, strict=False))
+        except ValueError:
+            logger.warning("SSRF guard: ignoring malformed CIDR in allowlist: %r", chunk)
+    return tuple(nets)
+
+
+@lru_cache(maxsize=1)
+def _skill_allowlist() -> _Allowlist:
+    """Return the skill-fetch bypass allowlist (github_extra_hosts only).
+
+    Built-in public forge domains are intentionally absent: they get full IP
+    validation. Only operator-configured GHES hosts skip the private-IP block.
+    Cached because settings are immutable per-process.
+    """
+    return _Allowlist(hosts=_parse_hosts(settings.github_extra_hosts))
+
+
+@lru_cache(maxsize=1)
+def _proxy_allowlist() -> _Allowlist:
+    """Return the server/agent target bypass allowlist.
+
+    Reads ``settings.ssrf_allowed_hosts`` and ``settings.ssrf_allowed_cidrs`` so
+    operators can proxy to internal MCP servers. Cached because settings are
+    immutable per-process.
+    """
+    return _Allowlist(
+        hosts=_parse_hosts(settings.ssrf_allowed_hosts),
+        cidrs=_parse_cidrs(settings.ssrf_allowed_cidrs),
+    )
+
+
+@dataclass(frozen=True)
+class _Profile:
+    """A named validation profile: which allowlist and scheme rules apply."""
+
+    name: str
+    allowlist_factory: object  # callable returning _Allowlist
+
+
+SKILL_PROFILE = _Profile(name="skill", allowlist_factory=_skill_allowlist)
+PROXY_PROFILE = _Profile(name="proxy", allowlist_factory=_proxy_allowlist)
+
+
+def _unwrap_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    """Unwrap an IPv4-mapped IPv6 address to its embedded IPv4 address."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+def _is_metadata_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True for cloud metadata endpoints (never allowlistable)."""
+    return str(ip) in _CLOUD_METADATA_IPS
+
+
+def _is_blocked_ip(
+    ip_str: str,
+    allowlist: _Allowlist,
+) -> bool:
+    """Return True if an IP must not be the target of a server-side fetch.
+
+    Blocks private, loopback, link-local, reserved, multicast, and unspecified
+    ranges. The cloud metadata endpoint is always blocked. An operator CIDR
+    allowlist can re-permit private ranges (but never the metadata endpoint).
+    Any unparseable address is treated as blocked (fail closed).
+
+    Args:
+        ip_str: IP address string to check.
+        allowlist: The profile allowlist (CIDRs that re-permit private ranges).
+
+    Returns:
+        True if the IP is unsafe to connect to, False if it is acceptable.
+    """
+    try:
+        ip = _unwrap_ip(ipaddress.ip_address(ip_str))
+    except ValueError:
+        return True
+
+    # The metadata endpoint is never reachable, even via an allowlist.
+    if _is_metadata_ip(ip):
+        return True
+
+    is_dangerous = (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+    if not is_dangerous:
+        return False
+
+    # Dangerous range: only acceptable if an operator CIDR allowlist re-permits.
+    return not allowlist.allows_ip(ip)
+
+
+def _resolve_public_ips(
+    hostname: str,
+    port: int,
+    allowlist: _Allowlist,
+) -> list[str]:
+    """Resolve a hostname and require all IPs to be acceptable.
+
+    Args:
+        hostname: The host to resolve.
+        port: The destination port (passed to ``getaddrinfo``).
+        allowlist: The profile allowlist (CIDRs re-permitting private ranges).
+
+    Returns:
+        The list of resolved IP address strings (all validated).
+
+    Raises:
+        UrlValidationError: If resolution fails or any resolved IP is blocked.
+    """
+    try:
+        addr_info = socket.getaddrinfo(
+            hostname,
+            port,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as e:
+        raise UrlValidationError(hostname, f"DNS resolution failed: {e}") from e
+
+    ips: list[str] = []
+    for _family, _socktype, _proto, _canonname, sockaddr in addr_info:
+        ip_str = sockaddr[0]
+        if _is_blocked_ip(ip_str, allowlist):
+            raise UrlValidationError(
+                hostname,
+                f"resolves to blocked/private IP {ip_str}",
+            )
+        ips.append(ip_str)
+
+    if not ips:
+        raise UrlValidationError(hostname, "resolved to no addresses")
+
+    return ips
+
+
+def contains_nginx_metacharacters(
+    value: str,
+) -> bool:
+    """Return True if a string contains characters that could break nginx config.
+
+    Used as defense-in-depth on proxy_pass_url so a crafted URL cannot terminate
+    an nginx directive or string literal even before the value reaches the
+    nginx-specific escaping.
+
+    Args:
+        value: The candidate string (typically a proxy_pass_url).
+
+    Returns:
+        True if any nginx metacharacter is present.
+    """
+    return any(ch in value for ch in _NGINX_METACHARACTERS)
+
+
+def validate_url(
+    url: str,
+    *,
+    profile: _Profile = SKILL_PROFILE,
+    require_https: bool = False,
+    reject_nginx_metacharacters: bool = False,
+    resolve: bool = True,
+) -> list[str]:
+    """Validate a URL for scheme, host, and public-IP resolution (fail closed).
+
+    This is the registration-time / pre-fetch check. It resolves DNS and
+    requires every resolved IP to be acceptable for the profile, so it also
+    serves as the resolution step feeding the pinned transport.
+
+    Args:
+        url: The URL to validate.
+        profile: Which allowlist/scheme rules apply (SKILL_PROFILE default,
+            PROXY_PROFILE for server/agent targets).
+        require_https: When True, reject non-https schemes (http is denied).
+        reject_nginx_metacharacters: When True, reject URLs containing nginx
+            metacharacters (used for proxy_pass_url).
+        resolve: When True (default), resolve DNS and require every resolved IP
+            to be acceptable. When False, only the static checks run (scheme,
+            metacharacters, host presence, and literal-IP private/metadata
+            block) — used at registration time, where the authoritative
+            rebinding-safe defense is the pinned transport at fetch time and a
+            live DNS lookup would be a fragile, network-dependent TOCTOU.
+
+    Returns:
+        The list of validated IP strings the host resolves to. Empty list when
+        the host is allowlisted or when ``resolve`` is False (no pinning info).
+
+    Raises:
+        UrlValidationError: On any validation failure (fails closed).
+    """
+    if not url or not isinstance(url, str):
+        raise UrlValidationError(str(url), "URL is empty or not a string")
+
+    if reject_nginx_metacharacters and contains_nginx_metacharacters(url):
+        raise UrlValidationError(url, "contains disallowed nginx metacharacters")
+
+    try:
+        parsed = urlparse(url)
+    except Exception as e:  # pragma: no cover - urlparse rarely raises
+        raise UrlValidationError(url, f"could not be parsed: {e}") from e
+
+    allowed_schemes = ("https",) if require_https else ("http", "https")
+    if parsed.scheme not in allowed_schemes:
+        raise UrlValidationError(url, f"scheme '{parsed.scheme}' is not allowed")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise UrlValidationError(url, "URL has no hostname")
+
+    hostname_lower = hostname.lower()
+    allowlist: _Allowlist = profile.allowlist_factory()  # type: ignore[operator]
+
+    # A hostname that is itself a literal IP must still pass the range check
+    # (this is always enforced, even when resolve=False, because it needs no
+    # network and catches the most direct SSRF payloads like the metadata IP).
+    try:
+        literal = ipaddress.ip_address(hostname)
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if _is_blocked_ip(hostname, allowlist):
+            raise UrlValidationError(url, f"targets blocked/private IP {hostname}")
+        return [str(literal)]
+
+    # Host explicitly allowlisted by the operator (e.g. GHES, or an internal
+    # MCP-server host): skip the IP block. We do not pin these (the transport
+    # falls back to normal DNS for them).
+    if allowlist.allows_host(hostname_lower):
+        logger.debug("URL guard[%s]: host '%s' is allowlisted", profile.name, hostname_lower)
+        return []
+
+    if not resolve:
+        # Registration-time structural validation only. The pinned transport
+        # performs the authoritative resolve-and-block at fetch time.
+        return []
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return _resolve_public_ips(hostname, port, allowlist)
+
+
+def validate_proxy_pass_url(
+    url: str,
+) -> None:
+    """Validate a server ``proxy_pass_url`` at registration time (fail closed).
+
+    Rejects non-http(s) schemes, nginx metacharacters, and literal
+    private/metadata IP targets. This does NOT perform a live DNS lookup: the
+    authoritative rebinding-safe block for hostname targets happens at fetch
+    time via the pinned guarded client (health checks). Raises on failure.
+
+    Raises:
+        UrlValidationError: On any validation failure.
+    """
+    validate_url(
+        url,
+        profile=PROXY_PROFILE,
+        reject_nginx_metacharacters=True,
+        resolve=False,
+    )
+
+
+def validate_server_path(
+    path: str,
+) -> None:
+    """Validate a server registration ``path`` for nginx-safe characters.
+
+    The path is interpolated into nginx ``location`` directives, so it must not
+    contain characters that could terminate a directive or comment out
+    surrounding config (``"``, ``;``, ``{``, ``}``, ``#``, ``$``, whitespace,
+    control chars, backslash). Legitimate paths only use URL path characters, so
+    this rejects rather than escapes. Fails closed.
+
+    Args:
+        path: The server path (e.g. ``/github``).
+
+    Raises:
+        UrlValidationError: If the path is empty or contains disallowed
+            nginx metacharacters.
+    """
+    if not path or not isinstance(path, str):
+        raise UrlValidationError(str(path), "server path is empty or not a string")
+    if contains_nginx_metacharacters(path):
+        raise UrlValidationError(path, "server path contains disallowed nginx metacharacters")
+
+
+def validate_agent_url(
+    url: str,
+) -> None:
+    """Validate an agent URL at registration time (fail closed).
+
+    Rejects non-http(s) schemes and literal private/metadata IP targets. Like
+    :func:`validate_proxy_pass_url`, this does not perform a live DNS lookup;
+    the pinned guarded client blocks hostname targets that resolve private at
+    fetch time (agent health check / card pull). Raises on failure.
+
+    Raises:
+        UrlValidationError: On any validation failure.
+    """
+    validate_url(url, profile=PROXY_PROFILE, resolve=False)
+
+
+class _PinnedResolverMixin:
+    """Shared logic for pinning a request to a validated IP.
+
+    Rewrites the outgoing request so httpx connects only to an IP that this
+    transport just validated, preserving the original Host header and TLS SNI.
+    Because the resolve+validate+connect all happen inside the transport call
+    for every request (including each redirect hop), there is no rebinding
+    window and no bypassable pre-check.
+    """
+
+    _guard_profile: _Profile = SKILL_PROFILE
+
+    def _pin_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Request:
+        """Validate the request host and rewrite it to a pinned IP.
+
+        Raises:
+            UrlValidationError: If the target host is unsafe (fails closed).
+        """
+        url = request.url
+        scheme = url.scheme
+        if scheme not in ("http", "https"):
+            raise UrlValidationError(str(url), f"scheme '{scheme}' is not allowed")
+
+        hostname = url.host
+        if not hostname:
+            raise UrlValidationError(str(url), "URL has no hostname")
+
+        hostname_lower = hostname.lower()
+        allowlist: _Allowlist = self._guard_profile.allowlist_factory()  # type: ignore[operator]
+
+        # Literal-IP host: validate directly, no rewrite needed.
+        try:
+            ipaddress.ip_address(hostname)
+            is_literal = True
+        except ValueError:
+            is_literal = False
+
+        if is_literal:
+            if _is_blocked_ip(hostname, allowlist):
+                raise UrlValidationError(str(url), f"targets blocked/private IP {hostname}")
+            return request
+
+        # Allowlisted host: do not pin (resolve normally).
+        if allowlist.allows_host(hostname_lower):
+            return request
+
+        port = url.port or (443 if scheme == "https" else 80)
+        pinned_ips = _resolve_public_ips(hostname, port, allowlist)
+        pinned_ip = pinned_ips[0]
+
+        # Rewrite the connection target to the validated IP while preserving the
+        # original hostname for the Host header and TLS SNI.
+        request.url = url.copy_with(host=pinned_ip)
+        request.headers["Host"] = hostname if url.port is None else f"{hostname}:{url.port}"
+        request.extensions = dict(request.extensions)
+        request.extensions["sni_hostname"] = hostname
+        return request
+
+
+class GuardedTransport(_PinnedResolverMixin, httpx.HTTPTransport):
+    """Synchronous httpx transport that pins requests to validated IPs."""
+
+    def __init__(
+        self,
+        *,
+        guard_profile: _Profile = SKILL_PROFILE,
+        **kwargs: object,
+    ) -> None:
+        self._guard_profile = guard_profile
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+
+    def handle_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        request = self._pin_request(request)
+        return super().handle_request(request)
+
+
+class GuardedAsyncTransport(_PinnedResolverMixin, httpx.AsyncHTTPTransport):
+    """Async httpx transport that pins requests to validated IPs."""
+
+    def __init__(
+        self,
+        *,
+        guard_profile: _Profile = SKILL_PROFILE,
+        **kwargs: object,
+    ) -> None:
+        self._guard_profile = guard_profile
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+
+    async def handle_async_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        request = self._pin_request(request)
+        return await super().handle_async_request(request)
+
+
+def guarded_client(
+    *,
+    profile: _Profile = SKILL_PROFILE,
+    timeout: float | httpx.Timeout | None = None,
+    verify: bool = True,
+    **kwargs: object,
+) -> httpx.Client:
+    """Return a sync httpx.Client that is SSRF/rebinding-safe.
+
+    Every request (and redirect hop) made through this client is validated and
+    pinned by :class:`GuardedTransport`. Use this in place of ``httpx.Client``
+    for any fetch built from user/registry-controlled URLs.
+    """
+    resolved_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT_SECONDS
+    return httpx.Client(
+        transport=GuardedTransport(guard_profile=profile, verify=verify),
+        timeout=resolved_timeout,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def guarded_async_client(
+    *,
+    profile: _Profile = SKILL_PROFILE,
+    timeout: float | httpx.Timeout | None = None,
+    verify: bool = True,
+    **kwargs: object,
+) -> httpx.AsyncClient:
+    """Return an async httpx.AsyncClient that is SSRF/rebinding-safe.
+
+    Every request (and redirect hop) made through this client is validated and
+    pinned by :class:`GuardedAsyncTransport`. Use this in place of
+    ``httpx.AsyncClient`` for any fetch built from user/registry-controlled
+    URLs.
+    """
+    resolved_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT_SECONDS
+    return httpx.AsyncClient(
+        transport=GuardedAsyncTransport(guard_profile=profile, verify=verify),
+        timeout=resolved_timeout,
+        **kwargs,  # type: ignore[arg-type]
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,6 +166,18 @@ os.environ.setdefault(
     "AUTH_SERVER_NGINX_MARKER_SECRET", "test-marker-secret-for-testing-only-do-not-use"
 )
 
+# SSRF guard allowlist for tests: fixtures register proxy_pass_url / agent URLs
+# on localhost and Docker-service hostnames. Allowlisting them lets the guard
+# accept these targets without a DNS lookup. Set at import time (before the
+# first Settings() construction) so registry.utils.url_guard reads it. Dedicated
+# SSRF rejection tests override url_guard.settings directly.
+os.environ.setdefault(
+    "SSRF_ALLOWED_HOSTS",
+    "localhost,127.0.0.1,mcpgw,auth-server,registry,keycloak,upstream,test,"
+    "host.docker.internal,example.com,server.com,test-server,fake-server,"
+    "currenttime,realserverfaketools,external.example.com",
+)
+
 
 # Now we can safely import registry modules
 from registry.core.config import Settings  # noqa: E402

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -1022,7 +1022,7 @@ class TestCheckAgentHealth:
         # Arrange
         with (
             patch("registry.api.agent_routes.agent_service") as mock_agent_service,
-            patch("httpx.AsyncClient") as mock_httpx_client,
+            patch("registry.api.agent_routes.guarded_async_client") as mock_httpx_client,
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
             mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
@@ -1055,7 +1055,7 @@ class TestCheckAgentHealth:
 
         with (
             patch("registry.api.agent_routes.agent_service") as mock_agent_service,
-            patch("httpx.AsyncClient") as mock_httpx_client,
+            patch("registry.api.agent_routes.guarded_async_client") as mock_httpx_client,
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=sample_agent_card)
             mock_agent_service.is_agent_enabled = AsyncMock(return_value=True)
@@ -1961,9 +1961,9 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
         assert search_repo_mock.index_agent.await_count == 1
         called_path, called_card = search_repo_mock.index_agent.await_args.args
         assert called_path == path
-        assert isinstance(called_card, AgentCard), (
-            f"index_agent was called with {type(called_card).__name__}, expected AgentCard"
-        )
+        assert isinstance(
+            called_card, AgentCard
+        ), f"index_agent was called with {type(called_card).__name__}, expected AgentCard"
 
     @pytest.mark.asyncio
     async def test_safe_scan_does_not_call_update_agent(

--- a/tests/unit/api/test_pull_card_helpers.py
+++ b/tests/unit/api/test_pull_card_helpers.py
@@ -173,20 +173,29 @@ def test_641_a2a_and_registrant_fields_disjoint():
 class TestFetchRemoteAgentCard:
     async def test_651_valid_object(self):
         body = json.dumps({"name": "a"}).encode()
-        with patch.object(httpx, "AsyncClient", _mock_async_client(_http_response(200, body))):
+        with patch(
+            "registry.api.agent_routes.guarded_async_client",
+            _mock_async_client(_http_response(200, body)),
+        ):
             card, url = await _fetch_remote_agent_card("http://h:9000/a")
         assert card == {"name": "a"}
         assert url.endswith("/.well-known/agent-card.json")
 
     async def test_652_json_array_rejected(self):
-        with patch.object(httpx, "AsyncClient", _mock_async_client(_http_response(200, b"[]"))):
+        with patch(
+            "registry.api.agent_routes.guarded_async_client",
+            _mock_async_client(_http_response(200, b"[]")),
+        ):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502
         assert "not a JSON object" in str(e.value.detail)
 
     async def test_653_non_200(self):
-        with patch.object(httpx, "AsyncClient", _mock_async_client(_http_response(404, b""))):
+        with patch(
+            "registry.api.agent_routes.guarded_async_client",
+            _mock_async_client(_http_response(404, b"")),
+        ):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502
@@ -194,7 +203,7 @@ class TestFetchRemoteAgentCard:
 
     async def test_654_timeout(self):
         client = _mock_async_client(exc=httpx.TimeoutException("t"))
-        with patch.object(httpx, "AsyncClient", client):
+        with patch("registry.api.agent_routes.guarded_async_client", client):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502
@@ -202,14 +211,17 @@ class TestFetchRemoteAgentCard:
 
     async def test_655_connect_error(self):
         client = _mock_async_client(exc=httpx.ConnectError("c"))
-        with patch.object(httpx, "AsyncClient", client):
+        with patch("registry.api.agent_routes.guarded_async_client", client):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502
         assert "Failed to fetch" in str(e.value.detail)
 
     async def test_656_invalid_json(self):
-        with patch.object(httpx, "AsyncClient", _mock_async_client(_http_response(200, b"{bad"))):
+        with patch(
+            "registry.api.agent_routes.guarded_async_client",
+            _mock_async_client(_http_response(200, b"{bad")),
+        ):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502
@@ -218,7 +230,10 @@ class TestFetchRemoteAgentCard:
     async def test_657_exceeds_size_cap(self):
         # S1: a body over 1 MiB is rejected before json.loads runs.
         oversized = b'{"name":"' + b"a" * 1_048_600 + b'"}'
-        with patch.object(httpx, "AsyncClient", _mock_async_client(_http_response(200, oversized))):
+        with patch(
+            "registry.api.agent_routes.guarded_async_client",
+            _mock_async_client(_http_response(200, oversized)),
+        ):
             with pytest.raises(HTTPException) as e:
                 await _fetch_remote_agent_card("http://h:9000/a")
         assert e.value.status_code == 502

--- a/tests/unit/api/test_skill_inline_content.py
+++ b/tests/unit/api/test_skill_inline_content.py
@@ -236,7 +236,10 @@ class TestSkillInlineContent:
 
         with (
             patch("registry.services.skill_service._is_safe_url", return_value=True),
-            patch("httpx.AsyncClient", return_value=mock_async_client),
+            patch(
+                "registry.services.skill_service.guarded_async_client",
+                return_value=mock_async_client,
+            ),
         ):
             # Act
             response = test_client.get("/api/skills/inline-test/content")
@@ -271,7 +274,10 @@ class TestSkillInlineContent:
 
         with (
             patch("registry.services.skill_service._is_safe_url", return_value=True),
-            patch("httpx.AsyncClient", return_value=mock_async_client),
+            patch(
+                "registry.services.skill_service.guarded_async_client",
+                return_value=mock_async_client,
+            ),
         ):
             # Act
             response = test_client.get("/api/skills/inline-test/content")

--- a/tests/unit/core/test_mcp_client.py
+++ b/tests/unit/core/test_mcp_client.py
@@ -836,3 +836,88 @@ async def test_full_tool_discovery_flow_sse(mock_tools_response):
 
                 assert result is not None
                 assert len(result) == 1
+
+
+# =============================================================================
+# TEST: SSRF guard on MCP SDK connection paths (credentials never sent to
+# private/metadata targets; SDK transports cannot be IP-pinned so the URL is
+# re-validated at fetch time before any connection or credential build).
+# =============================================================================
+
+
+class TestMcpClientSsrfGuard:
+    """The MCP SDK connection paths fail closed on private/metadata targets."""
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_blocks_private_ip_before_headers(self):
+        """A private-IP target is refused before credentials are built/sent."""
+        from registry.core.mcp_client import _get_tools_streamable_http
+
+        server_info = {"supported_transports": ["streamable-http"], "headers": []}
+
+        # streamablehttp_client and header build must NOT be reached.
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.streamablehttp_client") as mock_client,
+            patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve,
+        ):
+            mock_resolve.return_value = [(None, None, None, None, ("10.0.0.5", 443))]
+
+            result = await _get_tools_streamable_http("https://evil.example/mcp", server_info)
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_blocks_metadata_ip_literal(self):
+        """The cloud metadata IP literal is refused with no connection."""
+        from registry.core.mcp_client import _get_tools_streamable_http
+
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.streamablehttp_client") as mock_client,
+        ):
+            result = await _get_tools_streamable_http(
+                "http://169.254.169.254/latest/meta-data/", {"headers": []}
+            )
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sse_blocks_private_ip_before_headers(self):
+        """SSE path refuses a private-IP target before building credentials."""
+        from registry.core.mcp_client import _get_tools_sse
+
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.sse_client") as mock_client,
+            patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve,
+        ):
+            mock_resolve.return_value = [(None, None, None, None, ("192.168.1.10", 443))]
+
+            result = await _get_tools_sse("https://evil.example/sse", {"headers": []})
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connection_result_blocks_private_ip(self):
+        """get_mcp_connection_result refuses a private-IP target."""
+        from registry.core.mcp_client import get_mcp_connection_result
+
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.streamablehttp_client") as mock_client,
+            patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve,
+        ):
+            mock_resolve.return_value = [(None, None, None, None, ("10.1.2.3", 443))]
+
+            result = await get_mcp_connection_result("https://evil.example", {"headers": []})
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_client.assert_not_called()

--- a/tests/unit/core/test_nginx_local_skip.py
+++ b/tests/unit/core/test_nginx_local_skip.py
@@ -10,14 +10,20 @@ from registry.core.nginx_service import NginxConfigService
 
 @pytest.fixture(autouse=True)
 def mock_atomic_write():
-    """Stub _atomic_write_text so tests don't touch the real config path (#1044).
+    """Stub the config write + validate path so tests don't touch the real
+    config path (#1044) and don't shell out to ``nginx -t``.
 
-    Tests can declare this fixture as a parameter to inspect what was
-    written: each call is _atomic_write_text(path, content), so
-    mock_atomic_write.call_args_list[i][0][1] is the content string.
+    ``_write_and_validate_config`` is stubbed to delegate to the (mocked)
+    ``_atomic_write_text`` so tests that inspect what was written can declare
+    this fixture as a parameter: each recorded call is (path, content), so
+    ``mock_atomic_write.call_args_list[i][0][1]`` is the content string.
     """
     with patch("registry.core.nginx_service._atomic_write_text") as m:
-        yield m
+        with patch(
+            "registry.core.nginx_service._write_and_validate_config",
+            side_effect=lambda path, content: m(path, content),
+        ):
+            yield m
 
 
 @pytest.fixture

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -1148,9 +1148,7 @@ server {
                                 "registry.core.nginx_service.urlparse",
                                 side_effect=_selective_urlparse,
                             ):
-                                result = await nginx_service.generate_config_async(
-                                    sample_servers
-                                )
+                                result = await nginx_service.generate_config_async(sample_servers)
 
                                 assert result is True
                                 written_content = mock_atomic_write.call_args_list[0][0][1]
@@ -1376,3 +1374,44 @@ class TestResolveMcpProxyReadTimeout:
         fake_settings = MagicMock(mcp_proxy_timeout=None)
         with patch.object(ns, "settings", fake_settings):
             assert ns._resolve_mcp_proxy_read_timeout_seconds() == 60
+
+
+# =============================================================================
+# CONFIG-INJECTION DEFENSE: proxy_pass_url is escaped at interpolation
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_location_block_escapes_backend_url_metacharacters(nginx_service):
+    """A crafted proxy_pass_url cannot break out of the quoted set directive.
+
+    Registration validation already rejects nginx metacharacters, but the
+    location-block builder escapes defensively so legacy/persisted values still
+    cannot inject nginx directives.
+    """
+    malicious = 'http://evil.com/";}\nlocation /x { proxy_pass http://attacker;'
+
+    block = nginx_service._create_location_block(
+        path="/evil",
+        proxy_pass_url=malicious,
+        transport_type="streamable-http",
+        server_info={"server_name": "evil"},
+    )
+
+    # The raw injection payload must not appear verbatim: quotes/backslashes are
+    # escaped and newlines collapsed, so the "; }" directive terminator cannot
+    # close the `set $backend_url "..."` string context.
+    assert 'set $backend_url "http://evil.com/";}' not in block
+    # A real newline must not survive inside the generated directive value.
+    assert "\nlocation /x { proxy_pass http://attacker;" not in block
+    # The escaped form (backslash-quote) is what lands in the config.
+    assert '\\"' in block
+
+
+@pytest.mark.unit
+def test_sanitize_for_nginx_set_escapes_quotes_and_newlines():
+    """The nginx sanitizer escapes quotes/backslashes and collapses newlines."""
+    out = NginxConfigService._sanitize_for_nginx_set('a"b\\c\nd')
+    assert '"' not in out.replace('\\"', "")  # only escaped quotes remain
+    assert "\n" not in out
+>>>>>>> 62e9ac63 (fix: validate and pin outbound URLs against SSRF and nginx config injection)

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -12,7 +12,14 @@ import httpx
 import pytest
 
 from registry.constants import HealthStatus
+from registry.core import nginx_service as nginx_module
 from registry.core.nginx_service import NginxConfigService
+
+# Capture the real write-validate-promote helpers before the autouse fixture
+# stubs the module attributes, so the dedicated validation tests can exercise
+# the genuine flow (temp write, nginx -t gate, promote-or-restore).
+_REAL_WRITE_AND_VALIDATE = nginx_module._write_and_validate_config
+_REAL_ATOMIC_WRITE = nginx_module._atomic_write_text
 
 # =============================================================================
 # TEST FIXTURES
@@ -21,20 +28,26 @@ from registry.core.nginx_service import NginxConfigService
 
 @pytest.fixture(autouse=True)
 def mock_atomic_write():
-    """Stub _atomic_write_text so tests don't touch /etc/nginx (#1044).
+    """Stub the config write + validate path so tests don't touch /etc/nginx.
 
-    The real helper does tempfile + os.replace against
-    settings.nginx_config_path. In unit tests the path is a fixture
-    string ('/etc/nginx/conf.d/nginx_rev_proxy.conf') that the test
-    user typically can't write to. Patching here keeps every test
-    that reaches generate_config_async hermetic.
+    The real helpers do tempfile + os.replace against
+    settings.nginx_config_path and run ``nginx -t``. In unit tests the path is a
+    fixture string ('/etc/nginx/conf.d/nginx_rev_proxy.conf') that the test user
+    typically can't write to, and no nginx binary is present. Patching here keeps
+    every test that reaches generate_config_async hermetic.
 
-    Tests that need to inspect what was written can declare this
-    fixture as a parameter and read mock_atomic_write.call_args_list -
-    each call is (path, content).
+    ``_write_and_validate_config`` is stubbed to delegate to the (mocked)
+    ``_atomic_write_text`` so tests that inspect what was written can declare
+    this fixture as a parameter and read ``mock_atomic_write.call_args_list`` -
+    each call is (path, content). The dedicated validation tests below opt out
+    of this stub to exercise the real write-validate-promote flow.
     """
     with patch("registry.core.nginx_service._atomic_write_text") as mock_write:
-        yield mock_write
+        with patch(
+            "registry.core.nginx_service._write_and_validate_config",
+            side_effect=lambda path, content: mock_write(path, content),
+        ):
+            yield mock_write
 
 
 @pytest.fixture
@@ -1414,4 +1427,223 @@ def test_sanitize_for_nginx_set_escapes_quotes_and_newlines():
     out = NginxConfigService._sanitize_for_nginx_set('a"b\\c\nd')
     assert '"' not in out.replace('\\"', "")  # only escaped quotes remain
     assert "\n" not in out
->>>>>>> 62e9ac63 (fix: validate and pin outbound URLs against SSRF and nginx config injection)
+
+
+# =============================================================================
+# Config validation before persistence (cold-start DoS protection)
+# =============================================================================
+#
+# A malformed generated config must never overwrite the live config on disk:
+# even though a bad reload is skipped, a broken file on disk takes down the
+# NEXT nginx cold start (container restart), downing the whole gateway. These
+# tests exercise the real _write_and_validate_config flow (the autouse fixture
+# stubs the module attribute, so we call the captured real function directly).
+
+
+class TestConfigValidationBeforePersist:
+    @pytest.fixture(autouse=True)
+    def _real_atomic_write(self):
+        """Restore the real _atomic_write_text so these tests actually write to
+        the tmp_path (the module-level autouse fixture stubs it), and make the
+        nginx binary appear present by default so the validation branch runs.
+        Tests that model a missing binary re-patch shutil.which themselves."""
+        with (
+            patch.object(nginx_module, "_atomic_write_text", _REAL_ATOMIC_WRITE),
+            patch("shutil.which", return_value="/usr/sbin/nginx"),
+        ):
+            yield
+
+    def test_valid_config_is_promoted(self, tmp_path):
+        """A candidate that passes nginx -t replaces the live config."""
+        live = tmp_path / "nginx_rev_proxy.conf"
+        live.write_text("# last good\n")
+
+        with patch.object(nginx_module, "_run_nginx_config_test", return_value=(True, "")):
+            _REAL_WRITE_AND_VALIDATE(live, "# new valid config\n")
+
+        assert live.read_text() == "# new valid config\n"
+        # No backup left behind on success.
+        assert not (tmp_path / (live.name + nginx_module._LAST_GOOD_SUFFIX)).exists()
+
+    def test_invalid_config_does_not_overwrite_live_config(self, tmp_path):
+        """A candidate rejected by nginx -t must not persist; the last-good
+        config is restored so a subsequent cold start still boots."""
+        live = tmp_path / "nginx_rev_proxy.conf"
+        live.write_text("# last good\n")
+
+        with patch.object(
+            nginx_module,
+            "_run_nginx_config_test",
+            return_value=(False, "nginx: [emerg] unexpected }"),
+        ):
+            with pytest.raises(RuntimeError, match="nginx config rejected"):
+                _REAL_WRITE_AND_VALIDATE(live, "# broken }\ninjected junk\n")
+
+        # The broken candidate never survives on disk: last-good is intact.
+        assert live.read_text() == "# last good\n"
+        # No stray backup file remains.
+        assert not (tmp_path / (live.name + nginx_module._LAST_GOOD_SUFFIX)).exists()
+
+    def test_invalid_config_with_no_prior_config_leaves_nothing_on_disk(self, tmp_path):
+        """When there is no prior live config, a rejected candidate is removed
+        entirely so a cold start does not load a broken file."""
+        live = tmp_path / "nginx_rev_proxy.conf"
+        assert not live.exists()
+
+        with patch.object(nginx_module, "_run_nginx_config_test", return_value=(False, "bad")):
+            with pytest.raises(RuntimeError, match="nginx config rejected"):
+                _REAL_WRITE_AND_VALIDATE(live, "# broken\n")
+
+        assert not live.exists()
+
+    def test_missing_nginx_binary_promotes_without_validation(self, tmp_path):
+        """On a single-container host with no nginx (default), the candidate is
+        promoted without a test — there is no nginx cold start to protect."""
+        live = tmp_path / "nginx_rev_proxy.conf"
+        live.write_text("# last good\n")
+
+        settings_stub = MagicMock()
+        settings_stub.nginx_config_validation_required = False
+        settings_stub.nginx_updates_enabled = True
+        with (
+            patch.object(nginx_module, "settings", settings_stub),
+            patch("shutil.which", return_value=None),
+        ):
+            _REAL_WRITE_AND_VALIDATE(live, "# new config, unvalidatable\n")
+
+        assert live.read_text() == "# new config, unvalidatable\n"
+
+    def test_missing_nginx_binary_fails_closed_when_validation_required(self, tmp_path):
+        """In a split/sidecar topology (nginx in another container) the operator
+        sets nginx_config_validation_required=True. When the registry cannot run
+        nginx -t, an unvalidated config must NOT be promoted — and the candidate
+        must never even touch the live path (no TOCTOU window for the sidecar)."""
+        live = tmp_path / "nginx_rev_proxy.conf"
+        live.write_text("# last good\n")
+
+        settings_stub = MagicMock()
+        settings_stub.nginx_config_validation_required = True
+        with (
+            patch.object(nginx_module, "settings", settings_stub),
+            patch("shutil.which", return_value=None),
+        ):
+            with pytest.raises(RuntimeError, match="nginx config rejected"):
+                _REAL_WRITE_AND_VALIDATE(live, "# unvalidatable candidate\n")
+
+        # Last-good config is intact; the unvalidated candidate never reached disk.
+        assert live.read_text() == "# last good\n"
+
+
+class TestRunNginxConfigTest:
+    def test_returns_no_binary_sentinel_when_nginx_absent(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            passed, message = nginx_module._run_nginx_config_test()
+        assert passed is False
+        assert message == nginx_module._NGINX_TEST_NO_BINARY
+
+    def test_returns_false_on_nonzero_exit(self):
+        result = MagicMock()
+        result.returncode = 1
+        result.stderr = "nginx: [emerg] boom"
+        with patch("subprocess.run", return_value=result):
+            passed, message = nginx_module._run_nginx_config_test()
+        assert passed is False
+        assert "boom" in message
+
+    def test_returns_false_on_timeout(self):
+        import subprocess
+
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("nginx", 5)):
+            passed, message = nginx_module._run_nginx_config_test()
+        assert passed is False
+        assert "timed out" in message
+
+    def test_returns_true_on_success(self):
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = "syntax is ok"
+        with patch("subprocess.run", return_value=result):
+            passed, _message = nginx_module._run_nginx_config_test()
+        assert passed is True
+
+
+def _scheduler_settings(live):
+    """A settings stub exposing just the attributes the scheduler reload path
+    reads, so the read-only nginx_config_path property can be redirected."""
+    s = MagicMock()
+    s.nginx_config_path = live
+    s.nginx_updates_enabled = True
+    s.deployment_mode = MagicMock()
+    s.deployment_mode.value = "with-gateway"
+    return s
+
+
+@pytest.mark.asyncio
+async def test_scheduler_still_reloads_valid_config(monkeypatch, tmp_path):
+    """The debounced scheduler applies a changed, valid config and advances its
+    last-applied hash (validation is wired in without breaking the reload)."""
+    from registry.core.nginx_service import NginxReloadScheduler
+
+    scheduler = NginxReloadScheduler(debounce_seconds=0.0, poll_external=False)
+
+    live = tmp_path / "nginx_rev_proxy.conf"
+
+    async def _fake_fetch():
+        return {}
+
+    monkeypatch.setattr(nginx_module, "settings", _scheduler_settings(live))
+    monkeypatch.setattr(nginx_module, "_atomic_write_text", _REAL_ATOMIC_WRITE)
+    monkeypatch.setattr(nginx_module, "_write_and_validate_config", _REAL_WRITE_AND_VALIDATE)
+    monkeypatch.setattr(nginx_module, "_fetch_all_enabled_servers", _fake_fetch)
+    monkeypatch.setattr(
+        nginx_module.nginx_service, "render_config", AsyncMock(return_value="# valid config\n")
+    )
+    monkeypatch.setattr(nginx_module.nginx_service, "_commit_virtual_server_mappings", AsyncMock())
+    # nginx binary present; nginx -t accepts the candidate; reload succeeds.
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/sbin/nginx")
+    monkeypatch.setattr(nginx_module, "_run_nginx_config_test", lambda: (True, ""))
+    monkeypatch.setattr(nginx_module.nginx_service, "reload_nginx", MagicMock(return_value=True))
+
+    await scheduler._do_reload_if_changed()
+
+    assert live.read_text() == "# valid config\n"
+    assert scheduler._last_config_hash != ""
+
+
+@pytest.mark.asyncio
+async def test_scheduler_rejects_invalid_config_and_keeps_last_good(monkeypatch, tmp_path):
+    """When nginx -t rejects the rendered config, the scheduler must NOT
+    overwrite the live config, must NOT advance its hash, and must stay dirty
+    for a later retry."""
+    from registry.core.nginx_service import NginxReloadScheduler
+
+    scheduler = NginxReloadScheduler(debounce_seconds=0.0, poll_external=False)
+
+    live = tmp_path / "nginx_rev_proxy.conf"
+    live.write_text("# last good\n")
+
+    async def _fake_fetch():
+        return {}
+
+    monkeypatch.setattr(nginx_module, "settings", _scheduler_settings(live))
+    monkeypatch.setattr(nginx_module, "_atomic_write_text", _REAL_ATOMIC_WRITE)
+    monkeypatch.setattr(nginx_module, "_write_and_validate_config", _REAL_WRITE_AND_VALIDATE)
+    monkeypatch.setattr(nginx_module, "_fetch_all_enabled_servers", _fake_fetch)
+    monkeypatch.setattr(
+        nginx_module.nginx_service, "render_config", AsyncMock(return_value="# broken }\n")
+    )
+    monkeypatch.setattr(nginx_module.nginx_service, "_commit_virtual_server_mappings", AsyncMock())
+    # nginx binary present; nginx -t rejects the candidate.
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/sbin/nginx")
+    monkeypatch.setattr(nginx_module, "_run_nginx_config_test", lambda: (False, "emerg"))
+    reload_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(nginx_module.nginx_service, "reload_nginx", reload_mock)
+
+    await scheduler._do_reload_if_changed()
+
+    # Live config untouched, hash never advanced (stays initial ""), reload
+    # never issued, dirty stays set for a later retry.
+    assert live.read_text() == "# last good\n"
+    assert scheduler._last_config_hash == ""
+    reload_mock.assert_not_called()
+    assert scheduler._dirty is True

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -1394,3 +1394,60 @@ def test_health_service_get_service_health_data_legacy_method(health_service, mo
     health_data = health_service._get_service_health_data(service_path, mock_server_info)
 
     assert health_data["status"] == HealthStatus.HEALTHY
+
+
+# =============================================================================
+# SSRF: health check must not send credentials to a blocked proxy_pass_url
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://10.0.0.1:8000/mcp",  # RFC-1918
+        "http://127.0.0.1:8000/mcp",  # loopback
+        "gopher://acme.com/x",  # disallowed scheme
+    ],
+)
+async def test_endpoint_check_blocks_unsafe_url_without_sending_credentials(
+    health_service, bad_url
+):
+    """A blocked proxy_pass_url returns unhealthy and never builds/sends creds.
+
+    The credential header builder must not be invoked, and no HTTP request may
+    be issued, when the target fails SSRF validation.
+    """
+    from registry.utils import url_guard
+
+    url_guard._proxy_allowlist.cache_clear()
+
+    server_info = {
+        "server_name": "evil",
+        "proxy_pass_url": bad_url,
+        "supported_transports": ["streamable-http"],
+        "auth_scheme": "bearer",
+        "auth_credential_encrypted": "should-never-be-decrypted",
+    }
+
+    client = AsyncMock()
+    settings_stub = MagicMock()
+    settings_stub.ssrf_allowed_hosts = ""
+    settings_stub.ssrf_allowed_cidrs = ""
+
+    with patch.object(url_guard, "settings", settings_stub):
+        with patch.object(health_service, "_build_headers_for_server") as mock_build_headers:
+            is_healthy, status_detail = await health_service._check_server_endpoint_transport_aware(
+                client, bad_url, server_info
+            )
+
+    assert is_healthy is False
+    assert status_detail == HealthStatus.UNHEALTHY_URL_BLOCKED
+    # Credentials were never built for the blocked target.
+    mock_build_headers.assert_not_called()
+    # No outbound request was issued through the client.
+    client.get.assert_not_called()
+    client.head.assert_not_called()
+    client.post.assert_not_called()

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -271,6 +271,33 @@ class TestRegisterAgent:
 
         assert await fake_repo.get_state("/new-agent") is False
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://169.254.169.254/",  # cloud metadata literal
+            "http://10.0.0.1:9000/agent",  # RFC-1918 literal
+            # Non-http(s) schemes (ftp/file/gopher) are rejected earlier by the
+            # AgentCard Pydantic model before the service guard runs; the scheme
+            # check is exercised directly in tests/unit/utils/test_url_guard.py.
+        ],
+    )
+    async def test_register_agent_rejects_unsafe_url(
+        self,
+        agent_service: AgentService,
+        fake_repo: InMemoryAgentRepository,
+        bad_url,
+    ):
+        """A malicious agent url is rejected before the card is persisted."""
+        from registry.exceptions import UrlValidationError
+
+        agent_card = AgentCardFactory(path="/ssrf-agent", url=bad_url)
+
+        with pytest.raises(UrlValidationError):
+            await agent_service.register_agent(agent_card)
+
+        assert await fake_repo.get("/ssrf-agent") is None
+
 
 # =============================================================================
 # TEST: Get Agent

--- a/tests/unit/services/test_ai_catalog_client.py
+++ b/tests/unit/services/test_ai_catalog_client.py
@@ -3,28 +3,38 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
+
 from registry.services.federation import ai_catalog_client as c
+from registry.utils import url_guard
 
 
 def _manifest_payload(entries):
     return {
         "specVersion": "1.0",
-        "host": {"displayName": "Acme", "trustManifest": {"identity": "https://acme.com", "identityType": "https"}},
+        "host": {
+            "displayName": "Acme",
+            "trustManifest": {"identity": "https://acme.com", "identityType": "https"},
+        },
         "entries": entries,
     }
 
 
 def _server_entry(name):
     return {
-        "identifier": f"urn:air:acme.com:server:{name}", "displayName": name,
-        "type": "application/mcp-server-card+json", "url": f"https://acme.com/{name}",
+        "identifier": f"urn:air:acme.com:server:{name}",
+        "displayName": name,
+        "type": "application/mcp-server-card+json",
+        "url": f"https://acme.com/{name}",
     }
 
 
 def _catalog_entry(url):
     return {
-        "identifier": "urn:air:acme.com:catalog:child", "displayName": "Child",
-        "type": "application/ai-catalog+json", "url": url,
+        "identifier": "urn:air:acme.com:catalog:child",
+        "displayName": "Child",
+        "type": "application/ai-catalog+json",
+        "url": url,
     }
 
 
@@ -34,6 +44,7 @@ def _fake_stream(payload=None, *, oversize=False, content_length=None):
     body = b"x" * (c._MAX_BYTES + 1) if oversize else json.dumps(payload).encode()
     resp = MagicMock()
     resp.raise_for_status = MagicMock()
+    resp.status_code = 200
     resp.headers = {"content-length": content_length} if content_length else {}
     resp.iter_bytes = MagicMock(return_value=[body])
     cm = MagicMock()
@@ -47,8 +58,11 @@ class TestFetchCatalog:
         client = c.AiCatalogFederationClient(polite_interval_ms=0)
         with (
             patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
-            patch.object(client.client, "stream",
-                         return_value=_fake_stream(_manifest_payload([_server_entry("github")]))),
+            patch.object(
+                client.client,
+                "stream",
+                return_value=_fake_stream(_manifest_payload([_server_entry("github")])),
+            ),
         ):
             docs = client.fetch_catalog("https://acme.com/.well-known/ai-catalog.json")
         assert len(docs) == 1
@@ -57,7 +71,9 @@ class TestFetchCatalog:
 
     def test_recurses_nested_catalog_within_depth(self):
         client = c.AiCatalogFederationClient(polite_interval_ms=0, max_depth=2)
-        root = _manifest_payload([_catalog_entry("https://acme.com/child.json"), _server_entry("a")])
+        root = _manifest_payload(
+            [_catalog_entry("https://acme.com/child.json"), _server_entry("a")]
+        )
         child = _manifest_payload([_server_entry("b")])
         responses = {
             "https://acme.com/.well-known/ai-catalog.json": lambda: _fake_stream(root),
@@ -65,7 +81,9 @@ class TestFetchCatalog:
         }
         with (
             patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
-            patch.object(client.client, "stream", side_effect=lambda method, url, **kw: responses[url]()),
+            patch.object(
+                client.client, "stream", side_effect=lambda method, url, **kw: responses[url]()
+            ),
         ):
             docs = client.fetch_catalog("https://acme.com/.well-known/ai-catalog.json")
         assert len(docs) == 2  # root + child
@@ -75,7 +93,9 @@ class TestFetchCatalog:
         root = _manifest_payload([_catalog_entry("https://acme.com/.well-known/ai-catalog.json")])
         with (
             patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
-            patch.object(client.client, "stream", side_effect=lambda method, url, **kw: _fake_stream(root)),
+            patch.object(
+                client.client, "stream", side_effect=lambda method, url, **kw: _fake_stream(root)
+            ),
         ):
             docs = client.fetch_catalog("https://acme.com/.well-known/ai-catalog.json")
         assert len(docs) == 1  # visited set prevents re-fetch
@@ -91,7 +111,9 @@ class TestFetchCatalog:
 
     def test_oversized_content_length_rejected_early(self):
         client = c.AiCatalogFederationClient(polite_interval_ms=0)
-        cm = _fake_stream(_manifest_payload([_server_entry("a")]), content_length=str(c._MAX_BYTES + 1))
+        cm = _fake_stream(
+            _manifest_payload([_server_entry("a")]), content_length=str(c._MAX_BYTES + 1)
+        )
         with (
             patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
             patch.object(client.client, "stream", return_value=cm),
@@ -105,4 +127,135 @@ class TestFetchCatalog:
         client = c.AiCatalogFederationClient(polite_interval_ms=0)
         with patch.object(c, "assert_fetchable", side_effect=ArdValidationError("blocked")):
             docs = client.fetch_catalog("https://evil.com/x.json")
+        assert docs == []
+
+
+def _resolve_to(*ips: str):
+    """getaddrinfo stub resolving any host to the given IP(s)."""
+
+    def _stub(host, port, **kw):
+        return [(2, 1, 6, "", (ip, port)) for ip in ips]
+
+    return _stub
+
+
+class TestRebindingDefeat:
+    """The catalog fetch must connect to the IP the guard validated, not a
+    rebound one — the fetch goes through the pinned guarded client so a
+    DNS-rebind between validation and connect is blocked at connect time."""
+
+    def test_client_uses_guarded_transport(self):
+        client = c.AiCatalogFederationClient(polite_interval_ms=0)
+        transport = client.client._transport
+        assert isinstance(transport, url_guard.GuardedTransport)
+        # No auth is ever configured on the crawler client.
+        assert client.client.headers.get("authorization") is None
+        # Redirects are disabled so a 3xx cannot bounce off to a new host.
+        assert client.client.follow_redirects is False
+
+    def test_rebind_between_validate_and_connect_is_defeated(self):
+        """A host that passes assert_fetchable() (public) but rebinds to a
+        private IP before the connect is blocked by the pinned transport, and
+        the crawl skips it rather than crashing."""
+        client = c.AiCatalogFederationClient(polite_interval_ms=0)
+        url = "https://rebind.example/.well-known/ai-catalog.json"
+
+        settings_stub = MagicMock()
+        settings_stub.github_extra_hosts = ""
+        settings_stub.ssrf_allowed_hosts = ""
+        settings_stub.ssrf_allowed_cidrs = ""
+
+        with (
+            # assert_fetchable succeeds (host validated public out-of-band).
+            patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
+            patch.object(url_guard, "settings", settings_stub),
+            # The host now rebinds to a private IP; the pinned transport
+            # re-resolves inside the connect and blocks it.
+            patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.5")),
+        ):
+            url_guard._skill_allowlist.cache_clear()
+            url_guard._proxy_allowlist.cache_clear()
+            docs = client.fetch_catalog(url)
+
+        # Skipped, not fatal: the guard blocked the rebound connect.
+        assert docs == []
+
+    def test_public_ip_still_fetches(self):
+        """A host that validates public and stays public is fetched normally
+        (the pinned transport rewrites to the validated IP, no block)."""
+        client = c.AiCatalogFederationClient(polite_interval_ms=0)
+        payload = _manifest_payload([_server_entry("github")])
+
+        settings_stub = MagicMock()
+        settings_stub.github_extra_hosts = ""
+        settings_stub.ssrf_allowed_hosts = ""
+        settings_stub.ssrf_allowed_cidrs = ""
+
+        # Confirm the pinned transport accepts a public IP and rewrites to it,
+        # then let the (mocked) stream return the manifest body.
+        with (
+            patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
+            patch.object(url_guard, "settings", settings_stub),
+            patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")),
+        ):
+            url_guard._skill_allowlist.cache_clear()
+            url_guard._proxy_allowlist.cache_clear()
+            transport = client.client._transport
+            request = httpx.Request("GET", "https://acme.com/x.json")
+            pinned = transport._pin_request(request)
+            assert pinned.url.host == "93.184.216.34"
+            assert pinned.headers["Host"] == "acme.com"
+
+            with patch.object(client.client, "stream", return_value=_fake_stream(payload)):
+                docs = client.fetch_catalog("https://acme.com/.well-known/ai-catalog.json")
+
+        assert len(docs) == 1
+
+
+class TestCrawlResilienceAndRedirects:
+    def test_unexpected_error_on_one_url_does_not_crash_crawl(self):
+        """A poisoned nested URL that raises an unexpected error (e.g. an
+        httpx.InvalidURL that is not an HTTPError) must skip that node, not kill
+        the whole crawl — a hostile catalog cannot DoS ingestion with one link."""
+        client = c.AiCatalogFederationClient(polite_interval_ms=0, max_depth=2)
+        root = _manifest_payload(
+            [_catalog_entry("https://acme.com/bad.json"), _server_entry("good")]
+        )
+
+        def _stream(method, url, **kw):
+            if url == "https://acme.com/.well-known/ai-catalog.json":
+                return _fake_stream(root)
+            # The nested child raises a non-HTTPError, non-UrlValidationError.
+            raise RuntimeError("boom on nested fetch")
+
+        with (
+            patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
+            patch.object(client.client, "stream", side_effect=_stream),
+        ):
+            docs = client.fetch_catalog("https://acme.com/.well-known/ai-catalog.json")
+
+        # Root still processed despite the child blowing up.
+        assert len(docs) == 1
+        assert docs[0][0].entries[0].identifier.endswith("child")
+
+    def test_redirect_response_is_rejected(self):
+        """With follow_redirects=False, a 3xx response must be refused rather
+        than have its body parsed as a catalog (redirect-body injection)."""
+        client = c.AiCatalogFederationClient(polite_interval_ms=0)
+
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()  # httpx does not raise on 3xx
+        resp.status_code = 302
+        resp.headers = {}
+        resp.iter_bytes = MagicMock(return_value=[b'{"specVersion": "1.0"}'])
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=resp)
+        cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.object(c, "assert_fetchable", side_effect=lambda u, d=None: u),
+            patch.object(client.client, "stream", return_value=cm),
+        ):
+            docs = client.fetch_catalog("https://acme.com/redir.json")
+
         assert docs == []

--- a/tests/unit/services/test_server_service.py
+++ b/tests/unit/services/test_server_service.py
@@ -217,6 +217,73 @@ class TestLoadServersAndState:
 
 @pytest.mark.unit
 @pytest.mark.servers
+class TestRegisterServerUrlValidation:
+    """Registration-time SSRF/scheme validation of proxy_pass_url (fail closed)."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata literal
+            "http://10.0.0.1:8080/mcp",  # RFC-1918 literal
+            "http://127.0.0.1:8080/mcp",  # loopback literal
+            "ftp://acme.com/mcp",  # disallowed scheme
+            'http://acme.com/";} location /x { proxy_pass http://evil;',  # nginx injection
+        ],
+    )
+    async def test_register_rejects_unsafe_proxy_pass_url(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+        bad_url,
+    ):
+        """A malicious proxy_pass_url is rejected before anything is persisted."""
+        from registry.exceptions import UrlValidationError
+
+        mock_server_repository.get.return_value = None
+        payload = {**sample_server_dict, "proxy_pass_url": bad_url}
+
+        with pytest.raises(UrlValidationError):
+            await server_service.register_server(payload)
+
+        mock_server_repository.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_rejects_unsafe_proxy_pass_url(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+    ):
+        """Editing a server's proxy_pass_url to a metadata target is rejected."""
+        from registry.exceptions import UrlValidationError
+
+        payload = {**sample_server_dict, "proxy_pass_url": "http://169.254.169.254/"}
+
+        with pytest.raises(UrlValidationError):
+            await server_service.update_server(sample_server_dict["path"], payload)
+
+        mock_server_repository.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_without_url_change_is_not_validated(
+        self,
+        server_service: ServerService,
+        mock_server_repository,
+    ):
+        """Health/tool updates that omit proxy_pass_url are unaffected."""
+        mock_server_repository.update.return_value = True
+        mock_server_repository.get_state.return_value = False
+
+        # No proxy_pass_url in the payload -> no validation, update proceeds.
+        result = await server_service.update_server(
+            "/test-server", {"health_status": "healthy", "num_tools": 3}
+        )
+        assert result is True
+        mock_server_repository.update.assert_called_once()
+
+
 class TestRegisterServer:
     """Test server registration functionality."""
 

--- a/tests/unit/services/test_skill_resource_discovery.py
+++ b/tests/unit/services/test_skill_resource_discovery.py
@@ -207,8 +207,8 @@ class TestDiscoverSkillResources:
 
     @pytest.fixture
     def mock_async_client(self):
-        """Patch httpx.AsyncClient and yield the mock response object."""
-        with patch("registry.services.skill_service.httpx.AsyncClient") as client_cls:
+        """Patch the guarded async client and yield the mock response object."""
+        with patch("registry.services.skill_service.guarded_async_client") as client_cls:
             response = MagicMock()
             response.status_code = 200
             response.json = MagicMock()
@@ -397,7 +397,7 @@ class TestDiscoverSkillResources:
         client_instance.__aexit__ = AsyncMock(return_value=False)
 
         with patch(
-            "registry.services.skill_service.httpx.AsyncClient",
+            "registry.services.skill_service.guarded_async_client",
             return_value=client_instance,
         ):
             await _discover_skill_resources(

--- a/tests/unit/services/test_skill_service_ssrf_allowlist.py
+++ b/tests/unit/services/test_skill_service_ssrf_allowlist.py
@@ -1,182 +1,96 @@
 """
-Unit tests for SKILL.md SSRF allowlist derivation.
+Unit tests for SKILL.md SSRF handling via the hardened URL guard.
 
-These tests verify that the SSRF allowlist used by skill_service._is_safe_url
-honours settings.github_extra_hosts so GitHub Enterprise (GHES) hosts -- which
-typically resolve to private IPs -- can be reached for SKILL.md fetching once
-the operator has explicitly trusted them via configuration.
-
-Issue #938: Support SKILLS from Github Enterprise.
+skill_service._is_safe_url now delegates to registry.utils.url_guard. The only
+hosts that bypass the private-IP block are those explicitly configured in
+settings.github_extra_hosts (e.g. GitHub Enterprise Server on a private
+network, issue #938). Built-in public forge domains (github.com, gitlab.com,
+...) are NOT blindly trusted -- they are IP-validated like any other host, which
+closes the trusted-domain SSRF bypass.
 """
 
 import logging
 from unittest.mock import patch
 
-import pytest
-
 logger = logging.getLogger(__name__)
 
 
-# =============================================================================
-# Helpers
-# =============================================================================
-
-
-def _clear_trusted_domains_cache() -> None:
+def _clear_bypass_cache() -> None:
     """Reset the lru_cache so each test sees the patched settings value."""
-    from registry.services.skill_service import _trusted_domains
+    from registry.utils.url_guard import _skill_allowlist
 
-    _trusted_domains.cache_clear()
-
-
-# =============================================================================
-# Default allowlist (no GHES configured)
-# =============================================================================
+    _skill_allowlist.cache_clear()
 
 
-class TestDefaultTrustedDomains:
-    """Built-in allowlist behaviour when github_extra_hosts is empty."""
+def _bypass_hosts() -> frozenset[str]:
+    """Return the skill-fetch bypass host set derived from current settings."""
+    from registry.utils.url_guard import _skill_allowlist
 
-    @patch("registry.services.skill_service.settings")
-    def test_default_hosts_are_trusted(
+    return _skill_allowlist().hosts
+
+
+class TestBypassAllowlistDerivation:
+    """The operator bypass allowlist is derived solely from github_extra_hosts."""
+
+    @patch("registry.utils.url_guard.settings")
+    def test_empty_when_unconfigured(
         self,
         mock_settings,
     ) -> None:
-        """github.com, gitlab.com, raw.githubusercontent.com, bitbucket.org always trusted."""
+        """No configured hosts means an empty bypass set (public domains not in it)."""
         mock_settings.github_extra_hosts = ""
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
+        assert _bypass_hosts() == frozenset()
 
-        # With no extras configured the merged set must equal the defaults.
-        # Using equality (rather than per-host membership) catches accidental
-        # additions or omissions and keeps the assertion off CodeQL's
-        # py/incomplete-url-substring-sanitization radar.
-        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS
-
-    @patch("registry.services.skill_service.settings")
-    def test_unconfigured_ghes_host_not_trusted(
+    @patch("registry.utils.url_guard.settings")
+    def test_public_forge_domains_not_in_bypass(
         self,
         mock_settings,
     ) -> None:
-        """A GHES hostname not in github_extra_hosts is not in the allowlist."""
+        """Built-in public forge domains are never auto-bypassed."""
         mock_settings.github_extra_hosts = ""
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
+        assert "github.com" not in _bypass_hosts()
+        assert "gitlab.com" not in _bypass_hosts()
 
-        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS
-
-
-# =============================================================================
-# GHES hosts via github_extra_hosts
-# =============================================================================
-
-
-class TestGHESHostMerge:
-    """Configured GHES hosts are merged into the allowlist."""
-
-    @patch("registry.services.skill_service.settings")
+    @patch("registry.utils.url_guard.settings")
     def test_single_ghes_host_added(
         self,
         mock_settings,
     ) -> None:
-        """One configured GHES host extends the default trusted set by exactly that host."""
+        """One configured GHES host is the only member of the bypass set."""
         mock_settings.github_extra_hosts = "github.mycompany.com"
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
+        assert _bypass_hosts() == frozenset({"github.mycompany.com"})
 
-        assert _trusted_domains() == _DEFAULT_TRUSTED_DOMAINS | {"github.mycompany.com"}
-
-    @patch("registry.services.skill_service.settings")
-    def test_multiple_ghes_hosts_added(
-        self,
-        mock_settings,
-    ) -> None:
-        """Comma-separated GHES hosts all extend the default set."""
-        mock_settings.github_extra_hosts = (
-            "github.mycompany.com,raw.github.mycompany.com"
-        )
-        _clear_trusted_domains_cache()
-
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
-
-        expected = _DEFAULT_TRUSTED_DOMAINS | {
-            "github.mycompany.com",
-            "raw.github.mycompany.com",
-        }
-        assert _trusted_domains() == expected
-
-    @patch("registry.services.skill_service.settings")
+    @patch("registry.utils.url_guard.settings")
     def test_whitespace_and_case_normalised(
         self,
         mock_settings,
     ) -> None:
         """Whitespace is stripped and hostnames are lowercased."""
         mock_settings.github_extra_hosts = "  GitHub.MyCompany.com  ,  RAW.github.mycompany.com  "
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
-
-        expected = _DEFAULT_TRUSTED_DOMAINS | {
-            "github.mycompany.com",
-            "raw.github.mycompany.com",
-        }
-        assert _trusted_domains() == expected
-
-    @patch("registry.services.skill_service.settings")
-    def test_defaults_preserved_when_extras_present(
-        self,
-        mock_settings,
-    ) -> None:
-        """Adding GHES hosts does not drop the built-in defaults."""
-        mock_settings.github_extra_hosts = "github.mycompany.com"
-        _clear_trusted_domains_cache()
-
-        from registry.services.skill_service import (
-            _DEFAULT_TRUSTED_DOMAINS,
-            _trusted_domains,
-        )
-
-        # Subset assertion: every default must still be in the merged set.
-        assert _DEFAULT_TRUSTED_DOMAINS <= _trusted_domains()
-
-
-# =============================================================================
-# _is_safe_url integration with the merged allowlist
-# =============================================================================
+        assert _bypass_hosts() == frozenset({"github.mycompany.com", "raw.github.mycompany.com"})
 
 
 class TestSafeUrlForGHES:
-    """End-to-end: GHES URLs bypass the private-IP check once configured."""
+    """GHES URLs bypass the private-IP check only once explicitly configured."""
 
-    @patch("registry.services.skill_service.settings")
+    @patch("registry.utils.url_guard.settings")
     def test_ghes_url_blocked_when_not_configured(
         self,
         mock_settings,
     ) -> None:
         """Without github_extra_hosts, GHES on a private IP fails SSRF."""
         mock_settings.github_extra_hosts = ""
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        # Simulate DNS resolving the GHES host to an internal IP (10.0.0.5).
-        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
             mock_resolve.return_value = [
                 (None, None, None, None, ("10.0.0.5", 443)),
             ]
@@ -186,20 +100,22 @@ class TestSafeUrlForGHES:
             url = "https://github.mycompany.com/org/repo/blob/main/SKILL.md"
             assert _is_safe_url(url) is False
 
-    @patch("registry.services.skill_service.settings")
+    @patch("registry.utils.url_guard.settings")
     def test_ghes_url_allowed_when_configured(
         self,
         mock_settings,
     ) -> None:
-        """With github_extra_hosts set, GHES on a private IP passes SSRF."""
-        mock_settings.github_extra_hosts = "github.mycompany.com"
-        _clear_trusted_domains_cache()
+        """With github_extra_hosts set, GHES on a private IP passes SSRF.
 
-        # DNS resolution should be skipped entirely for trusted hosts -- we
-        # patch getaddrinfo to ensure the test fails loudly if it gets called.
-        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+        DNS resolution should be skipped entirely for bypass hosts -- patch
+        getaddrinfo to fail loudly if it gets called.
+        """
+        mock_settings.github_extra_hosts = "github.mycompany.com"
+        _clear_bypass_cache()
+
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
             mock_resolve.side_effect = AssertionError(
-                "getaddrinfo should not be called for trusted hosts"
+                "getaddrinfo should not be called for bypass hosts"
             )
 
             from registry.services.skill_service import _is_safe_url
@@ -207,34 +123,57 @@ class TestSafeUrlForGHES:
             url = "https://github.mycompany.com/org/repo/blob/main/SKILL.md"
             assert _is_safe_url(url) is True
 
-    @patch("registry.services.skill_service.settings")
-    def test_raw_ghes_url_allowed_when_configured(
+    @patch("registry.utils.url_guard.settings")
+    def test_public_github_on_private_ip_is_blocked(
         self,
         mock_settings,
     ) -> None:
-        """raw.* GHES host trusted when listed in github_extra_hosts."""
-        mock_settings.github_extra_hosts = "raw.github.mycompany.com"
-        _clear_trusted_domains_cache()
+        """A public forge domain resolving to a private IP is now BLOCKED.
 
-        from registry.services.skill_service import _is_safe_url
+        This is the core hardening: github.com is no longer a blind-trust
+        bypass, so an internal host masquerading as github.com (or DNS
+        poisoning) cannot reach private ranges.
+        """
+        mock_settings.github_extra_hosts = ""
+        _clear_bypass_cache()
 
-        url = "https://raw.github.mycompany.com/org/repo/refs/heads/main/SKILL.md"
-        assert _is_safe_url(url) is True
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [
+                (None, None, None, None, ("10.0.0.5", 443)),
+            ]
 
-    @patch("registry.services.skill_service.settings")
+            from registry.services.skill_service import _is_safe_url
+
+            assert _is_safe_url("https://github.com/org/repo/blob/main/SKILL.md") is False
+
+    @patch("registry.utils.url_guard.settings")
+    def test_public_github_on_public_ip_is_allowed(
+        self,
+        mock_settings,
+    ) -> None:
+        """A public forge domain resolving to a public IP is allowed."""
+        mock_settings.github_extra_hosts = ""
+        _clear_bypass_cache()
+
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [
+                (None, None, None, None, ("140.82.112.3", 443)),
+            ]
+
+            from registry.services.skill_service import _is_safe_url
+
+            assert _is_safe_url("https://github.com/org/repo/blob/main/SKILL.md") is True
+
+    @patch("registry.utils.url_guard.settings")
     def test_unconfigured_internal_host_still_blocked(
         self,
         mock_settings,
     ) -> None:
-        """A non-GitHub internal host on a private IP is still blocked.
-
-        Confirms the allowlist is narrow: only configured GHES hosts skip the
-        IP check, not arbitrary internal hostnames.
-        """
+        """A non-GitHub internal host on a private IP is still blocked."""
         mock_settings.github_extra_hosts = "github.mycompany.com"
-        _clear_trusted_domains_cache()
+        _clear_bypass_cache()
 
-        with patch("registry.services.skill_service.socket.getaddrinfo") as mock_resolve:
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
             mock_resolve.return_value = [
                 (None, None, None, None, ("10.0.0.5", 443)),
             ]
@@ -242,33 +181,3 @@ class TestSafeUrlForGHES:
             from registry.services.skill_service import _is_safe_url
 
             assert _is_safe_url("https://internal.example.com/foo") is False
-
-
-# =============================================================================
-# Cache invalidation
-# =============================================================================
-
-
-class TestCacheBehavior:
-    """The lru_cache on _trusted_domains is one-shot per process by design."""
-
-    @pytest.fixture(autouse=True)
-    def _reset_cache(self):
-        _clear_trusted_domains_cache()
-        yield
-        _clear_trusted_domains_cache()
-
-    @patch("registry.services.skill_service.settings")
-    def test_cache_returns_same_frozenset(
-        self,
-        mock_settings,
-    ) -> None:
-        """Repeated calls return the cached frozenset without re-reading settings."""
-        mock_settings.github_extra_hosts = "github.mycompany.com"
-
-        from registry.services.skill_service import _trusted_domains
-
-        first = _trusted_domains()
-        second = _trusted_domains()
-
-        assert first is second

--- a/tests/unit/test_skill_routes_github_auth.py
+++ b/tests/unit/test_skill_routes_github_auth.py
@@ -45,7 +45,7 @@ class TestGetSkillContentAuth:
         mock_response.text = "# My Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -86,7 +86,7 @@ class TestGetSkillContentAuth:
         mock_response.text = "# Public Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
 
-        with patch("httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/tests/unit/test_skill_scanner_service.py
+++ b/tests/unit/test_skill_scanner_service.py
@@ -272,3 +272,34 @@ class TestSkillScannerServiceUnit:
         parsed = service._parse_scanner_output(ansi_json)
         assert parsed["scan_results"] == {"findings": []}
         assert parsed["analysis_results"] == {}
+
+
+class TestSkillScannerDownloadSSRF:
+    """The scanner's download step must apply the SSRF guard before fetching."""
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.1/SKILL.md",
+            "ftp://acme.com/SKILL.md",
+        ],
+    )
+    def test_download_rejects_unsafe_url(self, bad_url):
+        """A private/metadata/bad-scheme URL is rejected before any HTTP call."""
+        from registry.exceptions import UrlValidationError
+        from registry.utils import url_guard
+
+        url_guard._skill_allowlist.cache_clear()
+        service = _create_service()
+
+        settings_stub = MagicMock()
+        settings_stub.github_extra_hosts = ""
+
+        with patch.object(url_guard, "settings", settings_stub):
+            # If the guard failed open, httpx.get would be reached; assert it is
+            # never called by patching the module-level guarded client factory.
+            with patch.object(url_guard, "guarded_client") as mock_client_factory:
+                with pytest.raises(UrlValidationError):
+                    service._download_skill_content(bad_url)
+                mock_client_factory.assert_not_called()

--- a/tests/unit/test_skill_service_github_auth.py
+++ b/tests/unit/test_skill_service_github_auth.py
@@ -17,7 +17,7 @@ class TestValidateSkillMdUrlAuth:
         mock_response.content = b"# Test Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
 
-        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -45,7 +45,7 @@ class TestValidateSkillMdUrlAuth:
         mock_response.content = b"# Test Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
 
-        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -80,7 +80,7 @@ class TestParseSkillMdContentAuth:
         mock_response.text = "---\nname: test\n---\n# Test Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md"
 
-        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -103,7 +103,9 @@ class TestParseSkillMdContentAuth:
     @patch("registry.services.skill_service.translate_skill_url")
     async def test_none_scheme_sends_no_headers(self, mock_translate, mock_safe_url, mock_auth):
         """auth_scheme=none sends no auth headers when parsing SKILL.md."""
-        mock_auth.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer ghp_should_not_appear"})
+        mock_auth.get_auth_headers = AsyncMock(
+            return_value={"Authorization": "Bearer ghp_should_not_appear"}
+        )
         mock_translate.return_value = (
             "https://github.com/o/r/blob/main/SKILL.md",
             "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md",
@@ -115,7 +117,7 @@ class TestParseSkillMdContentAuth:
         mock_response.text = "---\nname: test\n---\n# Test Skill"
         mock_response.url = "https://raw.githubusercontent.com/o/r/refs/heads/main/SKILL.md"
 
-        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.get.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -147,7 +149,7 @@ class TestCheckSkillHealthAuth:
         mock_response.status_code = 200
         mock_response.url = "https://raw.githubusercontent.com/o/r/main/SKILL.md"
 
-        with patch("registry.services.skill_service.httpx.AsyncClient") as mock_client_cls:
+        with patch("registry.services.skill_service.guarded_async_client") as mock_client_cls:
             mock_client = AsyncMock()
             mock_client.head.return_value = mock_response
             mock_client.__aenter__ = AsyncMock(return_value=mock_client)

--- a/tests/unit/utils/test_agent_validator_ssrf.py
+++ b/tests/unit/utils/test_agent_validator_ssrf.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for SSRF protection on the agent endpoint reachability probe.
+
+``_check_endpoint_reachability`` fetches a user-controlled agent URL's
+well-known card. It must resolve+validate+pin a public IP (proxy profile) so a
+private/metadata target cannot be reached, and a blocked URL must degrade to
+"unreachable" (advisory) rather than raise or fall through to a raw fetch.
+"""
+
+from unittest.mock import patch
+
+from registry.utils.agent_validator import _check_endpoint_reachability
+
+
+class TestReachabilitySsrfGuard:
+    """The reachability probe fails closed on private/metadata targets."""
+
+    def test_private_ip_reported_unreachable_not_fetched(self):
+        """A host resolving to a private IP is reported unreachable, not fetched."""
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [(None, None, None, None, ("10.0.0.5", 443))]
+
+            reachable, error = _check_endpoint_reachability("https://evil.example")
+
+            assert reachable is False
+            assert error == "Endpoint URL failed SSRF validation"
+
+    def test_metadata_ip_literal_reported_unreachable(self):
+        """The cloud metadata IP literal is blocked (never allowlistable)."""
+        reachable, error = _check_endpoint_reachability("http://169.254.169.254")
+
+        assert reachable is False
+        assert error == "Endpoint URL failed SSRF validation"
+
+    def test_public_host_uses_guarded_client(self):
+        """A public host resolves and is probed through the guarded client."""
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [(None, None, None, None, ("140.82.112.3", 443))]
+
+            with patch("registry.utils.url_guard.guarded_client") as mock_client_factory:
+                mock_client = mock_client_factory.return_value.__enter__.return_value
+                mock_client.get.return_value.status_code = 200
+
+                reachable, error = _check_endpoint_reachability("https://good.example")
+
+                assert reachable is True
+                assert error is None
+                mock_client.get.assert_called_once()

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -1,0 +1,335 @@
+"""Unit tests for the hardened SSRF URL guard (registry.utils.url_guard).
+
+Covers, for both validation profiles:
+- scheme rejection (only http/https, optional https-only),
+- private / loopback / link-local / reserved / multicast / unspecified / cloud
+  metadata rejection,
+- IPv4-mapped IPv6 unwrapping,
+- nginx metacharacter rejection for proxy_pass_url,
+- operator allowlist bypass (github_extra_hosts for skills; ssrf_allowed_hosts /
+  ssrf_allowed_cidrs for proxy targets),
+- DNS-rebinding defeat: the pinned transport rewrites the connection target to a
+  validated IP, preserving Host + SNI, and re-validates literal IPs.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from registry.exceptions import UrlValidationError
+from registry.utils import url_guard
+
+
+def _reset_caches() -> None:
+    url_guard._skill_allowlist.cache_clear()
+    url_guard._proxy_allowlist.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_allowlist_caches():
+    _reset_caches()
+    yield
+    _reset_caches()
+
+
+def _resolve_to(*ips: str):
+    """getaddrinfo stub resolving any host to the given IP(s)."""
+
+    def _stub(host, port, **kw):
+        return [(2, 1, 6, "", (ip, port)) for ip in ips]
+
+    return _stub
+
+
+def _settings(github_extra_hosts="", ssrf_allowed_hosts="", ssrf_allowed_cidrs=""):
+    s = MagicMock()
+    s.github_extra_hosts = github_extra_hosts
+    s.ssrf_allowed_hosts = ssrf_allowed_hosts
+    s.ssrf_allowed_cidrs = ssrf_allowed_cidrs
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Scheme validation
+# ---------------------------------------------------------------------------
+
+
+class TestScheme:
+    @pytest.mark.parametrize("url", ["ftp://x/y", "file:///etc/passwd", "gopher://x", "//x/y"])
+    def test_non_http_scheme_rejected(self, url):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_url(url)
+
+    def test_http_rejected_when_https_required(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("http://acme.com/x", require_https=True)
+
+    def test_missing_host_rejected(self):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_url("https:///nohost")
+
+    def test_empty_url_rejected(self):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_url("")
+
+
+# ---------------------------------------------------------------------------
+# Private / metadata blocking
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateAndMetadata:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",
+            "10.1.2.3",
+            "192.168.1.5",
+            "172.16.0.9",
+            "169.254.169.254",
+            "0.0.0.0",
+            "224.0.0.1",
+            "::1",
+            "::ffff:10.0.0.1",
+            "fe80::1",
+            "fc00::1",
+        ],
+    )
+    def test_blocked_targets_rejected(self, ip):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to(ip)):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://evil.example/x")
+
+    def test_public_ip_allowed(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+                assert url_guard.validate_url("https://acme.com/x") == ["93.184.216.34"]
+
+    def test_any_private_in_resolution_set_rejected(self):
+        """If a host resolves to a public AND a private IP, it is rejected."""
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(
+                url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34", "10.0.0.1")
+            ):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://acme.com/x")
+
+    def test_literal_private_ip_host_rejected(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_url("http://169.254.169.254/latest/meta-data/")
+
+    def test_literal_public_ip_host_allowed(self):
+        with patch.object(url_guard, "settings", _settings()):
+            assert url_guard.validate_url("https://93.184.216.34/x") == ["93.184.216.34"]
+
+    def test_dns_failure_fails_closed(self):
+        def _boom(host, port, **kw):
+            raise url_guard.socket.gaierror("nope")
+
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://acme.com/x")
+
+
+# ---------------------------------------------------------------------------
+# nginx metacharacters
+# ---------------------------------------------------------------------------
+
+
+class TestNginxMetacharacters:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            'http://evil.com/"; } location / { proxy_pass http://x;',
+            "http://evil.com/\n}",
+            "http://evil.com/a;b",
+            "http://evil.com/${x}",
+            "http://evil.com/a b",
+        ],
+    )
+    def test_metacharacters_rejected(self, url):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_url(url, reject_nginx_metacharacters=True)
+
+    def test_validate_proxy_pass_url_rejects_injection(self):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_proxy_pass_url('http://x/";}')
+
+    def test_validate_proxy_pass_url_rejects_metadata_literal(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_proxy_pass_url("http://169.254.169.254/")
+
+    def test_validate_proxy_pass_url_rejects_private_literal(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_proxy_pass_url("http://10.0.0.1/mcp")
+
+    def test_validate_proxy_pass_url_rejects_bad_scheme(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_proxy_pass_url("ftp://acme.com/mcp")
+
+    def test_validate_proxy_pass_url_allows_hostname_without_dns(self):
+        """Registration-time validation does not resolve DNS (structural only)."""
+
+        def _boom(*a, **k):
+            raise AssertionError("registration validation must not perform DNS resolution")
+
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                url_guard.validate_proxy_pass_url("https://acme.com/mcp")
+                url_guard.validate_agent_url("https://agent.example.com/a2a")
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/evil; }",
+            "/a\nb",
+            "/x${y}",
+            "/a b",
+            '/"quote',
+            "/has#comment",
+        ],
+    )
+    def test_validate_server_path_rejects_metacharacters(self, path):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_server_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        ["/github", "/tools/currenttime", "/a-b_c.d/leaf"],
+    )
+    def test_validate_server_path_allows_normal_paths(self, path):
+        url_guard.validate_server_path(path)  # does not raise
+
+    def test_validate_server_path_rejects_empty(self):
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_server_path("")
+
+
+# ---------------------------------------------------------------------------
+# Allowlist bypass behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlists:
+    def test_skill_profile_does_not_bypass_public_forge_domain(self):
+        """github.com is NOT auto-trusted; it must pass IP validation."""
+        with patch.object(url_guard, "settings", _settings(github_extra_hosts="")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.5")):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://github.com/x", profile=url_guard.SKILL_PROFILE)
+
+    def test_skill_profile_ghes_host_bypasses(self):
+        with patch.object(url_guard, "settings", _settings(github_extra_hosts="github.corp")):
+            # getaddrinfo must NOT be called for an allowlisted host.
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for allowlisted host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                assert (
+                    url_guard.validate_url("https://github.corp/x", profile=url_guard.SKILL_PROFILE)
+                    == []
+                )
+
+    def test_proxy_profile_host_allowlist_bypasses(self):
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="mcpgw,localhost")):
+
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for allowlisted host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                assert (
+                    url_guard.validate_url("http://mcpgw:8000/mcp", profile=url_guard.PROXY_PROFILE)
+                    == []
+                )
+
+    def test_proxy_profile_cidr_allowlist_permits_private(self):
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_cidrs="10.0.0.0/8")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.1.2.3")):
+                assert url_guard.validate_url(
+                    "http://internal.corp/mcp", profile=url_guard.PROXY_PROFILE
+                ) == ["10.1.2.3"]
+
+    def test_proxy_profile_cidr_allowlist_never_permits_metadata(self):
+        """Even a broad CIDR allowlist cannot re-permit the metadata endpoint."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_cidrs="169.254.0.0/16")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("169.254.169.254")):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("http://sneaky.corp/x", profile=url_guard.PROXY_PROFILE)
+
+    def test_skill_allowlist_does_not_leak_into_proxy_profile(self):
+        with patch.object(url_guard, "settings", _settings(github_extra_hosts="github.corp")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.5")):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://github.corp/x", profile=url_guard.PROXY_PROFILE)
+
+
+# ---------------------------------------------------------------------------
+# Pinned transport (DNS-rebinding defeat)
+# ---------------------------------------------------------------------------
+
+
+class TestPinnedTransport:
+    def test_pin_rewrites_host_to_validated_ip(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+                transport = url_guard.GuardedAsyncTransport(guard_profile=url_guard.SKILL_PROFILE)
+                request = httpx.Request("GET", "https://acme.com/path")
+                pinned = transport._pin_request(request)
+
+        # Connection target rewritten to the validated public IP.
+        assert pinned.url.host == "93.184.216.34"
+        # Host header and SNI preserve the original hostname (so TLS + vhost work).
+        assert pinned.headers["Host"] == "acme.com"
+        assert pinned.extensions["sni_hostname"] == "acme.com"
+
+    def test_pin_blocks_private_resolution(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.5")):
+                transport = url_guard.GuardedAsyncTransport(guard_profile=url_guard.SKILL_PROFILE)
+                request = httpx.Request("GET", "https://acme.com/path")
+                with pytest.raises(UrlValidationError):
+                    transport._pin_request(request)
+
+    def test_pin_blocks_metadata_literal_ip(self):
+        with patch.object(url_guard, "settings", _settings()):
+            transport = url_guard.GuardedAsyncTransport(guard_profile=url_guard.PROXY_PROFILE)
+            request = httpx.Request("GET", "http://169.254.169.254/latest/meta-data/")
+            with pytest.raises(UrlValidationError):
+                transport._pin_request(request)
+
+    def test_pin_rebinding_between_check_and_connect_is_defeated(self):
+        """A host that validated once but rebinds to a private IP is still blocked.
+
+        The transport resolves+validates at connect time, so a rebind after an
+        earlier validate_url() call cannot slip a private IP through.
+        """
+        with patch.object(url_guard, "settings", _settings()):
+            # First: passes an out-of-band pre-check (public IP).
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+                url_guard.validate_url("https://rebind.example/x")
+
+            # Then: the host rebinds to a private IP. The transport re-resolves
+            # inside _pin_request and blocks it.
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.5")):
+                transport = url_guard.GuardedAsyncTransport(guard_profile=url_guard.SKILL_PROFILE)
+                request = httpx.Request("GET", "https://rebind.example/x")
+                with pytest.raises(UrlValidationError):
+                    transport._pin_request(request)
+
+    def test_sync_transport_pins_too(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+                transport = url_guard.GuardedTransport(guard_profile=url_guard.SKILL_PROFILE)
+                request = httpx.Request("GET", "https://acme.com/path")
+                pinned = transport._pin_request(request)
+        assert pinned.url.host == "93.184.216.34"
+        assert pinned.headers["Host"] == "acme.com"


### PR DESCRIPTION
# Harden outbound URL handling against SSRF and nginx config injection

## Summary

Adds a single, fail-closed URL guard for every user- and registry-controlled
URL the registry stores or fetches server-side, and wires it into all outbound
fetch sinks and all registration write paths. Also escapes backend URLs before
they are interpolated into nginx configuration as defense-in-depth.

## What changed

### New shared guard — `registry/utils/url_guard.py`
- `validate_url()` rejects non-`http(s)` schemes, missing hosts, and any host
  that resolves to a private / loopback / link-local / reserved / multicast /
  unspecified address or the cloud metadata endpoint (`169.254.169.254`).
  IPv4-mapped IPv6 addresses are unwrapped so a private target cannot be smuggled
  through an IPv6 literal. It fails closed on any resolution error or ambiguity.
- `guarded_client()` / `guarded_async_client()` return httpx clients whose custom
  transport resolves, validates, and **pins the connection to a validated IP**
  inside the transport call — for the initial request and every redirect hop.
  This defeats DNS-rebinding: there is no window between the check and the
  connect, and no bypassable pre-check. The original hostname is preserved for
  the `Host` header and TLS SNI.
- Two profiles: skill fetches (bypass allowlist from `GITHUB_EXTRA_HOSTS`, for
  GitHub Enterprise Server on internal networks) and server/agent targets (bypass
  allowlist from the new `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS`). Public
  code-forge domains (github.com, gitlab.com, ...) are no longer blindly trusted
  — they are IP-validated like any other host. The cloud metadata endpoint can
  never be allowlisted.

### Registration-time validation (all write paths)
Server `proxy_pass_url`, the server registration `path`, and agent `url` are
validated at the service chokepoints (`server_service.register_server` /
`add_server_version` / `update_server` and `agent_service.register_agent` /
`update_agent`), so dashboard/API registration, internal registration, the CLI
(which registers over HTTP), and federation import are all covered by one check.
Registration validation is structural (scheme, nginx metacharacters, literal
private/metadata IPs) and does not perform a live DNS lookup — the authoritative,
rebinding-safe block for hostname targets happens at fetch time via the pinned
client. A global exception handler maps a rejected URL to HTTP 400.

### Fetch sinks wired to the guard
- Skill parsing / validation / health / integrity / authenticated content and
  resource discovery fetches (`services/skill_service.py`).
- Skill scanner download (`services/skill_scanner.py`) and the security scanner,
  which validates the target before spawning the scanner subprocess
  (`services/security_scanner.py`).
- Agent health check and remote agent-card pull (`api/agent_routes.py`). A remote
  card that tries to repoint the stored agent URL at an internal address is
  rejected in both preview and apply modes.
- The agent reachability probe (`utils/agent_validator.py`), previously a raw
  fetch, now uses the guarded client.
- Server health checks (`health/service.py`), where the URL is validated
  **before** any credential is decrypted or header built — so stored credentials
  are never sent to, or even assembled for, a target that fails validation.
- MCP tool-discovery paths (`core/mcp_client.py`). These use the MCP SDK's own
  HTTP client, so the target is validated immediately before connecting and
  before any credential header is built, ensuring decrypted backend credentials
  are never sent to a target that fails validation.

### Nginx config-injection defense-in-depth
`core/nginx_service.py` now escapes `proxy_pass_url`, the derived upstream Host
header, and server/virtual-server paths via the existing
`_sanitize_for_nginx_set()` at every interpolation site (the `set $backend_url`
directives, the version-routing `map` entries, the virtual-server backend block,
the `proxy_set_header Host` directive, and the commented-out unhealthy-server
block), so a value that somehow reaches config generation cannot break out of the
quoted directive context.

### Validate generated nginx config before it persists (cold-start protection)
Previously the regenerated config was written to the live path first and only
then tested with `nginx -t`; a malformed config was skipped for the live reload
but still persisted on disk, so the next nginx **cold start** (a routine
container restart) would fail to load it and take the whole gateway down. Both
config write paths (`generate_config_async` and the debounced
`NginxReloadScheduler`) now back up the current config, promote the candidate,
run `nginx -t`, and — if the test fails — **restore the last-known-good config**
(or remove the file when there was no prior config) and surface an error. A
config that cannot pass `nginx -t` never survives on disk. When the nginx binary
is absent, single-container / local-dev deployments promote as before (there is
no nginx to cold-start), while split deployments where nginx runs in a separate
container can set the new `NGINX_CONFIG_VALIDATION_REQUIRED=true` to fail closed
rather than promote an unvalidated config into the shared volume.

### Pin the ARD catalog crawler to the validated IP
The ARD `ai-catalog.json` ingestion crawler validated a URL's resolved IP and
then fetched it with a separate client that re-resolved DNS, leaving a
rebinding / TOCTOU window. It now fetches through the shared guarded client
(public-only profile, redirects disabled), so the connection is pinned to an IP
validated inside the same transport call and re-validated on every hop. The
scheme/same-domain pre-check is unchanged; a host that rebinds to a private or
metadata address between the pre-check and the connect is now blocked at connect
time, and a redirect response (3xx) is refused rather than parsed. One poisoned
nested catalog entry can no longer crash the whole crawl.

## Why it is safe / fails closed
- Any validation error, DNS failure, or ambiguity results in rejection, never a
  permissive fallback.
- The connection is pinned to an IP validated in the same transport call, so a
  hostname cannot rebind to a private address between check and connect, and
  redirects are re-validated per hop.
- Health checks return "unhealthy" and skip credential handling entirely for a
  blocked URL.
- Operators who legitimately proxy to internal MCP servers must explicitly
  opt those targets in via `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS`; the
  default denies private targets.

## Configuration
Two new optional settings (default empty = deny private targets):
- `SSRF_ALLOWED_HOSTS` — comma-separated hostnames/IPs that may resolve private.
- `SSRF_ALLOWED_CIDRS` — comma-separated CIDRs that may be treated as reachable.
The cloud metadata address is never permitted by either.

One new optional setting for nginx config validation:
- `NGINX_CONFIG_VALIDATION_REQUIRED` (default `false`) — when `true`, refuse to
  promote a generated nginx config that cannot be validated with `nginx -t`
  because the binary is absent from the registry process. Set this in split
  topologies where nginx runs in a separate container/sidecar sharing the config
  volume, so an unvalidated config cannot poison the sidecar's next cold start.

## Testing
- New `tests/unit/utils/test_url_guard.py`: scheme rejection, private/metadata/
  IPv4-mapped-IPv6 blocking, nginx-metacharacter and server-path rejection,
  allowlist bypass scoping per profile, and the pinned transport (host rewritten
  to a validated IP, Host/SNI preserved, rebinding between an earlier check and
  the connect is still blocked).
- Registration rejection tests in `test_server_service.py` and
  `test_agent_service.py` (metadata/RFC-1918/loopback/bad-scheme/nginx-injection).
- `test_health_service.py`: asserts the credential builder and the HTTP client
  are never invoked for a blocked `proxy_pass_url`.
- `test_skill_scanner_service.py`: scanner download rejects unsafe URLs before
  any HTTP call.
- New MCP-client tests: the SDK connection paths refuse private/metadata targets
  before credentials are built.
- New agent-reachability tests: a blocked URL is reported unreachable rather than
  fetched, and a public host is probed via the guarded client.
- nginx tests assert backend-URL escaping in generated location blocks, and a
  new suite asserts that a config rejected by `nginx -t` does not overwrite the
  last-known-good file (both the direct write path and the debounced scheduler),
  that a valid config is promoted, that no prior config leaves nothing on disk on
  rejection, and that a missing binary fails closed only when
  `NGINX_CONFIG_VALIDATION_REQUIRED` is set.
- New ARD-crawler tests: the crawler uses the pinned guarded transport, a rebind
  between validation and connect is defeated, a 3xx response is refused, and an
  error on one nested URL skips that node instead of crashing the crawl.
- Updated the skill SSRF-allowlist suite to reflect that public forge domains are
  IP-validated and only configured enterprise hosts bypass.
- Full unit suite passes; `ruff` and `bandit` clean on the changed files.

## Known limitation
The MCP SDK owns its own HTTP client and cannot use the pinned transport, so its
connections re-resolve DNS after validation. The target is validated immediately
before connecting (closing the registration-to-fetch gap) and no credentials are
built unless validation passes, but a sub-millisecond fast-flux rebind between
that validation and the SDK's own lookup is not fully eliminated for MCP targets.
Operators pin such internal targets via `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
