### PR TITLE
docs: stop instructing sslRequired=none; external is correct

### DIFF
--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -440,11 +440,15 @@ Log: `{ 8, "Keycloak Startup", DONE/FAILED, "Ready in Xs / timed out" }`
 
 ---
 
-### Phase 9: Fix macOS SSL Requirement
+### Phase 9: Verify Keycloak SSL Posture
 
-**Announce:** "Disabling Keycloak HTTPS requirement for local macOS development..."
+**Announce:** "Verifying Keycloak's SSL requirement (should be 'external', reachable over loopback)..."
 
-On macOS, Docker's VM causes Keycloak to enforce HTTPS on all connections. This must be disabled for local development.
+The realms ship with `sslRequired: external`, which requires TLS for external
+requests but allows plaintext HTTP from loopback (localhost). The setup commands
+talk to Keycloak over `http://localhost:8080`, so no change is needed. Do NOT set
+`sslRequired=NONE` — that disables TLS enforcement for external requests too,
+allowing admin login and OIDC/token traffic over plaintext HTTP.
 
 Detect the Keycloak container name:
 ```bash
@@ -453,23 +457,13 @@ echo "Keycloak container: ${KEYCLOAK_CONTAINER}"
 [ -z "$KEYCLOAK_CONTAINER" ] && echo "ERROR: No Keycloak container running" && docker ps && exit 1
 ```
 
-Disable SSL on master realm:
-```bash
-docker exec ${KEYCLOAK_CONTAINER} /opt/keycloak/bin/kcadm.sh config credentials \
-    --server http://localhost:8080 --realm master \
-    --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
-
-docker exec ${KEYCLOAK_CONTAINER} /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
-echo "SSL disabled for master realm, exit code: $?"
-```
-
-Verify:
+Confirm the master realm is reachable over loopback HTTP (external allows this):
 ```bash
 HTTP=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/admin/")
 echo "Admin endpoint: HTTP ${HTTP} (302 = success)"
 ```
 
-Log: `{ 9, "Keycloak SSL Fix (master realm)", DONE/FAILED, "HTTP ${HTTP}" }`
+Log: `{ 9, "Keycloak SSL Posture (external, loopback OK)", DONE/FAILED, "HTTP ${HTTP}" }`
 
 ---
 
@@ -488,18 +482,8 @@ export KEYCLOAK_ADMIN_PASSWORD="${KEYCLOAK_ADMIN_PASSWORD}"
 echo "Init exit code: $?"
 ```
 
-After initialization, disable SSL on the newly created `mcp-gateway` realm:
-
-```bash
-KEYCLOAK_CONTAINER=$(docker ps --format "{{.Names}}" | grep keycloak | grep -v db | head -1)
-
-docker exec ${KEYCLOAK_CONTAINER} /opt/keycloak/bin/kcadm.sh config credentials \
-    --server http://localhost:8080 --realm master \
-    --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
-
-docker exec ${KEYCLOAK_CONTAINER} /opt/keycloak/bin/kcadm.sh update realms/mcp-gateway -s sslRequired=NONE
-echo "SSL disabled for mcp-gateway realm, exit code: $?"
-```
+The newly created `mcp-gateway` realm ships with `sslRequired: external`, which
+works over loopback HTTP — no SSL change is needed. Do NOT set `sslRequired=NONE`.
 
 Verify both realms:
 ```bash
@@ -508,7 +492,7 @@ curl -s http://localhost:8080/realms/mcp-gateway | python3 -c "import sys,json; 
 ```
 
 **Common failures and fixes:**
-- If the script fails with an SSL error: re-run Phase 9 before retrying
+- If the script fails with an "HTTPS required" error: you are reaching Keycloak over a non-loopback address. Use `http://localhost:8080`. Do NOT lower `sslRequired` to `none`.
 - If Keycloak is not responding: wait 30 seconds and retry — it may still be initializing
 - If admin credentials are rejected: verify `KEYCLOAK_ADMIN_PASSWORD` matches what was set in Phase 3
 
