### PR TITLE
fix(security): enable MongoDB auth by default; drop weak admin password (SA-11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1147,12 +1147,17 @@ STORAGE_BACKEND=mongodb-ce
 # Amazon DocumentDB (MongoDB-compatible) or MongoDB connection settings
 
 # For local MongoDB CE (mongodb-ce backend):
-# Authentication with SCRAM-SHA-256 (stronger than SCRAM-SHA-1)
+# Authentication with SCRAM-SHA-256 (stronger than SCRAM-SHA-1).
+# The local MongoDB container runs with --auth and creates its root user from
+# these on first boot. There is NO default: set a strong password (or let
+# build_and_run.sh generate one). docker compose fails to start if unset.
 DOCUMENTDB_HOST=mongodb
 DOCUMENTDB_PORT=27017
 DOCUMENTDB_DATABASE=mcp_registry
 DOCUMENTDB_USERNAME=admin
-DOCUMENTDB_PASSWORD=admin
+# DOCUMENTDB_PASSWORD is intentionally left blank; build_and_run.sh generates a
+# strong random value on first run, or set your own here. Do NOT ship "admin".
+DOCUMENTDB_PASSWORD=
 DOCUMENTDB_USE_TLS=false
 DOCUMENTDB_NAMESPACE=default
 

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -373,6 +373,28 @@ else
     log "AUTH_SERVER_NGINX_MARKER_SECRET already exists in .env"
 fi
 
+# Generate a strong DOCUMENTDB_PASSWORD if not already set. The local MongoDB
+# container runs with --auth and creates its root user from this value on first
+# boot, so it must never be a weak default like "admin". We only generate when
+# the value is missing/empty; an operator-provided password is left untouched.
+# NOTE: this only helps a first-time install. If MongoDB was already initialized
+# with a different password (existing data volume), set DOCUMENTDB_PASSWORD to
+# that value or recreate the mongodb-data volume.
+if ! grep -q "^DOCUMENTDB_PASSWORD=" .env || grep -q "^DOCUMENTDB_PASSWORD=$" .env || grep -q "^DOCUMENTDB_PASSWORD=\"\"$" .env; then
+    log "Generating DOCUMENTDB_PASSWORD..."
+    DOCUMENTDB_PASSWORD=$(python3 -c 'import secrets; print(secrets.token_hex(24))') || handle_error "Failed to generate DOCUMENTDB_PASSWORD"
+
+    # Remove any existing empty DOCUMENTDB_PASSWORD line
+    sed -i '/^DOCUMENTDB_PASSWORD=$/d' .env 2>/dev/null || true
+    sed -i '/^DOCUMENTDB_PASSWORD=""$/d' .env 2>/dev/null || true
+
+    # Add new DOCUMENTDB_PASSWORD
+    echo "DOCUMENTDB_PASSWORD=$DOCUMENTDB_PASSWORD" >> .env
+    log "DOCUMENTDB_PASSWORD added to .env"
+else
+    log "DOCUMENTDB_PASSWORD already exists in .env"
+fi
+
 # Validate required environment variables
 log "Validating required environment variables..."
 source .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,42 @@ version: '3.8'
 # Note: DocumentDB is a managed AWS service and runs outside of Docker.
 
 services:
+  # MongoDB keyfile initialization: generates the shared keyfile that MongoDB
+  # requires for replica-set internal authentication when --auth is enabled.
+  # Runs once before mongodb starts; idempotent (skips if the keyfile exists).
+  mongodb-keyfile-init:
+    image: alpine:latest
+    container_name: mcp-mongodb-keyfile-init
+    volumes:
+      - mongodb-keyfile:/keyfile
+    command: >
+      sh -c "
+      if [ ! -f /keyfile/replica.key ]; then
+        echo 'Generating MongoDB keyfile...';
+        apk add --no-cache openssl;
+        openssl rand -base64 756 > /keyfile/replica.key;
+        chmod 400 /keyfile/replica.key;
+        chown 999:999 /keyfile/replica.key;
+        echo 'Keyfile generated successfully';
+      else
+        echo 'Keyfile already exists, skipping generation';
+      fi
+      "
+    restart: "no"
+
   # MongoDB Community Edition 8.2 (alternative to DocumentDB for local development)
   # Vector search is implemented in application code (see search_repository.py)
-  # Running without authentication for local development simplicity
+  # Authentication is enabled (--auth): the root user is created on first boot
+  # from DOCUMENTDB_USERNAME/DOCUMENTDB_PASSWORD, which must be set (no default).
   mongodb:
     image: mongo:8.2
     container_name: mcp-mongodb
-    command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb
+    command: mongod --replSet rs0 --bind_ip 127.0.0.1,mongodb --auth --keyFile /keyfile/replica.key
+    environment:
+      # Root user is created only on first boot (empty data dir). Fail closed if
+      # either is unset so we never fall back to a weak default like admin/admin.
+      - MONGO_INITDB_ROOT_USERNAME=${DOCUMENTDB_USERNAME:?set DOCUMENTDB_USERNAME in .env}
+      - MONGO_INITDB_ROOT_PASSWORD=${DOCUMENTDB_PASSWORD:?set DOCUMENTDB_PASSWORD in .env}
     ports:
       # Loopback-only: host tools (mongosh, tests) reach it via localhost, but it
       # is never exposed on other interfaces. Set HOST_BIND_IP=0.0.0.0 to override.
@@ -25,6 +54,7 @@ services:
     volumes:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
+      - mongodb-keyfile:/keyfile:ro
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -34,8 +64,11 @@ services:
       - SETGID   # Required by gosu to switch to mongodb group at startup
       - CHOWN    # Required by entrypoint to fix /data/db ownership
       - DAC_OVERRIDE  # Required by entrypoint to read /data/db before chown
+    depends_on:
+      mongodb-keyfile-init:
+        condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      test: ["CMD", "mongosh", "-u", "${DOCUMENTDB_USERNAME}", "-p", "${DOCUMENTDB_PASSWORD}", "--authenticationDatabase", "admin", "--eval", "db.adminCommand('ping')"]
       interval: 60s
       timeout: 5s
       retries: 5
@@ -53,8 +86,10 @@ services:
       - DOCUMENTDB_HOST=mongodb
       - DOCUMENTDB_PORT=27017
       - DOCUMENTDB_DATABASE=${DOCUMENTDB_DATABASE:-mcp_registry}
-      - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME:-}
-      - DOCUMENTDB_PASSWORD=${DOCUMENTDB_PASSWORD:-}
+      # Required (no default): must match the root creds MongoDB was initialized
+      # with, so the init job can authenticate against the now-authenticated DB.
+      - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME:?set DOCUMENTDB_USERNAME in .env}
+      - DOCUMENTDB_PASSWORD=${DOCUMENTDB_PASSWORD:?set DOCUMENTDB_PASSWORD in .env}
       - DOCUMENTDB_NAMESPACE=${DOCUMENTDB_NAMESPACE:-default}
       - ENTRA_GROUP_ADMIN_ID=${ENTRA_GROUP_ADMIN_ID:-}
     volumes:
