### PR TITLE
docs(auth): fix mermaid render of token placeholder

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -183,7 +183,7 @@ sequenceDiagram
     participant IdP as Identity Provider
     participant API as Registry API
 
-    Client->>NGINX: 1. API Request<br/>Authorization: Bearer <token>
+    Client->>NGINX: 1. API Request<br/>Authorization: Bearer [token]
     NGINX->>Auth: 2. auth_request /validate
 
     alt Self-Signed Token (iss: mcp-auth-server)


### PR DESCRIPTION
Fix a Mermaid placeholder that can be parsed as an HTML tag.

Matches the existing docs pattern of using bracketed placeholders in sequence diagrams.