### PR TITLE
fix(security): make peer federation_token write-only in responses (SA-24)

### DIFF
--- a/registry/api/peer_management_routes.py
+++ b/registry/api/peer_management_routes.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from ..auth.dependencies import nginx_proxied_auth
 from ..schemas.peer_federation_schema import (
     PeerRegistryConfig,
+    PeerRegistryConfigResponse,
     PeerSyncStatus,
     SyncResult,
 )
@@ -83,7 +84,7 @@ router = APIRouter(
 # ============================================================================
 
 
-@router.get("", response_model=list[PeerRegistryConfig])
+@router.get("", response_model=list[PeerRegistryConfigResponse])
 async def list_peers(
     enabled: bool | None = None,
     user_context: dict = Depends(nginx_proxied_auth),
@@ -113,7 +114,7 @@ async def list_peers(
     return peers
 
 
-@router.post("", response_model=PeerRegistryConfig, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=PeerRegistryConfigResponse, status_code=status.HTTP_201_CREATED)
 async def create_peer(
     config: PeerRegistryConfig,
     user_context: dict = Depends(nginx_proxied_auth),
@@ -285,7 +286,7 @@ async def get_shared_resources(
 # ============================================================================
 
 
-@router.get("/{peer_id}", response_model=PeerRegistryConfig)
+@router.get("/{peer_id}", response_model=PeerRegistryConfigResponse)
 async def get_peer(
     peer_id: str,
     user_context: dict = Depends(nginx_proxied_auth),
@@ -322,7 +323,7 @@ async def get_peer(
         )
 
 
-@router.put("/{peer_id}", response_model=PeerRegistryConfig)
+@router.put("/{peer_id}", response_model=PeerRegistryConfigResponse)
 async def update_peer(
     peer_id: str,
     updates: dict[str, Any] = Body(...),
@@ -578,7 +579,7 @@ async def get_peer_status(
     return sync_status
 
 
-@router.post("/{peer_id}/enable", response_model=PeerRegistryConfig)
+@router.post("/{peer_id}/enable", response_model=PeerRegistryConfigResponse)
 async def enable_peer(
     peer_id: str,
     user_context: dict = Depends(nginx_proxied_auth),
@@ -616,7 +617,7 @@ async def enable_peer(
         )
 
 
-@router.post("/{peer_id}/disable", response_model=PeerRegistryConfig)
+@router.post("/{peer_id}/disable", response_model=PeerRegistryConfigResponse)
 async def disable_peer(
     peer_id: str,
     user_context: dict = Depends(nginx_proxied_auth),

--- a/registry/schemas/peer_federation_schema.py
+++ b/registry/schemas/peer_federation_schema.py
@@ -318,6 +318,20 @@ class PeerRegistryConfig(BaseModel):
         return self
 
 
+class PeerRegistryConfigResponse(PeerRegistryConfig):
+    """Response view of a peer registry config.
+
+    ``federation_token`` is the static bearer token this registry uses to
+    authenticate against the remote peer. It is write-only: settable via
+    create/update and ``PATCH /{peer_id}/token``, but never serialized back out
+    (otherwise any principal with the federation scope could harvest peer
+    tokens and impersonate this registry). ``exclude`` drops it from every
+    response regardless of value.
+    """
+
+    federation_token: str | None = Field(default=None, exclude=True)
+
+
 class SyncHistoryEntry(BaseModel):
     """
     Record of a single sync operation.

--- a/tests/unit/api/test_peer_management_routes.py
+++ b/tests/unit/api/test_peer_management_routes.py
@@ -325,3 +325,61 @@ class TestUpdatePeerToken:
 
             # Assert
             assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# =============================================================================
+# federation_token must never be serialized in responses (write-only)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFederationTokenNotLeaked:
+    """GET /api/peers and GET /api/peers/{id} must not return federation_token."""
+
+    @pytest.mark.asyncio
+    async def test_list_peers_omits_federation_token(
+        self,
+        mock_auth_admin,
+        mock_peer_federation_service,
+        sample_peer_config,
+    ):
+        """The list endpoint must strip federation_token from every entry."""
+        from registry.main import app
+
+        client = TestClient(app)
+        mock_peer_federation_service.list_peers.return_value = [sample_peer_config]
+
+        with patch(
+            "registry.api.peer_management_routes.get_peer_federation_service",
+            return_value=mock_peer_federation_service,
+        ):
+            response = client.get("/api/peers")
+
+        assert response.status_code == status.HTTP_200_OK
+        # The token is set on the stored config, but must not appear in the body.
+        assert "original-token-abc123" not in response.text
+        for peer in response.json():
+            assert "federation_token" not in peer
+
+    @pytest.mark.asyncio
+    async def test_get_peer_omits_federation_token(
+        self,
+        mock_auth_admin,
+        mock_peer_federation_service,
+        sample_peer_config,
+    ):
+        """The single-peer GET must strip federation_token."""
+        from registry.main import app
+
+        client = TestClient(app)
+        mock_peer_federation_service.get_peer.return_value = sample_peer_config
+
+        with patch(
+            "registry.api.peer_management_routes.get_peer_federation_service",
+            return_value=mock_peer_federation_service,
+        ):
+            response = client.get(f"/api/peers/{sample_peer_config.peer_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "original-token-abc123" not in response.text
+        assert "federation_token" not in response.json()


### PR DESCRIPTION
## Summary

Fixes peer federation bearer tokens were returned in plaintext. `federation_token` — the static bearer token this registry uses to authenticate **against** a remote peer registry — was serialized in the peer read endpoints, both of which used `response_model=PeerRegistryConfig`:

- `GET /api/peers` (`list_peers`)
- `GET /api/peers/{peer_id}` (`get_peer`)

These are reachable by any principal with the `federation/peers` scope (not just admin). So a non-admin could enumerate peers, harvest their plaintext `federation_token`s, and **impersonate this registry against the remote peers**.

## Fix

The root cause: one model (`PeerRegistryConfig`) served as both the request body (create/update — token must be settable) and the response (read — token must not leak). Made the token write-only on responses:

- Added `PeerRegistryConfigResponse` (subclass of `PeerRegistryConfig`) that redeclares `federation_token` with `exclude=True`, so it is never serialized into a response regardless of value.
- Switched `response_model` to it on every endpoint that echoes a peer config back: `list`, `get`, `create`, `update`, `enable`, `disable`.
- Request bodies still use `PeerRegistryConfig` (token remains settable), and `PATCH /{peer_id}/token` stays the dedicated write path.

No service or DB change: the token is still stored and used for sync — it is simply never serialized out.

## Testing

- New `TestFederationTokenNotLeaked` in `tests/unit/api/test_peer_management_routes.py`: asserts `GET /api/peers` and `GET /api/peers/{id}` responses contain no `federation_token` key (and not the stored token value) even when one is set.
- **Mutation-checked**: reverting the fix fails both tests.
- Runtime-verified the response model drops the token while the request model retains it.
- No regressions: peer routes + schema + service suites → **124 passed**.

## Scope

Response-hiding only (per the finding's stated remediation); access scope to peer metadata is unchanged.