@@ -922,6 +957,7 @@ volumes:
   grafana-data:
   mongodb-data:
   mongodb-config:
+  mongodb-keyfile:
   pingfederate-data:
   # Application logs and scans (managed by containers, proper permissions)
   registry-logs:

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -24,6 +24,7 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [How do I monitor the health of MCP servers?](monitoring-server-health.md)
 - [How do I configure MongoDB Atlas instead of MongoDB CE?](configuring-mongodb-atlas-backend.md)
+- [How do I migrate an existing local MongoDB to authenticated mode? (local dev only)](migrate-local-mongodb-to-authenticated.md)
 - [Why are some of my assets not showing up in semantic search?](fix-missing-search-embeddings.md)
 - [Why do I sometimes see search results for assets that no longer exist?](fix-stale-search-embeddings.md)
 

--- a/docs/faq/migrate-local-mongodb-to-authenticated.md
+++ b/docs/faq/migrate-local-mongodb-to-authenticated.md
@@ -1,0 +1,133 @@
+# How do I migrate an existing local MongoDB to authenticated mode?
+
+> **This applies to LOCAL DEVELOPMENT (Docker Compose) ONLY.**
+>
+> It is relevant only if you previously ran the default `docker-compose.yml`
+> with **MongoDB CE and no authentication** and are now pulling a version where
+> the default MongoDB requires authentication.
+>
+> **You do NOT need this if any of the following are true:**
+> - You deploy on **AWS ECS / Terraform** or **EKS / Helm** — those use Amazon
+>   DocumentDB (or an external MongoDB), which is already authenticated and
+>   unaffected by this change.
+> - You used the **`docker-compose.prebuilt.yml`** variant — its MongoDB was
+>   already authenticated, so your data volume already has the admin user.
+> - This is a **fresh install** — MongoDB creates the admin user on first boot
+>   from `DOCUMENTDB_USERNAME` / `DOCUMENTDB_PASSWORD`, so there is nothing to
+>   migrate.
+
+## Why this is needed
+
+The default local `docker-compose.yml` now starts MongoDB with `--auth` and
+creates a root user on first boot from `DOCUMENTDB_USERNAME` /
+`DOCUMENTDB_PASSWORD`. MongoDB only creates that user when the **data directory
+is empty** (first boot). If you already have a `mongodb-data` volume that was
+created **without** authentication, turning on `--auth` leaves you in a state
+where authentication is required but **no user exists**, so every connection is
+rejected.
+
+You have two options. Pick based on whether your local data is worth keeping.
+
+---
+
+## Option A: Recreate the volume (simplest — discards local data)
+
+For most local-dev setups the MongoDB data is disposable (servers/agents are
+re-registered and scopes are re-seeded by `mongodb-init`). Drop and recreate the
+volume, then let the fresh-boot path create the user.
+
+```bash
+cd <your-clone>/mcp-gateway-registry
+
+# 1. Set a strong password in .env (build_and_run.sh also auto-generates one if
+#    DOCUMENTDB_PASSWORD is left blank).
+#    DOCUMENTDB_USERNAME=admin
+#    DOCUMENTDB_PASSWORD=<a strong value>
+
+# 2. Stop MongoDB and remove ONLY its volumes (leaves Keycloak/other data alone).
+#    The volume names are prefixed with the compose project name (the directory
+#    name by default, e.g. mcp-gateway-registry_mongodb-data).
+docker compose stop mongodb mongodb-init
+docker compose rm -f mongodb mongodb-init mongodb-keyfile-init
+docker volume rm \
+  "$(basename "$PWD")_mongodb-data" \
+  "$(basename "$PWD")_mongodb-config" \
+  "$(basename "$PWD")_mongodb-keyfile" 2>/dev/null || true
+
+# 3. Bring the stack back up. MongoDB creates the root user on first boot,
+#    mongodb-init re-seeds collections/scopes.
+./build_and_run.sh
+```
+
+Verify:
+
+```bash
+# Unauthenticated access is now rejected:
+docker exec mcp-mongodb mongosh --quiet --eval \
+  "db.getSiblingDB('mcp_registry').mcp_servers_default.countDocuments({})"
+# -> MongoServerError: ... requires authentication
+
+# Authenticated access succeeds:
+docker exec mcp-mongodb mongosh --quiet \
+  -u "$DOCUMENTDB_USERNAME" -p "$DOCUMENTDB_PASSWORD" \
+  --authenticationDatabase admin --eval "db.adminCommand('ping')"
+# -> { ok: 1 }
+```
+
+---
+
+## Option B: Keep your data (create the admin user in place)
+
+If you want to preserve the existing local database, create the admin user on
+the old no-auth volume **before** enabling `--auth`, then switch auth on.
+
+```bash
+cd <your-clone>/mcp-gateway-registry
+
+# 1. Start MongoDB WITHOUT auth on the existing volume (temporary), matching the
+#    replica set it was created with.
+docker run --rm -d --name mongo-migrate \
+  -v "$(basename "$PWD")_mongodb-data:/data/db" \
+  mongo:8.2 mongod --replSet rs0 --bind_ip 127.0.0.1
+
+# Wait a few seconds for it to accept connections.
+sleep 8
+
+# 2. Create the root user (use the SAME username/password you will put in .env).
+docker exec mongo-migrate mongosh --quiet admin --eval '
+  db.createUser({
+    user: "admin",
+    pwd:  "REPLACE_WITH_YOUR_STRONG_PASSWORD",
+    roles: [ { role: "root", db: "admin" } ]
+  })
+'
+
+# 3. Stop the temporary instance.
+docker rm -f mongo-migrate
+
+# 4. Put the SAME credentials in .env, then start the stack normally (now with --auth).
+#    DOCUMENTDB_USERNAME=admin
+#    DOCUMENTDB_PASSWORD=REPLACE_WITH_YOUR_STRONG_PASSWORD
+./build_and_run.sh
+```
+
+> **Note on the keyfile:** the authenticated stack also uses a replica-set
+> keyfile, generated automatically by the `mongodb-keyfile-init` service into
+> the `mongodb-keyfile` volume on startup. You do not need to create it by hand.
+
+Verify the same way as Option A.
+
+---
+
+## Troubleshooting
+
+- **`Authentication failed` from `mongodb-init` or the registry.** The password
+  in `.env` does not match the user stored in the volume. Either fix `.env` to
+  match, or use Option A to start clean.
+- **`docker compose up` errors with `required variable DOCUMENTDB_PASSWORD is
+  missing a value`.** That is the intended fail-closed behavior — set
+  `DOCUMENTDB_PASSWORD` in `.env` (or run `build_and_run.sh`, which generates
+  one).
+- **`node is not in primary or recovering state`.** The replica set needs to
+  reinitialize after the migration; restart the `mongodb` container and wait for
+  the healthcheck to pass.