@@ -773,7 +757,7 @@ Step Summary:
 |  6    | Embeddings Model Download                  | DONE     | ~90MB downloaded            |
 |  7    | Directory Creation                         | DONE     | ~/mcp-gateway/...           |
 |  8    | Keycloak Startup                           | DONE     | ready in Xs                 |
-|  9    | Keycloak SSL Fix (master)                  | DONE     | sslRequired=NONE            |
+|  9    | Keycloak SSL Posture (external)            | DONE     | loopback HTTP reachable     |
 | 10    | Keycloak Init (realm + clients)            | DONE     | mcp-gateway realm           |
 | 11    | Client Credentials Retrieved               | DONE     | .oauth-tokens/ updated      |
 | 12    | Test Agents Created                        | DONE     | test-agent, ai-assistant    |

--- a/docs/complete-setup-guide.md
+++ b/docs/complete-setup-guide.md
@@ -361,23 +361,19 @@ curl http://localhost:8080/realms/master
 # Should return JSON with realm information
 ```
 
-### Disable SSL Requirement for Master Realm
-```bash
-# Note: KEYCLOAK_ADMIN defaults to "admin" - ensure KEYCLOAK_ADMIN_PASSWORD is set
-export KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-admin}"
+### About Keycloak's SSL Requirement (no action needed)
 
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | \
-    jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/master" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
-```
+Both realms ship with `sslRequired: external`, which requires TLS for external
+requests but allows plaintext HTTP from private/loopback addresses. Because the
+setup commands below talk to Keycloak over `http://localhost:8080` (a loopback
+address), they work as-is. In a deployed stack, external traffic reaches
+Keycloak over HTTPS through the nginx front door, and Keycloak trusts the
+forwarded scheme via `KC_PROXY=edge`.
+
+Do NOT lower this to `sslRequired: none`. `none` disables TLS enforcement even
+for genuinely external requests, which allows admin login and all OIDC/token
+traffic over plaintext HTTP. `external` is the correct, secure value and needs
+no change.
 
 ### Initialize Keycloak Configuration
 
@@ -402,23 +398,7 @@ chmod +x keycloak/setup/init-keycloak.sh
 # IMPORTANT: The script will tell you to run get-all-client-credentials.sh
 # to retrieve and save the credentials. This is the next required step!
 
-# Step 2: Disable SSL for Application Realm
-# Note: KEYCLOAK_ADMIN defaults to "admin" - ensure KEYCLOAK_ADMIN_PASSWORD is set
-export KEYCLOAK_ADMIN="${KEYCLOAK_ADMIN:-admin}"
-
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | \
-    jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/mcp-gateway" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
-
-# Step 3: Retrieve and save all client credentials (REQUIRED)
+# Step 2: Retrieve and save all client credentials (REQUIRED)
 chmod +x keycloak/setup/get-all-client-credentials.sh
 ./keycloak/setup/get-all-client-credentials.sh
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -50,33 +50,14 @@ docker compose up mongodb-init
 docker compose restart auth-server
 
 # 7. Initialize Keycloak (wait for Keycloak to start first)
-# Disable SSL for master realm
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/master" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
+# Note: both realms ship with sslRequired=external, which requires TLS for
+# external requests but allows plaintext HTTP from loopback. These commands talk
+# to Keycloak over http://localhost, so no SSL change is needed. Do NOT set
+# sslRequired=none (that would disable TLS enforcement for external requests too).
 
 # Initialize realm and clients
 chmod +x keycloak/setup/init-keycloak.sh
 ./keycloak/setup/init-keycloak.sh
-
-# Disable SSL for application realm
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/mcp-gateway" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
 
 # Get client credentials
 chmod +x keycloak/setup/get-all-client-credentials.sh
@@ -150,33 +131,14 @@ podman compose up mongodb-init
 podman compose restart auth-server
 
 # 9. Initialize Keycloak (wait for Keycloak to start first)
