### PR TITLE
fix(security): remove weak Keycloak default credentials (SA-9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -481,7 +481,12 @@ KEYCLOAK_M2M_CLIENT_SECRET=your-keycloak-m2m-secret-here
 # Enable Keycloak in OAuth2 providers
 KEYCLOAK_ENABLED=true
 
-# Initial admin and test user passwords for Keycloak setup
+# Keycloak setup passwords. All are created with a temporary flag so each user
+# is forced to change the password on first login. There are no weak defaults:
+# the setup scripts fail if a required password is unset.
+#   INITIAL_ADMIN_PASSWORD  - realm 'admin' user (required by init-keycloak.sh)
+#   INITIAL_USER_PASSWORD   - human LOB/demo users created by
+#                             cli/bootstrap_user_and_m2m_setup.sh (required there)
 INITIAL_ADMIN_PASSWORD=your-secure-keycloak-admin-password
 INITIAL_USER_PASSWORD=your-secure-keycloak-user-password
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,8 +108,8 @@ tab_visible = REGISTRY_MODE enables the feature AND SHOW_*_TAB is true
 | `KEYCLOAK_M2M_CLIENT_ID` | Keycloak M2M client ID (see note below) | `mcp-gateway-m2m` | ✅ |
 | `KEYCLOAK_M2M_CLIENT_SECRET` | Keycloak M2M client secret (auto-generated) | `ZJqbsamnQs79hbUbkJLB...` | ✅ |
 | `KEYCLOAK_ENABLED` | Enable Keycloak in OAuth2 providers | `true` | ✅ |
-| `INITIAL_ADMIN_PASSWORD` | Initial admin user password | `changeme` | For setup |
-| `INITIAL_USER_PASSWORD` | Initial test user password | `testpass` | For setup |
+| `INITIAL_ADMIN_PASSWORD` | Realm admin user password (required, no default; set temporary) | `<your-secure-password>` | For setup |
+| `INITIAL_USER_PASSWORD` | Password for human LOB/demo users created by `bootstrap_user_and_m2m_setup.sh` (required, no default) | `<your-secure-password>` | For setup |
 
 **Note: Getting Keycloak Client IDs and Secrets**
 

--- a/docs/keycloak-mcp-clients.md
+++ b/docs/keycloak-mcp-clients.md
@@ -623,7 +623,7 @@ Run `bash keycloak/setup/init-keycloak.sh`. The script:
 2. Creates `mcp-gateway-web` and `mcp-gateway-m2m` pre-defined clients
 3. Creates the registry-internal scopes (`mcp-registry-admin`, etc.)
 4. Creates Keycloak groups + maps them to scopes
-5. Creates initial admin + testuser users
+5. Creates the realm admin user (password from `INITIAL_ADMIN_PASSWORD`, set temporary)
 6. Sets up groups mappers on the pre-defined clients (web-UI flow)
 7. **Sets up DCR-specific config (added by PR #1115)**:
    - Groups mapper on `basic` client-scope (covers DCR'd clients, emits `groups` claim)

--- a/infra/docs/DEPLOYMENT-GUIDE.md
+++ b/infra/docs/DEPLOYMENT-GUIDE.md
@@ -36,7 +36,7 @@ Standard mapping:
 | Where | Source |
 |---|---|
 | Keycloak admin | SSM `/keycloak/admin_password` (= `CDK_KEYCLOAK_ADMIN_PASSWORD`) |
-| Registry users (`admin`, `testuser`, `lob1-user`, `lob2-user`) | Created by `keycloak/setup/init-keycloak.sh`. `testuser`/`testpass123`; LOB users use `lob1pass`/`lob2pass`; admin = `CDK_KEYCLOAK_ADMIN_PASSWORD` |
+| Registry users (`admin`, `lob1-user`, `lob2-user`) | Created by `keycloak/setup/init-keycloak.sh`. All passwords are required env vars (no defaults) and are set temporary (reset forced on first login): admin = `INITIAL_ADMIN_PASSWORD`, LOB users = `LOB1_USER_PASSWORD`/`LOB2_USER_PASSWORD` |
 | Grafana admin | env `CDK_GRAFANA_ADMIN_PASSWORD` (default `admin`) |
 | DocumentDB | Secrets Manager `mcp-gateway/documentdb/credentials` |
 | Aurora MySQL | Secrets Manager `keycloak/database` |

--- a/keycloak/import/realm-config.json
+++ b/keycloak/import/realm-config.json
@@ -263,28 +263,6 @@
       "realmRoles": [
         "mcp-admin"
       ]
-    },
-    {
-      "username": "testuser",
-      "email": "testuser@example.com",
-      "enabled": true,
-      "emailVerified": true,
-      "firstName": "Test",
-      "lastName": "User",
-      "credentials": [
-        {
-          "type": "password",
-          "value": "${env.INITIAL_USER_PASSWORD:testpass}",
-          "temporary": true
-        }
-      ],
-      "groups": [
-        "mcp-registry-user",
-        "mcp-servers-restricted"
-      ],
-      "realmRoles": [
-        "mcp-user"
-      ]
     }
   ],
   

--- a/keycloak/setup/init-keycloak.sh
+++ b/keycloak/setup/init-keycloak.sh
@@ -359,17 +359,26 @@ create_service_account_user() {
     fi
 }
 
-# Function to create test users
+# Function to create the realm admin user
 create_users() {
     local token=$1
-    
-    echo "Creating test users..."
-    
+
+    # SA-9: never create the admin user with a weak default password. Require an
+    # explicit INITIAL_ADMIN_PASSWORD and force a reset on first login.
+    if [ -z "$INITIAL_ADMIN_PASSWORD" ]; then
+        echo -e "${RED}Error: INITIAL_ADMIN_PASSWORD environment variable is required${NC}"
+        echo "This password is used for the realm 'admin' user in the ${REALM} realm."
+        echo "Set it in .env or export it before running this script:"
+        echo "  export INITIAL_ADMIN_PASSWORD='YourSecurePassword'"
+        exit 1
+    fi
+
+    echo "Creating realm admin user..."
+
     # Define usernames for consistency
     local admin_username="admin"
-    local test_username="testuser"
-    
-    # Create admin user
+
+    # Create admin user (temporary: true forces a password change on first login)
     local admin_user_json='{
         "username": "'$admin_username'",
         "email": "'$admin_username'@example.com",
@@ -380,113 +389,51 @@ create_users() {
         "credentials": [
             {
                 "type": "password",
-                "value": "'${INITIAL_ADMIN_PASSWORD:-changeme}'",
-                "temporary": false
+                "value": "'${INITIAL_ADMIN_PASSWORD}'",
+                "temporary": true
             }
         ]
     }'
-    
+
     curl -s -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/users" \
         -H "Authorization: Bearer ${token}" \
         -H "Content-Type: application/json" \
         -d "$admin_user_json" > /dev/null
-    
-    # Create test user
-    local test_user_json='{
-        "username": "'$test_username'",
-        "email": "'$test_username'@example.com",
-        "enabled": true,
-        "emailVerified": true,
-        "firstName": "Test",
-        "lastName": "User",
-        "credentials": [
-            {
-                "type": "password",
-                "value": "'${INITIAL_USER_PASSWORD:-testpass}'",
-                "temporary": false
-            }
-        ]
-    }'
-    
-    curl -s -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/users" \
-        -H "Authorization: Bearer ${token}" \
-        -H "Content-Type: application/json" \
-        -d "$test_user_json" > /dev/null
-    
+
     echo "Assigning users to groups..."
-    
+
     # Get user IDs
     local admin_user_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$admin_username" | \
         jq -r '.[0].id')
-    
-    local test_user_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$test_username" | \
-        jq -r '.[0].id')
-    
-    # Get all group IDs
+
+    # Get the group IDs the admin user needs
     local admin_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
         jq -r '.[] | select(.name=="mcp-registry-admin") | .id')
