### PR TITLE
(fix): checkov skip placement

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -142,7 +142,10 @@ jobs:
           soft_fail: true
           output_format: cli,sarif
           output_file_path: console,checkov-results.sarif
-          download_external_modules: true
+          # Do not scan vendored terraform-aws-modules/* internals - findings in
+          # upstream module code are not actionable here and only add alert noise.
+          # Our own use of those modules is still evaluated via their inputs.
+          download_external_modules: false
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/terraform/aws-ecs/.checkov.yaml
+++ b/terraform/aws-ecs/.checkov.yaml
@@ -1,0 +1,12 @@
+# Checkov configuration for the aws-ecs Terraform stack.
+#
+# Do not download and scan external (registry) modules. When enabled, Checkov
+# pulls terraform-aws-modules/* source into .external_modules/ and reports
+# findings inside that upstream code we do not own or edit. Those findings are
+# not actionable here and only add noise to our code-scanning alerts. Checkov
+# still evaluates how we configure those modules via their input arguments;
+# only the modules' internal resources are skipped.
+#
+# Note: skip-path does NOT suppress downloaded-module findings (it is applied
+# before module resolution), so disabling the download is the effective control.
+download-external-modules: false

--- a/terraform/aws-ecs/alb-logging.tf
+++ b/terraform/aws-ecs/alb-logging.tf
@@ -3,11 +3,11 @@
 #
 
 # S3 bucket for ALB access logs
-#checkov:skip=CKV_AWS_18:This is a logging destination bucket - enabling access logging would create recursion
-#checkov:skip=CKV_AWS_144:Cross-region replication not required for logging bucket
-#checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for logging bucket
-#checkov:skip=CKV2_AWS_62:Event notifications not required for logging bucket
 resource "aws_s3_bucket" "alb_logs" {
+  #checkov:skip=CKV_AWS_18:This is a logging destination bucket - enabling access logging would create recursion
+  #checkov:skip=CKV_AWS_144:Cross-region replication not required for logging bucket
+  #checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for logging bucket
+  #checkov:skip=CKV2_AWS_62:Event notifications not required for logging bucket
   bucket = "${var.name}-${var.aws_region}-${data.aws_caller_identity.current.account_id}-alb-logs"
 
   tags = merge(
@@ -66,6 +66,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
 
     expiration {
       days = 90
+    }
+  }
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
     }
   }
 }

--- a/terraform/aws-ecs/cloudfront-logging.tf
+++ b/terraform/aws-ecs/cloudfront-logging.tf
@@ -8,11 +8,11 @@
 #
 # S3 Bucket for CloudFront Logs
 #
-#checkov:skip=CKV_AWS_18:This is a logging destination bucket - enabling access logging would create recursion
-#checkov:skip=CKV_AWS_144:Cross-region replication not required for logging bucket
-#checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for logging bucket
-#checkov:skip=CKV2_AWS_62:Event notifications not required for logging bucket
 resource "aws_s3_bucket" "cloudfront_logs" {
+  #checkov:skip=CKV_AWS_18:This is a logging destination bucket - enabling access logging would create recursion
+  #checkov:skip=CKV_AWS_144:Cross-region replication not required for logging bucket
+  #checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for logging bucket
+  #checkov:skip=CKV2_AWS_62:Event notifications not required for logging bucket
   bucket = "ai-registry-${var.aws_region}-${data.aws_caller_identity.current.account_id}-cloudfront-logs"
 
   tags = merge(
@@ -63,6 +63,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
       days = 90
     }
   }
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
 }
 
 #
@@ -72,8 +81,8 @@ resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_logs" {
 # so we need BucketOwnerPreferred to ensure the bucket owner
 # gets full control of the objects written by CloudFront.
 #
