### PR TITLE
fix(audit): record raw human-readable identity across all audit streams

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -298,6 +298,44 @@ def _canonical_egress_user(validation_result: dict) -> str:
     )
 
 
+def _audit_identity_display(validation_result: dict) -> str:
+    """The human-readable identity to record in AUDIT logs, for ONE human.
+
+    This is the counterpart to ``_canonical_egress_user``: that function resolves
+    the STABLE, provider-agnostic ``sub`` used to key the egress vault and bind
+    the OBO principal; this one resolves the most human-READABLE identity so an
+    operator reading an audit record knows who to contact without a reverse
+    lookup against the IdP. The two are intentionally separate -- do NOT route
+    auth/vault/OBO decisions through this value.
+
+    Resolution (first hit wins), per the audit-identity policy
+    (email -> preferred_username -> sub):
+      1. ``data.email`` / top-level ``email`` -- the self-signed token bakes in
+         an ``email`` claim (see the /internal/tokens mint) and the validated
+         claims are surfaced under ``data``; the session path carries it too.
+      2. ``data.preferred_username`` -- present on browser id_tokens; a readable
+         login handle when the IdP omits ``email``.
+      3. ``username`` -- the resolved username from validation; on the session
+         path this is already the human handle, on the self-signed path it is
+         the ``sub`` (opaque) -- which is why email/preferred_username come first.
+      4. ``data.sub`` / top-level ``sub`` -- opaque last resort.
+      5. ``"anonymous"`` -- nothing identified the caller.
+
+    Forward-only: this changes what NEW audit records store. Historical
+    ``sub``-only rows are not backfilled (no durable sub->email map exists).
+    """
+    data = validation_result.get("data") or {}
+    return (
+        data.get("email")
+        or validation_result.get("email")
+        or data.get("preferred_username")
+        or validation_result.get("username")
+        or data.get("sub")
+        or validation_result.get("sub")
+        or "anonymous"
+    )
+
+
 def _attach_mcp_proxy_token(
     request: "Request",
     response: "JSONResponse",
@@ -3143,7 +3181,12 @@ async def validate_request(request: Request):
                 try:
                     # Build identity from validation result
                     identity = Identity(
-                        username=validation_result.get("username") or "anonymous",
+                        # Human-readable identity for the audit record
+                        # (email -> preferred_username -> sub). The resolved
+                        # claims are surfaced under validation_result["data"];
+                        # the auth/vault/OBO plumbing continues to key on `sub`
+                        # via `username`, which this does not change.
+                        username=_audit_identity_display(validation_result),
                         auth_method=validation_result.get("method") or "unknown",
                         provider=validation_result.get("provider"),
                         groups=validation_result.get("groups", []),
@@ -3413,8 +3456,15 @@ async def _emit_token_mint_audit(
     expires_in_seconds: int | None,
     outcome: str,
     failure_reason: str | None = None,
+    display_username: str | None = None,
 ) -> None:
     """Emit a token-mint audit record and increment the mint metric.
+
+    ``username`` is what the record's DEPRECATED ``username_hash`` is derived
+    from (kept identical to preserve existing hash values / back-compat).
+    ``display_username`` is the raw, human-readable identity stored in the new
+    ``username`` field (email -> preferred_username -> sub); when omitted it
+    falls back to ``username`` (already human-readable on most mint paths).
 
     Best-effort: any failure here is logged and swallowed so token minting is
     never broken by observability.
@@ -3436,6 +3486,7 @@ async def _emit_token_mint_audit(
         record = TokenMintAuditRecord(
             request_id=request_id,
             correlation_id=correlation_id,
+            username=display_username or username or "anonymous",
             username_hash=hash_username(username),
             auth_method=auth_method,
             provider=provider,
@@ -3504,12 +3555,25 @@ async def generate_user_token(
     username = "unknown"
     auth_method = "unknown"
     provider = None
+    # Human-readable identity for the audit record; initialized before the try
+    # so the unexpected-error handler can reference it even if the failure
+    # happens before user_context is parsed.
+    audit_display_username = "unknown"
 
     try:
         # Extract user context
         user_context = request.user_context
         username = user_context.get("username")
         user_scopes = user_context.get("scopes", [])
+        # Human-readable identity for the audit record (email ->
+        # preferred_username -> username). `username` still drives the
+        # deprecated username_hash and all auth/vault logic unchanged.
+        audit_display_username = (
+            user_context.get("email")
+            or user_context.get("preferred_username")
+            or username
+            or "anonymous"
+        )
 
         if not username:
             raise HTTPException(
@@ -3524,6 +3588,7 @@ async def generate_user_token(
                 request_id=mint_request_id,
                 correlation_id=correlation_id,
                 username=username,
+                display_username=audit_display_username,
                 auth_method=user_context.get("auth_method", "unknown"),
                 provider=user_context.get("provider"),
                 internal_caller=caller,
@@ -3635,6 +3700,7 @@ async def generate_user_token(
                 request_id=mint_request_id,
                 correlation_id=correlation_id,
                 username=username,
+                display_username=audit_display_username,
                 auth_method=auth_method,
                 provider=provider,
                 internal_caller=caller,
@@ -3700,6 +3766,7 @@ async def generate_user_token(
                 request_id=mint_request_id,
                 correlation_id=correlation_id,
                 username=username,
+                display_username=audit_display_username,
                 auth_method=auth_method or "m2m",
                 provider=provider,
                 internal_caller=caller,
@@ -3728,6 +3795,7 @@ async def generate_user_token(
                 request_id=mint_request_id,
                 correlation_id=correlation_id,
                 username=username,
+                display_username=audit_display_username,
                 auth_method=auth_method or "m2m",
                 provider=provider,
                 internal_caller=caller,
@@ -3755,6 +3823,7 @@ async def generate_user_token(
             request_id=mint_request_id,
             correlation_id=correlation_id,
             username=username,
+            display_username=audit_display_username,
             auth_method=auth_method,
             provider=provider,
             internal_caller=caller,
@@ -5903,6 +5972,23 @@ async def mcp_proxy(
                 obo_auth_method = str((claims or {}).get("auth_method") or "") or "unknown"
                 obo_target_audience = vend.get("obo_target_audience") or ""
                 obo_scopes = vend.get("obo_scopes") or []
+                # Human-readable identity for the audit record. The internal
+                # proxy claims carry only `sub`; the raw ingress JWT (already
+                # signature-verified at /validate) carries email/preferred_
+                # username, so decode it unverified here purely to surface a
+                # contactable identity. Falls back to the sub principal.
+                try:
+                    _obo_ingress_claims = jwt.decode(
+                        subject_token, options={"verify_signature": False}
+                    )
+                except jwt.InvalidTokenError:
+                    _obo_ingress_claims = {}
+                # `username=obo_principal` makes the sub the fallback (ahead of
+                # the resolver's "anonymous"), so a token missing email/
+                # preferred_username still records the sub, not "anonymous".
+                obo_display = _audit_identity_display(
+                    {"data": _obo_ingress_claims, "username": obo_principal}
+                )
                 try:
                     obo_token = await obo_exchange(
                         get_auth_provider(),
@@ -5918,6 +6004,7 @@ async def mcp_proxy(
                         request_id=str(uuid.uuid4()),
                         correlation_id=None,
                         username=obo_principal,
+                        display_username=obo_display,
                         auth_method=obo_auth_method,
                         provider=settings.auth_provider,
                         internal_caller="mcp-proxy",
@@ -5935,6 +6022,7 @@ async def mcp_proxy(
                     request_id=str(uuid.uuid4()),
                     correlation_id=None,
                     username=obo_principal,
+                    display_username=obo_display,
                     auth_method=obo_auth_method,
                     provider=settings.auth_provider,
                     internal_caller="mcp-proxy",

--- a/frontend/src/components/AuditEventDetail.tsx
+++ b/frontend/src/components/AuditEventDetail.tsx
@@ -108,8 +108,11 @@ const AuditEventDetail: React.FC<AuditEventDetailProps> = ({ event, onClose }) =
             User
           </div>
           <div className="text-sm text-gray-900 dark:text-gray-100 flex items-center gap-1 min-w-0">
-            <span className="truncate" title={event.identity?.username || event.username_hash || '-'}>
-              {event.identity?.username || event.username_hash || '-'}
+            <span
+              className="truncate"
+              title={event.identity?.username || event.username || event.username_hash || '-'}
+            >
+              {event.identity?.username || event.username || event.username_hash || '-'}
             </span>
             {event.identity?.is_admin && (
               <span className="px-1.5 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded flex-shrink-0">

--- a/frontend/src/components/AuditLogTable.tsx
+++ b/frontend/src/components/AuditLogTable.tsx
@@ -74,6 +74,11 @@ export interface AuditEvent {
     error_code?: number;
     error_message?: string;
   };
+  // Token-mint-specific fields (token_mint stream has no `identity` block).
+  // `username` is the raw human-readable identity (email -> preferred_username
+  // -> sub); `username_hash` is DEPRECATED, kept only for old records.
+  username?: string;
+  username_hash?: string;
 }
 
 interface AuditLogTableProps {
@@ -329,7 +334,9 @@ const AuditLogTable: React.FC<AuditLogTableProps> = ({
                   <td className="px-4 py-3 text-sm">
                     <div className="flex items-center gap-1">
                       <span className="text-gray-900 dark:text-gray-100">
-                        {isTokenMintStream ? event.username_hash : event.identity?.username || '-'}
+                        {isTokenMintStream
+                          ? event.username || event.username_hash || '-'
+                          : event.identity?.username || '-'}
                       </span>
                       {!isTokenMintStream && event.identity?.is_admin && (
                         <span className="px-1.5 py-0.5 text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300 rounded">

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -682,7 +682,8 @@ async def get_full_config(
                 timestamp=datetime.now(UTC),
                 request_id=str(uuid.uuid4()),
                 identity=Identity(
-                    username=username,
+                    # Prefer human-readable email for the audit record.
+                    username=user_context.get("email") or username,
                     auth_method=user_context.get("auth_method", "unknown"),
                     is_admin=True,
                     credential_type="session_cookie",
@@ -1095,7 +1096,8 @@ async def export_config(
                 timestamp=datetime.now(UTC),
                 request_id=str(uuid.uuid4()),
                 identity=Identity(
-                    username=username,
+                    # Prefer human-readable email for the audit record.
+                    username=user_context.get("email") or username,
                     auth_method=user_context.get("auth_method", "unknown"),
                     is_admin=True,
                     credential_type="session_cookie",

--- a/registry/api/registry_routes.py
+++ b/registry/api/registry_routes.py
@@ -792,7 +792,8 @@ async def _audit_cloud_hint_set(
             timestamp=datetime.now(UTC),
             request_id=str(_uuid.uuid4()),
             identity=Identity(
-                username=user_context.get("username", "unknown"),
+                # Prefer human-readable email for the audit record.
+                username=user_context.get("email") or user_context.get("username", "unknown"),
                 auth_method=user_context.get("auth_method", "unknown"),
                 is_admin=True,
                 credential_type="session_cookie",

--- a/registry/audit/middleware.py
+++ b/registry/audit/middleware.py
@@ -189,6 +189,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
 
         return {
             "username": data["username"],
+            "email": data.get("email") or "",
             "auth_method": "session-cookie-fallback",
             "provider": data.get("provider"),
         }
@@ -212,7 +213,15 @@ class AuditMiddleware(BaseHTTPMiddleware):
 
         if user_context and isinstance(user_context, dict):
             return Identity(
-                username=user_context.get("username", "anonymous"),
+                # Human-readable identity for the audit record: prefer the
+                # email so an operator knows who to contact without an IdP
+                # reverse lookup. `username` may be the OIDC sub on some auth
+                # paths; email is threaded through user_context for this.
+                username=(
+                    user_context.get("email")
+                    or user_context.get("username")
+                    or "anonymous"
+                ),
                 auth_method=user_context.get("auth_method", "anonymous"),
                 provider=user_context.get("provider"),
                 groups=user_context.get("groups", []),
@@ -227,7 +236,7 @@ class AuditMiddleware(BaseHTTPMiddleware):
         fallback = await self._best_effort_session_identity(request)
         if fallback:
             return Identity(
-                username=fallback["username"],
+                username=fallback.get("email") or fallback["username"],
                 auth_method=fallback["auth_method"],
                 provider=fallback.get("provider"),
                 credential_type=self._get_credential_type(request),

--- a/registry/audit/models.py
+++ b/registry/audit/models.py
@@ -357,13 +357,19 @@ class TokenMintAuditRecord(BaseModel):
 
     Captures every mint (self-signed and M2M, success and failure) so reviewers
     can answer "which servers were scoped to a token, for whom, and did it succeed".
-    No raw token material is ever stored; the username is pre-hashed by the caller.
+    No raw token material is ever stored.
 
-    Note on ``username_hash``: the caller hashes with SHA-256 and keeps only the
-    first 8 hex chars (32 bits, ``user_<8hex>``). This is deliberate for privacy,
-    but it is a low-entropy hash: distinct usernames can collide once the audit
-    population grows into the tens of thousands (birthday bound ~2^16). Treat the
-    hash as a privacy-preserving grouping key for analytics, not a unique user id.
+    Identity: ``username`` holds the raw, human-readable identity (email ->
+    preferred_username -> sub), so an operator reading a mint record knows who to
+    contact without an IdP reverse lookup -- consistent with the raw identity the
+    Registry-API and MCP-access records already store.
+
+    ``username_hash`` is DEPRECATED and retained only for backward compatibility
+    with existing queries/dashboards/alerts that key on it; new consumers should
+    use ``username``. It is a low-entropy hash (SHA-256, first 8 hex / 32 bits,
+    ``user_<8hex>``): distinct users collide once the population reaches the tens
+    of thousands (birthday bound ~2^16), so it was never a unique id -- only a
+    grouping key. It will be removed in a later release once consumers migrate.
     """
 
     timestamp: datetime = Field(
@@ -385,9 +391,19 @@ class TokenMintAuditRecord(BaseModel):
     )
 
     # Who
+    username: str = Field(
+        default="anonymous",
+        description=(
+            "Raw human-readable identity of the requesting user "
+            "(email -> preferred_username -> sub). Preferred over username_hash."
+        ),
+    )
     username_hash: str = Field(
         ...,
-        description="SHA-256 (8 hex) hash of the requesting user; never the raw name",
+        description=(
+            "DEPRECATED (kept for back-compat): SHA-256 (8 hex) hash of the "
+            "requesting user. Use `username` instead."
+        ),
     )
     auth_method: str = Field(
         ...,

--- a/registry/audit/routes.py
+++ b/registry/audit/routes.py
@@ -462,7 +462,10 @@ def _build_query(
         # Escape special regex characters in the username
         escaped_username = re.escape(username)
         if stream == "token_mint":
-            query["username_hash"] = {"$regex": escaped_username, "$options": "i"}
+            # token_mint now stores the raw, human-readable `username` (email ->
+            # preferred_username -> sub); `username_hash` is deprecated. Match the
+            # raw field; pre-reconciliation records without it simply won't match.
+            query["username"] = {"$regex": escaped_username, "$options": "i"}
         else:
             query["identity.username"] = {"$regex": escaped_username, "$options": "i"}
 
@@ -547,7 +550,7 @@ async def get_filter_options(
 
     repository = get_audit_repository()
 
-    username_field = "username_hash" if stream == "token_mint" else "identity.username"
+    username_field = "username" if stream == "token_mint" else "identity.username"
     usernames = await repository.distinct(username_field, query)
 
     server_names: list[str] = []
@@ -609,8 +612,8 @@ async def get_statistics(
         escaped_username = re.escape(username)
         if stream == "token_mint":
             username_filter = {"$regex": escaped_username, "$options": "i"}
-            base_match["username_hash"] = username_filter
-            prior_match["username_hash"] = username_filter
+            base_match["username"] = username_filter
+            prior_match["username"] = username_filter
         else:
             username_filter = {"$regex": f"^{escaped_username}$", "$options": "i"}
             base_match["identity.username"] = username_filter
@@ -619,7 +622,7 @@ async def get_statistics(
     repository = get_audit_repository()
 
     # Build all pipelines upfront
-    user_field = "$username_hash" if stream == "token_mint" else "$identity.username"
+    user_field = "$username" if stream == "token_mint" else "$identity.username"
     op_field = (
         "$token_kind" if stream == "token_mint"
         else "$mcp_request.method" if stream == "mcp_access"

--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -469,6 +469,7 @@ async def _derive_user_context(
     session_id: str | None = None,
     client_id: str = "",
     egress_user: str = "",
+    email: str = "",
 ) -> dict[str, Any]:
     """Build the canonical user_context dict from authenticated identity inputs.
 
@@ -489,6 +490,7 @@ async def _derive_user_context(
     if auth_method == "federation-static":
         return {
             "username": username,
+            "email": email,
             "client_id": client_id,
             "groups": groups,
             "scopes": scopes,
@@ -511,6 +513,9 @@ async def _derive_user_context(
 
     return {
         "username": username,
+        # Human-readable email for audit records (preferred over username, which
+        # is the OIDC sub on some paths). Empty when the source carried none.
+        "email": email,
         "client_id": client_id,
         "groups": groups,
         "scopes": scopes,
@@ -542,6 +547,7 @@ async def _resolve_context_from_groups(
     session_id: str | None = None,
     client_id: str = "",
     egress_user: str = "",
+    email: str = "",
 ) -> dict[str, Any]:
     """Derive the canonical user_context from groups, server-side.
 
@@ -566,6 +572,7 @@ async def _resolve_context_from_groups(
         session_id=session_id,
         client_id=client_id,
         egress_user=egress_user,
+        email=email,
     )
 
 
@@ -612,6 +619,8 @@ async def _context_from_internal_token(
             # The auth_server stamps the canonical egress user (OIDC sub) into
             # the token; prefer it so the consent-write vault key matches vend.
             egress_user=claims.get("egress_user") or "",
+            # Human-readable email for audit records (from the session or claim).
+            email=session_data.get("email") or claims.get("email") or "",
         )
 
     # No session row (bearer / IdP-JWT / static-token caller): trust the claim's
@@ -624,6 +633,8 @@ async def _context_from_internal_token(
         provider=auth_method,
         client_id=claims.get("client_id") or "",
         egress_user=claims.get("egress_user") or "",
+        # Human-readable email for audit records when the claim carries it.
+        email=claims.get("email") or "",
     )
 
 
@@ -656,6 +667,8 @@ async def enhanced_auth(
         # consent-write path (which reaches enhanced_auth via the callback's
         # cookie, no internal token) keyed the same as the vend path. See #933.
         egress_user=session_data.get("subject") or "",
+        # Human-readable email for audit records (session store persists it).
+        email=session_data.get("email") or "",
     )
 
     # Set user context on request state for audit logging middleware

--- a/tests/auth_server/unit/test_egress_mint.py
+++ b/tests/auth_server/unit/test_egress_mint.py
@@ -119,6 +119,60 @@ class TestCanonicalEgressUser:
         assert server._canonical_egress_user({}) == ""
 
 
+@pytest.mark.unit
+class TestAuditIdentityDisplay:
+    """`_audit_identity_display` resolves the HUMAN-READABLE audit identity
+    (email -> preferred_username -> username/sub), the counterpart to
+    `_canonical_egress_user` (which resolves the stable sub for vault keying).
+    The two must NOT converge: audit prefers readability, vault prefers stability.
+    """
+
+    def test_prefers_email_from_data(self):
+        vr = {
+            "username": "00000000-sub-alice",
+            "data": {"email": "alice@example.com", "preferred_username": "alice", "sub": "00000000-sub-alice"},
+        }
+        assert server._audit_identity_display(vr) == "alice@example.com"
+
+    def test_prefers_top_level_email_when_no_data_email(self):
+        vr = {"username": "00000000-sub-alice", "email": "alice@example.com", "data": {}}
+        assert server._audit_identity_display(vr) == "alice@example.com"
+
+    def test_falls_back_to_preferred_username(self):
+        vr = {
+            "username": "00000000-sub-alice",
+            "data": {"preferred_username": "alice@contoso.com", "sub": "00000000-sub-alice"},
+        }
+        assert server._audit_identity_display(vr) == "alice@contoso.com"
+
+    def test_falls_back_to_username_when_no_email_or_pref(self):
+        # Session path: username is already the human handle.
+        vr = {"username": "alice@example.com", "data": {"sub": "00000000-sub-alice"}}
+        assert server._audit_identity_display(vr) == "alice@example.com"
+
+    def test_falls_back_to_sub_when_only_sub(self):
+        # Self-signed token whose readable claims are absent: sub, not anonymous.
+        vr = {"data": {"sub": "00000000-sub-alice"}}
+        assert server._audit_identity_display(vr) == "00000000-sub-alice"
+
+    def test_anonymous_when_nothing_present(self):
+        assert server._audit_identity_display({}) == "anonymous"
+
+    def test_diverges_from_canonical_egress_user(self):
+        # REGRESSION: the same Entra-shaped result must yield the READABLE email
+        # for audit but the STABLE sub for the vault key -- they must not collapse
+        # into one value (that divergence is the whole point of the split).
+        vr = {
+            "method": "session_cookie",
+            "username": "alice@contoso.com",
+            "email": "alice@contoso.com",
+            "data": {"subject": "entra-oid-sub-123", "auth_method": "oauth2"},
+        }
+        assert server._audit_identity_display(vr) == "alice@contoso.com"
+        assert server._canonical_egress_user(vr) == "entra-oid-sub-123"
+        assert server._audit_identity_display(vr) != server._canonical_egress_user(vr)
+
+
 def _decode(token: str) -> dict:
     return pyjwt.decode(
         token,

--- a/tests/auth_server/unit/test_token_mint_audit.py
+++ b/tests/auth_server/unit/test_token_mint_audit.py
@@ -144,3 +144,44 @@ async def test_audit_sink_failure_is_swallowed(_mock_metric, mock_emit, _mock_lo
         **_COMMON,
     )
     assert result is None
+
+
+@patch("auth_server.server.get_audit_logger", return_value=None)
+@patch("auth_server.server.emit_audit_event")
+@patch("auth_server.server.token_mint_total")
+async def test_display_username_stored_raw_and_hash_still_populated(
+    _mock_metric, mock_emit, _mock_logger
+):
+    # The raw human-readable field is stored verbatim while the deprecated
+    # username_hash keeps being derived from `username` (back-compat).
+    await _emit_token_mint_audit(
+        token_kind="user",
+        resource_type=None,
+        resource_id=None,
+        token_path="self_signed",
+        outcome="success",
+        display_username="alice@example.com",
+        **_COMMON,
+    )
+    record = mock_emit.call_args.args[0]
+    assert record.username == "alice@example.com"  # raw, human-readable
+    assert record.username_hash == hash_username("alice@example.com")  # still hashed
+    assert record.username_hash.startswith("user_")
+
+
+@patch("auth_server.server.get_audit_logger", return_value=None)
+@patch("auth_server.server.emit_audit_event")
+@patch("auth_server.server.token_mint_total")
+async def test_display_username_falls_back_to_username(_mock_metric, mock_emit, _mock_logger):
+    # When no display identity is supplied, the raw field falls back to the
+    # (possibly opaque) username so a record is never left blank.
+    await _emit_token_mint_audit(
+        token_kind="user",
+        resource_type=None,
+        resource_id=None,
+        token_path="self_signed",
+        outcome="success",
+        **_COMMON,
+    )
+    record = mock_emit.call_args.args[0]
+    assert record.username == "alice@example.com"

--- a/tests/unit/audit/test_token_mint_model.py
+++ b/tests/unit/audit/test_token_mint_model.py
@@ -53,6 +53,15 @@ class TestDefaults:
     def test_requested_scopes_defaults_empty_list(self):
         assert _minimal().requested_scopes == []
 
+    def test_username_defaults_anonymous(self):
+        # The raw human-readable field is optional (back-compat with callers that
+        # only set username_hash); it defaults to "anonymous", never blank.
+        assert _minimal().username == "anonymous"
+
+    def test_username_stores_raw_email(self):
+        r = _minimal(username="alice@example.com")
+        assert r.username == "alice@example.com"
+
 
 class TestRequiredFields:
     @pytest.mark.parametrize(

--- a/tests/unit/audit/test_token_mint_routes.py
+++ b/tests/unit/audit/test_token_mint_routes.py
@@ -1,9 +1,12 @@
 """Unit tests for the token_mint branch of the audit query builder (#1308).
 
-The token_mint stream stores a hashed username at the top level
-(``username_hash``) and flat resource fields (not nested under ``action.*``),
-so ``_build_query`` must route filters differently than the other streams.
+The token_mint stream stores the raw, human-readable identity at the top level
+(``username``; ``username_hash`` is deprecated) and flat resource fields (not
+nested under ``action.*``), so ``_build_query`` must route filters differently
+than the other streams.
 """
+
+import re
 
 from registry.audit.routes import _build_query
 
@@ -30,11 +33,15 @@ class TestTokenMintQuery:
     def test_stream_maps_to_token_mint_log_type(self):
         assert _q() == {"log_type": "token_mint"}
 
-    def test_username_filters_on_hash_not_identity(self):
-        query = _q(username="user_abcd1234")
-        assert "username_hash" in query
-        assert query["username_hash"]["$regex"] == "user_abcd1234"
-        assert query["username_hash"]["$options"] == "i"
+    def test_username_filters_on_raw_username_not_identity(self):
+        query = _q(username="alice@example.com")
+        # Filters on the raw, human-readable `username` field (not the
+        # deprecated `username_hash`, and not the nested identity field).
+        # The value is regex-escaped (the "." in an email is a metachar).
+        assert "username" in query
+        assert query["username"]["$regex"] == re.escape("alice@example.com")
+        assert query["username"]["$options"] == "i"
+        assert "username_hash" not in query
         # Must NOT use the registry_api/mcp_access identity field.
         assert "identity.username" not in query
 
@@ -53,8 +60,8 @@ class TestTokenMintQuery:
         assert "action.resource_id" not in query
 
     def test_combined_filters(self):
-        query = _q(username="user_dead", operation="user", resource_type="agent")
+        query = _q(username="alice@example.com", operation="user", resource_type="agent")
         assert query["log_type"] == "token_mint"
-        assert query["username_hash"]["$regex"] == "user_dead"
+        assert query["username"]["$regex"] == re.escape("alice@example.com")
         assert query["token_kind"] == "user"
         assert query["resource_type"] == "agent"


### PR DESCRIPTION
Audit records represented one user three incompatible ways: token-mint stored hash_username(...) (user_<8hex>), while MCP-access and Registry-API stored a mix of raw email and opaque OIDC sub depending on the auth path. The same human could not be correlated across streams, and a sub-only row gave an operator no one to contact (there is no durable sub->email map).

Standardize on the raw, human-readable identity (email -> preferred_username -> sub) everywhere identity enters an audit record, WITHOUT changing the `sub`-keyed value that the egress vault and OBO principal-binding depend on:

- Add `_audit_identity_display(validation_result)` in auth_server: the human-readable counterpart to `_canonical_egress_user` (which stays sub-keyed for vault/OBO). Use it for the MCP-access Identity and the OBO mint display.
- TokenMintAuditRecord: add a raw `username` field; keep populating (now deprecated) `username_hash` for back-compat. `_emit_token_mint_audit` gains `display_username`; all mint call sites (token-gen + OBO) pass the readable identity, resolving email off the self-signed/ingress token claims.
- Thread `email` through the registry `user_context` (`_derive_user_context`, `_resolve_context_from_groups`, `enhanced_auth`, `_context_from_internal_token`, middleware session fallback); middleware + direct-Identity route sites prefer it.
- Audit read layer + frontend: switch the token_mint stream's query/filter/ statistics fields and the table/detail display from `username_hash` to the raw `username` (frontend falls back to username_hash for old records).

Forward-only: historical records are not backfilled (old sub/hash values are not reversible to email). Tests cover the resolver (incl. divergence from `_canonical_egress_user`), the new raw field, and display fallback.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