-    
-    local user_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
-        jq -r '.[] | select(.name=="mcp-registry-user") | .id')
-    
-    local developer_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
-        jq -r '.[] | select(.name=="mcp-registry-developer") | .id')
-    
-    local operator_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
-        jq -r '.[] | select(.name=="mcp-registry-operator") | .id')
-    
+
     local unrestricted_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
         jq -r '.[] | select(.name=="mcp-servers-unrestricted") | .id')
-    
-    local restricted_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" | \
-        jq -r '.[] | select(.name=="mcp-servers-restricted") | .id')
-    
+
     # Define usernames for consistent logging
     local admin_username="admin"
-    local test_username="testuser"
-    
+
     # Assign admin user to admin group and unrestricted servers group
     if [ ! -z "$admin_user_id" ] && [ ! -z "$admin_group_id" ]; then
         curl -s -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/users/$admin_user_id/groups/$admin_group_id" \
             -H "Authorization: Bearer ${token}" > /dev/null
         echo "  - $admin_username assigned to mcp-registry-admin group"
     fi
-    
+
     # Also assign admin to unrestricted servers group for full access
     if [ ! -z "$admin_user_id" ] && [ ! -z "$unrestricted_group_id" ]; then
         curl -s -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/users/$admin_user_id/groups/$unrestricted_group_id" \
             -H "Authorization: Bearer ${token}" > /dev/null
         echo "  - $admin_username assigned to mcp-servers-unrestricted group"
     fi
