### PR TITLE
fix(podman): repair fresh-deploy path (realm setup, OAuth discovery, mongo-init) (#1377, #1378, #1379)

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -118,6 +118,13 @@ services:
       - AUTH_PROVIDER=${AUTH_PROVIDER:-cognito}
       - KEYCLOAK_ENABLED=${KEYCLOAK_ENABLED:-false}
       - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
+      # Browser-reachable Keycloak URL: the wellknown/OAuth-discovery responses
+      # must advertise a host clients can reach, not the internal keycloak:8080.
+      # Podman maps Keycloak to host 18080 (8080 is taken by the registry UI).
+      - KEYCLOAK_EXTERNAL_URL=${KEYCLOAK_EXTERNAL_URL:-http://localhost:18080}
+      # Allow plain-HTTP resource URLs for local dev; the RFC 9728
+      # /.well-known/oauth-protected-resource endpoint 500s otherwise (enforce_https).
+      - MCP_HTTPS_REQUIRED=${MCP_HTTPS_REQUIRED:-false}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-mcp-gateway}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-mcp-gateway-web}
       - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}
@@ -398,6 +405,8 @@ services:
       # Podman note: host port 8080 is used by the registry UI (8080->80),
       # so Keycloak is exposed on 18080->8080 by default in this Podman compose.
       - KEYCLOAK_EXTERNAL_URL=${KEYCLOAK_EXTERNAL_URL:-http://localhost:18080}
+      # Allow plain-HTTP resource URLs for local dev (see registry service note).
+      - MCP_HTTPS_REQUIRED=${MCP_HTTPS_REQUIRED:-false}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-mcp-gateway}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-mcp-gateway-web}
       - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}
@@ -644,6 +653,12 @@ services:
   # Keycloak Identity Provider
   keycloak:
     image: quay.io/keycloak/keycloak:25.0
+    # Realm setup is NOT done by --import-realm. The mcp-gateway realm, clients,
+    # groups, and users are created programmatically by keycloak/setup/init-keycloak.sh,
+    # which you run once after the stack is up (see docs/complete-setup-guide.md).
+    # keycloak/import/realm-config.json is not imported here (it is not compatible
+    # with stock --import-realm on this Keycloak version), so do NOT add
+    # --import-realm expecting it to work -- run init-keycloak.sh instead.
     command: start-dev  # Use 'start' for production with proper SSL
     environment:
       # Database configuration
@@ -761,8 +776,12 @@ services:
       - DOCUMENTDB_HOST=mongodb
       - DOCUMENTDB_PORT=27017
       - DOCUMENTDB_DATABASE=${DOCUMENTDB_DATABASE:-mcp_registry}
-      - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME:-admin}
-      - DOCUMENTDB_PASSWORD=${DOCUMENTDB_PASSWORD:-admin}
+      # The paired mongodb service in this file runs WITHOUT authentication, so
+      # these must default to empty (not admin/admin) -- init-mongodb-ce.py only
+      # builds a SCRAM auth string when a username is set, and authenticating
+      # against a no-user Mongo fails. Leave blank for the no-auth local setup.
+      - DOCUMENTDB_USERNAME=${DOCUMENTDB_USERNAME:-}
+      - DOCUMENTDB_PASSWORD=${DOCUMENTDB_PASSWORD:-}
       - DOCUMENTDB_NAMESPACE=${DOCUMENTDB_NAMESPACE:-default}
       - ENTRA_GROUP_ADMIN_ID=${ENTRA_GROUP_ADMIN_ID:-}
     volumes:


### PR DESCRIPTION
## Summary

Fixes three independent bugs that broke a fresh **Podman Compose** deployment (`docker-compose.podman.yml`). All three live in the same file and the same fresh-deploy path, so they are fixed together.

Closes #1377, closes #1378, closes #1379.

## #1379 — mongodb-init default credentials don't match the no-auth mongo

`mongodb-init` defaulted `DOCUMENTDB_USERNAME`/`DOCUMENTDB_PASSWORD` to `admin`/`admin`, but the paired `mongodb` service in this file runs **without authentication**. `scripts/init-mongodb-ce.py` builds a SCRAM connection string whenever a username is set, so it tries to authenticate against a Mongo with no users and fails (`Authentication failed`). Empty in `.env` doesn't help because `${VAR:-admin}` treats empty as unset.

**Fix:** default both to empty (`${DOCUMENTDB_USERNAME:-}`), matching the no-auth service.

## #1378 — KEYCLOAK_EXTERNAL_URL / MCP_HTTPS_REQUIRED not wired in

Both are documented in `.env.example` and read by the code (`registry/api/wellknown_routes.py` reads `mcp_https_required`; `auth_server/providers/keycloak.py` reads `KEYCLOAK_EXTERNAL_URL`), but neither was referenced in the `registry`/`auth-server` `environment:` blocks, so setting them in `.env` had no effect. Result: `GET /.well-known/oauth-protected-resource` 500s (`enforce_https`), and once worked around it advertised the internal `keycloak:8080` host.

**Fix:** wire `KEYCLOAK_EXTERNAL_URL` (default `http://localhost:18080`, matching this file's Keycloak host-port mapping) and `MCP_HTTPS_REQUIRED` (default `false`) into both services. (The Keycloak `ports:` mapping the issue also asked for already exists in the current file at `18080:8080`.)

## #1377 — realm never imported

The reporter observed the `mcp-gateway` realm is never imported. Investigation: **no compose variant passes `--import-realm`**, and the realm/clients/users are instead created programmatically by `keycloak/setup/init-keycloak.sh` (the documented post-startup step for every variant). `keycloak/import/realm-config.json` is vestigial and not compatible with stock `--import-realm` on this Keycloak version (`eventsConfig` + unsubstituted `${env.X}` placeholders).

**Fix:** rather than wire up the broken import, add a comment on the `keycloak` service documenting that realm setup is done by `init-keycloak.sh` — so nobody adds `--import-realm` expecting the mounted file to work.

## Testing

- `docker compose -f docker-compose.podman.yml config` parses cleanly.
- Resolved config confirms: `mongodb-init` gets empty `DOCUMENTDB_USERNAME`/`PASSWORD`; `registry` and `auth-server` both carry `KEYCLOAK_EXTERNAL_URL` and `MCP_HTTPS_REQUIRED`.
- No Podman runtime on the dev box, so the live fresh-deploy repro (realm via init-keycloak.sh, OAuth discovery reachable, mongo-init succeeds) should be confirmed by the reporter or CI. Change is compose-config-only and does not alter the docker-compose.yml path.