--- a/docs/faq/migrate-local-mongodb-to-authenticated.md
+++ b/docs/faq/migrate-local-mongodb-to-authenticated.md
@@ -1,30 +1,15 @@
 # How do I migrate an existing local MongoDB to authenticated mode?
 
-> **This applies to LOCAL DEVELOPMENT (Docker Compose) ONLY.**
->
-> It is relevant only if you previously ran the default `docker-compose.yml`
-> with **MongoDB CE and no authentication** and are now pulling a version where
-> the default MongoDB requires authentication.
+> **This applies to LOCAL DEVELOPMENT (Docker Compose) ONLY.** It is relevant only if you previously ran the default `docker-compose.yml` with **MongoDB CE and no authentication** and are now pulling a version where the default MongoDB requires authentication.
 >
 > **You do NOT need this if any of the following are true:**
-> - You deploy on **AWS ECS / Terraform** or **EKS / Helm** — those use Amazon
->   DocumentDB (or an external MongoDB), which is already authenticated and
->   unaffected by this change.
-> - You used the **`docker-compose.prebuilt.yml`** variant — its MongoDB was
->   already authenticated, so your data volume already has the admin user.
-> - This is a **fresh install** — MongoDB creates the admin user on first boot
->   from `DOCUMENTDB_USERNAME` / `DOCUMENTDB_PASSWORD`, so there is nothing to
->   migrate.
+> - You deploy on **AWS ECS / Terraform** or **EKS / Helm** — those use Amazon DocumentDB (or an external MongoDB), which is already authenticated and unaffected by this change.
+> - You used the **`docker-compose.prebuilt.yml`** variant — its MongoDB was already authenticated, so your data volume already has the admin user.
+> - This is a **fresh install** — MongoDB creates the admin user on first boot from `DOCUMENTDB_USERNAME` / `DOCUMENTDB_PASSWORD`, so there is nothing to migrate.
 
 ## Why this is needed
 
