### PR TITLE
Add Xquik MCP gateway example

### DIFF
--- a/cli/examples/xquik-server-config.json
+++ b/cli/examples/xquik-server-config.json
@@ -1,0 +1,24 @@
+{
+  "server_name": "Xquik MCP Server",
+  "description": "Connect agents to Xquik for X data workflows through the hosted MCP endpoint.",
+  "path": "/xquik",
+  "proxy_pass_url": "https://xquik.com/mcp",
+  "auth_scheme": "bearer",
+  "supported_transports": ["streamable-http"],
+  "headers": [
+    {
+      "Authorization": "Bearer $XQUIK_API_KEY"
+    }
+  ],
+  "tags": ["x", "twitter", "social-media", "mcp", "data"],
+  "status": "active",
+  "provider_organization": "Xquik",
+  "provider_url": "https://docs.xquik.com",
+  "visibility": "public",
+  "license": "MIT",
+  "metadata": {
+    "category": "social-data",
+    "mcp_compatible": "1.0",
+    "requires_api_key": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add an example gateway config for the hosted Xquik MCP endpoint.
- Include bearer auth and Streamable HTTP transport metadata from Xquik public MCP manifest.

## Validation

- `node -e 'JSON.parse(require("fs").readFileSync("cli/examples/xquik-server-config.json", "utf8"))'
- `git diff --check`
- Duplicate gate: no existing Xquik entries, PRs, or issues found in this repository.
