### PR TITLE
route OAuth token calls through the SSRF guard

### DIFF
--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -21,6 +21,7 @@ Security model for POST /internal/egress-token:
 
 import logging
 import secrets
+from html import escape
 from typing import Annotated
 from urllib.parse import urlencode, urlparse
 
@@ -36,9 +37,11 @@ from registry.core.config import settings
 from registry.egress_auth.factory import get_egress_auth_service
 from registry.egress_auth.providers import list_provider_names, resolve_provider
 from registry.egress_auth.service import EgressAuthError, is_per_user_auth_method
+from registry.exceptions import UrlValidationError
 from registry.repositories.factory import get_server_repository
 from registry.services.server_service import server_service
 from registry.utils.credential_encryption import encrypt_credential
+from registry.utils.url_guard import PROXY_PROFILE, validate_url
 
 logger = logging.getLogger(__name__)
 
@@ -366,6 +369,31 @@ async def configure_egress_auth(
             "custom_scope_separator": body.custom_scope_separator,
             "custom_token_auth_style": body.custom_token_auth_style,
         }
+        # For a 'custom' provider the authorize/token URLs are registrant-supplied
+        # and become an outbound token POST (carrying the client_secret) and a
+        # browser 302. Fail closed at registration: require https and reject any
+        # literal private/metadata IP or bad scheme via the shared SSRF guard, so
+        # a config that would exfiltrate the secret to an internal target (e.g.
+        # 169.254.169.254) can never be persisted. resolve=False keeps this a
+        # structural check; the rebinding-safe block for hostname targets is the
+        # pinned guarded client at token-exchange time.
+        if body.egress_provider == "custom":
+            for field, url in (
+                ("custom_authorize_url", body.custom_authorize_url),
+                ("custom_token_url", body.custom_token_url),
+            ):
+                try:
+                    validate_url(
+                        url or "",
+                        profile=PROXY_PROFILE,
+                        require_https=True,
+                        resolve=False,
+                    )
+                except UrlValidationError as exc:
+                    raise HTTPException(
+                        status.HTTP_400_BAD_REQUEST,
+                        detail=f"{field} rejected: {exc}",
+                    ) from exc
         # Validate provider resolution (custom requires URLs) before persisting.
         try:
             resolve_provider(eo)
@@ -553,13 +581,17 @@ async def egress_callback(
         )
     except EgressAuthError as exc:
         logger.warning("egress callback failed: %s", exc)
-        return HTMLResponse(f"<h3>Connection failed: {exc}.</h3>", status_code=400)
+        # HTML-escape: the message can embed server/state-derived values.
+        return HTMLResponse(f"<h3>Connection failed: {escape(str(exc))}.</h3>", status_code=400)
 
     # The egress consent is the web Connected-Accounts / MCP URL-mode elicitation
     # flow: the token is now vaulted, so show the close-tab page and let the user
-    # retry their original request.
+    # retry their original request. HTML-escape the interpolated values: the
+    # server_path is admin-registrant-supplied and validate_server_path blocks
+    # nginx metacharacters but not '<'/'>' (a different sink), so escape here to
+    # keep a crafted path (e.g. /<svg onload=...>) from executing in the browser.
     return HTMLResponse(
-        f"<h3>Connected {conn.provider} for {conn.server_path}.</h3>"
+        f"<h3>Connected {escape(conn.provider)} for {escape(conn.server_path)}.</h3>"
         "<p>You can close this tab and retry your request.</p>"
     )
 

--- a/registry/egress_auth/oauth_engine.py
+++ b/registry/egress_auth/oauth_engine.py
@@ -28,6 +28,8 @@ from registry.egress_auth.schemas import (
     StoredToken,
     TokenEndpointAuthStyle,
 )
+from registry.exceptions import UrlValidationError
+from registry.utils.url_guard import PROXY_PROFILE, guarded_async_client
 
 logger = logging.getLogger(__name__)
 