-# Note: Podman uses port 18080 for Keycloak
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:18080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | jq -r '.access_token') && \
-curl -X PUT "http://localhost:18080/admin/realms/master" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
+# Note: Podman uses port 18080 for Keycloak.
+# Both realms ship with sslRequired=external (TLS required for external requests,
+# plaintext allowed from loopback). These commands talk to Keycloak over
+# http://localhost, so no SSL change is needed. Do NOT set sslRequired=none.
 
 # Initialize realm and clients
 chmod +x keycloak/setup/init-keycloak.sh
 KEYCLOAK_URL=http://localhost:18080 ./keycloak/setup/init-keycloak.sh
-
-# Disable SSL for application realm
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:18080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | jq -r '.access_token') && \
-curl -X PUT "http://localhost:18080/admin/realms/mcp-gateway" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
 
 # Get client credentials
 chmod +x keycloak/setup/get-all-client-credentials.sh

--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -226,10 +226,11 @@ docker-compose ps keycloak
 # Configure Keycloak admin CLI (use your actual admin password)
 docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
 
-# Disable SSL requirement for master realm
-docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
+# Note: the realms ship with sslRequired=external, which allows plaintext HTTP
+# from loopback (localhost) while still requiring TLS for external requests.
+# No SSL change is needed. Do NOT set sslRequired=NONE.
 
-# Verify the fix worked
+# Verify admin API is reachable over loopback HTTP
 curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/admin/"
 # Should return: 302 (redirect to login - this is correct)
 ```
@@ -281,17 +282,15 @@ chmod +x keycloak/setup/get-all-client-credentials.sh
 # Files created in: .oauth-tokens/
 ```
 
-### Fix SSL Requirement for mcp-gateway Realm
-**Important**: Now that the mcp-gateway realm is created, we need to disable SSL for it as well:
+### SSL Requirement for the mcp-gateway Realm (no action needed)
+
+**Note**: The mcp-gateway realm is created with `sslRequired: external`, which
+requires TLS for external requests but allows plaintext HTTP from loopback. No
+SSL change is needed. Do NOT set `sslRequired=NONE` (it disables TLS enforcement
+for external requests too).
 
 ```bash
-# Configure Keycloak admin CLI (if session expired)
-docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
-
-# Disable SSL requirement for the mcp-gateway realm
-docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh update realms/mcp-gateway -s sslRequired=NONE
-
-# Verify both realms are accessible
+# Verify both realms are accessible over loopback HTTP
 curl -s -o /dev/null -w "%{http_code}" "http://localhost:8080/admin/"
 # Should return: 302
 
@@ -650,13 +649,9 @@ podman compose logs -f keycloak
 **3. Configure Keycloak (same as Section 5-6)**
 
 ```bash
-# Disable SSL requirement
-podman exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh config credentials \
-  --server http://localhost:8080 --realm master \
-  --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
-
-podman exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh \
-  update realms/master -s sslRequired=NONE
+# Note: the realms ship with sslRequired=external, which allows plaintext HTTP
+# from loopback while requiring TLS for external requests. No SSL change is
+# needed. Do NOT set sslRequired=NONE.
 
 # Run Keycloak setup scripts
 cd keycloak/setup
@@ -942,17 +937,21 @@ chmod +x build_and_run.sh
 ```
 
 #### Keycloak "HTTPS Required" Error
+
+The realms use `sslRequired: external`, which permits plaintext HTTP only from
+loopback. If you hit "HTTPS Required", you are almost certainly reaching Keycloak
+over a non-loopback address (a LAN IP or hostname) rather than `localhost`.
+
 ```bash
-# This was fixed in Section 4, but if it persists:
-
-# Re-run SSL disable commands (use your actual admin password)
+# Confirm the realm's current setting (should be "external")
 docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin --password "${KEYCLOAK_ADMIN_PASSWORD}"
-
-docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
-
-# Also disable for the mcp-gateway realm after it's created
-docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh update realms/mcp-gateway -s sslRequired=NONE
+docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh get realms/master --fields sslRequired
 ```
+
+Fix by accessing Keycloak via `http://localhost:8080` (loopback), or by putting
+it behind the nginx/TLS front door for external access. Do NOT set
+`sslRequired=NONE`: that disables TLS enforcement for external requests and is
+the weakness removed by the SA-8 security fix.
 
 #### Services Won't Start
 ```bash

--- a/docs/macos-setup-guide.md
+++ b/docs/macos-setup-guide.md
@@ -950,8 +950,8 @@ docker exec mcp-gateway-registry-keycloak-1 /opt/keycloak/bin/kcadm.sh get realm
 
 Fix by accessing Keycloak via `http://localhost:8080` (loopback), or by putting
 it behind the nginx/TLS front door for external access. Do NOT set