-#checkov:skip=CKV2_AWS_65:Access point policy not applicable for CloudFront logging bucket
 resource "aws_s3_bucket_ownership_controls" "cloudfront_logs" {
+  #checkov:skip=CKV2_AWS_65:Access point policy not applicable for CloudFront logging bucket
   bucket = aws_s3_bucket.cloudfront_logs.id
 
   rule {

--- a/terraform/aws-ecs/cloudfront.tf
+++ b/terraform/aws-ecs/cloudfront.tf
@@ -24,10 +24,10 @@ data "aws_cloudfront_origin_request_policy" "all_viewer" {
 }
 
 # CloudFront distribution for MCP Gateway ALB
-#checkov:skip=CKV2_AWS_32:Response headers policy managed at application level
-#checkov:skip=CKV2_AWS_46:Origin failover not required for this distribution
-#checkov:skip=CKV2_AWS_47:WAF integration managed separately
 resource "aws_cloudfront_distribution" "mcp_gateway" {
+  #checkov:skip=CKV2_AWS_32:Response headers policy managed at application level
+  #checkov:skip=CKV2_AWS_46:Origin failover not required for this distribution
+  #checkov:skip=CKV2_AWS_47:WAF integration managed separately
   count = var.enable_cloudfront ? 1 : 0
 
   enabled             = true
@@ -115,10 +115,10 @@ resource "aws_cloudfront_distribution" "mcp_gateway" {
 }
 
 # CloudFront distribution for Keycloak ALB
-#checkov:skip=CKV2_AWS_32:Response headers policy managed at application level
-#checkov:skip=CKV2_AWS_46:Origin failover not required for this distribution
-#checkov:skip=CKV2_AWS_47:WAF integration managed separately
 resource "aws_cloudfront_distribution" "keycloak" {
+  #checkov:skip=CKV2_AWS_32:Response headers policy managed at application level
+  #checkov:skip=CKV2_AWS_46:Origin failover not required for this distribution
+  #checkov:skip=CKV2_AWS_47:WAF integration managed separately
   count = var.enable_cloudfront ? 1 : 0
 
   enabled     = true

--- a/terraform/aws-ecs/codebuild.tf
+++ b/terraform/aws-ecs/codebuild.tf
@@ -35,8 +35,8 @@ locals {
   ])
 }
 
-#checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
 resource "aws_ecr_repository" "services" {
+  #checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
   for_each = var.create_codebuild ? local.ecr_repositories : toset([])
 
   name                 = each.key
@@ -95,11 +95,11 @@ resource "aws_ecr_lifecycle_policy" "services" {
 # S3 BUCKET FOR CODEBUILD ARTIFACTS
 # =============================================================================
 
-#checkov:skip=CKV_AWS_18:This is a build artifacts bucket - access logging not required
-#checkov:skip=CKV_AWS_144:Cross-region replication not required for build artifacts
-#checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for build artifacts
-#checkov:skip=CKV2_AWS_62:Event notifications not required for build artifacts bucket
 resource "aws_s3_bucket" "codebuild" {
+  #checkov:skip=CKV_AWS_18:This is a build artifacts bucket - access logging not required
+  #checkov:skip=CKV_AWS_144:Cross-region replication not required for build artifacts
+  #checkov:skip=CKV_AWS_145:SSE-S3 encryption is sufficient for build artifacts
+  #checkov:skip=CKV2_AWS_62:Event notifications not required for build artifacts bucket
   count  = var.create_codebuild ? 1 : 0
   bucket = "mcp-gateway-terraform-${data.aws_caller_identity.current.account_id}"
 

--- a/terraform/aws-ecs/codebuild.tf
+++ b/terraform/aws-ecs/codebuild.tf
@@ -37,6 +37,7 @@ locals {
 
 resource "aws_ecr_repository" "services" {
   #checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
+  #checkov:skip=CKV_AWS_136:AES256 default encryption is sufficient for these container images
   for_each = var.create_codebuild ? local.ecr_repositories : toset([])
 
   name                 = each.key

--- a/terraform/aws-ecs/documentdb.tf
+++ b/terraform/aws-ecs/documentdb.tf
@@ -226,8 +226,8 @@ resource "aws_kms_alias" "documentdb" {
 # apply that re-plans this out destroys the secret IMMEDIATELY with no
 # recovery window. See PR release notes for the rollout warning.
 #
-#checkov:skip=CKV2_AWS_57:Secret rotation managed externally via dedicated rotation Lambda
 resource "aws_secretsmanager_secret" "documentdb_credentials" {
+  #checkov:skip=CKV2_AWS_57:Secret rotation managed externally via dedicated rotation Lambda
   count = local.is_aws_documentdb ? 1 : 0
 
   name                    = "${var.name}/documentdb/credentials"
@@ -416,8 +416,8 @@ resource "aws_docdb_cluster_instance" "registry_primary" {
 #
 # Update SSM Parameters with new cluster endpoints (gated on is_aws_documentdb)
 #
-#checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
 resource "aws_ssm_parameter" "documentdb_endpoint" {
+  #checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
   count = local.is_aws_documentdb ? 1 : 0
 
   name        = "/${var.name}/documentdb/endpoint"
@@ -434,8 +434,8 @@ resource "aws_ssm_parameter" "documentdb_endpoint" {
   )
 }
 
-#checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
 resource "aws_ssm_parameter" "documentdb_reader_endpoint" {
+  #checkov:skip=CKV2_AWS_34:SSM parameter stores non-sensitive endpoint hostname, SecureString not required
   count = local.is_aws_documentdb ? 1 : 0
 
   name        = "/${var.name}/documentdb/reader_endpoint"

--- a/terraform/aws-ecs/ecs.tf
+++ b/terraform/aws-ecs/ecs.tf
@@ -2,8 +2,8 @@ data "aws_region" "current" {}
 data "aws_partition" "current" {}
 
 # ECS Cluster using terraform-aws-modules/ecs/aws//modules/cluster
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_cluster" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/cluster"
   version = "~> 6.0"
 

--- a/terraform/aws-ecs/keycloak-alb.tf
+++ b/terraform/aws-ecs/keycloak-alb.tf
@@ -2,9 +2,9 @@
 # Keycloak Application Load Balancer
 #
 
-#checkov:skip=CKV_AWS_150:Deletion protection managed at deployment level
-#checkov:skip=CKV2_AWS_76:Target group is attached to ALB listener and ECS service
 resource "aws_lb" "keycloak" {
+  #checkov:skip=CKV_AWS_150:Deletion protection managed at deployment level
+  #checkov:skip=CKV2_AWS_76:Target group is attached to ALB listener and ECS service
   name               = "keycloak-alb"
   internal           = false
   load_balancer_type = "application"
@@ -44,8 +44,8 @@ resource "random_string" "alb_tg_suffix" {
 }
 
 # Target Group
-#checkov:skip=CKV_AWS_378:HTTP backend protocol is intentional - TLS terminates at ALB
 resource "aws_lb_target_group" "keycloak" {
+  #checkov:skip=CKV_AWS_378:HTTP backend protocol is intentional - TLS terminates at ALB
   name                 = "keycloak-tg-${random_string.alb_tg_suffix.result}"
   port                 = 8080
   protocol             = "HTTP"

--- a/terraform/aws-ecs/keycloak-database.tf
+++ b/terraform/aws-ecs/keycloak-database.tf
@@ -39,13 +39,13 @@ resource "aws_db_proxy_target" "keycloak" {
 }
 
 # Aurora MySQL Serverless v2 Cluster
-#checkov:skip=CKV_AWS_139:Deletion protection configured per environment
-#checkov:skip=CKV_AWS_162:IAM database authentication not used - Keycloak uses password auth
-#checkov:skip=CKV_AWS_324:CloudWatch log exports not enabled for Keycloak database - log volume is low and Keycloak application logs provide sufficient observability
-#checkov:skip=CKV_AWS_325:Preferred backup window is configured on this resource
-#checkov:skip=CKV_AWS_326:Serverless v2 scaling configuration is present on this resource
-#checkov:skip=CKV2_AWS_8:Backup retention period of 7 days is configured on this resource
 resource "aws_rds_cluster" "keycloak" {
+  #checkov:skip=CKV_AWS_139:Deletion protection configured per environment
+  #checkov:skip=CKV_AWS_162:IAM database authentication not used - Keycloak uses password auth
+  #checkov:skip=CKV_AWS_324:CloudWatch log exports not enabled for Keycloak database - log volume is low and Keycloak application logs provide sufficient observability
+  #checkov:skip=CKV_AWS_325:Preferred backup window is configured on this resource
+  #checkov:skip=CKV_AWS_326:Serverless v2 scaling configuration is present on this resource
+  #checkov:skip=CKV2_AWS_8:Backup retention period of 7 days is configured on this resource
   cluster_identifier = "keycloak"
   engine             = "aurora-mysql"
   engine_version     = "8.0.mysql_aurora.3.10.3"
@@ -81,9 +81,9 @@ resource "aws_rds_cluster" "keycloak" {
 }
 
 # Aurora Cluster Instance (Serverless v2)
-#checkov:skip=CKV_AWS_118:Enhanced monitoring configured per environment requirements
-#checkov:skip=CKV_AWS_353:Performance insights configured per environment requirements
 resource "aws_rds_cluster_instance" "keycloak" {
+  #checkov:skip=CKV_AWS_118:Enhanced monitoring configured per environment requirements
+  #checkov:skip=CKV_AWS_353:Performance insights configured per environment requirements
   cluster_identifier = aws_rds_cluster.keycloak.id
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.keycloak.engine
@@ -255,8 +255,8 @@ resource "aws_iam_role_policy" "rds_proxy_policy" {
 }
 
 # Secrets Manager Secret for Database Credentials
-#checkov:skip=CKV2_AWS_57:Secret rotation managed externally via dedicated rotation Lambda
 resource "aws_secretsmanager_secret" "keycloak_db_secret" {
+  #checkov:skip=CKV2_AWS_57:Secret rotation managed externally via dedicated rotation Lambda
   name                    = "keycloak/database"
   description             = "Keycloak database credentials"
   recovery_window_in_days = 0

--- a/terraform/aws-ecs/keycloak-ecr.tf
+++ b/terraform/aws-ecs/keycloak-ecr.tf
@@ -4,6 +4,7 @@
 
 resource "aws_ecr_repository" "keycloak" {
   #checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
+  #checkov:skip=CKV_AWS_136:AES256 default encryption is sufficient for these container images
   name                 = "keycloak"
   image_tag_mutability = "MUTABLE"
   force_delete         = true

--- a/terraform/aws-ecs/keycloak-ecr.tf
+++ b/terraform/aws-ecs/keycloak-ecr.tf
@@ -2,8 +2,8 @@
 # Keycloak ECR Repository
 #
 
-#checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
 resource "aws_ecr_repository" "keycloak" {
+  #checkov:skip=CKV_AWS_51:Mutable tags required for latest tag workflow in CI/CD pipeline
   name                 = "keycloak"
   image_tag_mutability = "MUTABLE"
   force_delete         = true

--- a/terraform/aws-ecs/keycloak-ecs.tf
+++ b/terraform/aws-ecs/keycloak-ecs.tf
@@ -131,6 +131,7 @@ resource "aws_ecs_cluster_capacity_providers" "keycloak" {
 # CloudWatch Log Group
 resource "aws_cloudwatch_log_group" "keycloak" {
   #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
+  #checkov:skip=CKV_AWS_338:Short retention is intentional for Keycloak container logs - cost-controlled
   name              = "/ecs/keycloak"
   retention_in_days = 7
 

--- a/terraform/aws-ecs/keycloak-ecs.tf
+++ b/terraform/aws-ecs/keycloak-ecs.tf
@@ -129,8 +129,8 @@ resource "aws_ecs_cluster_capacity_providers" "keycloak" {
 }
 
 # CloudWatch Log Group
-#checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
 resource "aws_cloudwatch_log_group" "keycloak" {
+  #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
   name              = "/ecs/keycloak"
   retention_in_days = 7
 
@@ -164,9 +164,9 @@ resource "aws_iam_role_policy_attachment" "keycloak_task_exec_role_policy" {
 }
 
 # Policy to read from SSM Parameter Store
-#checkov:skip=CKV_AWS_290:kms:Decrypt requires wildcard resource as KMS key ARN is determined at runtime by SSM
-#checkov:skip=CKV_AWS_355:kms:Decrypt requires wildcard resource as KMS key ARN is determined at runtime by SSM
 resource "aws_iam_role_policy" "keycloak_task_exec_ssm_policy" {
+  #checkov:skip=CKV_AWS_290:kms:Decrypt requires wildcard resource as KMS key ARN is determined at runtime by SSM
+  #checkov:skip=CKV_AWS_355:kms:Decrypt requires wildcard resource as KMS key ARN is determined at runtime by SSM
   name = "keycloak-task-exec-ssm-policy"
   role = aws_iam_role.keycloak_task_exec_role.id
 
@@ -249,10 +249,10 @@ resource "aws_iam_role" "keycloak_task_role" {
 }
 
 # Policy for SSM Session Manager
-#checkov:skip=CKV_AWS_290:SSM Session Manager actions require wildcard resource per AWS documentation
-#checkov:skip=CKV_AWS_355:SSM Session Manager actions require wildcard resource per AWS documentation
-#checkov:skip=CKV_AWS_336:ECS Exec requires ssmmessages permissions which cannot be scoped to specific resources
 resource "aws_iam_role_policy" "keycloak_task_ssm_policy" {
+  #checkov:skip=CKV_AWS_290:SSM Session Manager actions require wildcard resource per AWS documentation
+  #checkov:skip=CKV_AWS_355:SSM Session Manager actions require wildcard resource per AWS documentation
+  #checkov:skip=CKV_AWS_336:ECS Exec requires ssmmessages permissions which cannot be scoped to specific resources
   name = "keycloak-task-ssm-policy"
   role = aws_iam_role.keycloak_task_role.id
 

--- a/terraform/aws-ecs/keycloak-security-groups.tf
+++ b/terraform/aws-ecs/keycloak-security-groups.tf
@@ -87,8 +87,8 @@ resource "aws_security_group" "keycloak_lb" {
 }
 
 # Load Balancer Ingress from allowed CIDR blocks (HTTP)
-#checkov:skip=CKV_AWS_260:HTTP ingress is intentional - ALB redirects to HTTPS or CloudFront terminates TLS
 resource "aws_security_group_rule" "keycloak_lb_ingress_http" {
+  #checkov:skip=CKV_AWS_260:HTTP ingress is intentional - ALB redirects to HTTPS or CloudFront terminates TLS
   description       = "Ingress from allowed CIDR blocks to load balancer (HTTP)"
   type              = "ingress"
   from_port         = 80

--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -1,8 +1,8 @@
 # ECS Services for MCP Gateway Registry
 
 # ECS Service: Auth Server
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_auth" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
 
@@ -675,8 +675,8 @@ module "ecs_service_auth" {
 }
 
 # ECS Service: Registry (Main service with nginx, SSL, FAISS, models)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_registry" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
 
@@ -1803,8 +1803,8 @@ resource "aws_vpc_security_group_ingress_rule" "auth_to_mcpgw" {
 
 
 # ECS Service: CurrentTime MCP Server (demo, opt-in via enable_demo_servers)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_currenttime" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
   count   = var.enable_demo_servers ? 1 : 0
@@ -1930,8 +1930,8 @@ module "ecs_service_currenttime" {
 
 
 # ECS Service: MCPGW MCP Server
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_mcpgw" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
 
@@ -2186,8 +2186,8 @@ module "ecs_service_mcpgw" {
 
 
 # ECS Service: RealServerFakeTools MCP Server (demo, opt-in via enable_demo_servers)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_realserverfaketools" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
   count   = var.enable_demo_servers ? 1 : 0
@@ -2309,8 +2309,8 @@ module "ecs_service_realserverfaketools" {
 
 
 # ECS Service: Flight Booking A2A Agent (demo, opt-in via enable_demo_servers)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_flight_booking_agent" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
   count   = var.enable_demo_servers ? 1 : 0
@@ -2432,8 +2432,8 @@ module "ecs_service_flight_booking_agent" {
 
 
 # ECS Service: Travel Assistant A2A Agent (demo, opt-in via enable_demo_servers)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_travel_assistant_agent" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"
   count   = var.enable_demo_servers ? 1 : 0

--- a/terraform/aws-ecs/modules/mcp-gateway/monitoring.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/monitoring.tf
@@ -1,8 +1,8 @@
 # CloudWatch Monitoring and Alarms for MCP Gateway
 
 # SNS Topic for Alarm Notifications
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "sns_alarms" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/sns/aws"
   version = "~> 7.0"
 
@@ -155,4 +155,3 @@ resource "aws_cloudwatch_metric_alarm" "alb_response_time" {
     LoadBalancer = module.alb.arn_suffix
   }
 }
-

--- a/terraform/aws-ecs/modules/mcp-gateway/networking.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/networking.tf
@@ -18,8 +18,8 @@ data "aws_ec2_managed_prefix_list" "cloudfront" {
 # Separate security group for CloudFront prefix list ingress
 # This avoids hitting the 60 rules per security group limit since the CloudFront
 # prefix list has ~55 reserved entries that count against the quota
-#checkov:skip=CKV2_AWS_5:Security group is attached to ALB via security_groups parameter
 resource "aws_security_group" "alb_cloudfront" {
+  #checkov:skip=CKV2_AWS_5:Security group is attached to ALB via security_groups parameter
   count       = var.cloudfront_prefix_list_name != "" ? 1 : 0
   name        = "${local.name_prefix}-alb-cloudfront"
   description = "Security group for CloudFront access to MCP Gateway ALB"
@@ -44,8 +44,8 @@ resource "aws_security_group_rule" "alb_cloudfront_ingress_http" {
   security_group_id = aws_security_group.alb_cloudfront[0].id
 }
 
-# checkov:skip=CKV_AWS_382:ALB security group requires unrestricted egress to reach ECS tasks and health checks
 resource "aws_security_group_rule" "alb_cloudfront_egress" {
+  #checkov:skip=CKV_AWS_382:ALB security group requires unrestricted egress to reach ECS tasks and health checks
   count             = var.cloudfront_prefix_list_name != "" ? 1 : 0
   description       = "Egress to all"
   type              = "egress"
@@ -57,8 +57,8 @@ resource "aws_security_group_rule" "alb_cloudfront_egress" {
 }
 
 # Main Application Load Balancer (for registry, auth, gradio)
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "alb" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/alb/aws"
   version = "~> 9.0"
 

--- a/terraform/aws-ecs/modules/mcp-gateway/observability.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/observability.tf
@@ -126,8 +126,8 @@ locals {
 # METRICS-SERVICE ECS SERVICE
 # =============================================================================
 
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_metrics" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   # metrics-service is optional: the core services (registry/auth/mcpgw) emit OTel
   # straight to their own ADOT sidecars, so the standalone metrics-service is only
   # created when an image is explicitly provided. Avoids requiring a build for a
@@ -412,8 +412,8 @@ resource "aws_iam_policy" "grafana_amp_query" {
 }
 
 # ALB target group for Grafana
-#checkov:skip=CKV_AWS_378:HTTP backend protocol is intentional - TLS terminates at ALB
 resource "aws_lb_target_group" "grafana" {
+  #checkov:skip=CKV_AWS_378:HTTP backend protocol is intentional - TLS terminates at ALB
   count       = var.enable_observability ? 1 : 0
   name_prefix = "graf-"
   port        = 3000
@@ -477,8 +477,8 @@ resource "aws_lb_listener_rule" "grafana_https" {
   tags = local.common_tags
 }
 
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "ecs_service_grafana" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   count   = var.enable_observability ? 1 : 0
   source  = "terraform-aws-modules/ecs/aws//modules/service"
   version = "~> 6.0"

--- a/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/secrets.tf
@@ -87,8 +87,8 @@ resource "random_password" "secret_key" {
 
 # Core application secrets
 
-#checkov:skip=CKV2_AWS_57:Application-generated secret key - rotation requires coordinated service restart
 resource "aws_secretsmanager_secret" "secret_key" {
+  #checkov:skip=CKV2_AWS_57:Application-generated secret key - rotation requires coordinated service restart
   name_prefix             = "${local.name_prefix}-secret-key-"
   description             = "Secret key for MCP Gateway Registry"
   recovery_window_in_days = 0
@@ -113,8 +113,8 @@ resource "random_password" "nginx_marker_secret" {
   special = false
 }
 
-#checkov:skip=CKV2_AWS_57:Application-generated marker secret - rotation requires coordinated service restart
 resource "aws_secretsmanager_secret" "nginx_marker_secret" {
+  #checkov:skip=CKV2_AWS_57:Application-generated marker secret - rotation requires coordinated service restart
   name_prefix             = "${local.name_prefix}-nginx-marker-"
   description             = "nginx marker secret shared by auth-server and registry (guards mcp-proxy token minting)"
   recovery_window_in_days = 0
@@ -129,8 +129,8 @@ resource "aws_secretsmanager_secret_version" "nginx_marker_secret" {
 }
 
 # Keycloak client secrets (created with placeholder, updated by init-keycloak.sh)
-#checkov:skip=CKV2_AWS_57:Keycloak client secret managed by Keycloak init script, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "keycloak_client_secret" {
+  #checkov:skip=CKV2_AWS_57:Keycloak client secret managed by Keycloak init script, not rotatable via Secrets Manager
   name                    = "mcp-gateway-keycloak-client-secret"
   description             = "Keycloak web client secret (updated by init-keycloak.sh after deployment)"
   recovery_window_in_days = 0
@@ -149,8 +149,8 @@ resource "aws_secretsmanager_secret_version" "keycloak_client_secret" {
   }
 }
 
-#checkov:skip=CKV2_AWS_57:Keycloak M2M client secret managed by Keycloak init script, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "keycloak_m2m_client_secret" {
+  #checkov:skip=CKV2_AWS_57:Keycloak M2M client secret managed by Keycloak init script, not rotatable via Secrets Manager
   name                    = "mcp-gateway-keycloak-m2m-client-secret"
   description             = "Keycloak M2M client secret (updated by init-keycloak.sh after deployment)"
   recovery_window_in_days = 0
@@ -171,8 +171,8 @@ resource "aws_secretsmanager_secret_version" "keycloak_m2m_client_secret" {
 
 
 # Keycloak admin password secret (for Management API operations)
-#checkov:skip=CKV2_AWS_57:Keycloak admin password managed by Keycloak, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "keycloak_admin_password" {
+  #checkov:skip=CKV2_AWS_57:Keycloak admin password managed by Keycloak, not rotatable via Secrets Manager
   name_prefix             = "${local.name_prefix}-keycloak-admin-password-"
   description             = "Keycloak admin password for Management API user/group operations"
   recovery_window_in_days = 0
@@ -187,8 +187,8 @@ resource "aws_secretsmanager_secret_version" "keycloak_admin_password" {
 
 
 # Embeddings API key secret (optional - only needed for LiteLLM provider)
-#checkov:skip=CKV2_AWS_57:Third-party API key managed in external provider dashboard, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "embeddings_api_key" {
+  #checkov:skip=CKV2_AWS_57:Third-party API key managed in external provider dashboard, not rotatable via Secrets Manager
   name_prefix             = "${local.name_prefix}-embeddings-api-key-"
   description             = "API key for embeddings provider (OpenAI, Anthropic, etc.)"
   recovery_window_in_days = 0
@@ -207,8 +207,8 @@ resource "aws_secretsmanager_secret_version" "embeddings_api_key" {
 
 
 # Microsoft Entra ID client secret (for OAuth and IAM operations)
-#checkov:skip=CKV2_AWS_57:IdP client secret managed in Microsoft Entra ID portal, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "entra_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP client secret managed in Microsoft Entra ID portal, not rotatable via Secrets Manager
   count = var.entra_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-entra-client-secret-"
@@ -231,8 +231,8 @@ resource "aws_secretsmanager_secret_version" "entra_client_secret" {
 
 
 # Amazon Cognito App Client secret (for OAuth authentication)
-#checkov:skip=CKV2_AWS_57:IdP client secret managed in the Cognito App Client, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "cognito_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP client secret managed in the Cognito App Client, not rotatable via Secrets Manager
   count = var.cognito_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-cognito-client-secret-"
@@ -255,8 +255,8 @@ resource "aws_secretsmanager_secret_version" "cognito_client_secret" {
 
 
 # Okta client secret (for OAuth authentication)
-#checkov:skip=CKV2_AWS_57:IdP client secret managed in Okta admin console, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "okta_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP client secret managed in Okta admin console, not rotatable via Secrets Manager
   count = var.okta_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-okta-client-secret-"
@@ -279,8 +279,8 @@ resource "aws_secretsmanager_secret_version" "okta_client_secret" {
 
 
 # Okta M2M client secret (for service account operations)
-#checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in Okta admin console, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "okta_m2m_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in Okta admin console, not rotatable via Secrets Manager
   count = var.okta_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-okta-m2m-client-secret-"
@@ -303,8 +303,8 @@ resource "aws_secretsmanager_secret_version" "okta_m2m_client_secret" {
 
 
 # Okta API token (for management operations)
-#checkov:skip=CKV2_AWS_57:IdP API token managed in Okta admin console, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "okta_api_token" {
+  #checkov:skip=CKV2_AWS_57:IdP API token managed in Okta admin console, not rotatable via Secrets Manager
   count = var.okta_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-okta-api-token-"
@@ -331,9 +331,9 @@ resource "aws_secretsmanager_secret_version" "okta_api_token" {
 # =============================================================================
 
 # Auth0 client secret (for OAuth authentication)
-#checkov:skip=CKV_AWS_149:Rotation managed externally in Auth0 dashboard, not applicable for IdP client secrets
-#checkov:skip=CKV2_AWS_57:IdP client secret managed in Auth0 dashboard, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "auth0_client_secret" {
+  #checkov:skip=CKV_AWS_149:Rotation managed externally in Auth0 dashboard, not applicable for IdP client secrets
+  #checkov:skip=CKV2_AWS_57:IdP client secret managed in Auth0 dashboard, not rotatable via Secrets Manager
   count = var.auth0_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-auth0-client-secret-"
@@ -356,9 +356,9 @@ resource "aws_secretsmanager_secret_version" "auth0_client_secret" {
 
 
 # Auth0 M2M client secret (for IAM Management operations)
-#checkov:skip=CKV_AWS_149:Rotation managed externally in Auth0 dashboard, not applicable for IdP client secrets
-#checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in Auth0 dashboard, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "auth0_m2m_client_secret" {
+  #checkov:skip=CKV_AWS_149:Rotation managed externally in Auth0 dashboard, not applicable for IdP client secrets
+  #checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in Auth0 dashboard, not rotatable via Secrets Manager
   count = var.auth0_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-auth0-m2m-client-secret-"
@@ -385,8 +385,8 @@ resource "aws_secretsmanager_secret_version" "auth0_m2m_client_secret" {
 # =============================================================================
 
 # PingFederate client secret (for OAuth authentication)
-#checkov:skip=CKV2_AWS_57:IdP client secret managed in PingFederate admin console
 resource "aws_secretsmanager_secret" "pingfederate_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP client secret managed in PingFederate admin console
   count = var.pingfederate_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-pingfederate-client-secret-"
@@ -408,8 +408,8 @@ resource "aws_secretsmanager_secret_version" "pingfederate_client_secret" {
 }
 
 # PingFederate M2M client secret (for service account operations)
-#checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in PingFederate admin console
 resource "aws_secretsmanager_secret" "pingfederate_m2m_client_secret" {
+  #checkov:skip=CKV2_AWS_57:IdP M2M client secret managed in PingFederate admin console
   count = var.pingfederate_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-pingfederate-m2m-client-secret-"
@@ -431,8 +431,8 @@ resource "aws_secretsmanager_secret_version" "pingfederate_m2m_client_secret" {
 }
 
 # PingFederate Admin API password (used by registry to call PF admin API)
-#checkov:skip=CKV2_AWS_57:PingFederate admin password managed in PingFederate admin console
 resource "aws_secretsmanager_secret" "pf_admin_pass" {
+  #checkov:skip=CKV2_AWS_57:PingFederate admin password managed in PingFederate admin console
   count = var.pingfederate_enabled ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-pf-admin-pass-"
@@ -461,8 +461,8 @@ resource "random_password" "metrics_api_key" {
   special = false
 }
 
-#checkov:skip=CKV2_AWS_57:Application-generated API key - rotation requires coordinated service restart
 resource "aws_secretsmanager_secret" "metrics_api_key" {
+  #checkov:skip=CKV2_AWS_57:Application-generated API key - rotation requires coordinated service restart
   count = var.enable_observability ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-metrics-api-key-"
@@ -484,8 +484,8 @@ resource "aws_secretsmanager_secret_version" "metrics_api_key" {
 # Terraform state. Now stored in Secrets Manager and referenced via valueFrom so
 # it no longer appears in the rendered task definition. Sourced from the
 # operator-supplied var.grafana_admin_password.
-#checkov:skip=CKV2_AWS_57:Operator-supplied Grafana admin password - rotation requires coordinated service restart
 resource "aws_secretsmanager_secret" "grafana_admin_password" {
+  #checkov:skip=CKV2_AWS_57:Operator-supplied Grafana admin password - rotation requires coordinated service restart
   count = var.enable_observability ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-grafana-admin-"
@@ -505,8 +505,8 @@ resource "aws_secretsmanager_secret_version" "grafana_admin_password" {
 
 # OTLP exporter headers (e.g., dd-api-key=xxx for Datadog)
 # Only created when observability is enabled AND an OTLP endpoint is configured
-#checkov:skip=CKV2_AWS_57:Observability provider API key managed in external provider dashboard, not rotatable via Secrets Manager
 resource "aws_secretsmanager_secret" "otlp_exporter_headers" {
+  #checkov:skip=CKV2_AWS_57:Observability provider API key managed in external provider dashboard, not rotatable via Secrets Manager
   count = var.enable_observability && var.otel_otlp_endpoint != "" ? 1 : 0
 
   name_prefix             = "${local.name_prefix}-otlp-exporter-headers-"

--- a/terraform/aws-ecs/modules/mcp-gateway/storage.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/storage.tf
@@ -1,7 +1,7 @@
 # EFS storage resources for MCP Gateway Registry
 
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "efs" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/efs/aws"
   version = "~> 2.0"
 

--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -43,9 +43,9 @@ resource "aws_iam_role" "rotation_lambda" {
 # does not reference non-existent resources when DocumentDB is gated out.
 # Issue #955.
 #
-#checkov:skip=CKV_AWS_290:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
-#checkov:skip=CKV_AWS_355:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
 resource "aws_iam_role_policy" "rotation_lambda" {
+  #checkov:skip=CKV_AWS_290:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
+  #checkov:skip=CKV_AWS_355:GetRandomPassword and EC2 network interface actions require wildcard resource per AWS API design
   name = "${var.name}-secret-rotation-policy"
   role = aws_iam_role.rotation_lambda.id
 
@@ -257,8 +257,8 @@ resource "aws_vpc_security_group_egress_rule" "lambda_to_https" {
 #
 # CloudWatch Log Groups for Lambda Functions
 #
-#checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
 resource "aws_cloudwatch_log_group" "documentdb_rotation" {
+  #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
   count = local.is_aws_documentdb ? 1 : 0
 
   name              = "/aws/lambda/${var.name}-rotate-documentdb"
@@ -272,8 +272,8 @@ resource "aws_cloudwatch_log_group" "documentdb_rotation" {
   )
 }
 
-#checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
 resource "aws_cloudwatch_log_group" "rds_rotation" {
+  #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
   name              = "/aws/lambda/${var.name}-rotate-rds"
   retention_in_days = 30
 
@@ -310,11 +310,11 @@ data "archive_file" "rds_rotation" {
 #
 # Lambda Function - DocumentDB Rotation (gated on is_aws_documentdb)
 #
-#checkov:skip=CKV_AWS_115:Reserved concurrency not needed for secret rotation Lambda
-#checkov:skip=CKV_AWS_116:DLQ not needed for synchronous secret rotation Lambda
-#checkov:skip=CKV_AWS_173:Lambda environment variables use default encryption
-#checkov:skip=CKV_AWS_272:Code signing not configured for internal rotation Lambdas
 resource "aws_lambda_function" "documentdb_rotation" {
+  #checkov:skip=CKV_AWS_115:Reserved concurrency not needed for secret rotation Lambda
+  #checkov:skip=CKV_AWS_116:DLQ not needed for synchronous secret rotation Lambda
+  #checkov:skip=CKV_AWS_173:Lambda environment variables use default encryption
+  #checkov:skip=CKV_AWS_272:Code signing not configured for internal rotation Lambdas
   count = local.is_aws_documentdb ? 1 : 0
 
   filename         = data.archive_file.documentdb_rotation[0].output_path
@@ -359,11 +359,11 @@ resource "aws_lambda_function" "documentdb_rotation" {
 #
 # Lambda Function - RDS Rotation
 #
-#checkov:skip=CKV_AWS_115:Reserved concurrency not needed for secret rotation Lambda
-#checkov:skip=CKV_AWS_116:DLQ not needed for synchronous secret rotation Lambda
-#checkov:skip=CKV_AWS_173:Lambda environment variables use default encryption
-#checkov:skip=CKV_AWS_272:Code signing not configured for internal rotation Lambdas
 resource "aws_lambda_function" "rds_rotation" {
+  #checkov:skip=CKV_AWS_115:Reserved concurrency not needed for secret rotation Lambda
+  #checkov:skip=CKV_AWS_116:DLQ not needed for synchronous secret rotation Lambda
+  #checkov:skip=CKV_AWS_173:Lambda environment variables use default encryption
+  #checkov:skip=CKV_AWS_272:Code signing not configured for internal rotation Lambdas
   filename         = data.archive_file.rds_rotation.output_path
   function_name    = "${var.name}-rotate-rds"
   role             = aws_iam_role.rotation_lambda.arn
@@ -406,8 +406,8 @@ resource "aws_lambda_function" "rds_rotation" {
 #
 # Lambda Permission for Secrets Manager - DocumentDB (gated on is_aws_documentdb)
 #
-#checkov:skip=CKV_AWS_364:Lambda resource-based policy does not use IAM policy document version field
 resource "aws_lambda_permission" "documentdb_rotation" {
+  #checkov:skip=CKV_AWS_364:Lambda resource-based policy does not use IAM policy document version field
   count = local.is_aws_documentdb ? 1 : 0
 
   statement_id  = "AllowExecutionFromSecretsManager"
@@ -419,8 +419,8 @@ resource "aws_lambda_permission" "documentdb_rotation" {
 #
 # Lambda Permission for Secrets Manager - RDS
 #
-#checkov:skip=CKV_AWS_364:Lambda resource-based policy does not use IAM policy document version field
 resource "aws_lambda_permission" "rds_rotation" {
+  #checkov:skip=CKV_AWS_364:Lambda resource-based policy does not use IAM policy document version field
   statement_id  = "AllowExecutionFromSecretsManager"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.rds_rotation.function_name

--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -259,6 +259,7 @@ resource "aws_vpc_security_group_egress_rule" "lambda_to_https" {
 #
 resource "aws_cloudwatch_log_group" "documentdb_rotation" {
   #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
+  #checkov:skip=CKV_AWS_338:Short retention is intentional for rotation Lambda logs - operational diagnostics
   count = local.is_aws_documentdb ? 1 : 0
 
   name              = "/aws/lambda/${var.name}-rotate-documentdb"
@@ -274,6 +275,7 @@ resource "aws_cloudwatch_log_group" "documentdb_rotation" {
 
 resource "aws_cloudwatch_log_group" "rds_rotation" {
   #checkov:skip=CKV_AWS_158:KMS encryption for CloudWatch logs not required in this deployment
+  #checkov:skip=CKV_AWS_338:Short retention is intentional for rotation Lambda logs - operational diagnostics
   name              = "/aws/lambda/${var.name}-rotate-rds"
   retention_in_days = 30
 

--- a/terraform/aws-ecs/vpc.tf
+++ b/terraform/aws-ecs/vpc.tf
@@ -20,8 +20,8 @@ data "aws_vpc" "existing" {
   id = var.existing_vpc_id
 }
 
-#checkov:skip=CKV_TF_1:Module version is pinned via version constraint
 module "vpc" {
+  #checkov:skip=CKV_TF_1:Module version is pinned via version constraint
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 6.0"
 

--- a/terraform/aws-ecs/vpc.tf
+++ b/terraform/aws-ecs/vpc.tf
@@ -113,6 +113,7 @@ resource "aws_vpc_endpoint" "s3" {
 
 # Security group for VPC endpoints
 resource "aws_security_group" "vpc_endpoints" {
+  #checkov:skip=CKV2_AWS_5:Attached to the STS interface VPC endpoint via security_group_ids; Checkov does not trace the count-indexed reference
   count = var.create_vpc_endpoints ? 1 : 0
 
   name        = "${var.name}-vpc-endpoints"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The checkov skip placements were incorrect in the terraform modules. This places them in the right place and adds a default to delete incomplete downloads in s3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