-    
-    # Assign test user to all groups except admin
-    if [ ! -z "$test_user_id" ]; then
-        # Arrays of group IDs and names for loop processing
-        local group_ids=("$user_group_id" "$developer_group_id" "$operator_group_id" "$unrestricted_group_id" "$restricted_group_id")
-        local group_names=("mcp-registry-user" "mcp-registry-developer" "mcp-registry-operator" "mcp-servers-unrestricted" "mcp-servers-restricted")
-        
-        # Loop through groups and assign test user to each
-        for i in "${!group_ids[@]}"; do
-            local group_id="${group_ids[$i]}"
-            local group_name="${group_names[$i]}"
-            
-            if [ ! -z "$group_id" ]; then
-                curl -s -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/users/$test_user_id/groups/$group_id" \
-                    -H "Authorization: Bearer ${token}" > /dev/null
-                echo "  - $test_username assigned to $group_name group"
-            fi
-        done
-    fi
-    
-    echo -e "${GREEN}Users created and assigned to groups successfully!${NC}"
+
+    echo -e "${GREEN}Admin user created and assigned to groups successfully!${NC}"
 }
 
 # Function to create client secrets
@@ -925,11 +872,11 @@ main() {
     echo "Admin console: ${KEYCLOAK_URL}/admin"
     echo "Realm: ${REALM}"
     echo ""
-    echo "Default users created:"
-    echo "  - admin/changeme (admin access)"
-    echo "  - testuser/testpass (user access)"
+    echo "Users created:"
+    echo "  - admin (admin access) — password from INITIAL_ADMIN_PASSWORD"
     echo ""
-    echo -e "${YELLOW}Remember to change the default passwords!${NC}"
+    echo -e "${YELLOW}The admin password is set to 'temporary': you will be prompted to${NC}"
+    echo -e "${YELLOW}change it on first login.${NC}"
 }
 
 # Run main function