-The default local `docker-compose.yml` now starts MongoDB with `--auth` and
-creates a root user on first boot from `DOCUMENTDB_USERNAME` /
-`DOCUMENTDB_PASSWORD`. MongoDB only creates that user when the **data directory
-is empty** (first boot). If you already have a `mongodb-data` volume that was
-created **without** authentication, turning on `--auth` leaves you in a state
-where authentication is required but **no user exists**, so every connection is
-rejected.
+The default local `docker-compose.yml` now starts MongoDB with `--auth` and creates a root user on first boot from `DOCUMENTDB_USERNAME` / `DOCUMENTDB_PASSWORD`. MongoDB only creates that user when the **data directory is empty** (first boot). If you already have a `mongodb-data` volume that was created **without** authentication, turning on `--auth` leaves you in a state where authentication is required but **no user exists**, so every connection is rejected.
 
 You have two options. Pick based on whether your local data is worth keeping.
 
@@ -32,9 +17,7 @@ You have two options. Pick based on whether your local data is worth keeping.
 
 ## Option A: Recreate the volume (simplest — discards local data)
 
-For most local-dev setups the MongoDB data is disposable (servers/agents are
-re-registered and scopes are re-seeded by `mongodb-init`). Drop and recreate the
-volume, then let the fresh-boot path create the user.
+For most local-dev setups the MongoDB data is disposable (servers/agents are re-registered and scopes are re-seeded by `mongodb-init`). Drop and recreate the volume, then let the fresh-boot path create the user.
 
 ```bash
 cd <your-clone>/mcp-gateway-registry
@@ -78,8 +61,7 @@ docker exec mcp-mongodb mongosh --quiet \
 
 ## Option B: Keep your data (create the admin user in place)
 
-If you want to preserve the existing local database, create the admin user on
-the old no-auth volume **before** enabling `--auth`, then switch auth on.
+If you want to preserve the existing local database, create the admin user on the old no-auth volume **before** enabling `--auth`, then switch auth on.
 
 ```bash
 cd <your-clone>/mcp-gateway-registry
