### PR TITLE
Add redirect stubs for moved release notes; fix stale path references (follow-up to #1411)

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -356,15 +356,18 @@ After writing the release notes file:
 
 Once the user confirms the release notes are ready:
 
-1. **Add the new version to `mkdocs.yml`** so it appears at the top of the Release Notes nav in descending order. Find the `Release Notes:` section and insert the new entry immediately after the `- Overview:` line:
+1. **Confirm the new version appears in the `mkdocs.yml` Release Notes nav.** The nav uses a
+   single directory entry that auto-includes every file in `docs/release-notes/`:
    ```yaml
    - Release Notes:
-     - Overview: release-notes/DISCLAIMER.md
-     - {version}: release-notes/{version}.md   # <-- insert here
-     - {previous_version}: release-notes/{previous_version}.md
-     ...
+     - release-notes
    ```
-   Use Edit to insert the single line `    - {version}: release-notes/{version}.md` after the `Overview` line.
+   Because the whole directory is included automatically, **a new `docs/release-notes/{version}.md`
+   file needs no `mkdocs.yml` edit** — it is picked up on the next build. Verify with
+   `mkdocs build` (or check the built `site/release-notes/{version}/` directory exists) and
+   confirm no new build warnings were introduced. Do NOT hand-maintain a per-version nav list;
+   the directory entry owns ordering. If the maintainer later wants an explicit descending
+   order, that is a separate, deliberate `mkdocs.yml` change — not part of the routine release cut.
 
 2. **Commit the release notes and nav update together:**
    ```bash

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           # docker/metadata-action v5 accepts both `v`-prefixed and bare semver
           # tags (e.g. `v1.0.22` and `1.23.0`). See the strict-semver switch in
-          # release-notes/1.23.0.md.
+          # docs/release-notes/1.23.0.md.
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ matrix.service }}
           tags: |
             type=semver,pattern={{version}}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -565,10 +565,10 @@
         "line_number": 211
       }
     ],
-    "release-notes/v1.0.9.md": [
+    "docs/release-notes/v1.0.9.md": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "release-notes/v1.0.9.md",
+        "filename": "docs/release-notes/v1.0.9.md",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
         "line_number": 104

--- a/docs/security-posture.md
+++ b/docs/security-posture.md
@@ -1020,7 +1020,7 @@ curl -X POST /api/servers/{path}/rescan -H "Authorization: Bearer $TOKEN"
 - **Do NOT create public GitHub issues for security vulnerabilities**
 
 **Security Updates:**
-- Monitor [release notes](release-notes/) for security patches
+- Monitor [release notes](https://github.com/agentic-community/mcp-gateway-registry/releases) for security patches
 - Subscribe to [GitHub Security Advisories](https://github.com/agentic-community/mcp-gateway-registry/security/advisories)
 
 ---

--- a/release-notes/1.23.0.md
+++ b/release-notes/1.23.0.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.23.0.md](../docs/release-notes/1.23.0.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.23.0/).

--- a/release-notes/1.24.0.md
+++ b/release-notes/1.24.0.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.0.md](../docs/release-notes/1.24.0.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.0/).

--- a/release-notes/1.24.1.md
+++ b/release-notes/1.24.1.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.1.md](../docs/release-notes/1.24.1.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.1/).

--- a/release-notes/1.24.2.md
+++ b/release-notes/1.24.2.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.2.md](../docs/release-notes/1.24.2.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.2/).

--- a/release-notes/1.24.3.md
+++ b/release-notes/1.24.3.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.3.md](../docs/release-notes/1.24.3.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.3/).

--- a/release-notes/1.24.4.md
+++ b/release-notes/1.24.4.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.4.md](../docs/release-notes/1.24.4.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.4/).

--- a/release-notes/1.24.5.md
+++ b/release-notes/1.24.5.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.5.md](../docs/release-notes/1.24.5.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.5/).

--- a/release-notes/1.24.6.md
+++ b/release-notes/1.24.6.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.6.md](../docs/release-notes/1.24.6.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.6/).

--- a/release-notes/1.24.7.md
+++ b/release-notes/1.24.7.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.24.7.md](../docs/release-notes/1.24.7.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.24.7/).

--- a/release-notes/1.25.0.md
+++ b/release-notes/1.25.0.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.25.0.md](../docs/release-notes/1.25.0.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.25.0/).

--- a/release-notes/1.26.0.md
+++ b/release-notes/1.26.0.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/1.26.0.md](../docs/release-notes/1.26.0.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/1.26.0/).

--- a/release-notes/DISCLAIMER.md
+++ b/release-notes/DISCLAIMER.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/DISCLAIMER.md](../docs/release-notes/DISCLAIMER.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/DISCLAIMER/).

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,8 @@
+# Release notes have moved
+
+Release notes now live in [`docs/release-notes/`](../docs/release-notes/) and are published
+on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/).
+
+The files in this directory are permanent redirect stubs kept so that historical links
+(from old release notifications, emails, and posts) do not 404. **Do not add new release
+notes here.** New releases are written to `docs/release-notes/` by the release-notes skill.

--- a/release-notes/v1.0.10.md
+++ b/release-notes/v1.0.10.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.10.md](../docs/release-notes/v1.0.10.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.10/).

--- a/release-notes/v1.0.12.md
+++ b/release-notes/v1.0.12.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.12.md](../docs/release-notes/v1.0.12.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.12/).

--- a/release-notes/v1.0.13.md
+++ b/release-notes/v1.0.13.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.13.md](../docs/release-notes/v1.0.13.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.13/).

--- a/release-notes/v1.0.14.md
+++ b/release-notes/v1.0.14.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.14.md](../docs/release-notes/v1.0.14.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.14/).

--- a/release-notes/v1.0.15.md
+++ b/release-notes/v1.0.15.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.15.md](../docs/release-notes/v1.0.15.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.15/).

--- a/release-notes/v1.0.16.md
+++ b/release-notes/v1.0.16.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.16.md](../docs/release-notes/v1.0.16.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.16/).

--- a/release-notes/v1.0.17.md
+++ b/release-notes/v1.0.17.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.17.md](../docs/release-notes/v1.0.17.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.17/).

--- a/release-notes/v1.0.18.md
+++ b/release-notes/v1.0.18.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.18.md](../docs/release-notes/v1.0.18.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.18/).

--- a/release-notes/v1.0.19.md
+++ b/release-notes/v1.0.19.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.19.md](../docs/release-notes/v1.0.19.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.19/).

--- a/release-notes/v1.0.20.md
+++ b/release-notes/v1.0.20.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.20.md](../docs/release-notes/v1.0.20.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.20/).

--- a/release-notes/v1.0.21.md
+++ b/release-notes/v1.0.21.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.21.md](../docs/release-notes/v1.0.21.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.21/).

--- a/release-notes/v1.0.22-p1.md
+++ b/release-notes/v1.0.22-p1.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.22-p1.md](../docs/release-notes/v1.0.22-p1.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.22-p1/).

--- a/release-notes/v1.0.22.md
+++ b/release-notes/v1.0.22.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.22.md](../docs/release-notes/v1.0.22.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.22/).

--- a/release-notes/v1.0.3.md
+++ b/release-notes/v1.0.3.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.3.md](../docs/release-notes/v1.0.3.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.3/).

--- a/release-notes/v1.0.4.md
+++ b/release-notes/v1.0.4.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.4.md](../docs/release-notes/v1.0.4.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.4/).

--- a/release-notes/v1.0.5.md
+++ b/release-notes/v1.0.5.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.5.md](../docs/release-notes/v1.0.5.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.5/).

--- a/release-notes/v1.0.6.md
+++ b/release-notes/v1.0.6.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.6.md](../docs/release-notes/v1.0.6.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.6/).

--- a/release-notes/v1.0.9-patch1.md
+++ b/release-notes/v1.0.9-patch1.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.9-patch1.md](../docs/release-notes/v1.0.9-patch1.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.9-patch1/).

--- a/release-notes/v1.0.9.md
+++ b/release-notes/v1.0.9.md
@@ -1,0 +1,5 @@
+# Moved
+
+This release note has moved to [docs/release-notes/v1.0.9.md](../docs/release-notes/v1.0.9.md).
+
+It is published on the [documentation site](https://agentic-community.github.io/mcp-gateway-registry/release-notes/v1.0.9/).


### PR DESCRIPTION
## Summary

Follow-up to #1411 (which moved release notes from repo-root `release-notes/` to `docs/release-notes/` and published them on the docs site). That move broke every historical link of the form `https://github.com/agentic-community/mcp-gateway-registry/blob/main/release-notes/<file>.md` — these appear in old GitHub Release bodies, release email notifications, and posts. This PR restores those links and cleans up stale root-path references.

Refs #1410, #1411.

## Why stubs, not a symlink

GitHub's web UI does not traverse symlinked directories server-side: a symlink at `release-notes/` renders as a blob containing the target path string, so a deep link to `release-notes/v1.24.0.md` still 404s. Symlinks also cause friction on Windows checkouts and in Docker COPY. Per the maintainer decision, this uses **stub redirect files** instead.

## What changed

**Task A — frozen redirect stubs.** Recreated repo-root `release-notes/` with one small markdown stub per file that existed in the pre-move tree (authoritative list from `git ls-tree <pre-move>^ release-notes/` = 31 files, a clean 1:1 with `docs/release-notes/`; no renames or non-md assets). Each stub links to the new location with a **relative** path (works on github.com, forks, any branch) and also links the published docs-site URL (`/release-notes/<slug>/`). Added `release-notes/README.md` for anyone landing on the bare directory. This directory is now a **frozen redirect archive** — no new release notes go here.

**Task B — stale-path audit.** Repo-wide grep for old `release-notes/` references (excluding `docs/release-notes/` and the new stubs). Fixed 3:
- `.secrets.baseline` — repointed the audited `v1.0.9.md` entry to `docs/release-notes/v1.0.9.md` (2-line surgical edit; no full re-scan).
- `.github/workflows/release-images.yml` — comment reference.
- `docs/security-posture.md` — "Monitor release notes" link now points at the GitHub Releases page (the `docs/release-notes/` directory has no site index page).

**Task C — skill link emission.** The `release-notes` skill does **not** create a GitHub Release body or emit any externally-shared `blob/main/...` links, so there is nothing to future-proof there. While verifying, I found and fixed a real discrepancy: the skill's Step 7 instructed editing a per-version descending nav list in `mkdocs.yml`, but #1411's merged nav uses a bare `- release-notes` directory entry (auto-discovery). Following the old instructions would break the next release cut, so Step 7 now matches the actual nav (no per-version edit needed).

## Verification

- `mkdocs build --strict`: **239 warnings before and after** this PR (identical) — my changes introduce zero new warnings. Note: `mkdocs` only scans `docs/`, so the root stubs are invisible to it.
- Every stub's relative link resolves (scripted `test -e` from each file's directory) — all 32 pass.
- Task B grep returns zero un-triaged hits.
- Root `release-notes/` contains only stubs + README (no real release content).

## Out-of-scope observations (not fixed here)

`mkdocs build --strict` already fails on `main` with 239 pre-existing warnings — ~36 broken intra-page anchors across ~15 docs pages, plus ~18 broken relative links *inside* the moved release-note files (e.g. `../../terraform/aws-ecs/README.md`) introduced by #1411's move. These are unrelated to redirect stubs and will be addressed in a separate dedicated docs-hygiene PR to keep this one surgical.

`release-notes/` is now a frozen redirect archive.