--- a/terraform/aws-ecs/scripts/init-keycloak.sh
+++ b/terraform/aws-ecs/scripts/init-keycloak.sh
@@ -585,11 +585,11 @@ update_user_password() {
         return 1
     fi
     
-    # Reset password
+    # Reset password (temporary: true forces a change on next login)
     local password_json='{
         "type": "password",
         "value": "'"${password}"'",
-        "temporary": false
+        "temporary": true
     }'
     
     local response=$(curl -s -o /dev/null -w "%{http_code}" \
@@ -609,13 +609,23 @@ create_users() {
 
     echo "Creating test users..."
 
+    # SA-9: LOB demo users must not fall back to weak default passwords. Require
+    # explicit passwords for any LOB user that will be created.
+    if [ -z "$LOB1_USER_PASSWORD" ] || [ -z "$LOB2_USER_PASSWORD" ]; then
+        echo -e "${RED}Error: LOB1_USER_PASSWORD and LOB2_USER_PASSWORD are required${NC}"
+        echo "These set the passwords for the lob1-user / lob2-user demo accounts."
+        echo "Export both before running this script, e.g.:"
+        echo "  export LOB1_USER_PASSWORD='YourSecurePassword1'"
+        echo "  export LOB2_USER_PASSWORD='YourSecurePassword2'"
+        exit 1
+    fi
+
     # Define usernames for consistency
     local admin_username="admin"
-    local test_username="testuser"
     local lob1_username="lob1-user"
     local lob2_username="lob2-user"
 
-    # Create admin user
+    # Create admin user (temporary: true forces a password change on first login)
     local admin_user_json='{
         "username": "'$admin_username'",
         "email": "'$admin_username'@example.com",
@@ -627,17 +637,17 @@ create_users() {
             {
                 "type": "password",
                 "value": "'${INITIAL_ADMIN_PASSWORD}'",
-                "temporary": false
+                "temporary": true
             }
         ]
     }'
-    
+
     local admin_response=$(curl -s -o /dev/null -w "%{http_code}" \
         -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/users" \
         -H "Authorization: Bearer ${token}" \
         -H "Content-Type: application/json" \
         -d "$admin_user_json")
-    
+
     if [ "$admin_response" = "201" ]; then
         echo "  - Created admin user with password from Secrets Manager"
     elif [ "$admin_response" = "409" ]; then
@@ -650,30 +660,8 @@ create_users() {
     else
         echo -e "${RED}  - Failed to create admin user (HTTP $admin_response)${NC}"
     fi
-    
-    # Create test user
-    local test_user_json='{
-        "username": "'$test_username'",
-        "email": "'$test_username'@example.com",
-        "enabled": true,
-        "emailVerified": true,
-        "firstName": "Test",
-        "lastName": "User",
-        "credentials": [
-            {
-                "type": "password",
-                "value": "'${INITIAL_USER_PASSWORD:-testpass}'",
-                "temporary": false
-            }
-        ]
-    }'
-    
-    curl -s -X POST "${KEYCLOAK_URL}/admin/realms/${REALM}/users" \
-        -H "Authorization: Bearer ${token}" \
-        -H "Content-Type: application/json" \
-        -d "$test_user_json" > /dev/null
 
-    # Create lob1-user
+    # Create lob1-user (temporary: true forces a password change on first login)
     local lob1_user_json='{
         "username": "'$lob1_username'",
         "email": "'$lob1_username'@example.com",
@@ -684,8 +672,8 @@ create_users() {
         "credentials": [
             {
                 "type": "password",
-                "value": "'${LOB1_USER_PASSWORD:-lob1pass}'",
-                "temporary": false
+                "value": "'${LOB1_USER_PASSWORD}'",
+                "temporary": true
             }
         ]
     }'
@@ -695,7 +683,7 @@ create_users() {
         -H "Content-Type: application/json" \
         -d "$lob1_user_json" > /dev/null
 
-    # Create lob2-user
+    # Create lob2-user (temporary: true forces a password change on first login)
     local lob2_user_json='{
         "username": "'$lob2_username'",
         "email": "'$lob2_username'@example.com",
@@ -706,8 +694,8 @@ create_users() {
         "credentials": [
             {
                 "type": "password",
-                "value": "'${LOB2_USER_PASSWORD:-lob2pass}'",
-                "temporary": false
+                "value": "'${LOB2_USER_PASSWORD}'",
+                "temporary": true
             }
         ]
     }'
@@ -724,10 +712,6 @@ create_users() {
         "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$admin_username" 2>/dev/null | \
         jq -r 'if type == "array" then (.[0].id // empty) else empty end' 2>/dev/null)
 
-    local test_user_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$test_username" 2>/dev/null | \
-        jq -r 'if type == "array" then (.[0].id // empty) else empty end' 2>/dev/null)
-
     local lob1_user_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$lob1_username" 2>/dev/null | \
         jq -r 'if type == "array" then (.[0].id // empty) else empty end' 2>/dev/null)
@@ -735,31 +719,15 @@ create_users() {
     local lob2_user_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/users?username=$lob2_username" 2>/dev/null | \
         jq -r 'if type == "array" then (.[0].id // empty) else empty end' 2>/dev/null)
-    
-    # Get all group IDs
+
+    # Get the group IDs the admin and LOB users need
     local admin_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
         jq -r 'if type == "array" then (.[] | select(.name=="mcp-registry-admin") | .id) else empty end' 2>/dev/null)
 
-    local user_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
-        jq -r 'if type == "array" then (.[] | select(.name=="mcp-registry-user") | .id) else empty end' 2>/dev/null)
-
-    local developer_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
-        jq -r 'if type == "array" then (.[] | select(.name=="mcp-registry-developer") | .id) else empty end' 2>/dev/null)
-
-    local operator_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
-        jq -r 'if type == "array" then (.[] | select(.name=="mcp-registry-operator") | .id) else empty end' 2>/dev/null)
-
     local unrestricted_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
         jq -r 'if type == "array" then (.[] | select(.name=="mcp-servers-unrestricted") | .id) else empty end' 2>/dev/null)