@@ -111,9 +93,7 @@ docker rm -f mongo-migrate
 ./build_and_run.sh
 ```
 
-> **Note on the keyfile:** the authenticated stack also uses a replica-set
-> keyfile, generated automatically by the `mongodb-keyfile-init` service into
-> the `mongodb-keyfile` volume on startup. You do not need to create it by hand.
+> **Note on the keyfile:** the authenticated stack also uses a replica-set keyfile, generated automatically by the `mongodb-keyfile-init` service into the `mongodb-keyfile` volume on startup. You do not need to create it by hand.
 
 Verify the same way as Option A.
 
@@ -121,13 +101,6 @@ Verify the same way as Option A.
 
 ## Troubleshooting
 
-- **`Authentication failed` from `mongodb-init` or the registry.** The password
-  in `.env` does not match the user stored in the volume. Either fix `.env` to
-  match, or use Option A to start clean.
-- **`docker compose up` errors with `required variable DOCUMENTDB_PASSWORD is
-  missing a value`.** That is the intended fail-closed behavior — set
-  `DOCUMENTDB_PASSWORD` in `.env` (or run `build_and_run.sh`, which generates
-  one).
-- **`node is not in primary or recovering state`.** The replica set needs to
-  reinitialize after the migration; restart the `mongodb` container and wait for
-  the healthcheck to pass.
+- **`Authentication failed` from `mongodb-init` or the registry.** The password in `.env` does not match the user stored in the volume. Either fix `.env` to match, or use Option A to start clean.
+- **`docker compose up` errors with `required variable DOCUMENTDB_PASSWORD is missing a value`.** That is the intended fail-closed behavior — set `DOCUMENTDB_PASSWORD` in `.env` (or run `build_and_run.sh`, which generates one).
+- **`node is not in primary or recovering state`.** The replica set needs to reinitialize after the migration; restart the `mongodb` container and wait for the healthcheck to pass.

--- a/tests/security/test_mongodb_auth_default.py
+++ b/tests/security/test_mongodb_auth_default.py
@@ -1,0 +1,68 @@
+"""
+Regression tests for SA-11: the default MongoDB in docker-compose must run with
+authentication enabled and must not ship a weak default password.
+
+Static-content assertions over docker-compose.yml and .env.example, so they hold
+without a live MongoDB.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    """Get repository root directory."""
+    return Path(__file__).parent.parent.parent
+
+
+def test_default_mongodb_runs_with_auth(repo_root: Path):
+    """The default docker-compose.yml mongodb must enable --auth and a keyFile."""
+    content = (repo_root / "docker-compose.yml").read_text()
+    # Locate the mongodb service command line.
+    cmd_match = re.search(r"^\s*command:\s*mongod .*$", content, re.MULTILINE)
+    assert cmd_match, "Could not find the mongod command in docker-compose.yml"
+    joined = "\n".join(
+        line for line in content.splitlines() if "mongod" in line and "--replSet" in line
+    )
+    assert "--auth" in joined, "docker-compose.yml mongodb must run with --auth"
+    assert "--keyFile" in joined, "docker-compose.yml mongodb must run with --keyFile (replica-set auth)"
+
+
+def test_default_mongodb_has_keyfile_init(repo_root: Path):
+    """A keyfile-init helper must exist to generate the replica-set keyfile."""
+    content = (repo_root / "docker-compose.yml").read_text()
+    assert "mongodb-keyfile-init:" in content, (
+        "docker-compose.yml must define mongodb-keyfile-init to generate the keyfile"
+    )
+    assert "mongodb-keyfile:" in content, "docker-compose.yml must define the mongodb-keyfile volume"
+
+
+def test_mongodb_credentials_fail_closed(repo_root: Path):
+    """Root creds must use the required-form ${VAR:?...}, never a weak default."""
+    content = (repo_root / "docker-compose.yml").read_text()
+    assert "MONGO_INITDB_ROOT_USERNAME=${DOCUMENTDB_USERNAME:?" in content, (
+        "MONGO_INITDB_ROOT_USERNAME must fail closed on unset DOCUMENTDB_USERNAME"
+    )
+    assert "MONGO_INITDB_ROOT_PASSWORD=${DOCUMENTDB_PASSWORD:?" in content, (
+        "MONGO_INITDB_ROOT_PASSWORD must fail closed on unset DOCUMENTDB_PASSWORD"
+    )
+    # No weak admin/admin fallback anywhere for the mongo root password.
+    assert "DOCUMENTDB_PASSWORD:-admin" not in content, (
+        "docker-compose.yml must not fall back to the weak 'admin' password"
+    )
+
+
+def test_env_example_has_no_admin_password_default(repo_root: Path):
+    """.env.example must not ship an active DOCUMENTDB_PASSWORD=admin assignment."""
+    content = (repo_root / ".env.example").read_text()
+    # Any active (uncommented) DOCUMENTDB_PASSWORD line must not be 'admin'.
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("DOCUMENTDB_PASSWORD="):
+            value = stripped.split("=", 1)[1].strip()
+            assert value != "admin", (
+                ".env.example ships DOCUMENTDB_PASSWORD=admin; must be blank or a placeholder"
+            )


### PR DESCRIPTION
## Summary

The default local install shipped MongoDB with **no authentication**, and `.env.example` shipped an active `DOCUMENTDB_PASSWORD=admin` (copied verbatim to `.env`). Together these seeded a weak/absent database credential on every fresh install. This PR enables MongoDB authentication by default and removes the weak password.

## Changes

**`docker-compose.yml`**
- New `mongodb-keyfile-init` one-shot service (ported from `docker-compose.prebuilt.yml`) generates the replica-set keyfile (`openssl rand -base64 756`, `chmod 400`, `chown 999:999`) into a new `mongodb-keyfile` volume.
- `mongodb` now runs `--auth --keyFile /keyfile/replica.key`; the root user is created on first boot from `DOCUMENTDB_USERNAME` / `DOCUMENTDB_PASSWORD` using the required `${VAR:?...}` form, so compose **fails closed** instead of falling back to a weak default.
- Healthcheck authenticates; `mongodb-init` now requires the same creds.

**`.env.example`**
- `DOCUMENTDB_PASSWORD` no longer ships `admin` — left blank with guidance.

**`build_and_run.sh`**
- Auto-generates a strong `DOCUMENTDB_PASSWORD` on first run when unset (same pattern already used for `SECRET_KEY`), so the turnkey install still works with zero manual steps.

## No application code change

`registry/utils/mongodb_connection.py` already builds a SCRAM-authenticated URI when `documentdb_username` + `documentdb_password` are set (SCRAM-SHA-256 for MongoDB CE, SCRAM-SHA-1 for DocumentDB), falling back to no-auth otherwise. So enabling auth needed only compose/env/generation changes.

## Testing

- **`tests/security/test_mongodb_auth_default.py`** (4 tests): `--auth`+`--keyFile` present, keyfile-init + volume defined, root creds use fail-closed `${VAR:?}` (no `:-admin`), and `.env.example` has no `DOCUMENTDB_PASSWORD=admin`. All pass.
- **`docker compose config`**: fails with `required variable DOCUMENTDB_PASSWORD is missing a value: set DOCUMENTDB_PASSWORD in .env` when unset; parses when set.
- **Live fresh-volume validation** (fresh MongoDB data volume so `--auth` initializes the root user):
  - Unauthenticated `mongosh` → **rejected** (`Command aggregate requires authentication`).
  - Authenticated `mongosh` → succeeds (`{"ok":1}`).
  - `mongodb-init` → exit 0; `registry` + `auth-server` → healthy, no auth errors; `/health` healthy.

## Upgrade note for existing local installs

Enabling `--auth` against a MongoDB **data volume that was created without auth** will lock it out (auth required, no user exists). Existing local dev stacks should either recreate the `mongodb-data` / `mongodb-config` volumes, or manually create the admin user, and set `DOCUMENTDB_PASSWORD` to a known value. Fresh installs are unaffected.

## Scope

Docker-compose (local dev) only. Production uses AWS DocumentDB (auth + TLS enforced by the managed service). The `docker-compose.prebuilt.yml` variant already ran authenticated; this brings the default file to parity while removing the weak `admin/admin` fallback that variant still used.
