### PR TITLE
fix(ssrf): trust bundled first-party MCP hosts by default in the proxy SSRF guard

### DIFF
--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -59,6 +59,19 @@ _DEFAULT_TIMEOUT_SECONDS: float = 15.0
 # The cloud metadata endpoint can never be reached, regardless of allowlists.
 _CLOUD_METADATA_IPS: frozenset[str] = frozenset({"169.254.169.254", "fd00:ec2::254"})
 
+# The gateway's own bundled registry-tools MCP server (airegistry-tools ->
+# mcpgw-server), reached over private container/service DNS (Docker Compose
+# service name, ECS Service Connect alias, Kubernetes service name). This is a
+# first-party component of the gateway itself, not an operator-supplied target,
+# so the SSRF guard trusts it by default -- an operator upgrading to a build with
+# the SSRF guard should not have to hand-configure SSRF_ALLOWED_HOSTS just to
+# keep the built-in registry-tools server healthy. Operator-supplied
+# ssrf_allowed_hosts are UNIONED with this set, never replace it. The cloud
+# metadata endpoint is still never reachable. (The demo servers -- currenttime,
+# realserverfaketools -- are opt-in via enable_demo_servers and are NOT trusted
+# by default; operators who enable them add them to SSRF_ALLOWED_HOSTS.)
+_BUILTIN_PROXY_ALLOWED_HOSTS: frozenset[str] = frozenset({"mcpgw-server"})
+
 # Nginx metacharacters that must never appear in a proxy_pass_url. A valid URL
 # never legitimately contains these; their presence indicates an attempt to
 # break out of an nginx directive/string context (config injection).
@@ -142,11 +155,13 @@ def _proxy_allowlist() -> _Allowlist:
     """Return the server/agent target bypass allowlist.
 
     Reads ``settings.ssrf_allowed_hosts`` and ``settings.ssrf_allowed_cidrs`` so
-    operators can proxy to internal MCP servers. Cached because settings are
-    immutable per-process.
+    operators can proxy to internal MCP servers. The bundled first-party MCP
+    server hostnames (_BUILTIN_PROXY_ALLOWED_HOSTS) are always unioned in so an
+    upgrade to an SSRF-guarded build keeps them healthy with zero configuration.
+    Cached because settings are immutable per-process.
     """
     return _Allowlist(
-        hosts=_parse_hosts(settings.ssrf_allowed_hosts),
+        hosts=_BUILTIN_PROXY_ALLOWED_HOSTS | _parse_hosts(settings.ssrf_allowed_hosts),
         cidrs=_parse_cidrs(settings.ssrf_allowed_cidrs),
     )
 

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -251,6 +251,59 @@ class TestAllowlists:
                     == []
                 )
 
+    def test_proxy_profile_builtin_mcpgw_bypasses_with_no_config(self):
+        """The bundled registry-tools server (mcpgw-server) is trusted with ZERO
+        operator config, so upgrading to an SSRF-guarded build keeps
+        airegistry-tools healthy (mcpgw-server resolves to a private container IP)."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="")):
+
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for built-in host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                assert (
+                    url_guard.validate_url(
+                        "http://mcpgw-server:8003/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+
+    def test_proxy_profile_demo_servers_not_trusted_by_default(self):
+        """Demo servers (currenttime, realserverfaketools) are opt-in and are NOT
+        in the built-in trust set: they resolve normally and a private IP is
+        blocked unless the operator allowlists them."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="")):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.0.0.7")):
+                for host in ("currenttime-server", "realserverfaketools-server"):
+                    with pytest.raises(UrlValidationError):
+                        url_guard.validate_url(
+                            f"http://{host}:8000/mcp", profile=url_guard.PROXY_PROFILE
+                        )
+
+    def test_proxy_profile_builtin_hosts_survive_operator_allowlist(self):
+        """Operator-supplied ssrf_allowed_hosts is UNIONED with the built-ins, not
+        a replacement: setting a custom host must not drop the bundled servers."""
+        with patch.object(url_guard, "settings", _settings(ssrf_allowed_hosts="internal.corp")):
+
+            def _boom(*a, **k):
+                raise AssertionError("resolution should be skipped for allowlisted host")
+
+            with patch.object(url_guard.socket, "getaddrinfo", _boom):
+                # operator host works
+                assert (
+                    url_guard.validate_url(
+                        "http://internal.corp/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+                # built-in host STILL works alongside it
+                assert (
+                    url_guard.validate_url(
+                        "http://mcpgw-server:8003/mcp", profile=url_guard.PROXY_PROFILE
+                    )
+                    == []
+                )
+
     def test_proxy_profile_cidr_allowlist_permits_private(self):
         with patch.object(url_guard, "settings", _settings(ssrf_allowed_cidrs="10.0.0.0/8")):
             with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("10.1.2.3")):


### PR DESCRIPTION
## Problem

The proxy SSRF guard added in #1363 fails closed on private/internal targets. That is correct for operator-supplied `proxy_pass_url`s, but it also blocked the gateway's **own bundled registry-tools server** — `airegistry-tools`, proxied to `mcpgw-server:8003` — because it is reached over private container/service DNS (Docker Compose service name, ECS Service Connect, K8s service).

On any deployment upgrading to an SSRF-guarded build, `airegistry-tools` immediately goes **`UNHEALTHY_URL_BLOCKED`** unless the operator manually sets `SSRF_ALLOWED_HOSTS`. Observed live on ECS: `Health check failed for /airegistry-tools/ (http://mcpgw-server:8003/): HealthStatus.UNHEALTHY_URL_BLOCKED`.

## Fix

Union a single built-in first-party hostname into the proxy allowlist so it is trusted with **zero configuration**:

```python
_BUILTIN_PROXY_ALLOWED_HOSTS = {"mcpgw-server"}
```

`mcpgw-server` backs the gateway's own `airegistry-tools` MCP server — a first-party component, not an operator-supplied target. Key properties:

- **Zero-config:** upgrading keeps `airegistry-tools` healthy without touching `SSRF_ALLOWED_HOSTS`.
- **Union, not replace:** operator-supplied `ssrf_allowed_hosts` are unioned with the built-in, so a custom allowlist never drops it.
- **Demo servers are NOT trusted by default:** `currenttime-server` / `realserverfaketools-server` are opt-in (`enable_demo_servers`); operators who enable them add them to `SSRF_ALLOWED_HOSTS`. Scoped deliberately tight.
- **Metadata still blocked:** `169.254.169.254` remains unreachable regardless of any allowlist.

## Tests

- `test_proxy_profile_builtin_mcpgw_bypasses_with_no_config` — mcpgw-server passes with empty operator config.
- `test_proxy_profile_demo_servers_not_trusted_by_default` — demo servers with a private IP are still blocked.
- `test_proxy_profile_builtin_hosts_survive_operator_allowlist` — union behavior.
- Full `tests/unit/utils/test_url_guard.py`: 57 passed. ruff clean.

Independent of the egress-auth work (#1266); this is a follow-up to #1363.