@@ -169,9 +171,22 @@ def _build_token_request(
 
 
 async def _post_token(cfg: OAuthProviderConfig, data: dict, headers: dict) -> dict:
+    # The token endpoint receives the operator client_secret (and, on refresh, the
+    # user's refresh_token). For a 'custom' provider cfg.token_url is registrant-
+    # supplied, so the request MUST go through the SSRF/rebinding-safe client: it
+    # pins the connection to a validated public IP at connect time (blocking a
+    # post-registration DNS rebind to a private/metadata address) and rejects a
+    # non-http(s) scheme, so the credential can never be exfiltrated to an
+    # internal target. Built-in providers resolve to public hosts and pass
+    # through unchanged.
     try:
-        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        async with guarded_async_client(profile=PROXY_PROFILE, timeout=_HTTP_TIMEOUT) as client:
             resp = await client.post(cfg.token_url, data=data, headers=headers)
+    except UrlValidationError as exc:
+        # The pinned guard rejected the target (private/metadata IP, bad scheme,
+        # or a post-registration DNS rebind). Fail closed WITHOUT having sent the
+        # client_secret/refresh_token; surface it in the engine's own contract.
+        raise OAuthEngineError(f"token endpoint blocked by SSRF guard: {exc}") from exc
     except httpx.HTTPError as exc:
         raise OAuthEngineError(f"token endpoint unreachable: {exc}") from exc
 

--- a/tests/unit/egress_auth/test_configure_egress_url_validation.py
+++ b/tests/unit/egress_auth/test_configure_egress_url_validation.py
@@ -1,0 +1,152 @@
+"""Registration-time SSRF/scheme validation for POST /servers/{path}/egress-auth.
+
+The 'custom' provider's ``custom_authorize_url``/``custom_token_url`` are
+registrant-supplied and become an outbound token POST (carrying the operator
+client_secret) and a browser 302. The configure route -- the sole write path
+for a server's ``egress_oauth`` -- must reject at registration time any URL that
+is non-https, points at a literal private/metadata IP, or uses a disallowed
+scheme, so a config that would exfiltrate the secret to an internal target can
+never be persisted. Built-in providers ignore the custom URLs and are unaffected.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import registry.api.egress_auth_routes as routes
+
+
+class _StubServerService:
+    def __init__(self, server):
+        self._server = server
+        self.updated_with = None
+
+    async def get_server_info(self, path, include_credentials=False):
+        return dict(self._server)
+
+    async def update_server(self, path, server):
+        self.updated_with = server
+        return True
+
+
+@pytest.fixture
+def make_client(monkeypatch):
+    def _build(server=None):
+        monkeypatch.setattr(routes.settings, "egress_auth_enabled", True)
+        svc = _StubServerService(server or {"path": "/gh", "egress_oauth": None})
+        monkeypatch.setattr(routes, "server_service", svc)
+        # Deterministic encryption stub so a persisted secret is non-empty.
+        monkeypatch.setattr(routes, "encrypt_credential", lambda s: f"enc:{s}")
+
+        app = FastAPI()
+        app.include_router(routes.router)
+        # Admin principal; CSRF satisfied (both are sibling dependencies).
+        app.dependency_overrides[routes.nginx_proxied_auth] = lambda: {
+            "username": "admin",
+            "is_admin": True,
+            "auth_method": "keycloak",
+        }
+        app.dependency_overrides[routes.verify_csrf_token_flexible] = lambda: None
+        client = TestClient(app)
+        client._svc = svc
+        return client
+
+    return _build
+
+
+def _body(**over):
+    base = {
+        "egress_auth_mode": "oauth_user",
+        "egress_provider": "custom",
+        "client_id": "cid",
+        "client_secret": "supersecret",
+        "scopes": ["read"],
+        "custom_authorize_url": "https://idp.example.com/authorize",
+        "custom_token_url": "https://idp.example.com/token",
+        "custom_scope_separator": " ",
+        "custom_token_auth_style": "post_body",
+    }
+    base.update(over)
+    return base
+
+
+@pytest.mark.unit
+class TestConfigureEgressUrlValidation:
+    def test_valid_custom_https_urls_accepted(self, make_client):
+        client = make_client()
+        resp = client.post("/servers/gh/egress-auth", json=_body())
+        assert resp.status_code == 200, resp.text
+        # The config was persisted with the supplied URLs.
+        eo = client._svc.updated_with["egress_oauth"]
+        assert eo["custom_token_url"] == "https://idp.example.com/token"
+
+    @pytest.mark.parametrize(
+        "field",
+        ["custom_authorize_url", "custom_token_url"],
+    )
+    def test_metadata_ip_rejected(self, make_client, field):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(**{field: "http://169.254.169.254/latest/meta-data/"}),
+        )
+        assert resp.status_code == 400
+        assert field in resp.json()["detail"]
+        # Nothing persisted.
+        assert client._svc.updated_with is None
+
+    @pytest.mark.parametrize(
+        "field",
+        ["custom_authorize_url", "custom_token_url"],
+    )
+    def test_http_scheme_rejected(self, make_client, field):
+        # http:// would send the client_secret in cleartext to any observer.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(**{field: "http://idp.example.com/token"}),
+        )
+        assert resp.status_code == 400
+        assert field in resp.json()["detail"]
+
+    def test_loopback_rejected(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(custom_token_url="https://127.0.0.1/token"),
+        )
+        assert resp.status_code == 400
+        assert "custom_token_url" in resp.json()["detail"]
+
+    def test_rfc1918_rejected(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(custom_authorize_url="https://10.0.0.5/authorize"),
+        )
+        assert resp.status_code == 400
+        assert "custom_authorize_url" in resp.json()["detail"]
+
+    def test_non_http_scheme_rejected(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(custom_token_url="file:///etc/passwd"),
+        )
+        assert resp.status_code == 400
+        assert "custom_token_url" in resp.json()["detail"]
+
+    def test_builtin_provider_ignores_custom_url_fields(self, make_client):
+        # A built-in provider has hardcoded https endpoints; a stray (even unsafe)
+        # custom_* value must not be validated or used -- the built-in wins.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(
+                egress_provider="github",
+                custom_authorize_url="http://169.254.169.254/",
+                custom_token_url="http://169.254.169.254/",
+            ),
+        )
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_oauth"]["provider"] == "github"

--- a/tests/unit/egress_auth/test_oauth_engine.py
+++ b/tests/unit/egress_auth/test_oauth_engine.py
@@ -184,3 +184,51 @@ class TestQuirkParsers:
         assert data["client_secret"] == "sec"
         assert "Authorization" not in headers
         assert headers["Accept"] == "application/json"
+
+
+@pytest.mark.unit
+class TestPostTokenSsrfGuard:
+    """The token endpoint receives the operator client_secret (and, on refresh,
+    the user's refresh_token). For a 'custom' provider the token_url is
+    registrant-supplied, so ``_post_token`` must route through the SSRF/rebinding
+    -safe client and refuse a target that resolves to a private/metadata address
+    -- otherwise the credential is exfiltrated via SSRF. These exercise the real
+    ``_post_token`` (no monkeypatch of the chokepoint) so the transport guard is
+    on the path.
+    """
+
+    def _custom_cfg(self, token_url: str) -> OAuthProviderConfig:
+        return OAuthProviderConfig(
+            name="custom",
+            display_name="Custom OIDC",
+            is_builtin=False,
+            authorize_url="https://evil.example.com/authorize",
+            token_url=token_url,
+            use_pkce=True,
+        )
+
+    async def test_token_url_to_metadata_ip_fails_closed(self):
+        # A literal cloud-metadata target must be blocked before the secret is
+        # ever sent, surfaced as an OAuthEngineError (unreachable), not a token.
+        cfg = self._custom_cfg("http://169.254.169.254/latest/meta-data/")
+        data, headers = oauth_engine._build_token_request(
+            cfg, "cid", "supersecret", {"grant_type": "x"}
+        )
+        with pytest.raises(oauth_engine.OAuthEngineError, match="SSRF guard"):
+            await oauth_engine._post_token(cfg, data, headers)
+
+    async def test_token_url_to_loopback_fails_closed(self):
+        cfg = self._custom_cfg("http://127.0.0.1:8200/v1/secret")
+        data, headers = oauth_engine._build_token_request(
+            cfg, "cid", "supersecret", {"grant_type": "x"}
+        )
+        with pytest.raises(oauth_engine.OAuthEngineError, match="SSRF guard"):
+            await oauth_engine._post_token(cfg, data, headers)
+
+    async def test_token_url_to_rfc1918_fails_closed(self):
+        cfg = self._custom_cfg("http://10.0.0.5/token")
+        data, headers = oauth_engine._build_token_request(
+            cfg, "cid", "supersecret", {"grant_type": "x"}
+        )
+        with pytest.raises(oauth_engine.OAuthEngineError, match="SSRF guard"):
+            await oauth_engine._post_token(cfg, data, headers)

--- a/tests/unit/egress_auth/test_public_routes.py
+++ b/tests/unit/egress_auth/test_public_routes.py
@@ -227,3 +227,36 @@ class TestCallback:
         assert "Connected github" in r.text
         assert svc.handle_callback.await_count == 1
         state_codec.reset_cipher_for_tests()
+
+    def test_callback_success_page_escapes_server_path(self, client, monkeypatch):
+        # server_path is admin-registrant-supplied; validate_server_path blocks
+        # nginx metacharacters but not '<'/'>', so the success HTML must escape it
+        # or a crafted path executes script in the connecting user's browser.
+        monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only-do-not-use")
+        from registry.egress_auth import state_codec
+        from registry.egress_auth.schemas import EgressConnection, OAuthState
+
+        state_codec.reset_cipher_for_tests()
+        evil_path = "/<svg/onload=alert(1)>"
+        blob = state_codec.encode_state(
+            OAuthState(
+                user_id="alice",
+                auth_method="oauth2",
+                provider="github",
+                server_path=evil_path,
+                nonce="n1",
+                issued_at="2026-06-19T00:00:00+00:00",
+            )
+        )
+        svc = AsyncMock()
+        svc.handle_callback = AsyncMock(
+            return_value=EgressConnection(provider="<b>github</b>", server_path=evil_path)
+        )
+        c = client(USER, server=_server(), svc=svc)
+        r = c.get("/api/oauth2/egress/callback", params={"code": "the-code", "state": blob})
+        assert r.status_code == 200
+        # The raw script-bearing markup must NOT appear; the escaped form must.
+        assert "<svg/onload=alert(1)>" not in r.text
+        assert "<b>github</b>" not in r.text
+        assert "&lt;svg/onload=alert(1)&gt;" in r.text
+        state_codec.reset_cipher_for_tests()


### PR DESCRIPTION
# Route egress OAuth token calls through the SSRF guard; escape the callback HTML

## Summary

The per-user egress credential vault lets a server registrant configure a
third-party OAuth provider, including a `custom` provider whose authorize and
token endpoint URLs the registrant supplies. Those URLs become a server-side
`POST` that carries the operator OAuth `client_secret` (and, on refresh, the
user's `refresh_token`) and a browser redirect.

This wires the egress token exchange into that same guard and validates the
custom URLs at registration, so the client secret can never be sent to an
internal or attacker-chosen destination. It also HTML-escapes the values
interpolated into the OAuth callback page.

## The problem

- **SSRF / credential exfiltration.** `oauth_engine._post_token` posted to
  `cfg.token_url` via a bare `httpx.AsyncClient`. For a `custom` provider that
  URL is registrant-supplied and unvalidated, so a registrant could point
  `custom_token_url` at `http://169.254.169.254/…` (cloud metadata) or an
  internal service and the gateway would deliver the operator `client_secret`
  (and each user's `refresh_token` on every refresh) there. `http://` also
  exposed the secret to any network observer.
- **No registration-time validation.** `resolve_provider` only checked that the
  custom URLs were non-empty. There was no scheme, private-IP, or metadata-IP
  check on the value being persisted.
- **Callback HTML injection.** The `/oauth2/egress/callback` success and error
  pages interpolated `conn.provider` / `conn.server_path` / the error message
  into HTML without escaping. `validate_server_path` blocks nginx
  metacharacters but not `<`/`>`, so an admin-registrant could register a path
  like `/<svg/onload=…>` that executes in the connecting user's browser.

## The fix (fail closed)

- **Guarded token exchange.** `_post_token` now uses
  `guarded_async_client(profile=PROXY_PROFILE)`. Every request (and redirect
  hop) is validated and pinned to a resolved public IP at connect time, so a
  target that resolves to a private/loopback/link-local/metadata address is
  refused before the secret is sent — closing the DNS-rebinding TOCTOU as well.
  A guard rejection surfaces as the engine's own `OAuthEngineError` (fail
  closed), so the credential is never transmitted.
- **Registration-time validation.** `configure_egress_auth` now validates both
  `custom_authorize_url` and `custom_token_url` for a `custom` provider with
  `validate_url(profile=PROXY_PROFILE, require_https=True, resolve=False)`
  before persisting: https-only, and literal private/metadata IPs and bad
  schemes are rejected with a 400. This is the sole write path for a server's
  `egress_oauth` (the normal register/update models reject the field), so the
  check cannot be bypassed. Built-in providers ignore the custom URL fields and
  are unaffected.
- **Escaped callback HTML.** The callback success and error responses now
  `html.escape()` the interpolated provider, server path, and error text.

## Why it is safe

The token endpoint is the only place the client secret and refresh token leave
the gateway, and it now goes through the same pinned, private-IP-blocking client
the rest of the registry uses for untrusted outbound URLs — the registration
check rejects an unsafe value up front, and the fetch-time pin catches a later
DNS rebind. The cloud metadata address is never allowlistable in either guard
profile. The callback page can no longer be turned into a script sink by a
crafted server path.

## Testing

- `_post_token` fails closed (as `OAuthEngineError`) for a `token_url` that
  targets the metadata IP, loopback, and an RFC1918 address — exercising the
  real guarded transport, not a stub.
- `configure_egress_auth` rejects (400) a `custom_authorize_url` /
  `custom_token_url` that is a metadata IP, loopback, RFC1918, `http://`, or a
  non-http scheme, on both fields; accepts valid https URLs; and ignores the
  custom URL fields for a built-in provider (no false rejection).
- The callback success page escapes a `<svg/onload=…>` server path (raw markup
  absent, escaped form present).
- The full egress unit suite, the egress config-validation suite, and the
  auth-server egress-mint suite pass; ruff and bandit are clean on the changed
  files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