-
-    local restricted_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
-        "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
-        jq -r 'if type == "array" then (.[] | select(.name=="mcp-servers-restricted") | .id) else empty end' 2>/dev/null)
 
     local lob1_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
@@ -771,10 +739,9 @@ create_users() {
 
     # Define usernames for consistent logging
     local admin_username="admin"
-    local test_username="testuser"
     local lob1_username="lob1-user"
     local lob2_username="lob2-user"
-    
+
     # Get registry-admins group ID for admin user
     local registry_admins_group_id=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/groups" 2>/dev/null | \
@@ -801,25 +768,6 @@ create_users() {
         echo "  - $admin_username assigned to registry-admins group"
     fi
     
-    # Assign test user to all groups except admin
-    if [ ! -z "$test_user_id" ]; then
-        # Arrays of group IDs and names for loop processing
-        local group_ids=("$user_group_id" "$developer_group_id" "$operator_group_id" "$unrestricted_group_id" "$restricted_group_id")
-        local group_names=("mcp-registry-user" "mcp-registry-developer" "mcp-registry-operator" "mcp-servers-unrestricted" "mcp-servers-restricted")
-        
-        # Loop through groups and assign test user to each
-        for i in "${!group_ids[@]}"; do
-            local group_id="${group_ids[$i]}"
-            local group_name="${group_names[$i]}"
-            
-            if [ ! -z "$group_id" ]; then
-                curl -s -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/users/$test_user_id/groups/$group_id" \
-                    -H "Authorization: Bearer ${token}" > /dev/null
-                echo "  - $test_username assigned to $group_name group"
-            fi
-        done
-    fi
-
     # Assign lob1-user to registry-users-lob1 group
     if [ ! -z "$lob1_user_id" ] && [ ! -z "$lob1_group_id" ]; then
         curl -s -X PUT "${KEYCLOAK_URL}/admin/realms/${REALM}/users/$lob1_user_id/groups/$lob1_group_id" \
@@ -1229,11 +1177,10 @@ main() {
     echo "Admin console: ${KEYCLOAK_URL}/admin"
     echo "Realm: ${REALM}"
     echo ""
-    echo "Users created:"
-    echo "  - admin/${INITIAL_ADMIN_PASSWORD} (realm admin - all groups including mcp-registry-admin)"
-    echo "  - testuser/${INITIAL_USER_PASSWORD:-testpass} (test user - user/developer/operator groups)"
-    echo "  - lob1-user/${LOB1_USER_PASSWORD:-lob1pass} (LOB1 user - registry-users-lob1 group)"
-    echo "  - lob2-user/${LOB2_USER_PASSWORD:-lob2pass} (LOB2 user - registry-users-lob2 group)"
+    echo "Users created (passwords are temporary; each user is prompted to reset on first login):"
+    echo "  - admin (realm admin - all groups including mcp-registry-admin)"
+    echo "  - lob1-user (LOB1 user - registry-users-lob1 group)"
+    echo "  - lob2-user (LOB2 user - registry-users-lob2 group)"
     echo "  - service-account-mcp-gateway-m2m (service account for M2M access)"
     echo ""
     echo "Service Account Clients (M2M):"

--- a/terraform/aws-ecs/scripts/post-deployment-setup.sh
+++ b/terraform/aws-ecs/scripts/post-deployment-setup.sh
@@ -27,11 +27,8 @@
 #   AWS_REGION                    AWS region (default: us-east-1)
 #   KEYCLOAK_ADMIN_PASSWORD       Keycloak admin password (or loaded from SSM)
 #   INITIAL_ADMIN_PASSWORD        Password for admin user in mcp-gateway realm
-#
-# Optional Environment Variables:
-#   INITIAL_USER_PASSWORD         Password for testuser (default: testpass)
-#   LOB1_USER_PASSWORD            Password for lob1-user (default: lob1pass)
-#   LOB2_USER_PASSWORD            Password for lob2-user (default: lob2pass)
+#   LOB1_USER_PASSWORD            Password for lob1-user (required, no default)
+#   LOB2_USER_PASSWORD            Password for lob2-user (required, no default)
 #
 ################################################################################
 
@@ -485,6 +482,17 @@ _initialize_keycloak() {
         log_error "INITIAL_ADMIN_PASSWORD could not be loaded from Secrets Manager."
         log_error "Either set it manually or ensure the secret exists:"
         log_error "  export INITIAL_ADMIN_PASSWORD='YourSecurePassword123'"
+        STEPS_FAILED=$((STEPS_FAILED + 1))
+        return 1
+    fi
+
+    # SA-9: init-keycloak.sh now requires explicit LOB user passwords (no weak
+    # defaults). Fail early here with a clear message rather than mid-run.
+    if [[ -z "${LOB1_USER_PASSWORD:-}" || -z "${LOB2_USER_PASSWORD:-}" ]]; then
+        log_error "LOB1_USER_PASSWORD and LOB2_USER_PASSWORD are required (no default)."
+        log_error "Export both before running post-deployment setup, e.g.:"
+        log_error "  export LOB1_USER_PASSWORD='YourSecurePassword1'"
+        log_error "  export LOB2_USER_PASSWORD='YourSecurePassword2'"
         STEPS_FAILED=$((STEPS_FAILED + 1))
         return 1
     fi

--- a/tests/security/test_keycloak_init_credentials.py
+++ b/tests/security/test_keycloak_init_credentials.py
@@ -1,0 +1,103 @@
+"""
+Regression tests for SA-9: Keycloak init scripts must not create users with weak
+default passwords, must force a reset on first login (temporary: true), and must
+not print credential values.
+
+These are static-content assertions over the setup scripts and the realm import,
+so they cannot regress even without a live Keycloak.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    """Get repository root directory."""
+    return Path(__file__).parent.parent.parent
+
+
+# Both copies of the Keycloak init script must satisfy the SA-9 invariants.
+INIT_SCRIPTS = [
+    "keycloak/setup/init-keycloak.sh",
+    "terraform/aws-ecs/scripts/init-keycloak.sh",
+]
+
+# Weak default-password patterns that must never reappear in the init scripts.
+FORBIDDEN_FALLBACKS = [
+    ":-changeme",
+    ":-testpass",
+    ":-lob1pass",
+    ":-lob2pass",
+]
+
+
+@pytest.mark.parametrize("script_path", INIT_SCRIPTS)
+def test_init_script_has_no_weak_password_fallbacks(
+    repo_root: Path,
+    script_path: str,
+):
+    """No `${VAR:-weakdefault}` password fallbacks in the init scripts."""
+    content = (repo_root / script_path).read_text()
+    offenders = [pat for pat in FORBIDDEN_FALLBACKS if pat in content]
+    assert not offenders, (
+        f"{script_path}: weak default-password fallback(s) present: {offenders}. "
+        "Require the password env var instead (fail closed when unset)."
+    )
+
+
+@pytest.mark.parametrize("script_path", INIT_SCRIPTS)
+def test_init_script_creates_no_testuser(
+    repo_root: Path,
+    script_path: str,
+):
+    """The insecure `testuser` demo account must not be created."""
+    content = (repo_root / script_path).read_text()
+    assert "testuser" not in content, (
+        f"{script_path}: still references 'testuser'; the weak demo account was removed."
+    )
+
+
+@pytest.mark.parametrize("script_path", INIT_SCRIPTS)
+def test_init_script_users_are_temporary(
+    repo_root: Path,
+    script_path: str,
+):
+    """Every created credential forces a reset on first login (no temporary:false)."""
+    content = (repo_root / script_path).read_text()
+    assert '"temporary": false' not in content, (
+        f"{script_path}: a user credential is created with 'temporary': false; "
+        "all created users must use 'temporary': true to force a first-login reset."
+    )
+
+
+def test_primary_init_requires_admin_password(repo_root: Path):
+    """The primary init script fails closed when INITIAL_ADMIN_PASSWORD is unset."""
+    content = (repo_root / "keycloak/setup/init-keycloak.sh").read_text()
+    assert 'if [ -z "$INITIAL_ADMIN_PASSWORD" ]' in content, (
+        "keycloak/setup/init-keycloak.sh must guard on INITIAL_ADMIN_PASSWORD being set."
+    )
+
+
+def test_ecs_init_requires_lob_passwords(repo_root: Path):
+    """The ECS init script fails closed when LOB user passwords are unset."""
+    content = (repo_root / "terraform/aws-ecs/scripts/init-keycloak.sh").read_text()
+    assert 'if [ -z "$LOB1_USER_PASSWORD" ] || [ -z "$LOB2_USER_PASSWORD" ]' in content, (
+        "terraform/aws-ecs/scripts/init-keycloak.sh must guard on LOB user passwords."
+    )
+
+
+def test_realm_import_has_no_testuser(repo_root: Path):
+    """The realm import must not ship a testuser with a weak default password."""
+    data = json.loads((repo_root / "keycloak/import/realm-config.json").read_text())
+    usernames = {u.get("username") for u in data.get("users", [])}
+    assert "testuser" not in usernames, "realm-config.json still defines a 'testuser'."
+    # Every remaining user credential must be temporary.
+    for user in data.get("users", []):
+        for cred in user.get("credentials", []):
+            assert cred.get("temporary") is True, (
+                f"realm-config.json user {user.get('username')!r} has a "
+                "non-temporary credential; must be temporary: true."
+            )


### PR DESCRIPTION
## Summary

Fixes security finding **SA-9** (HIGH): the `init-keycloak.sh` scripts created Keycloak users with weak fallback passwords that were never forced to rotate, and printed those credentials to the console.

## What was wrong

- **`keycloak/setup/init-keycloak.sh`** (docker / manual): admin fell back to `changeme`, test user to `testpass`, both `"temporary": false`, and it printed `admin/changeme` + `testuser/testpass` to the console.
- **`terraform/aws-ecs/scripts/init-keycloak.sh`** (ECS): admin was already guarded, but test/LOB users fell back to `testpass`/`lob1pass`/`lob2pass`, all `"temporary": false`, and it echoed the real passwords (including `admin/${INITIAL_ADMIN_PASSWORD}`) to the console.
- **`keycloak/import/realm-config.json`**: shipped a `testuser` with a `testpass` default.

## Changes

- **Require passwords, no weak defaults:**
  - Primary script now fails closed when `INITIAL_ADMIN_PASSWORD` is unset (drops `:-changeme`).
  - ECS script now requires `LOB1_USER_PASSWORD` / `LOB2_USER_PASSWORD` (drops `:-lob1pass`/`:-lob2pass`), and `post-deployment-setup.sh` preflights both with a clear early error.
- **Force first-login reset:** every created or reset credential is now `"temporary": true` (including the ECS `update_user_password` reset path).
- **Remove the insecure `testuser` account** from both init scripts and the realm import. Nothing functionally depends on it (all `tests/**` "testuser" hits are generic mock strings, not the provisioned account).
- **Keep the LOB demo feature** (`registry-users-lob1/2` groups + `lob1-user`/`lob2-user`) — it's a documented A2A access-control walkthrough — but harden how the accounts are created.
- **Stop printing credential values** to the console in both scripts.
- **Docs / config updated:** `.env.example`, `docs/configuration.md`, `docs/keycloak-mcp-clients.md`, `infra/docs/DEPLOYMENT-GUIDE.md`.

## Testing

- New `tests/security/test_keycloak_init_credentials.py` (9 tests): no weak fallbacks, no `testuser`, all credentials `temporary: true`, required-password guards present, realm import clean.
- Mutation-proven: reintroducing `:-changeme` fails the suite; restored to green.
- Full `tests/security/` suite: **65 passed**.
- `bash -n` clean on all three scripts; `realm-config.json` valid JSON.

## Out of scope (separate PRs)

- **CDK**: `infra/scripts/post-deploy.sh` hardcodes `INITIAL_USER_PASSWORD=testpass123` — belongs with the CDK follow-ups (also carries the `sslRequired=NONE` fix from SA-8).
- **Helm**: `charts/keycloak-configure` creates a `testuser` and handles passwords its own way — dedicated PR with `helm-unittest` coverage.
