### PR TITLE
fix(security): loopback-bind non-front-door compose ports (SA-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,15 @@
 # For custom HTTPS domain: https://mcpgateway.mycorp.com
 REGISTRY_URL=http://localhost
 
+# Host interface that docker-compose publishes service ports on.
+# Defaults to 127.0.0.1 (loopback) so datastores, the vault, admin consoles and
+# backend MCP servers are reachable only from the host, never from the network.
+# Only the nginx front door (80/443) is always published on all interfaces.
+# Set to 0.0.0.0 ONLY if you deliberately need LAN/remote access to these ports
+# (understand that this exposes unauthenticated Mongo, the OpenBao root token,
+# and the auth bypass ports to anyone who can reach the host).
+# HOST_BIND_IP=127.0.0.1
+
 # ARD Catalog Publisher (issue #1294): publishes /.well-known/ai-catalog.json
 # ARD_CATALOG_ENABLED: set to false to disable the public ARD catalog endpoint.
 # ARD_PUBLISHER_DOMAIN: FQDN used as the URN publisher (urn:air:<domain>:...).

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -18,7 +18,9 @@ services:
       - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
       - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     ports:
-      - "8200:8200"
+      # Loopback-only: vault root == all egress credentials; never expose beyond
+      # the host. Override with HOST_BIND_IP=0.0.0.0 only if you understand the risk.
+      - "${HOST_BIND_IP:-127.0.0.1}:8200:8200"
     healthcheck:
       # Health endpoint reports 200 once the API is listening (dev mode is
       # always unsealed + initialized, so the default codes are fine).
@@ -336,8 +338,11 @@ services:
       - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
       - METRICS_RATE_LIMIT=1000
     ports:
-      - "8890:8890"
-      - "9465:9465"  # Prometheus metrics endpoint
+      # Loopback-only API port (build_and_run.sh health-checks it from the host).
+      - "${HOST_BIND_IP:-127.0.0.1}:8890:8890"
+      # 9465 (Prometheus exporter) is scraped container-to-container by Prometheus
+      # (see config/prometheus.yml job 'mcp-metrics-service' -> metrics-service:9465),
+      # so it needs no host mapping. Not published.
     volumes:
       - metrics-db-data:/var/lib/sqlite
       - ${HOME}/mcp-gateway/logs:/app/logs
@@ -468,7 +473,9 @@ services:
       - INTERNAL_TOKEN_TTL_SECONDS=${INTERNAL_TOKEN_TTL_SECONDS:-30}
       - INTERNAL_TOKEN_LEEWAY_SECONDS=${INTERNAL_TOKEN_LEEWAY_SECONDS:-5}
     ports:
-      - "8888:8888"
+      # Loopback-only: normal traffic goes through the nginx front door; direct
+      # port is for host health checks / tests only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8888:8888"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -499,7 +506,8 @@ services:
       - PORT=8000
       - MCP_TRANSPORT=streamable-http
     ports:
-      - "8000:8000"
+      # Loopback-only: reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:8000:8000"
     restart: unless-stopped
 
   # MCP Gateway Server
@@ -535,7 +543,8 @@ services:
       # Application log file (bind mount to host for Splunk ingestion, Issue #987)
       - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
-      - "8003:8003"
+      # Loopback-only: reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:8003:8003"
     depends_on:
       - registry
     restart: unless-stopped
@@ -550,7 +559,8 @@ services:
     environment:
       - PORT=8002
     ports:
-      - "8002:8002"
+      # Loopback-only: reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:8002:8002"
     restart: unless-stopped
 
 
@@ -575,7 +585,8 @@ services:
   prometheus:
     image: prom/prometheus:latest
     ports:
-      - "9090:9090"
+      # Loopback-only: Prometheus UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:9090:9090"
     volumes:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
@@ -596,7 +607,8 @@ services:
   grafana:
     image: grafana/grafana:12.3.1
     ports:
-      - "3000:3000"
+      # Loopback-only: Grafana UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}
       - GF_USERS_ALLOW_SIGN_UP=false
@@ -666,7 +678,8 @@ services:
       KC_HEALTH_ENABLED: 'true'
 
     ports:
-      - "18080:8080"
+      # Loopback-only: Keycloak is reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:18080:8080"
     depends_on:
       keycloak-db:
         condition: service_healthy
@@ -693,8 +706,9 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=getting-started/pingfederate
     ports:
-      - "9031:9031"
-      - "9999:9999"
+      # Loopback-only: PingFederate runtime + admin console stay on the host.
+      - "${HOST_BIND_IP:-127.0.0.1}:9031:9031"
+      - "${HOST_BIND_IP:-127.0.0.1}:9999:9999"
     volumes:
       - pingfederate-data:/opt/out/instance/server/default/data
     restart: unless-stopped
@@ -713,7 +727,9 @@ services:
     container_name: mcp-mongodb
     command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb
     ports:
-      - "27017:27017"
+      # Loopback-only: host tools (mongosh, tests) reach it via localhost, but it
+      # is never exposed on other interfaces. Set HOST_BIND_IP=0.0.0.0 to override.
+      - "${HOST_BIND_IP:-127.0.0.1}:27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -27,7 +27,9 @@ services:
       - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
       - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     ports:
-      - "8200:8200"
+      # Loopback-only: vault root == all egress credentials; never expose beyond
+      # the host. Override with HOST_BIND_IP=0.0.0.0 only if you understand the risk.
+      - "${HOST_BIND_IP:-127.0.0.1}:8200:8200"
     healthcheck:
       # Health endpoint reports 200 once the API is listening (dev mode is
       # always unsealed + initialized, so the default codes are fine).
@@ -438,7 +440,9 @@ services:
       - INTERNAL_TOKEN_TTL_SECONDS=${INTERNAL_TOKEN_TTL_SECONDS:-30}
       - INTERNAL_TOKEN_LEEWAY_SECONDS=${INTERNAL_TOKEN_LEEWAY_SECONDS:-5}
     ports:
-      - "8888:8888"
+      # Loopback-only: normal traffic goes through the nginx front door; direct
+      # port is for host health checks / tests only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8888:8888"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -494,7 +498,8 @@ services:
       # Application log file (bind mount to host for Splunk ingestion, Issue #987)
       - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
-      - "8003:8003"
+      # Loopback-only: reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:8003:8003"
     depends_on:
       - registry
     restart: unless-stopped
@@ -503,7 +508,8 @@ services:
   prometheus:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
     ports:
-      - "9090:9090"
+      # Loopback-only: Prometheus UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:9090:9090"
     volumes:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
@@ -524,7 +530,8 @@ services:
   grafana:
     image: grafana/grafana:${GRAFANA_VERSION:-12.3.1}
     ports:
-      - "3000:3000"
+      # Loopback-only: Grafana UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}
       - GF_USERS_ALLOW_SIGN_UP=false
@@ -589,7 +596,8 @@ services:
       KC_LOG_LEVEL: INFO
 
     ports:
-      - "8080:8080"
+      # Loopback-only: Keycloak is reached through the nginx front door in normal use.
+      - "${HOST_BIND_IP:-127.0.0.1}:8080:8080"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -620,8 +628,9 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=getting-started/pingfederate
     ports:
-      - "9031:9031"
-      - "9999:9999"
+      # Loopback-only: PingFederate runtime + admin console stay on the host.
+      - "${HOST_BIND_IP:-127.0.0.1}:9031:9031"
+      - "${HOST_BIND_IP:-127.0.0.1}:9999:9999"
     volumes:
       - pingfederate-data:/opt/out/instance/server/default/data
     restart: unless-stopped
@@ -665,7 +674,9 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=${DOCUMENTDB_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${DOCUMENTDB_PASSWORD:-admin}
     ports:
-      - "27017:27017"
+      # Loopback-only: host tools (mongosh, tests) reach it via localhost, but it
+      # is never exposed on other interfaces. Set HOST_BIND_IP=0.0.0.0 to override.
+      - "${HOST_BIND_IP:-127.0.0.1}:27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
     container_name: mcp-mongodb
     command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb
     ports:
-      - "27017:27017"
+      # Loopback-only: host tools (mongosh, tests) reach it via localhost, but it
+      # is never exposed on other interfaces. Set HOST_BIND_IP=0.0.0.0 to override.
+      - "${HOST_BIND_IP:-127.0.0.1}:27017:27017"
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
@@ -85,7 +87,10 @@ services:
       - BAO_DEV_ROOT_TOKEN_ID=${OPENBAO_TOKEN:-dev-root-token}
       - BAO_DEV_LISTEN_ADDRESS=0.0.0.0:8200
     ports:
-      - "8200:8200"
+      # Loopback-only: reaching the vault means root access to every stored egress
+      # credential, so it must never be exposed beyond the host. Override with
+      # HOST_BIND_IP=0.0.0.0 only if you understand the risk.
+      - "${HOST_BIND_IP:-127.0.0.1}:8200:8200"
     healthcheck:
       # Health endpoint reports 200 once the API is listening (dev mode is
       # always unsealed + initialized, so the default codes are fine).
@@ -448,8 +453,11 @@ services:
       - OTEL_OTLP_EXPORT_INTERVAL_MS=${OTEL_OTLP_EXPORT_INTERVAL_MS:-30000}
       - OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=${OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE:-cumulative}
     ports:
-      - "8890:8890"
-      - "9465:9465"  # Prometheus metrics endpoint
+      # Loopback-only API port (build_and_run.sh health-checks it from the host).
+      - "${HOST_BIND_IP:-127.0.0.1}:8890:8890"
+      # 9465 (Prometheus exporter) is scraped container-to-container by Prometheus
+      # (see config/prometheus.yml job 'mcp-metrics-service' -> metrics-service:9465),
+      # so it needs no host mapping. Not published.
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -610,7 +618,9 @@ services:
       - INTERNAL_TOKEN_TTL_SECONDS=${INTERNAL_TOKEN_TTL_SECONDS:-30}
       - INTERNAL_TOKEN_LEEWAY_SECONDS=${INTERNAL_TOKEN_LEEWAY_SECONDS:-5}
     ports:
-      - "8888:8888"
+      # Loopback-only: normal traffic reaches auth-server through the nginx front
+      # door; this direct port is for host health checks / tests only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8888:8888"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -643,7 +653,9 @@ services:
       - PORT=8000
       - MCP_TRANSPORT=streamable-http
     ports:
-      - "8000:8000"
+      # Loopback-only: reached through the nginx front door in normal use; direct
+      # port is for host testing only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8000:8000"
     restart: unless-stopped
 
   # MCP Gateway Server
@@ -684,7 +696,9 @@ services:
       # Application log file (bind mount to host for Splunk ingestion, Issue #987)
       - /var/log/containers/ai-registry:/var/log/containers/ai-registry
     ports:
-      - "8003:8003"
+      # Loopback-only: reached through the nginx front door in normal use; direct
+      # port is for host testing only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8003:8003"
     depends_on:
       - registry
     restart: unless-stopped
@@ -700,7 +714,9 @@ services:
     environment:
       - PORT=8002
     ports:
-      - "8002:8002"
+      # Loopback-only: reached through the nginx front door in normal use; direct
+      # port is for host testing only.
+      - "${HOST_BIND_IP:-127.0.0.1}:8002:8002"
     restart: unless-stopped
 
   # SQLite container for metrics database
@@ -737,10 +753,15 @@ services:
     volumes:
       - ./config/otel/collector.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "4317:4317"   # OTLP gRPC (services push here)
-      - "4318:4318"   # OTLP HTTP
-      - "8889:8889"   # Prometheus exporter on the collector itself
-      - "13133:13133" # health_check extension
+      # Loopback-only OTLP receivers so a locally-run (non-compose) service can
+      # still push to the collector via localhost. Compose services push over the
+      # container network (otel-collector:4317) regardless of these mappings.
+      - "${HOST_BIND_IP:-127.0.0.1}:4317:4317"   # OTLP gRPC (services push here)
+      - "${HOST_BIND_IP:-127.0.0.1}:4318:4318"   # OTLP HTTP
+      # 8889 (Prometheus exporter) is scraped container-to-container (see
+      # config/prometheus.yml job 'otel-collector' -> otel-collector:8889) and
+      # 13133 (health_check) is used only by the in-container healthcheck below,
+      # so neither needs a host mapping. Not published.
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:13133"]
       interval: 10s
@@ -757,7 +778,8 @@ services:
   prometheus:
     image: prom/prometheus:v3.11.3
     ports:
-      - "9090:9090"
+      # Loopback-only: Prometheus UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:9090:9090"
     volumes:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
@@ -778,7 +800,8 @@ services:
   grafana:
     image: grafana/grafana:12.3.1
     ports:
-      - "3000:3000"
+      # Loopback-only: Grafana UI is a local-dev convenience, not a public surface.
+      - "${HOST_BIND_IP:-127.0.0.1}:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}
       - GF_USERS_ALLOW_SIGN_UP=false
@@ -843,7 +866,9 @@ services:
       KC_LOG_LEVEL: INFO
 
     ports:
-      - "8080:8080"
+      # Loopback-only: Keycloak is reached through the nginx front door in normal
+      # use; direct admin/console access stays on the host.
+      - "${HOST_BIND_IP:-127.0.0.1}:8080:8080"
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -874,9 +899,10 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=baseline/pingfederate
     ports:
-      - "9031:9031"
-      - "9032:9032"
-      - "9999:9999"
+      # Loopback-only: PingFederate runtime + admin console stay on the host.
+      - "${HOST_BIND_IP:-127.0.0.1}:9031:9031"
+      - "${HOST_BIND_IP:-127.0.0.1}:9032:9032"
+      - "${HOST_BIND_IP:-127.0.0.1}:9999:9999"
     volumes:
       - pingfederate-data:/opt/out/instance/server/default/data
       - ./pingfederate/config/run.properties:/opt/staging/instance/bin/run.properties

--- a/tests/security/test_container_security.py
+++ b/tests/security/test_container_security.py
@@ -6,12 +6,33 @@ Tests verify that Dockerfiles follow CIS Docker Benchmark 4.1 requirements:
 - No sudo package
 - HEALTHCHECK directives
 - Proper environment variables (PIP_NO_CACHE_DIR)
+
+Also verifies the compose port-exposure hardening for SA-5: every published
+port except the nginx front door (80/443) must be bound to a loopback-by-default
+host interface (``${HOST_BIND_IP:-127.0.0.1}``) so datastores, the vault, admin
+consoles and backend MCP servers are never exposed on all interfaces out of the
+box.
 """
 
 import re
 from pathlib import Path
 
 import pytest
+import yaml
+
+# Compose files that must follow the loopback-bind invariant.
+COMPOSE_FILES = [
+    "docker-compose.yml",
+    "docker-compose.prebuilt.yml",
+    "docker-compose.podman.yml",
+]
+
+# The only host-published container ports allowed to bind all interfaces: the
+# nginx front door. Keyed by container-side target port.
+FRONT_DOOR_TARGET_PORTS = {8080, 8443}
+
+# Expected loopback-default host-bind expression for every other published port.
+LOOPBACK_BIND_PREFIX = "${HOST_BIND_IP:-127.0.0.1}:"
 
 # List of Dockerfiles to test
 DOCKERFILES = [
@@ -166,6 +187,151 @@ def test_docker_compose_registry_port_mapping(repo_root: Path):
 
     content = compose_file.read_text()
 
-    # Check for port mapping 80:8080 and 443:8443
-    assert '"80:8080"' in content or "'80:8080'" in content, "Missing port mapping 80:8080"
-    assert '"443:8443"' in content or "'443:8443'" in content, "Missing port mapping 443:8443"
+    # Check for port mapping 80:8080 and 443:8443 (front door, bound on all
+    # interfaces; the loopback-bind invariant tests below exempt these).
+    assert "80:8080" in content, "Missing port mapping 80:8080"
+    assert "443:8443" in content, "Missing port mapping 443:8443"
+
+
+# ---------------------------------------------------------------------------
+# SA-5: compose port-exposure hardening (loopback-by-default binds)
+# ---------------------------------------------------------------------------
+
+
+def _iter_published_ports(
+    compose_path: Path,
+):
+    """Yield (service_name, raw_port_mapping) for every published compose port.
+
+    Reads the raw, un-interpolated ``ports:`` entries so the test asserts on the
+    literal ``${HOST_BIND_IP:-127.0.0.1}:`` prefix an operator sees in the file,
+    not a value resolved from the current environment. Only short-syntax string
+    mappings (``"HOST:CONTAINER"`` / ``"IP:HOST:CONTAINER"``) are yielded; the
+    long-syntax dict form is yielded as its raw dict for the caller to inspect.
+    """
+    data = yaml.safe_load(compose_path.read_text())
+    services = data.get("services", {})
+    for service_name, service in services.items():
+        for entry in service.get("ports", []) or []:
+            yield service_name, entry
+
+
+def _target_port(raw_mapping: str) -> int | None:
+    """Extract the container-side target port from a short-syntax mapping.
+
+    Handles ``HOST:CONTAINER`` and ``IP:HOST:CONTAINER`` (the IP segment may
+    itself contain a ``${VAR:-default}`` expression, which never contains a
+    trailing ``:CONTAINER`` port, so splitting on the final colon is safe).
+    Returns None if the container port cannot be parsed as an int.
+    """
+    container_side = str(raw_mapping).rsplit(":", 1)[-1].strip().strip('"').strip("'")
+    # A container port may carry a /protocol suffix (e.g. "53/udp").
+    container_side = container_side.split("/", 1)[0]
+    try:
+        return int(container_side)
+    except ValueError:
+        return None
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_compose_only_front_door_binds_all_interfaces(
+    repo_root: Path,
+    compose_filename: str,
+):
+    """Every published port except the nginx front door must be loopback-bound.
+
+    This is the core SA-5 invariant: a fresh checkout must not expose MongoDB,
+    the OpenBao vault, IdP admin consoles, or backend MCP servers on 0.0.0.0.
+    Only 80->8080 and 443->8443 (the authenticated nginx entry point) may bind
+    all interfaces.
+    """
+    compose_file = repo_root / compose_filename
+    assert compose_file.exists(), f"{compose_filename} not found"
+
+    offenders: list[str] = []
+    for service_name, entry in _iter_published_ports(compose_file):
+        # Long-syntax dict form: assert host_ip is loopback unless front door.
+        if isinstance(entry, dict):
+            target = entry.get("target")
+            if target in FRONT_DOOR_TARGET_PORTS:
+                continue
+            host_ip = str(entry.get("host_ip", ""))
+            if host_ip not in ("127.0.0.1", "::1"):
+                offenders.append(f"{service_name}: {entry}")
+            continue
+
+        raw = str(entry)
+        target = _target_port(raw)
+        if target in FRONT_DOOR_TARGET_PORTS:
+            # Front door is intentionally published on all interfaces.
+            continue
+        if not raw.strip().strip('"').strip("'").startswith(LOOPBACK_BIND_PREFIX):
+            offenders.append(f"{service_name}: {raw}")
+
+    assert not offenders, (
+        f"{compose_filename}: these published ports are not loopback-bound "
+        f"(must be prefixed with '{LOOPBACK_BIND_PREFIX}'): {offenders}"
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_compose_front_door_still_published(
+    repo_root: Path,
+    compose_filename: str,
+):
+    """The nginx front door (80/443) must remain published on all interfaces.
+
+    Guards against an over-eager hardening pass that accidentally loopback-binds
+    the public entry point and breaks external access.
+    """
+    compose_file = repo_root / compose_filename
+    content = compose_file.read_text()
+
+    assert "80:8080" in content, f"{compose_filename}: front-door 80:8080 mapping missing"
+    assert "443:8443" in content, f"{compose_filename}: front-door 443:8443 mapping missing"
+    # The front door must NOT carry a loopback prefix.
+    assert f"{LOOPBACK_BIND_PREFIX}80:8080" not in content, (
+        f"{compose_filename}: front-door 80:8080 must stay on all interfaces, not loopback"
+    )
+    assert f"{LOOPBACK_BIND_PREFIX}443:8443" not in content, (
+        f"{compose_filename}: front-door 443:8443 must stay on all interfaces, not loopback"
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_compose_sensitive_ports_are_loopback(
+    repo_root: Path,
+    compose_filename: str,
+):
+    """The highest-risk ports must be loopback-bound wherever they are published.
+
+    MongoDB (27017) and the OpenBao vault (8200) are the two ports whose exposure
+    is most damaging (unauthenticated DB access; vault root == all egress
+    credentials). This test pins them explicitly so a future edit cannot quietly
+    re-expose them even if the generic invariant test is changed.
+    """
+    compose_file = repo_root / compose_filename
+    sensitive_targets = {27017, 8200}
+
+    seen: set[int] = set()
+    for _service_name, entry in _iter_published_ports(compose_file):
+        if isinstance(entry, dict):
+            continue
+        raw = str(entry).strip().strip('"').strip("'")
+        target = _target_port(raw)
+        if target in sensitive_targets:
+            seen.add(target)
+            assert raw.startswith(LOOPBACK_BIND_PREFIX), (
+                f"{compose_filename}: sensitive port {target} must be loopback-bound, got {raw!r}"
+            )
+
+    # Not every file publishes both (e.g. some variants omit a service), so we
+    # only assert on what is present; nothing to require here beyond the loop.
+
+
+def test_host_bind_ip_documented_in_env_example(repo_root: Path):
+    """HOST_BIND_IP must be documented so operators know how to opt into 0.0.0.0."""
+    env_example = repo_root / ".env.example"
+    assert env_example.exists(), ".env.example not found"
+    content = env_example.read_text()
+    assert "HOST_BIND_IP" in content, ".env.example must document HOST_BIND_IP"


### PR DESCRIPTION
## Summary

Fixes security finding **SA-5** (HIGH): the docker-compose stack published every service port on `0.0.0.0` (all host interfaces), exposing unauthenticated/default-credentialed admin surfaces to the network on a fresh checkout.

This change makes every published port **loopback-by-default** except the nginx front door.

## What changed

- **`docker-compose.yml`, `docker-compose.prebuilt.yml`, `docker-compose.podman.yml`** — every non-front-door published port now binds `${HOST_BIND_IP:-127.0.0.1}:` instead of `0.0.0.0`. Affected: MongoDB (`27017`), OpenBao vault (`8200`), auth-server (`8888`), backend MCP servers (`8000/8002/8003`), Keycloak (`8080`), PingFederate (`9031/9032/9999`), Prometheus (`9090`), Grafana (`3000`), metrics-service (`8890`), otel OTLP (`4317/4318`).
  - The nginx **front door `80:8080` / `443:8443` stays on all interfaces** (intended public entry point).
  - Dropped host mappings for `9465`, `8889`, `13133`: these are only scraped/used container-to-container (Prometheus targets `metrics-service:9465` and `otel-collector:8889` over the compose network; `13133` is the collector's internal healthcheck).
- **`.env.example`** — documents the new `HOST_BIND_IP` variable and the security rationale for the `0.0.0.0` opt-out.
- **`tests/security/test_container_security.py`** — adds YAML-parsed regression tests.

## Why loopback-bind rather than removing the mappings

Several of these ports are consumed **from the host**: the integration test suite connects to `localhost:27017` and `127.0.0.1:8200`, and `build_and_run.sh` health-checks `localhost:8888/8890/8000/...`. Loopback-binding keeps `localhost` access working (so tests and `mongosh` are unaffected) while ensuring nothing is published on other interfaces. Operators who genuinely need LAN/remote access set `HOST_BIND_IP=0.0.0.0` explicitly.

## Scope

Docker-compose only. The Terraform/ECS surface already scopes datastore ports (e.g. DocumentDB `27017`) to security-group references with no `0.0.0.0/0` ingress, and the Helm charts expose all services as `ClusterIP` (in-cluster only). Neither has the SA-5 exposure, so no changes were warranted there.

## Testing

- **Automated invariant tests** (parametrized across all three compose files):
  - `test_compose_only_front_door_binds_all_interfaces` — the core invariant; auto-covers any future port.
  - `test_compose_front_door_still_published` — guards against accidentally loopback-binding the public entry point.
  - `test_compose_sensitive_ports_are_loopback` — explicit pin on the two highest-risk ports (`27017`, `8200`).
  - `test_host_bind_ip_documented_in_env_example`.
  - Result: `56 passed`.
- **Mutation-proof:** temporarily reverting `27017` to `0.0.0.0` fails 2 tests; restored to green.
- **`docker compose config`** parses clean on all three files and resolves internal ports to `host_ip: 127.0.0.1` by default; `HOST_BIND_IP=0.0.0.0` correctly flips them.
- **Live reachability verified** on a running stack by execing into the registry and auth-server containers:

  | Path | Result |
  |------|--------|
  | registry -> mongodb:27017 / openbao:8200 / otel-collector:4317 | OK / HTTP 200 / OK |
  | auth -> mongodb:27017 / openbao:8200 / otel-collector:4317 | OK (live audit writes succeeding) |
  | auth -> registry:8080 (vend hop) | HTTP 200 |
  | Registry app health (front door, uses Mongo) | healthy |
  | Host `localhost:27017/8200/8888` | all OK |

  Container-to-container traffic uses compose service DNS and is unaffected by the host bind address, as expected.
