### PR TITLE
fix(egress): treat client auth headers as ingress-only, strip on egress (#1266)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,6 @@ pingfederate/setup/pingfederate-ca-bundle.pem
 
 # Local Docker Compose override (machine-specific paths, e.g. macOS log-dir redirect)
 docker-compose.override.yml
+
+# Local MCP connect command with bearer token (never commit)
+.mcp

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -4748,19 +4748,48 @@ async def _read_bounded(
     return b"".join(chunks)
 
 
+# Client-sent auth headers are INGRESS credentials (issue #1266): they
+# authenticate the caller to the GATEWAY and are stripped on the egress hop --
+# they are never forwarded to an upstream MCP server. Upstream credentials are
+# supplied exclusively by the egress vault (oauth_user / PAT / custom-header),
+# never relayed from the client. The single exception is the built-in,
+# same-trust-domain registry-tools server (see _INTERNAL_INGRESS_RELAY_SERVERS).
+
+# The ONLY servers whose backend receives the relayed ingress Authorization.
+# Hardcoded (not configurable) and internal by design: airegistry-tools is the
+# gateway's own bundled registry-tools MCP server (proxied to mcpgw), a
+# same-trust-domain component. Keyed on the verified, path-validated `server`
+# claim (first path segment). This is NOT a general relay feature -- external
+# servers that need an upstream credential use the egress vault.
+_INTERNAL_INGRESS_RELAY_SERVERS: frozenset[str] = frozenset({"airegistry-tools"})
+
+
 def _forward_headers(
     incoming: dict[str, str],
+    relay_authorization: bool = False,
 ) -> dict[str, str]:
-    """Copy incoming request headers, stripping hop-by-hop and proxy-hint
-    headers so httpx can set them correctly for the upstream connection.
+    """Copy incoming request headers to the upstream, stripping hop-by-hop and
+    proxy-hint headers so httpx can set them correctly for the connection.
+
+    Ingress-auth policy (issue #1266): X-Authorization and Cookie are ALWAYS
+    stripped (never forwarded to any upstream). Authorization is also stripped
+    UNLESS ``relay_authorization`` is True -- set only for the built-in internal
+    registry-tools server (_INTERNAL_INGRESS_RELAY_SERVERS). Every other server
+    gets no client auth header on egress; upstream creds come from the vault.
     """
     forwarded: dict[str, str] = {}
     for key, value in incoming.items():
         lower = key.lower()
         if lower in _HOP_BY_HOP_HEADERS:
             continue
-        if lower in ("x-upstream-url",):
+        if lower == "x-upstream-url":
             # Never leak this internal routing header to the upstream.
+            continue
+        if lower in ("x-authorization", "cookie"):
+            # Ingress-only credentials; never forwarded to any upstream.
+            continue
+        if lower == "authorization" and not relay_authorization:
+            # Ingress token; forwarded only for the internal relay server.
             continue
         forwarded[key] = value
     return forwarded
@@ -5140,7 +5169,18 @@ async def mcp_proxy(
     filter_enabled = _read_mcp_filter_enabled()
     max_body_bytes = _read_mcp_proxy_max_body_bytes()
     proxy_timeout = _read_mcp_proxy_timeout()
-    forward_headers = _forward_headers(dict(request.headers))
+
+    # Ingress-auth policy (issue #1266): client auth headers authenticate the
+    # caller to the gateway and are stripped on egress. The ONLY exception is
+    # the built-in internal registry-tools server, which receives the relayed
+    # Authorization (it is a same-trust-domain component). The decision keys on
+    # the verified, path-validated `server` claim, never a forgeable header.
+    registered_server = (claims.get("server") or "").lower()
+    relay_ingress_auth = registered_server in _INTERNAL_INGRESS_RELAY_SERVERS
+    forward_headers = _forward_headers(
+        dict(request.headers),
+        relay_authorization=relay_ingress_auth,
+    )
 
     # True once we inject a vaulted egress token below. An egress upstream is
     # itself an OAuth resource server: if it rejects our injected token it 401s

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -652,6 +652,15 @@ When AI coding assistants connect to a server through the gateway:
 3. Gateway retrieves and decrypts server credential
 4. Gateway proxies the request with the server's auth header
 
+> **Ingress vs egress (issue #1266).** The client's `X-Authorization` (or
+> `Authorization`) is an **ingress** credential: it authenticates the caller to
+> the gateway and is **stripped on egress** — never forwarded to the upstream
+> MCP server. Upstream credentials are supplied by the gateway itself (stored
+> server credential, or the per-user egress vault), not by relaying the client's
+> gateway token. Custom headers the server expects (e.g. `CONTEXT7_API_KEY`) are
+> not affected. The sole exception is the built-in internal `airegistry-tools`
+> server, which receives the relayed `Authorization`.
+
 **Example MCP client configuration:**
 
 ```json

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -213,6 +213,19 @@ What this shows:
 - **mcpgw calls the registry API as itself** (M2M) in the standard deployment, so the user's token is not chained through a second time; `REGISTRY_API_TOKEN` overrides that if an operator sets it. The caller-bearer fallback only applies when neither is configured.
 - **`X-Authorization` and `Cookie` are stripped even on this relay path** — only `Authorization` is relayed, and only for this one hardcoded internal server.
 
+### Operational note: SSRF guard and internal MCP hosts
+
+The registry's outbound SSRF guard (`registry/utils/url_guard.py`, `PROXY_PROFILE`) fails closed on any `proxy_pass_url` that resolves to a **private/internal IP** — which every in-cluster MCP server does (Docker Compose service names, ECS Service Connect aliases, Kubernetes service names all resolve to private addresses). Without an allowlist entry the server's **health check** returns `UNHEALTHY_URL_BLOCKED`, even though the server itself is fine.
+
+`mcpgw-server` (the backend for the built-in `airegistry-tools`) is trusted by default via a small hardcoded set (`_BUILTIN_PROXY_ALLOWED_HOSTS` in `url_guard.py`), so the bundled registry-tools server stays healthy with no configuration.
+
+**If you add more internal, same-cluster MCP servers** (another first-party server reached over a private hostname, e.g. an additional `*-server` service on ECS/EKS/Compose), you must opt each one into the SSRF guard or it will show Unhealthy. Do this with the operator allowlist settings (these are UNIONED with the built-in set, never replace it):
+
+- `SSRF_ALLOWED_HOSTS` — comma-separated internal hostnames, e.g. `SSRF_ALLOWED_HOSTS=my-other-server,another-mcp-server`.
+- `SSRF_ALLOWED_CIDRS` — comma-separated private CIDR ranges when you prefer to trust a whole internal subnet, e.g. `SSRF_ALLOWED_CIDRS=10.0.0.0/8`. Useful on ECS/EKS where the task/pod subnet is stable.
+
+Wire the chosen value on the **registry** container across your deployment surface (`.env` / `docker-compose*.yml`, the registry Helm values, or the Terraform/ECS registry env block). Public-internet MCP upstreams (e.g. `https://mcp.slack.com`) need no allowlisting — they resolve to public IPs and pass the guard. The cloud metadata endpoint (`169.254.169.254`) is never allowlistable, regardless of these settings.
+
 ---
 
 ## The egress modes

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -1,36 +1,25 @@
 # Egress Authentication Design (Per-User Credentials to Third-Party MCP Servers)
 
-How the MCP Gateway lets a user reach an authentication-protected ("auth-based")
-third-party MCP server — GitHub, Slack, Atlassian, etc. — **as themselves**,
-without the coding assistant ever handling the third-party token.
+How the MCP Gateway lets a user reach an authentication-protected ("auth-based") third-party MCP server — GitHub, Slack, Atlassian, etc. — **as themselves**, without the coding assistant ever handling the third-party token.
 
-- Status of the three modes: **`vault-oauth` (3LO) is implemented today**;
-  **`token-exchange` (OBO)** and **`vault-pat` (PAT)** are designed but not yet
-  built (placeholders below).
-- Authoritative implementation references: `registry/egress_auth/`,
-  `registry/secrets/`, `registry/api/egress_auth_routes.py`,
-  `auth_server/server.py` (`mcp_proxy`, `_vend_egress_token`).
+- Status of the modes: **`none` (no egress auth) and `vault-oauth` (3LO) are implemented today**; **`token-exchange` (OBO)**, **`vault-pat` (PAT)**, and a **custom-header** egress mode are designed but not yet built (placeholders below).
+- Authoritative implementation references: `registry/egress_auth/`, `registry/secrets/`, `registry/api/egress_auth_routes.py`, `auth_server/server.py` (`mcp_proxy`, `_vend_egress_token`, `_forward_headers`).
+
+---
+
+## First principle: client auth headers are INGRESS-only (issue #1266)
+
+Everything below rests on one rule. Every auth header a client sends (`Authorization`, `X-Authorization`, `Cookie`) is an **ingress** credential: it authenticates the caller **to the gateway** and is **stripped on the egress hop** — it is never forwarded to an upstream MCP server. A coding assistant only ever holds its gateway ingress token; it never holds an upstream credential.
+
+The upstream credential (when the server needs one) is supplied **by the gateway**, from the egress vault — never by relaying a client header. This is what makes "no third-party token on the laptop" true by construction.
+
+**The one exception** is the gateway's own built-in, same-trust-domain registry-tools server (`airegistry-tools`, proxied to the bundled mcpgw). A hardcoded, non-configurable constant (`_INTERNAL_INGRESS_RELAY_SERVERS` in `auth_server/server.py`) relays the ingress `Authorization` to it (never `X-Authorization`/`Cookie`). This is internal plumbing, not a user-facing relay feature — a server registrant cannot enable it.
 
 ---
 
 ## The core idea (in one paragraph)
 
-The user's OAuth to the third party happens **out of band** from the
-coding-assistant ↔ gateway interaction. The gateway UI provides an easy way to
-start the OAuth flow with the third-party ("auth-based") MCP server. The thing
-that **links the gateway to the third-party MCP server is the redirect URL** you
-configure when creating the OAuth app on the third-party side
-(`https://<gateway>/oauth2/egress/callback`). When the user completes the OAuth
-flow, the third party sends the authorization code to the gateway **because that
-callback URL is registered in the OAuth app** — the gateway exchanges it for a
-token and stores that token in a secrets vault, keyed by a **4-tuple**
-`(auth_method, user_id, provider, server_path)`. Later, when the user (through
-their coding assistant) calls that MCP server, the assistant only presents its
-**ingress token** (obtained via DCR today; CIMD in the future). The gateway
-validates the ingress token, looks up the vault for a token matching this user +
-this server (the 4-tuple), and if present **injects it as the `Authorization`
-header** on the outbound request to the third-party MCP server. Everything just
-works, and **the third-party token is never stored on the user's laptop.**
+The user's OAuth to the third party happens **out of band** from the coding-assistant ↔ gateway interaction. The gateway UI provides an easy way to start the OAuth flow with the third-party ("auth-based") MCP server. The thing that **links the gateway to the third-party MCP server is the redirect URL** you configure when creating the OAuth app on the third-party side (`https://<gateway>/oauth2/egress/callback`). When the user completes the OAuth flow, the third party sends the authorization code to the gateway **because that callback URL is registered in the OAuth app** — the gateway exchanges it for a token and stores that token in a secrets vault, keyed by a **4-tuple** `(auth_method, user_id, provider, server_path)`. Later, when the user (through their coding assistant) calls that MCP server, the assistant only presents its **ingress token** (obtained via DCR today; CIMD in the future). The gateway validates the ingress token, looks up the vault for a token matching this user + this server (the 4-tuple), and if present **injects it as the `Authorization` header** on the outbound request to the third-party MCP server. Everything just works, and **the third-party token is never stored on the user's laptop.**
 
 ---
 
@@ -71,23 +60,15 @@ flowchart TB
 
 Key properties visible in the diagram:
 
-- The **redirect URL** (`/oauth2/egress/callback`) is the only link between the
-  gateway and the provider IdP — it is what causes the code (and thus the token)
-  to land at the gateway rather than the laptop.
-- The **coding assistant only ever holds the ingress token** (its credential to
-  the gateway). It never sees the third-party token.
-- The **vault is the single source of truth** for third-party tokens, addressed
-  by the 4-tuple.
+- The **redirect URL** (`/oauth2/egress/callback`) is the only link between the gateway and the provider IdP — it is what causes the code (and thus the token) to land at the gateway rather than the laptop.
+- The **coding assistant only ever holds the ingress token** (its credential to the gateway). It never sees the third-party token.
+- The **vault is the single source of truth** for third-party tokens, addressed by the 4-tuple.
 
 ---
 
 ## The vault key: a 4-tuple
 
-Every stored third-party token is addressed by
-`(auth_method, user_id, provider, server_path)`
-(`registry/egress_auth/schemas.py`, `registry/secrets/openbao/store.py`). In the
-OpenBao KV v2 backend the path is (each segment base64url-encoded so it is
-path-safe):
+Every stored third-party token is addressed by `(auth_method, user_id, provider, server_path)` (`registry/egress_auth/schemas.py`, `registry/secrets/openbao/store.py`). In the OpenBao KV v2 backend the path is (each segment base64url-encoded so it is path-safe):
 
 ```
 {mount}/data/{prefix}/{enc(auth_method)}/{enc(user_id)}/{enc(provider)}/{enc(server_path)}
@@ -100,14 +81,9 @@ path-safe):
 | `provider` | The egress OAuth provider | `github` / `slack` / `atlassian` / `custom` |
 | `server_path` | The registered MCP server path | `/slack` |
 
-The stored payload (`StoredToken`) holds `access_token`, optional
-`refresh_token`, `expires_at`, `status`, and timestamps — the vault read returns
-everything needed to decide vend-vs-refresh. **There is no companion app-DB row;
-the vault is the only place token state lives.**
+The stored payload (`StoredToken`) holds `access_token`, optional `refresh_token`, `expires_at`, `status`, and timestamps — the vault read returns everything needed to decide vend-vs-refresh. **There is no companion app-DB row; the vault is the only place token state lives.**
 
-Because the key includes `user_id`, one user can never vend another user's
-token — the identity comes from the **verified** signed internal-hop claims, not
-a forgeable header.
+Because the key includes `user_id`, one user can never vend another user's token — the identity comes from the **verified** signed internal-hop claims, not a forgeable header.
 
 ---
 
@@ -136,9 +112,7 @@ sequenceDiagram
     REG-->>User: "Connected" — token vaulted, laptop holds nothing
 ```
 
-The consent `state` is AEAD-encrypted and session-bound (anti-phishing): the
-callback verifies the opener is the same user who started the flow, so a stolen
-consent URL opened by someone else cannot bind a token to the wrong account.
+The consent `state` is AEAD-encrypted and session-bound (anti-phishing): the callback verifies the opener is the same user who started the flow, so a stolen consent URL opened by someone else cannot bind a token to the wrong account.
 
 ---
 
@@ -174,95 +148,62 @@ sequenceDiagram
 
 What each hop guarantees:
 
-- **`/validate`** binds the verified `subject` (user identity) into a signed
-  `X-Internal-Token`. `mcp_proxy` reads identity from these verified claims, not
-  from forgeable inbound headers (internal-hop hardening, #1260/#1262).
-- **`/internal/egress-token`** (registry) is guarded by internal auth, re-checks
-  the server is `egress_auth_mode == oauth_user`, and returns the access token
-  only (never the refresh token). Lazy refresh + cross-replica single-flight
-  happen here.
-- **Injection** happens last in `mcp_proxy`: the user's own gateway
-  credentials/identity headers are stripped and replaced with
-  `Authorization: Bearer <vaulted third-party token>`. The token never transits
-  the coding assistant.
+- **`/validate`** binds the verified `subject` (user identity) into a signed `X-Internal-Token`. `mcp_proxy` reads identity from these verified claims, not from forgeable inbound headers (internal-hop hardening, #1260/#1262).
+- **`/internal/egress-token`** (registry) is guarded by internal auth, re-checks the server is `egress_auth_mode == oauth_user`, and returns the access token only (never the refresh token). Lazy refresh + cross-replica single-flight happen here.
+- **Injection** happens last in `mcp_proxy`: the user's own gateway credentials/identity headers are stripped and replaced with `Authorization: Bearer <vaulted third-party token>`. The token never transits the coding assistant.
 
 ---
 
 ## Why this is simple and safe
 
-- **Out-of-band OAuth.** The consent dance is entirely separate from the
-  assistant ↔ gateway traffic; the assistant is never part of the third-party
-  OAuth. It only does its own ingress auth (DCR today, CIMD in future).
-- **The redirect URL is the link.** Registering
-  `https://<gateway>/oauth2/egress/callback` in the provider's OAuth app is what
-  routes the token to the gateway instead of the laptop. No token ever lands on
-  the user's machine.
-- **The 4-tuple keeps it per-user and per-server.** A vault lookup that includes
-  the verified user identity means users can only ever use their own tokens, and
-  only for the servers they connected.
-- **The vault is the single source of truth.** Tokens live only in OpenBao / AWS
-  Secrets Manager; there is no copy in the app DB and none on the client.
+- **Out-of-band OAuth.** The consent dance is entirely separate from the assistant ↔ gateway traffic; the assistant is never part of the third-party OAuth. It only does its own ingress auth (DCR today, CIMD in future).
+- **The redirect URL is the link.** Registering `https://<gateway>/oauth2/egress/callback` in the provider's OAuth app is what routes the token to the gateway instead of the laptop. No token ever lands on the user's machine.
+- **The 4-tuple keeps it per-user and per-server.** A vault lookup that includes the verified user identity means users can only ever use their own tokens, and only for the servers they connected.
+- **The vault is the single source of truth.** Tokens live only in OpenBao / AWS Secrets Manager; there is no copy in the app DB and none on the client.
 
 ### Why this matters for enterprise security & governance
 
-The gateway **owns the authentication to every third-party MCP server**, which
-turns a sprawl of per-laptop credentials and outbound connections into a single,
-governable choke point:
+The gateway **owns the authentication to every third-party MCP server**, which turns a sprawl of per-laptop credentials and outbound connections into a single, governable choke point:
 
-- **No third-party tokens on user machines.** The token exists only in the
-  vault and is injected server-side. A lost/compromised laptop leaks no
-  third-party credentials; offboarding a user is a vault delete, not a hunt
-  across devices.
-- **Clients need connectivity only to the gateway, not to each MCP server.**
-  All egress to GitHub/Slack/Atlassian/etc. originates from the gateway. In an
-  enterprise you can put the gateway in a controlled network zone with the only
-  sanctioned outbound path, instead of allowing every developer machine to reach
-  every SaaS endpoint directly.
-- **One place to enforce and observe.** Access control (which user may reach
-  which server), credential rotation/revocation, per-call audit logging, and
-  network egress policy are all applied at the gateway — centrally — rather than
-  replicated and hoped-for on each client.
+- **No third-party tokens on user machines.** The token exists only in the vault and is injected server-side. A lost/compromised laptop leaks no third-party credentials; offboarding a user is a vault delete, not a hunt across devices.
+- **Clients need connectivity only to the gateway, not to each MCP server.** All egress to GitHub/Slack/Atlassian/etc. originates from the gateway. In an enterprise you can put the gateway in a controlled network zone with the only sanctioned outbound path, instead of allowing every developer machine to reach every SaaS endpoint directly.
+- **One place to enforce and observe.** Access control (which user may reach which server), credential rotation/revocation, per-call audit logging, and network egress policy are all applied at the gateway — centrally — rather than replicated and hoped-for on each client.
 
 ---
 
-## The three egress modes
+## The egress modes
 
-`egress_auth_mode` on the server entry selects how the gateway obtains the
-outbound credential. Today only the vault-OAuth (3LO) path is implemented; the
-other two are designed and reserved.
+`egress_auth_mode` on the server entry selects how the gateway obtains the outbound credential. Today the **no-auth** and **vault-OAuth (3LO)** paths are implemented; the others are designed and reserved.
 
 | Mode | Vault used? | How the egress credential is obtained | Status |
 |------|-------------|----------------------------------------|--------|
+| **`none` (no egress auth)** | No | The server needs no upstream credential. All client auth headers are stripped on egress; nothing is injected. The default for every server. | **Implemented** (`egress_auth_mode = "none"`) |
 | **`vault-oauth` (3LO)** | Yes | User completes provider OAuth (3LO) out of band; the gateway vaults the per-user token and injects it. This document's main flow. | **Implemented** (`egress_auth_mode = "oauth_user"`) |
 | **`token-exchange` (OBO)** | No | For same-trust-domain backends, the gateway exchanges the user's ingress token for a backend-audience token (RFC 8693 / Entra jwt-bearer). `sub` preserved; nothing stored. | **Placeholder — not implemented** |
 | **`vault-pat` (PAT)** | Yes | A per-user static Personal Access Token / API key is stored in the vault and injected. No OAuth dance. | **Placeholder — not implemented** |
+| **custom-header** | Yes | A per-user credential the operator specifies by header **name + value**, stored in the vault and injected verbatim on egress. For backends with a bespoke/out-of-band auth scheme. Generalizes `vault-pat`. | **Placeholder — not implemented (planned with PAT, #1268)** |
+
+> **Internal relay (not a configurable mode).** The built-in `airegistry-tools` server receives the relayed ingress `Authorization` via a hardcoded constant (see "First principle" above). It is not an `egress_auth_mode` value and is not selectable per server — external servers that need an upstream credential use the vault modes above.
+
+### `none` (no egress auth) — implemented
+
+The default. The server needs no upstream credential (or it is a public endpoint). On egress the client's ingress auth headers are stripped (`_forward_headers`) and nothing is injected. Most registered servers are `none`.
 
 ### `vault-oauth` (3LO) — implemented
 
-The flow described throughout this document. `egress_auth_mode = "oauth_user"`
-on the server, `egress_oauth` holds the provider config (client_id, encrypted
-client_secret, scopes). See
-[Per-User Egress Credential Vault](../egress-credential-vault.md) and the FAQ
-[Registering third-party MCP servers](../faq/registering-third-party-mcp-servers.md).
+The flow described throughout this document. `egress_auth_mode = "oauth_user"` on the server, `egress_oauth` holds the provider config (client_id, encrypted client_secret, scopes). See [Per-User Egress Credential Vault](../egress-credential-vault.md) and the FAQ [Registering third-party MCP servers](../faq/registering-third-party-mcp-servers.md).
 
 ### `token-exchange` (OBO) — placeholder
 
-> Not yet implemented. Design intent: when the gateway IdP and the backend share
-> a trust domain (e.g. M365 in the same Entra tenant), exchange the user's
-> verified ingress token for a token scoped to the backend's audience and inject
-> that. `sub` is carried cryptographically across the exchange; **no vault, no
-> refresh loop, nothing stored per user.** Fails closed (never relays the ingress
-> token, never falls back to app-only credentials). Its reach is limited to
-> same-trust-domain backends — public SaaS (GitHub/Slack) does not federate with
-> the gateway IdP, so those use `vault-oauth` instead.
+> Not yet implemented. Design intent: when the gateway IdP and the backend share a trust domain (e.g. M365 in the same Entra tenant), exchange the user's verified ingress token for a token scoped to the backend's audience and inject that. `sub` is carried cryptographically across the exchange; **no vault, no refresh loop, nothing stored per user.** Fails closed (never relays the ingress token, never falls back to app-only credentials). Its reach is limited to same-trust-domain backends — public SaaS (GitHub/Slack) does not federate with the gateway IdP, so those use `vault-oauth` instead.
 
 ### `vault-pat` (PAT) — placeholder
 
-> Not yet implemented. Design intent: for backends that only accept a static
-> Personal Access Token / API key, store a per-user PAT in the same vault
-> (keyed by the same 4-tuple) and inject it on egress, skipping the OAuth dance.
-> Admin seed-on-behalf is planned (an admin may seed a PAT for another user,
-> audit-logged). Same "token never on the laptop" property as 3LO.
+> Not yet implemented. Design intent: for backends that only accept a static Personal Access Token / API key, store a per-user PAT in the same vault (keyed by the same 4-tuple) and inject it on egress, skipping the OAuth dance. Admin seed-on-behalf is planned (an admin may seed a PAT for another user, audit-logged). Same "token never on the laptop" property as 3LO.
+
+### custom-header — placeholder (planned with PAT, #1268)
+
+> Not yet implemented. Design intent: the replacement for "I did the auth out of band and just want to send a token to this upstream." The operator specifies the header **name** and **value** in the registry UI/API; the value is stored in the same secrets vault (keyed by the 4-tuple) and injected verbatim under that header name on egress — like `vault-pat`, but for a backend whose scheme is a non-`Authorization` header or a bespoke format. This is the sanctioned way to reach a custom-auth upstream now that client-header relay is ingress-only; it is expected to land as part of the `vault-pat` (#1268) work, not as a relay feature.
 
 ---
 

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -171,6 +171,50 @@ The gateway **owns the authentication to every third-party MCP server**, which t
 
 ---
 
+## The internal relay: airegistry-tools -> registry API (sequence)
+
+The one exception to "client auth headers are stripped on egress" (issue #1266). `airegistry-tools` is the gateway's own bundled registry-tools MCP server (the `mcpgw` service). It is same-trust-domain, so a hardcoded constant (`_INTERNAL_INGRESS_RELAY_SERVERS = {"airegistry-tools"}` in `auth_server/server.py`) relays the ingress `Authorization` to it (never `X-Authorization`/`Cookie`). The mcpgw server then needs to call the **registry API** (list/search servers, agents, skills) — and it chooses which credential to present for that call, NOT the relayed one by default.
+
+Key point: the relayed ingress `Authorization` lets mcpgw's FastMCP front door admit the MCP call when it is configured to validate a bearer (`OIDC_ENABLED=true`). For its OUTBOUND registry API calls, mcpgw's `_get_registry_headers` picks a credential by priority — static `REGISTRY_API_TOKEN`, else its own M2M token, else (fallback) the caller's bearer. So in the common deployment mcpgw reaches the registry as **itself** (M2M), not by forwarding the user's token again.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CA as Coding assistant
+    participant NGINX as nginx
+    participant AS as auth-server<br/>(mcp_proxy)
+    participant MCPGW as mcpgw<br/>(airegistry-tools upstream)
+    participant REG as registry API
+
+    CA->>NGINX: tools/call on /airegistry-tools/mcp<br/>Authorization: Bearer <ingress token>
+    NGINX->>AS: auth_request /validate
+    AS-->>NGINX: 200 + signed X-Internal-Token (server claim = "airegistry-tools")
+    NGINX->>AS: proxy_pass /mcp-proxy/airegistry-tools/...
+
+    Note over AS: relay decision: claims["server"] == "airegistry-tools"<br/>-> in _INTERNAL_INGRESS_RELAY_SERVERS -> relay_authorization=True
+    Note over AS: _forward_headers: KEEP Authorization;<br/>STRIP X-Authorization + Cookie (always)
+
+    AS->>MCPGW: forward request, Authorization: Bearer <ingress token>
+    Note over MCPGW: FastMCP front door admits the call.<br/>If OIDC_ENABLED=true it validates this bearer<br/>(same Keycloak realm as the gateway).
+
+    MCPGW->>MCPGW: _get_registry_headers() picks the credential for the registry call:<br/>1. REGISTRY_API_TOKEN (static) if set<br/>2. else M2M token (client_credentials) -> X-Authorization<br/>3. else fallback: caller bearer -> X-Authorization
+    MCPGW->>NGINX: GET /api/... (registry API) with chosen credential
+    NGINX->>AS: auth_request /validate (validates that credential)
+    AS-->>NGINX: 200 + identity
+    NGINX->>REG: proxy_pass /api/...
+    REG-->>MCPGW: servers / agents / skills JSON
+    MCPGW-->>AS: MCP tool result
+    AS-->>CA: result
+```
+
+What this shows:
+
+- **The relayed `Authorization` is only for reaching mcpgw's front door** (the internal same-trust hop). It is NOT forwarded onward to any third party.
+- **mcpgw calls the registry API as itself** (M2M) in the standard deployment, so the user's token is not chained through a second time; `REGISTRY_API_TOKEN` overrides that if an operator sets it. The caller-bearer fallback only applies when neither is configured.
+- **`X-Authorization` and `Cookie` are stripped even on this relay path** — only `Authorization` is relayed, and only for this one hardcoded internal server.
+
+---
+
 ## The egress modes
 
 `egress_auth_mode` on the server entry selects how the gateway obtains the outbound credential. Today the **no-auth** and **vault-OAuth (3LO)** paths are implemented; the others are designed and reserved.

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -7,7 +7,7 @@ How the MCP Gateway lets a user reach an authentication-protected ("auth-based")
 
 ---
 
-## First principle: client auth headers are INGRESS-only (issue #1266)
+## First principle: client auth headers are INGRESS-only
 
 Everything below rests on one rule. Every auth header a client sends (`Authorization`, `X-Authorization`, `Cookie`) is an **ingress** credential: it authenticates the caller **to the gateway** and is **stripped on the egress hop** — it is never forwarded to an upstream MCP server. A coding assistant only ever holds its gateway ingress token; it never holds an upstream credential.
 
@@ -148,7 +148,7 @@ sequenceDiagram
 
 What each hop guarantees:
 
-- **`/validate`** binds the verified `subject` (user identity) into a signed `X-Internal-Token`. `mcp_proxy` reads identity from these verified claims, not from forgeable inbound headers (internal-hop hardening, #1260/#1262).
+- **`/validate`** binds the verified `subject` (user identity) into a signed `X-Internal-Token`. `mcp_proxy` reads identity from these verified claims, not from forgeable inbound headers (internal-hop hardening).
 - **`/internal/egress-token`** (registry) is guarded by internal auth, re-checks the server is `egress_auth_mode == oauth_user`, and returns the access token only (never the refresh token). Lazy refresh + cross-replica single-flight happen here.
 - **Injection** happens last in `mcp_proxy`: the user's own gateway credentials/identity headers are stripped and replaced with `Authorization: Bearer <vaulted third-party token>`. The token never transits the coding assistant.
 
@@ -173,7 +173,7 @@ The gateway **owns the authentication to every third-party MCP server**, which t
 
 ## The internal relay: airegistry-tools -> registry API (sequence)
 
-The one exception to "client auth headers are stripped on egress" (issue #1266). `airegistry-tools` is the gateway's own bundled registry-tools MCP server (the `mcpgw` service). It is same-trust-domain, so a hardcoded constant (`_INTERNAL_INGRESS_RELAY_SERVERS = {"airegistry-tools"}` in `auth_server/server.py`) relays the ingress `Authorization` to it (never `X-Authorization`/`Cookie`). The mcpgw server then needs to call the **registry API** (list/search servers, agents, skills) — and it chooses which credential to present for that call, NOT the relayed one by default.
+The one exception to "client auth headers are stripped on egress." `airegistry-tools` is the gateway's own bundled registry-tools MCP server (the `mcpgw` service). It is same-trust-domain, so a hardcoded constant (`_INTERNAL_INGRESS_RELAY_SERVERS = {"airegistry-tools"}` in `auth_server/server.py`) relays the ingress `Authorization` to it (never `X-Authorization`/`Cookie`). The mcpgw server then needs to call the **registry API** (list/search servers, agents, skills) — and it chooses which credential to present for that call, NOT the relayed one by default.
 
 Key point: the relayed ingress `Authorization` lets mcpgw's FastMCP front door admit the MCP call when it is configured to validate a bearer (`OIDC_ENABLED=true`). For its OUTBOUND registry API calls, mcpgw's `_get_registry_headers` picks a credential by priority — static `REGISTRY_API_TOKEN`, else its own M2M token, else (fallback) the caller's bearer. So in the common deployment mcpgw reaches the registry as **itself** (M2M), not by forwarding the user's token again.
 
@@ -225,7 +225,7 @@ What this shows:
 | **`vault-oauth` (3LO)** | Yes | User completes provider OAuth (3LO) out of band; the gateway vaults the per-user token and injects it. This document's main flow. | **Implemented** (`egress_auth_mode = "oauth_user"`) |
 | **`token-exchange` (OBO)** | No | For same-trust-domain backends, the gateway exchanges the user's ingress token for a backend-audience token (RFC 8693 / Entra jwt-bearer). `sub` preserved; nothing stored. | **Placeholder — not implemented** |
 | **`vault-pat` (PAT)** | Yes | A per-user static Personal Access Token / API key is stored in the vault and injected. No OAuth dance. | **Placeholder — not implemented** |
-| **custom-header** | Yes | A per-user credential the operator specifies by header **name + value**, stored in the vault and injected verbatim on egress. For backends with a bespoke/out-of-band auth scheme. Generalizes `vault-pat`. | **Placeholder — not implemented (planned with PAT, #1268)** |
+| **custom-header** | Yes | A per-user credential the operator specifies by header **name + value**, stored in the vault and injected verbatim on egress. For backends with a bespoke/out-of-band auth scheme. Generalizes `vault-pat`. | **Placeholder — not implemented (planned with PAT)** |
 
 > **Internal relay (not a configurable mode).** The built-in `airegistry-tools` server receives the relayed ingress `Authorization` via a hardcoded constant (see "First principle" above). It is not an `egress_auth_mode` value and is not selectable per server — external servers that need an upstream credential use the vault modes above.
 
@@ -245,9 +245,9 @@ The flow described throughout this document. `egress_auth_mode = "oauth_user"` o
 
 > Not yet implemented. Design intent: for backends that only accept a static Personal Access Token / API key, store a per-user PAT in the same vault (keyed by the same 4-tuple) and inject it on egress, skipping the OAuth dance. Admin seed-on-behalf is planned (an admin may seed a PAT for another user, audit-logged). Same "token never on the laptop" property as 3LO.
 
-### custom-header — placeholder (planned with PAT, #1268)
+### custom-header — placeholder (planned with PAT)
 
-> Not yet implemented. Design intent: the replacement for "I did the auth out of band and just want to send a token to this upstream." The operator specifies the header **name** and **value** in the registry UI/API; the value is stored in the same secrets vault (keyed by the 4-tuple) and injected verbatim under that header name on egress — like `vault-pat`, but for a backend whose scheme is a non-`Authorization` header or a bespoke format. This is the sanctioned way to reach a custom-auth upstream now that client-header relay is ingress-only; it is expected to land as part of the `vault-pat` (#1268) work, not as a relay feature.
+> Not yet implemented. Design intent: the replacement for "I did the auth out of band and just want to send a token to this upstream." The operator specifies the header **name** and **value** in the registry UI/API; the value is stored in the same secrets vault (keyed by the 4-tuple) and injected verbatim under that header name on egress — like `vault-pat`, but for a backend whose scheme is a non-`Authorization` header or a bespoke format. This is the sanctioned way to reach a custom-auth upstream now that client-header relay is ingress-only; it is expected to land as part of the `vault-pat` work, not as a relay feature.
 
 ---
 

--- a/docs/design/session-flow-jwt-bearer.md
+++ b/docs/design/session-flow-jwt-bearer.md
@@ -145,7 +145,7 @@ forwarding the upstream request to the registry.
 
 | Header | Purpose |
 |--------|---------|
-| `X-Authorization` (preferred) or `Authorization` | The bearer token. Custom `X-Authorization` is the canonical form to avoid clashing with downstream `Authorization` use. |
+| `X-Authorization` (preferred) or `Authorization` | The gateway ingress bearer token. `X-Authorization` is the canonical custom header; `Authorization` is accepted too. Both are **ingress-only** and stripped on the egress hop (issue #1266) — neither is forwarded to an upstream (except the internal `airegistry-tools` relay). |
 | `Cookie` | If a session cookie is present and no Authorization header is set, the cookie path is used (rare; mostly browser SSE). |
 | `X-User-Pool-Id` | Cognito-specific — required to validate Cognito tokens against the right user pool. |
 | `X-Client-Id` | Cognito-specific — used to set the audience constraint. |
@@ -377,11 +377,22 @@ code reads. Both are set for backward compatibility with older upstreams.
 The registry's `nginx_proxied_auth` reads `X-Username or X-User`.
 
 **Q: Why does `/validate` accept both `X-Authorization` and `Authorization`?**
-A: Because some downstream MCP servers also use `Authorization` for their
-own purposes (e.g. an MCP server that proxies to GitHub needs to forward the
-GitHub token). Using `X-Authorization` for the gateway-level token avoids
-the clash. The standard `Authorization` is accepted as a fallback for
-clients that can't set custom headers.
+A: Both are accepted as the gateway ingress token (`/validate` checks
+`X-Authorization` first, then `Authorization`). `X-Authorization` is the
+canonical custom header; `Authorization` is accepted for clients that cannot
+set custom headers.
+
+> **Ingress vs egress (issue #1266).** All client-sent auth headers
+> (`Authorization`, `X-Authorization`, `Cookie`) are **ingress** credentials:
+> they authenticate the caller to the gateway and are **stripped on the egress
+> hop** — they are never forwarded to an upstream MCP server. An upstream that
+> needs a credential gets it from the egress vault (per-user OAuth/3LO, PAT),
+> not by relaying a client header. The one exception is the gateway's built-in,
+> same-trust-domain registry-tools server (`airegistry-tools`), a hardcoded
+> internal constant that receives the relayed `Authorization` (never
+> `X-Authorization`/`Cookie`). So the historical "downstream server reuses
+> `Authorization`" pattern is no longer served by client-header relay for
+> external servers — use the vault.
 
 **Q: Can a client present both a cookie and a Bearer token?**
 A: Yes. The header path takes precedence — `nginx_proxied_auth` checks

--- a/registry/secrets/factory.py
+++ b/registry/secrets/factory.py
@@ -8,6 +8,7 @@ misconfigured deployment fails fast.
 """
 
 import logging
+import os
 
 from ..core.config import settings
 from .interfaces import SecretStoreBase
@@ -22,9 +23,22 @@ def _build_secrets_manager() -> SecretStoreBase:
 
     from .secrets_manager.store import SecretsManagerStore
 
-    region = settings.aws_secrets_region or None
+    # Prefer the explicit AWS_SECRETS_REGION, but fall back to the standard AWS
+    # region env vars (AWS_REGION / AWS_DEFAULT_REGION) that are always present on
+    # ECS/EKS and in the AWS SDK's own resolution. This means an operator does not
+    # have to set a dedicated AWS_SECRETS_REGION just to use the secrets-manager
+    # backend when the task already runs in a known region.
+    region = (
+        settings.aws_secrets_region
+        or os.getenv("AWS_REGION")
+        or os.getenv("AWS_DEFAULT_REGION")
+        or None
+    )
     if not region:
-        raise ValueError("SECRET_STORE_BACKEND=secrets-manager requires AWS_SECRETS_REGION.")
+        raise ValueError(
+            "SECRET_STORE_BACKEND=secrets-manager requires a region: set "
+            "AWS_SECRETS_REGION (or AWS_REGION / AWS_DEFAULT_REGION)."
+        )
     client = boto3.client("secretsmanager", region_name=region)
     return SecretsManagerStore(
         client=client,

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -59,6 +59,19 @@ _DEFAULT_TIMEOUT_SECONDS: float = 15.0
 # The cloud metadata endpoint can never be reached, regardless of allowlists.
 _CLOUD_METADATA_IPS: frozenset[str] = frozenset({"169.254.169.254", "fd00:ec2::254"})
 
+# The gateway's own bundled registry-tools MCP server (airegistry-tools ->
+# mcpgw-server), reached over private container/service DNS (Docker Compose
+# service name, ECS Service Connect alias, Kubernetes service name). This is a
+# first-party component of the gateway itself, not an operator-supplied target,
+# so the SSRF guard trusts it by default -- an operator upgrading to a build with
+# the SSRF guard should not have to hand-configure SSRF_ALLOWED_HOSTS just to
+# keep the built-in registry-tools server healthy. Operator-supplied
+# ssrf_allowed_hosts are UNIONED with this set, never replace it. The cloud
+# metadata endpoint is still never reachable. (The demo servers -- currenttime,
+# realserverfaketools -- are opt-in via enable_demo_servers and are NOT trusted
+# by default; operators who enable them add them to SSRF_ALLOWED_HOSTS.)
+_BUILTIN_PROXY_ALLOWED_HOSTS: frozenset[str] = frozenset({"mcpgw-server"})
+
 # Nginx metacharacters that must never appear in a proxy_pass_url. A valid URL
 # never legitimately contains these; their presence indicates an attempt to
 # break out of an nginx directive/string context (config injection).
@@ -142,11 +155,13 @@ def _proxy_allowlist() -> _Allowlist:
     """Return the server/agent target bypass allowlist.
 
     Reads ``settings.ssrf_allowed_hosts`` and ``settings.ssrf_allowed_cidrs`` so
-    operators can proxy to internal MCP servers. Cached because settings are
-    immutable per-process.
+    operators can proxy to internal MCP servers. The bundled first-party MCP
+    server hostnames (_BUILTIN_PROXY_ALLOWED_HOSTS) are always unioned in so an
+    upgrade to an SSRF-guarded build keeps them healthy with zero configuration.
+    Cached because settings are immutable per-process.
     """
     return _Allowlist(
-        hosts=_parse_hosts(settings.ssrf_allowed_hosts),
+        hosts=_BUILTIN_PROXY_ALLOWED_HOSTS | _parse_hosts(settings.ssrf_allowed_hosts),
         cidrs=_parse_cidrs(settings.ssrf_allowed_cidrs),
     )
 

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -1753,6 +1753,20 @@ module "ecs_service_registry" {
       ip_protocol                  = "tcp"
       referenced_security_group_id = module.ecs_service_mcpgw.security_group_id
     }
+    # Egress credential vault: the auth-server mcp_proxy calls the registry's
+    # internal egress-token vend endpoint (auth -> registry:8080 ->
+    # /_egress_internal/egress-token) to fetch a user's vaulted upstream token
+    # before proxying an MCP call. Without this the vend hop times out
+    # ("egress vend: registry unreachable"), no token is injected, and the
+    # upstream 3rd-party server 401s (surfacing in the client as
+    # "Protected resource ... does not match").
+    auth_internal = {
+      description                  = "HTTP from auth-server for the egress-token vend hop (non-root nginx)"
+      from_port                    = 8080
+      to_port                      = 8080
+      ip_protocol                  = "tcp"
+      referenced_security_group_id = module.ecs_service_auth.security_group_id
+    }
   }
   security_group_egress_rules = {
     all = {

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -3618,3 +3618,71 @@ class TestForwardHeadersIngressStrip:
         from auth_server.server import _INTERNAL_INGRESS_RELAY_SERVERS
 
         assert _INTERNAL_INGRESS_RELAY_SERVERS == frozenset({"airegistry-tools"})
+
+    def test_proxy_authorization_stripped(self):
+        """Proxy-Authorization (hop-by-hop and an auth header) never reaches upstream."""
+        out = self._forward({"Proxy-Authorization": "Bearer p"}, relay=True)
+        assert "proxy-authorization" not in {k.lower() for k in out}
+
+    def test_empty_headers_no_crash(self):
+        """Empty input yields empty output without error."""
+        assert self._forward({}) == {}
+
+    def test_relay_false_strips_all_three_auth_headers_together(self):
+        """The core leak-closure: a request carrying all three auth headers to a
+        non-internal server forwards none of them."""
+        out = self._forward(
+            {
+                "Authorization": "Bearer a",
+                "X-Authorization": "Bearer x",
+                "Cookie": "mcp_gateway_session=s",
+                "Accept": "application/json",
+            },
+            relay=False,
+        )
+        assert set(k.lower() for k in out) == {"accept"}
+
+    def test_bearer_value_not_needed_key_only(self):
+        """Stripping is by header name, independent of value shape."""
+        out = self._forward({"Authorization": "Basic Zm9vOmJhcg=="}, relay=False)
+        assert "authorization" not in {k.lower() for k in out}
+
+
+class TestInternalRelayDecision:
+    """The mcp_proxy relay decision keys on the verified `server` claim (first
+    path segment), matches the hardcoded internal set exactly, and normalizes
+    case. Mirrors the inline logic in mcp_proxy (issue #1266).
+    """
+
+    def _decides_relay(self, server_claim):
+        from auth_server.server import _INTERNAL_INGRESS_RELAY_SERVERS
+
+        # Mirror mcp_proxy: registered_server = (claims.get("server") or "").lower()
+        registered_server = (server_claim or "").lower()
+        return registered_server in _INTERNAL_INGRESS_RELAY_SERVERS
+
+    def test_exact_internal_server_relays(self):
+        assert self._decides_relay("airegistry-tools") is True
+
+    def test_case_insensitive_match(self):
+        assert self._decides_relay("AiRegistry-Tools") is True
+
+    def test_missing_claim_does_not_relay(self):
+        assert self._decides_relay("") is False
+        assert self._decides_relay(None) is False
+
+    def test_similar_but_not_exact_name_does_not_relay(self):
+        """No substring/prefix match: only the exact internal name relays."""
+        for name in (
+            "airegistry-tools-evil",
+            "evil-airegistry-tools",
+            "airegistry",
+            "airegistry_tools",
+            "ai-registry",
+        ):
+            assert self._decides_relay(name) is False, name
+
+    def test_federated_prefixed_name_does_not_relay(self):
+        """A federated copy (e.g. server claim 'ai-registry' from /ai-registry/...)
+        is a different first path segment and must NOT relay."""
+        assert self._decides_relay("ai-registry") is False

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -3540,3 +3540,81 @@ class TestSessionCookieSecureDefault:
         """Even secure-by-default must not emit Secure over plain HTTP."""
         assert self._resolve_cookie_secure({}, is_https=False) is False
         assert self._resolve_cookie_secure({"secure": True}, is_https=False) is False
+
+class TestForwardHeadersIngressStrip:
+    """Egress ingress-auth policy (issue #1266): client auth headers are ingress
+    credentials, stripped on egress. X-Authorization and Cookie are ALWAYS
+    stripped; Authorization is stripped unless relay_authorization=True (set only
+    for the built-in internal registry-tools server). No general relay mode --
+    upstream creds come from the egress vault.
+    """
+
+    def _forward(self, incoming, relay=False):
+        from auth_server.server import _forward_headers
+
+        return _forward_headers(incoming, relay_authorization=relay)
+
+    def test_strips_authorization_by_default(self):
+        """Non-relay (default): Authorization stripped."""
+        out = self._forward({"Authorization": "Bearer a", "Accept": "x"})
+        assert "authorization" not in {k.lower() for k in out}
+        assert out.get("Accept") == "x"
+
+    def test_strips_x_authorization_always_even_when_relaying(self):
+        """X-Authorization is never forwarded, even for the internal relay server."""
+        out = self._forward({"X-Authorization": "Bearer x"}, relay=True)
+        assert "x-authorization" not in {k.lower() for k in out}
+
+    def test_strips_cookie_always_even_when_relaying(self):
+        """Cookie is never forwarded, even for the internal relay server."""
+        out = self._forward({"Cookie": "mcp_gateway_session=abc"}, relay=True)
+        assert "cookie" not in {k.lower() for k in out}
+
+    def test_relays_authorization_only_when_flag_set(self):
+        """relay_authorization=True keeps Authorization (internal relay server)."""
+        out = self._forward({"Authorization": "Bearer a"}, relay=True)
+        assert out.get("Authorization") == "Bearer a"
+
+    def test_relay_flag_does_not_readmit_x_authorization_or_cookie(self):
+        """With relay on, only Authorization is relayed; X-Authorization/Cookie stay stripped."""
+        out = self._forward(
+            {"Authorization": "Bearer a", "X-Authorization": "Bearer x", "Cookie": "s=1"},
+            relay=True,
+        )
+        assert out.get("Authorization") == "Bearer a"
+        assert "x-authorization" not in {k.lower() for k in out}
+        assert "cookie" not in {k.lower() for k in out}
+
+    def test_case_insensitive(self):
+        """Lowercase header keys are handled identically."""
+        out = self._forward(
+            {"authorization": "Bearer a", "x-authorization": "Bearer x", "cookie": "s=1"},
+            relay=False,
+        )
+        assert "authorization" not in {k.lower() for k in out}
+        assert "x-authorization" not in {k.lower() for k in out}
+        assert "cookie" not in {k.lower() for k in out}
+
+    def test_still_strips_hop_by_hop_and_x_upstream_url(self):
+        """Regression: existing exclusions (hop-by-hop, X-Upstream-Url) still apply."""
+        out = self._forward(
+            {"X-Upstream-Url": "http://x", "Connection": "keep-alive", "Accept": "y"},
+        )
+        assert "x-upstream-url" not in {k.lower() for k in out}
+        assert "connection" not in {k.lower() for k in out}
+        assert out.get("Accept") == "y"
+
+    def test_preserves_non_auth_headers(self):
+        """Regression: non-auth headers pass through untouched."""
+        out = self._forward(
+            {"Content-Type": "application/json", "Mcp-Session-Id": "vs-abc", "Accept": "z"},
+        )
+        assert out.get("Content-Type") == "application/json"
+        assert out.get("Mcp-Session-Id") == "vs-abc"
+        assert out.get("Accept") == "z"
+
+    def test_internal_relay_server_set_is_airegistry_tools(self):
+        """The internal relay allowlist is the single hardcoded registry-tools server."""
+        from auth_server.server import _INTERNAL_INGRESS_RELAY_SERVERS
+
+        assert _INTERNAL_INGRESS_RELAY_SERVERS == frozenset({"airegistry-tools"})

--- a/tests/unit/secrets/test_factory.py
+++ b/tests/unit/secrets/test_factory.py
@@ -51,10 +51,39 @@ class TestSecretStoreFactory:
         assert factory.get_secret_store() is not first
 
     def test_secrets_manager_requires_region(self, monkeypatch):
+        """With no explicit region AND no AWS_REGION/AWS_DEFAULT_REGION env, fail."""
         monkeypatch.setattr(factory.settings, "secret_store_backend", "secrets-manager")
         monkeypatch.setattr(factory.settings, "aws_secrets_region", "")
-        with pytest.raises(ValueError, match="AWS_SECRETS_REGION"):
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        with pytest.raises(ValueError, match="requires a region"):
             factory.get_secret_store()
+
+    def test_secrets_manager_falls_back_to_aws_region_env(self, monkeypatch):
+        """When AWS_SECRETS_REGION is unset, AWS_REGION is used (no error)."""
+        monkeypatch.setattr(factory.settings, "secret_store_backend", "secrets-manager")
+        monkeypatch.setattr(factory.settings, "aws_secrets_region", "")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
+        store = factory.get_secret_store()
+        assert isinstance(store, SecretStoreBase)
+
+    def test_secrets_manager_falls_back_to_aws_default_region_env(self, monkeypatch):
+        """AWS_DEFAULT_REGION is also honored when AWS_REGION is absent."""
+        monkeypatch.setattr(factory.settings, "secret_store_backend", "secrets-manager")
+        monkeypatch.setattr(factory.settings, "aws_secrets_region", "")
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+        store = factory.get_secret_store()
+        assert isinstance(store, SecretStoreBase)
+
+    def test_secrets_manager_explicit_region_takes_precedence(self, monkeypatch):
+        """An explicit AWS_SECRETS_REGION wins over the env fallback."""
+        monkeypatch.setattr(factory.settings, "secret_store_backend", "secrets-manager")
+        monkeypatch.setattr(factory.settings, "aws_secrets_region", "ap-south-1")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        store = factory.get_secret_store()
+        assert isinstance(store, SecretStoreBase)
 
     def test_openbao_requires_addr(self, monkeypatch):
         monkeypatch.setattr(factory.settings, "secret_store_backend", "openbao")

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -251,6 +251,59 @@ class TestAllowlists:
                     == []
                 )
 
+    def test_proxy_profile_builtin_mcpgw_bypasses_with_no_config(self):
+        """The bundled registry-tools server (mcpgw-server) is trusted with ZERO
+        operator config, so upgrading to an SSRF-guarded build keeps
+        airegistry-tools healthy (mcpgw-server resolves to a private container IP)."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="")):
+
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for built-in host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                assert (
+                    url_guard.validate_url(
+                        "http://mcpgw-server:8003/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+
+    def test_proxy_profile_demo_servers_not_trusted_by_default(self):
+        """Demo servers (currenttime, realserverfaketools) are opt-in and are NOT
+        in the built-in trust set: they resolve normally and a private IP is
+        blocked unless the operator allowlists them."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.7")):
+                for host in ("currenttime-server", "realserverfaketools-server"):
+                    with pytest.raises(UrlValidationError):
+                        url_guard.validate_url(
+                            f"http://{host}:8000/mcp", profile=url_guard.PROXY_PROFILE
+                        )
+
+    def test_proxy_profile_builtin_hosts_survive_operator_allowlist(self):
+        """Operator-supplied ssrf_allowed_hosts is UNIONED with the built-ins, not
+        a replacement: setting a custom host must not drop the bundled servers."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="internal.corp")):
+
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for allowlisted host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                # operator host works
+                assert (
+                    url_guard.validate_url(
+                        "http://internal.corp/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+                # built-in host STILL works alongside it
+                assert (
+                    url_guard.validate_url(
+                        "http://mcpgw-server:8003/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+
     def test_proxy_profile_cidr_allowlist_permits_private(self):
         with patch.object(url_guard, "settings", _settings(ssrf_allowed_cidrs="10.0.0.0/8")):
             with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.1.2.3")):


### PR DESCRIPTION
## Summary

Closes the ingress-token leak on the egress hop (#1266). Client-sent auth headers (`Authorization`, `X-Authorization`, `Cookie`) are **ingress** credentials: they authenticate the caller to the gateway and are now **stripped on the auth-server egress hop** — never forwarded to an upstream MCP server. Previously a third-party backend could receive the gateway's own Keycloak/ingress JWT (e.g. GitHub returned `400 invalid_token`, and the gateway identity token leaked to an external party).

Upstream credentials come exclusively from the egress vault (per-user OAuth/3LO today; PAT and a custom-header mode planned in #1268). There is **no configurable relay mode** — the single exception is the gateway's own built-in, same-trust-domain registry-tools server (`airegistry-tools`), handled by a hardcoded, non-configurable constant. This keeps the change tiny and unabusable: a server registrant cannot enable relay.

## Design (after discussion)

An earlier iteration proposed a configurable, triple-gated relay mode with two new env vars, an `egress_auth_mode` enum value, frontend toggle, and full Docker/ECS/Helm wiring. That was **rejected** in favor of this much simpler model:

- All client auth headers are ingress-only, stripped on egress. Always. No config.
- Upstream creds come only from the vault.
- One hardcoded internal constant (`_INTERNAL_INGRESS_RELAY_SERVERS = {"airegistry-tools"}`) relays `Authorization` (never `X-Authorization`/`Cookie`) to the bundled registry-tools server, keyed on the verified, path-validated `server` claim.

Rationale: the egress vault already exists to make upstream creds gateway-managed and off-the-client; relaying a client token end-to-end is the pattern the vault replaces. This collapsed the diff from ~24 files to code + tests + docs, with **no new config parameters** on any surface.

## Changes

- `auth_server/server.py`: `_forward_headers` strips `X-Authorization`/`Cookie` always and `Authorization` unless `relay_authorization=True`; `mcp_proxy` sets that flag from the verified `server` claim against the hardcoded internal set. The `oauth_user` vault-inject path is unchanged.
- `tests/auth_server/unit/test_server.py`: `TestForwardHeadersIngressStrip` + `TestInternalRelayDecision` (18 cases) — strip behavior, hard-exclusion of X-Authorization/Cookie even when relaying, and exact-match-only relay decision (similar/federated names do NOT relay).
- Docs: `docs/design/egress-auth-design.md` (full mode model incl. `none`/3LO implemented, OBO/PAT/custom-header placeholders + the ingress-first principle), plus ingress/egress clarifications in `docs/auth.md` and `docs/design/session-flow-jwt-bearer.md`.
- `.gitignore`: add `.mcp` (local connect command holds a bearer token).

## Verification

- Unit: 18 new egress tests pass; auth-server suite + egress routes **287 passed** on the rebased tree.
- Live E2E through the real proxy chain: registered a throwaway `none`-mode server pointing at a header-echo upstream and sent `Authorization` + `X-Authorization` + `Cookie` + `Proxy-Authorization` — the upstream received **none** of them. `airegistry-tools` correctly still receives the relayed `Authorization` (X-Authorization/Cookie stripped).
- ruff clean. No new config parameters (verified: `registry/core/config.py`, compose, tfvars, Helm untouched).

## Follow-up

- Custom-header egress mode (operator-specified header name+value, vaulted and injected) will land with the PAT work in #1268.