-`sslRequired=NONE`: that disables TLS enforcement for external requests and is
-the weakness removed by the SA-8 security fix.
+`sslRequired=NONE`: that disables TLS enforcement for external requests too,
+allowing admin login and OIDC/token traffic over plaintext HTTP.
 
 #### Services Won't Start
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -195,40 +195,17 @@ curl http://localhost:8080/realms/master
 # Should return JSON with realm information
 ```
 
-**6b. Disable SSL for master realm (required for HTTP access):**
-```bash
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | \
-    jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/master" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
-```
+**6b. About SSL (no action needed):**
+
+Both realms ship with `sslRequired: external`, which requires TLS for external
+requests but allows plaintext HTTP from loopback. The commands below reach
+Keycloak over `http://localhost`, so they work without any change. Do NOT set
+`sslRequired: none` — that disables TLS enforcement for external requests too.
 
 **6c. Initialize Keycloak realm and clients:**
 ```bash
 chmod +x keycloak/setup/init-keycloak.sh
 ./keycloak/setup/init-keycloak.sh
-```
-
-**6d. Disable SSL for application realm:**
-```bash
-ADMIN_TOKEN=$(curl -s -X POST "http://localhost:8080/realms/master/protocol/openid-connect/token" \
-    -H "Content-Type: application/x-www-form-urlencoded" \
-    -d "username=${KEYCLOAK_ADMIN}" \
-    -d "password=${KEYCLOAK_ADMIN_PASSWORD}" \
-    -d "grant_type=password" \
-    -d "client_id=admin-cli" | \
-    jq -r '.access_token') && \
-curl -X PUT "http://localhost:8080/admin/realms/mcp-gateway" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" \
-    -H "Content-Type: application/json" \
-    -d '{"sslRequired": "none"}'
 ```
 
 **6e. Retrieve and save client credentials:**


### PR DESCRIPTION
## Summary

Removes the `sslRequired: none` instructions from the setup guides and the macOS setup skill. Telling users to lower Keycloak to `none` re-introduces a real weakness: `none` disables TLS enforcement for *external* requests too, so admin login and all OIDC/token traffic can flow over plaintext HTTP.

## Why `external` is correct (and needs no change)

Both realms ship with `sslRequired: external` (via `keycloak/import/realm-config.json`). `external` requires TLS for external requests but permits plaintext HTTP from loopback/private addresses. The setup commands talk to Keycloak over `http://localhost:8080`, so they work unchanged. In a deployed stack, external traffic reaches Keycloak over HTTPS through the nginx front door with `KC_PROXY=edge`.

## Verified on a fresh install

Confirmed on a brand-new docker install cloned from `main`: Keycloak came up with `master` and `mcp-gateway` both at `sslRequired: external`, the admin token was obtained over `http://localhost:8080`, and `init-keycloak.sh` completed successfully with **no SSL-disable step**.

## Changes

- **`docs/complete-setup-guide.md`** — removed the "Disable SSL Requirement for Master Realm" section and the "Disable SSL for Application Realm" step; renumbered; added a note.
- **`docs/installation.md`** — removed both disable-ssl curl blocks (8080 and podman 18080 variants).
- **`docs/quickstart.md`** — removed the two disable-ssl steps.
- **`docs/macos-setup-guide.md`** — removed the `kcadm ... sslRequired=NONE` instructions; rewrote the "HTTPS Required" troubleshooting entry to explain the loopback rule instead of weakening to `none`.
- **`.claude/skills/macos-setup/SKILL.md`** — the runnable playbook had live `sslRequired=NONE` steps; rewrote Phase 9 to a verify-only step and removed the Phase 10 disable-ssl block.

All actual `sslRequired: none` instructions are gone; only explicit "do NOT set none" warnings remain.
