### PR TITLE
reuse uv.lock for precommit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
       # Run fast unit tests
       - id: pytest-fast
         name: Run fast tests
-        entry: uv run pytest -m "not slow" --tb=short
+        entry: uv run --frozen pytest -m "not slow" --tb=short
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Uses the uv.lock rather than regenerating it during pre-commit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
