### PR TITLE
fix(frontend): page through list APIs so dashboard is not hard-capped (#880)

### DIFF
--- a/frontend/src/contexts/ServerStatsContext.tsx
+++ b/frontend/src/contexts/ServerStatsContext.tsx
@@ -3,6 +3,10 @@ import axios from 'axios';
 import { useRegistryConfig } from '../hooks/useRegistryConfig';
 import type { LocalRuntime } from '../types/server';
 import type { CustomEntityRecord, CustomTypeDescriptor } from '../types/customEntity';
+import {
+  CUSTOM_ENTITY_PAGE_SIZE,
+  fetchAllPages,
+} from '../utils/fetchAllPages';
 
 interface ServerVersion {
   version: string;
@@ -154,45 +158,68 @@ export const ServerStatsProvider: React.FC<ServerStatsProviderProps> = ({ childr
       const agentsEnabled = registryConfig?.features.agents !== false;
       const skillsEnabled = registryConfig?.features.skills !== false;
 
-      // Build fetch promises based on enabled features
-      const fetchPromises: Promise<any>[] = [];
+      // Issue #880: page through list APIs (max page size 2000/1000) so the UI
+      // is not hard-capped to a single request's limit.
+      const fetchPromises: Promise<any[]>[] = [];
 
       if (serversEnabled) {
         // include_tools=false: the dashboard only needs num_tools for the card
         // badge, not the full per-server tool_list. Omitting it shrinks the
         // payload and skips per-server tool filtering on the backend.
-        fetchPromises.push(axios.get('/api/servers?limit=2000&include_tools=false').catch(() => ({ data: { servers: [] } })));
+        fetchPromises.push(
+          fetchAllPages({
+            url: '/api/servers',
+            itemsKey: 'servers',
+            params: { include_tools: false },
+          }).catch(() => [] as any[]),
+        );
       } else {
-        fetchPromises.push(Promise.resolve({ data: { servers: [] } }));
+        fetchPromises.push(Promise.resolve([]));
       }
 
       if (agentsEnabled) {
-        fetchPromises.push(axios.get('/api/agents?limit=2000').catch(() => ({ data: { agents: [] } })));
+        fetchPromises.push(
+          fetchAllPages({
+            url: '/api/agents',
+            itemsKey: 'agents',
+          }).catch(() => [] as any[]),
+        );
       } else {
-        fetchPromises.push(Promise.resolve({ data: { agents: [] } }));
+        fetchPromises.push(Promise.resolve([]));
       }
 
       // Fetch skills for stats if skills are enabled
       if (skillsEnabled) {
-        fetchPromises.push(axios.get('/api/skills?include_disabled=true&limit=2000').catch(() => ({ data: { skills: [] } })));
+        fetchPromises.push(
+          fetchAllPages({
+            url: '/api/skills',
+            itemsKey: 'skills',
+            params: { include_disabled: true },
+          }).catch(() => [] as any[]),
+        );
       } else {
-        fetchPromises.push(Promise.resolve({ data: { skills: [] } }));
+        fetchPromises.push(Promise.resolve([]));
       }
 
       // Fetch custom entity records (one call per type) alongside the core
       // entities so every count lands in the SAME stats update — no visible
       // jump from a core-only total to the full total. Each type 404s only if
-      // deleted mid-session.
+      // deleted mid-session. Custom list API uses skip/limit (max 1000).
       const customTypes = registryConfig?.features.custom_types
         ? (registryConfig.custom_types ?? [])
         : [];
       const customPromises = customTypes.map((t) =>
-        axios.get(`/api/custom/${t.name}?limit=1000`).catch((err) => {
+        fetchAllPages({
+          url: `/api/custom/${t.name}`,
+          itemsKey: 'records',
+          pageSize: CUSTOM_ENTITY_PAGE_SIZE,
+          offsetParam: 'skip',
+        }).catch((err) => {
           // Treat as zero records so one stale type doesn't blank the sidebar.
           // Log so a real failure (auth, 422, 5xx) is visible rather than
           // silently zeroed out.
           console.error(`Failed to fetch custom records for "${t.name}":`, err);
-          return { data: { records: [] } };
+          return [] as CustomEntityRecord[];
         }),
       );
       // One bulk fetch of every descriptor so Discover can render record cards
@@ -207,12 +234,12 @@ export const ServerStatsProvider: React.FC<ServerStatsProviderProps> = ({ childr
             })
         : Promise.resolve({ data: { custom_types: [] } });
 
-      const [coreResponses, customResponses, descriptorsResponse] = await Promise.all([
+      const [coreLists, customLists, descriptorsResponse] = await Promise.all([
         Promise.all(fetchPromises),
         Promise.all(customPromises),
         descriptorsPromise,
       ]);
-      const [serversResponse, agentsResponse, skillsResponse] = coreResponses;
+      const [serversList, agentsList, skillsList] = coreLists;
 
       const descriptorsByName = new Map<string, CustomTypeDescriptor>(
         ((descriptorsResponse.data?.custom_types ?? []) as CustomTypeDescriptor[]).map(
@@ -223,22 +250,10 @@ export const ServerStatsProvider: React.FC<ServerStatsProviderProps> = ({ childr
         name: t.name,
         displayName: t.display_name,
         descriptor: descriptorsByName.get(t.name) ?? null,
-        records: (customResponses[i].data?.records ?? []) as CustomEntityRecord[],
+        records: (customLists[i] ?? []) as CustomEntityRecord[],
       }));
       setCustomRecordsByType(customByType);
       const customRecords = customByType.flatMap((ct) => ct.records);
-
-      // The API returns {"servers": [...]}
-      const responseData = serversResponse.data || {};
-      const serversList = responseData.servers || [];
-
-      // The agents API returns {"agents": [...]}
-      const agentsData = agentsResponse.data || {};
-      const agentsList = agentsData.agents || [];
-
-      // The skills API returns {"skills": [...]}
-      const skillsData = skillsResponse.data || {};
-      const skillsList = skillsData.skills || [];
 
       // Transform server data from backend format to frontend format
       const transformedServers: Server[] = serversList.map((serverInfo: any) => {

--- a/frontend/src/contexts/__tests__/ServerStatsContext.test.tsx
+++ b/frontend/src/contexts/__tests__/ServerStatsContext.test.tsx
@@ -40,10 +40,11 @@ function setConfig(customTypes: { name: string; display_name: string }[]) {
 }
 
 // Route axios.get by URL so the order of the parallel fetches doesn't matter.
+// fetchAllPages uses axios.get(url, { params }) — match on the path only.
 function mockGetByUrl(handlers: Record<string, any>) {
   mockedAxios.get.mockImplementation((url: string) => {
     for (const [needle, response] of Object.entries(handlers)) {
-      if (url.startsWith(needle)) {
+      if (url === needle || url.startsWith(needle)) {
         return response instanceof Error
           ? Promise.reject(response)
           : Promise.resolve({ data: response });
@@ -62,20 +63,74 @@ describe('ServerStatsContext custom entities', () => {
     jest.clearAllMocks();
   });
 
-  test('requests each custom type with limit=1000 (the endpoint max)', async () => {
+  test('requests each custom type with skip/limit page size 1000 (issue #880)', async () => {
     setConfig([{ name: 'prompt_template', display_name: 'Prompt Templates' }]);
     mockGetByUrl({
-      '/api/servers': { servers: [] },
-      '/api/agents': { agents: [] },
-      '/api/skills': { skills: [] },
-      '/api/custom/prompt_template': { records: [] },
+      '/api/servers': { servers: [], total_count: 0 },
+      '/api/agents': { agents: [], total_count: 0 },
+      '/api/skills': { skills: [], total_count: 0 },
+      '/api/custom/prompt_template': { records: [], total_count: 0 },
     });
 
     const { result } = renderHook(() => useServerStats(), { wrapper });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockedAxios.get).toHaveBeenCalledWith('/api/custom/prompt_template?limit=1000');
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/custom/prompt_template', {
+      params: { limit: 1000, skip: 0 },
+    });
+  });
+
+  test('pages through servers when total_count exceeds one page', async () => {
+    setConfig([]);
+    let serverCalls = 0;
+    mockedAxios.get.mockImplementation((url: string, config?: any) => {
+      if (url === '/api/servers') {
+        serverCalls += 1;
+        const offset = config?.params?.offset ?? 0;
+        if (offset === 0) {
+          return Promise.resolve({
+            data: {
+              servers: Array.from({ length: 2000 }, (_, i) => ({
+                path: `/s${i}`,
+                display_name: `S${i}`,
+                is_enabled: true,
+                health_status: 'healthy',
+              })),
+              total_count: 2001,
+            },
+          });
+        }
+        return Promise.resolve({
+          data: {
+            servers: [
+              {
+                path: '/s2000',
+                display_name: 'S2000',
+                is_enabled: true,
+                health_status: 'healthy',
+              },
+            ],
+            total_count: 2001,
+          },
+        });
+      }
+      if (url === '/api/agents') {
+        return Promise.resolve({ data: { agents: [], total_count: 0 } });
+      }
+      if (url === '/api/skills') {
+        return Promise.resolve({ data: { skills: [], total_count: 0 } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    const { result } = renderHook(() => useServerStats(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(serverCalls).toBe(2);
+    expect(result.current.servers).toHaveLength(2001);
+    expect(result.current.stats.total).toBe(2001);
   });
 
   test('folds custom records into stats and exposes them by type', async () => {
@@ -84,17 +139,19 @@ describe('ServerStatsContext custom entities', () => {
       { name: 'dataset', display_name: 'Datasets' },
     ]);
     mockGetByUrl({
-      '/api/servers': { servers: [] },
-      '/api/agents': { agents: [] },
-      '/api/skills': { skills: [] },
+      '/api/servers': { servers: [], total_count: 0 },
+      '/api/agents': { agents: [], total_count: 0 },
+      '/api/skills': { skills: [], total_count: 0 },
       '/api/custom/prompt_template': {
         records: [
           { path: '/prompt_template/a', name: 'A', is_enabled: true },
           { path: '/prompt_template/b', name: 'B', is_enabled: true },
         ],
+        total_count: 2,
       },
       '/api/custom/dataset': {
         records: [{ path: '/dataset/c', name: 'C', is_enabled: false }],
+        total_count: 1,
       },
     });
 

--- a/frontend/src/hooks/useAgentList.ts
+++ b/frontend/src/hooks/useAgentList.ts
@@ -6,22 +6,13 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import axios from 'axios';
+import { fetchAllPages } from '../utils/fetchAllPages';
 
 
 export interface AgentInfo {
   name: string;
   path: string;
   description: string;
-}
-
-interface AgentListResponse {
-  agents: Array<{
-    name: string;
-    path: string;
-    description?: string;
-    [key: string]: unknown;
-  }>;
 }
 
 interface UseAgentListReturn {
@@ -42,10 +33,17 @@ export function useAgentList(): UseAgentListReturn {
     setError(null);
 
     try {
-      const response = await axios.get<AgentListResponse>('/api/agents');
-      const data = response.data;
+      // Issue #880: default API limit is 20; page through all agents.
+      const rawAgents = await fetchAllPages<{
+        name: string;
+        path: string;
+        description?: string;
+      }>({
+        url: '/api/agents',
+        itemsKey: 'agents',
+      });
 
-      const agentList: AgentInfo[] = (data.agents || []).map((agent) => ({
+      const agentList: AgentInfo[] = rawAgents.map((agent) => ({
         name: agent.name,
         path: agent.path,
         description: agent.description || '',

--- a/frontend/src/hooks/useServerStats.ts
+++ b/frontend/src/hooks/useServerStats.ts
@@ -1,5 +1,6 @@
 // Server stats are now backed by a shared context provider so that the
-// triple `limit=2000` fetch runs once per dashboard view instead of once
-// per consumer (Layout + Dashboard previously each ran their own fetch).
+// multi-page list fetch (servers/agents/skills, issue #880) runs once per
+// dashboard view instead of once per consumer (Layout + Dashboard previously
+// each ran their own fetch).
 // The hook is re-exported here to keep existing import paths working.
 export { useServerStats, ServerStatsProvider } from '../contexts/ServerStatsContext';

--- a/frontend/src/hooks/useSkills.ts
+++ b/frontend/src/hooks/useSkills.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import axios from 'axios';
 import { Skill } from '../types/skill';
+import { fetchAllPages } from '../utils/fetchAllPages';
 
 export type { Skill } from '../types/skill';
 
@@ -22,11 +22,12 @@ export const useSkills = (): UseSkillsReturn => {
       setLoading(true);
       setError(null);
 
-      const response = await axios.get('/api/skills?include_disabled=true&limit=2000');
-
-      // The API returns {"skills": [...]}
-      const responseData = response.data || {};
-      const skillsList = responseData.skills || [];
+      // Issue #880: page through /api/skills (max 2000 per request)
+      const skillsList = await fetchAllPages<any>({
+        url: '/api/skills',
+        itemsKey: 'skills',
+        params: { include_disabled: true },
+      });
 
       console.log(`Skills returned from API: ${skillsList.length}`);
 

--- a/frontend/src/hooks/useToolCatalog.ts
+++ b/frontend/src/hooks/useToolCatalog.ts
@@ -7,6 +7,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
+import { fetchAllPages } from '../utils/fetchAllPages';
 
 
 export interface ServerInfo {
@@ -20,16 +21,6 @@ export interface ToolInfo {
   name: string;
   description: string;
   serverPath: string;
-}
-
-interface ServerListResponse {
-  servers: Array<{
-    path: string;
-    server_name?: string;
-    name?: string;
-    description?: string;
-    [key: string]: unknown;
-  }>;
 }
 
 interface VirtualServerListResponse {
@@ -83,14 +74,22 @@ export function useServerList(): UseServerListReturn {
     setError(null);
 
     try {
-      // Fetch both regular servers and virtual servers in parallel
-      const [serversResponse, virtualServersResponse] = await Promise.all([
-        axios.get<ServerListResponse>('/api/servers?limit=500'),
+      // Issue #880: page through /api/servers (not a single hard-capped page).
+      const [rawServers, virtualServersResponse] = await Promise.all([
+        fetchAllPages<{
+          path: string;
+          server_name?: string;
+          name?: string;
+          description?: string;
+        }>({
+          url: '/api/servers',
+          itemsKey: 'servers',
+        }),
         axios.get<VirtualServerListResponse>('/api/virtual-servers'),
       ]);
 
       // Map regular MCP servers
-      const mcpServers: ServerInfo[] = (serversResponse.data.servers || []).map((s) => ({
+      const mcpServers: ServerInfo[] = rawServers.map((s) => ({
         path: s.path,
         name: s.server_name || s.name || s.path,
         description: s.description || '',

--- a/frontend/src/utils/__tests__/fetchAllPages.test.ts
+++ b/frontend/src/utils/__tests__/fetchAllPages.test.ts
@@ -1,0 +1,169 @@
+import axios from 'axios';
+import {
+  CUSTOM_ENTITY_PAGE_SIZE,
+  DEFAULT_MAX_PAGES,
+  fetchAllPages,
+  REGISTRY_LIST_PAGE_SIZE,
+} from '../fetchAllPages';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('fetchAllPages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns a single page when total_count fits in one page', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        servers: [{ path: '/a' }, { path: '/b' }],
+        total_count: 2,
+        limit: 2000,
+        offset: 0,
+      },
+    });
+
+    const items = await fetchAllPages<{ path: string }>({
+      url: '/api/servers',
+      itemsKey: 'servers',
+      params: { include_tools: false },
+    });
+
+    expect(items).toEqual([{ path: '/a' }, { path: '/b' }]);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/servers', {
+      params: {
+        limit: REGISTRY_LIST_PAGE_SIZE,
+        offset: 0,
+        include_tools: false,
+      },
+    });
+  });
+
+  test('fetches subsequent pages until all items are collected (issue #880)', async () => {
+    const pageSize = 2;
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        data: {
+          servers: [{ path: '/1' }, { path: '/2' }],
+          total_count: 5,
+          limit: pageSize,
+          offset: 0,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          servers: [{ path: '/3' }, { path: '/4' }],
+          total_count: 5,
+          limit: pageSize,
+          offset: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          servers: [{ path: '/5' }],
+          total_count: 5,
+          limit: pageSize,
+          offset: 4,
+        },
+      });
+
+    const items = await fetchAllPages<{ path: string }>({
+      url: '/api/servers',
+      itemsKey: 'servers',
+      pageSize,
+    });
+
+    expect(items.map((i) => i.path)).toEqual(['/1', '/2', '/3', '/4', '/5']);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(2, '/api/servers', {
+      params: { limit: pageSize, offset: 2 },
+    });
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(3, '/api/servers', {
+      params: { limit: pageSize, offset: 4 },
+    });
+  });
+
+  test('stops when a full page returns with no total_count but short final page is not needed', async () => {
+    const pageSize = 2;
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        data: {
+          agents: [{ path: '/a1' }, { path: '/a2' }],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          agents: [{ path: '/a3' }],
+        },
+      });
+
+    const items = await fetchAllPages<{ path: string }>({
+      url: '/api/agents',
+      itemsKey: 'agents',
+      pageSize,
+    });
+
+    expect(items).toHaveLength(3);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses skip param for custom entity endpoints', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: {
+        records: [{ path: '/prompt/1' }],
+        total_count: 1,
+        skip: 0,
+        limit: CUSTOM_ENTITY_PAGE_SIZE,
+      },
+    });
+
+    const items = await fetchAllPages({
+      url: '/api/custom/prompt_template',
+      itemsKey: 'records',
+      pageSize: CUSTOM_ENTITY_PAGE_SIZE,
+      offsetParam: 'skip',
+    });
+
+    expect(items).toHaveLength(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/custom/prompt_template', {
+      params: {
+        limit: CUSTOM_ENTITY_PAGE_SIZE,
+        skip: 0,
+      },
+    });
+  });
+
+  test('stops after maxPages even if more data is claimed', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        skills: [{ path: '/s' }, { path: '/t' }],
+        total_count: 100,
+      },
+    });
+
+    const items = await fetchAllPages({
+      url: '/api/skills',
+      itemsKey: 'skills',
+      pageSize: 2,
+      maxPages: 3,
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(items).toHaveLength(6);
+    expect(DEFAULT_MAX_PAGES).toBeGreaterThan(0);
+  });
+
+  test('returns empty array when collection key is missing', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: { total_count: 0 } });
+
+    const items = await fetchAllPages({
+      url: '/api/servers',
+      itemsKey: 'servers',
+    });
+
+    expect(items).toEqual([]);
+  });
+});

--- a/frontend/src/utils/fetchAllPages.ts
+++ b/frontend/src/utils/fetchAllPages.ts
@@ -1,0 +1,102 @@
+/**
+ * Multi-page collection fetcher for registry list APIs.
+ *
+ * Backend endpoints (/api/servers, /api/agents, /api/skills, /api/custom/{type})
+ * enforce a max page size (typically 2000 or 1000). Issue #880: the UI must not
+ * hard-cap visible items to a single page — loop with limit/offset (or skip)
+ * until all rows are collected using total_count when present.
+ */
+
+import axios, { AxiosRequestConfig } from 'axios';
+
+/** API max for servers, agents, and skills list endpoints. */
+export const REGISTRY_LIST_PAGE_SIZE = 2000;
+
+/** API max for custom entity list endpoints. */
+export const CUSTOM_ENTITY_PAGE_SIZE = 1000;
+
+/** Safety cap: max pages to fetch (prevents infinite loops on bad total_count). */
+export const DEFAULT_MAX_PAGES = 50;
+
+export interface FetchAllPagesOptions {
+  /** Absolute path, e.g. `/api/servers`. */
+  url: string;
+  /** Response array property name, e.g. `servers`, `agents`, `skills`, `records`. */
+  itemsKey: string;
+  /** Page size; must be within the endpoint's allowed range. */
+  pageSize?: number;
+  /** Extra query params (must not include limit/offset/skip). */
+  params?: Record<string, string | number | boolean | undefined | null>;
+  /** Offset query parameter name (`offset` for most routes, `skip` for custom entities). */
+  offsetParam?: 'offset' | 'skip';
+  /** Abort after this many pages. */
+  maxPages?: number;
+  /** Optional axios config (headers, signal, etc.). */
+  axiosConfig?: AxiosRequestConfig;
+}
+
+/**
+ * Fetch every page of a paginated list endpoint and return the concatenated items.
+ */
+export async function fetchAllPages<T = unknown>(
+  options: FetchAllPagesOptions,
+): Promise<T[]> {
+  const {
+    url,
+    itemsKey,
+    pageSize = REGISTRY_LIST_PAGE_SIZE,
+    params = {},
+    offsetParam = 'offset',
+    maxPages = DEFAULT_MAX_PAGES,
+    axiosConfig,
+  } = options;
+
+  if (pageSize < 1) {
+    throw new Error('pageSize must be >= 1');
+  }
+
+  const all: T[] = [];
+  let offset = 0;
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const query: Record<string, string | number | boolean> = {
+      limit: pageSize,
+      [offsetParam]: offset,
+    };
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null) {
+        query[key] = value;
+      }
+    }
+
+    const response = await axios.get(url, {
+      ...axiosConfig,
+      params: {
+        ...(axiosConfig?.params as Record<string, unknown> | undefined),
+        ...query,
+      },
+    });
+
+    const data = response.data || {};
+    const items = (Array.isArray(data[itemsKey]) ? data[itemsKey] : []) as T[];
+    const totalCount =
+      typeof data.total_count === 'number' && Number.isFinite(data.total_count)
+        ? data.total_count
+        : null;
+
+    all.push(...items);
+
+    // Empty page or short page => no more data
+    if (items.length === 0 || items.length < pageSize) {
+      break;
+    }
+    // total_count says we have everything
+    if (totalCount !== null && all.length >= totalCount) {
+      break;
+    }
+
+    offset += pageSize;
+  }
+
+  return all;
+}


### PR DESCRIPTION
## Summary

Fixes #880. The dashboard and related hooks no longer hard-cap servers, agents, and skills to a single API page response.

List endpoints enforce a max page size (2000 for servers/agents/skills, 1000 for custom entities). The UI previously issued one request with a fixed `limit`, so registries larger than that page size silently dropped items. This change pages through `limit`/`offset` (or `skip` for custom entities) using `total_count` until the full collection is loaded.

### Changes

- Add `frontend/src/utils/fetchAllPages.ts` to loop list API pages safely (short page, `total_count`, and `maxPages` guards).
- Wire multi-page fetch into:
  - `ServerStatsContext` (servers, agents, skills, custom entity records)
  - `useSkills`
  - `useAgentList`
  - `useToolCatalog`
- Keep existing client-side UI pagination (`PAGE_SIZE = 50` in the Dashboard) for display density only; it now pages over the full in-memory set.

### Acceptance criteria (issue #880)

- [x] All servers are available to the UI regardless of total count
- [x] All agents are available to the UI regardless of total count
- [x] All skills are available to the UI regardless of total count
- [x] No single hardcoded request limit caps the number of loaded items

### Out of scope

- Server-side search/filter redesign
- Changing API max page sizes
- Infinite-scroll UX (UI still uses Prev/Next over the loaded set)

## Test plan

- [x] `npm test -- --testPathPattern=fetchAllPages --watchAll=false`
- [x] `npm test -- --testPathPattern=ServerStatsContext --watchAll=false`
- [x] Unit coverage for multi-page server fetch when `total_count` exceeds one page (2001 items → 2 requests)
- [ ] Optional: manual Dashboard check with a registry containing more than one API page of servers/agents/skills

## Branch

- `fix/880-frontend-pagination`