### PR TITLE
Fix DocumentDB rotation IAM actions

### DIFF
--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -116,8 +116,10 @@ resource "aws_iam_role_policy" "rotation_lambda" {
         Sid    = "DocumentDBAccess"
         Effect = "Allow"
         Action = [
-          "docdb:DescribeDBClusters",
-          "docdb:ModifyDBCluster"
+          # Amazon DocumentDB shares the RDS control-plane API; boto3 docdb
+          # calls are authorized as rds:* actions against the DocDB cluster ARN.
+          "rds:DescribeDBClusters",
+          "rds:ModifyDBCluster"
         ]
         Resource = aws_docdb_cluster.registry[0].arn
       }] : [],


### PR DESCRIPTION
## Summary
- use the RDS IAM action namespace for DocumentDB rotation control-plane calls
- keep the policy scoped to the DocumentDB cluster ARN

Closes #1348

## Checks
- terraform fmt -check secret-rotation.tf
- terraform init -backend=false
- terraform validate