### PR TITLE
admin safety guards followup

### DIFF
--- a/docker/auth-entrypoint.sh
+++ b/docker/auth-entrypoint.sh
@@ -125,12 +125,16 @@ source .venv/bin/activate
 # Only trust proxy headers when the peer is loopback. The auth-server is reached
 # solely via nginx (the /validate subrequest and OAuth callbacks), whose peer is
 # NOT loopback, so uvicorn will not derive request.client from a forwarded header
-# at all — request.client stays the real (non-spoofable) nginx peer. The real
-# client IP still reaches get_client_ip via nginx's X-Real-IP header (tier 1),
-# and HTTPS/OAuth detection reads the X-Forwarded-Proto header directly, so both
-# are unaffected. Using "*" let uvicorn overwrite request.client with the
-# left-most (client-controlled) X-Forwarded-For entry, poisoning the tier-3
-# fallback in get_client_ip(). ::1 covers the BIND_HOST=:: dual-stack case.
+# at all — request.client stays the nginx peer, not a client-controlled value.
+# Scope of this setting: it governs ONLY the request.client (tier-3) fallback in
+# get_client_ip(). The audit client IP normally comes from the X-Real-IP /
+# X-Forwarded-For headers (tiers 1-2), whose trustworthiness depends on nginx
+# OVERWRITING those headers on every path that reaches get_client_ip — including
+# the auth_request /validate subrequest, which must set X-Real-IP itself because
+# auth_request subrequests do NOT inherit the parent location's proxy_set_header
+# (see docker/nginx_rev_proxy_*.conf). This flag does not cover that; it only
+# hardens the tier-3 fallback. HTTPS/OAuth detection reads X-Forwarded-Proto from
+# the header directly, so it is unaffected. ::1 covers BIND_HOST=:: dual-stack.
 FORWARDED_ALLOW_IPS="127.0.0.1,::1"
 if [ -n "${OTEL_EXPORTER_OTLP_ENDPOINT}" ] && command -v opentelemetry-instrument >/dev/null 2>&1; then
     echo "Using OTEL_EXPORTER_OTLP_ENDPOINT at ${OTEL_EXPORTER_OTLP_ENDPOINT}"

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -222,6 +222,17 @@ server {
         proxy_set_header X-Region $http_x_region;
         proxy_set_header X-Authorization $http_x_authorization;
 
+        # Overwrite the client-supplied source headers with nginx's own view of
+        # the peer. An auth_request subrequest does NOT inherit the parent
+        # location's proxy_set_header directives, and proxy_pass_request_headers
+        # below forwards the ORIGINAL client headers verbatim -- so without these
+        # two lines a client could send X-Real-IP: 8.8.8.8 and have it recorded as
+        # the source in the auth-server MCP access audit (get_client_ip prefers
+        # X-Real-IP). $remote_addr honours the realip module (set_real_ip_from),
+        # so this is the real client behind a trusted proxy and non-spoofable
+        # otherwise. Must stay ABOVE proxy_pass_request_headers on;.
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         # Pass all original headers (including Authorization and X-Body from Lua)
         proxy_pass_request_headers on;

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -230,7 +230,9 @@ server {
         # the source in the auth-server MCP access audit (get_client_ip prefers
         # X-Real-IP). $remote_addr honours the realip module (set_real_ip_from),
         # so this is the real client behind a trusted proxy and non-spoofable
-        # otherwise. Must stay ABOVE proxy_pass_request_headers on;.
+        # otherwise. (proxy_set_header overrides the forwarded client header
+        # declaratively regardless of its position relative to
+        # proxy_pass_request_headers on.)
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
@@ -1001,6 +1003,18 @@ server {
         proxy_set_header X-Client-Id $http_x_client_id;
         proxy_set_header X-Region $http_x_region;
         proxy_set_header X-Authorization $http_x_authorization;
+
+        # Overwrite the client-supplied source headers with nginx's own view of
+        # the peer. An auth_request subrequest does NOT inherit the parent
+        # location's proxy_set_header directives, and proxy_pass_request_headers
+        # below forwards the ORIGINAL client headers verbatim -- so without these
+        # two lines a client could send X-Real-IP: 8.8.8.8 and have it recorded as
+        # the source in the auth-server MCP access audit (get_client_ip prefers
+        # X-Real-IP). $remote_addr honours the realip module (set_real_ip_from),
+        # so this is the real client behind a trusted proxy and non-spoofable
+        # otherwise.
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         # Pass all original headers (including Authorization and X-Body from Lua)
         proxy_pass_request_headers on;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -427,6 +427,17 @@ server {
         # Forward Authorization header as X-Authorization (auth-server expects this)
         proxy_set_header X-Authorization $http_x_authorization;
 
+        # Overwrite the client-supplied source headers with nginx's own view of
+        # the peer. An auth_request subrequest does NOT inherit the parent
+        # location's proxy_set_header directives, and proxy_pass_request_headers
+        # below forwards the ORIGINAL client headers verbatim -- so without these
+        # two lines a client could send X-Real-IP: 8.8.8.8 and have it recorded as
+        # the source in the auth-server MCP access audit (get_client_ip prefers
+        # X-Real-IP). $remote_addr honours the realip module (set_real_ip_from),
+        # so this is the real client behind a trusted proxy and non-spoofable
+        # otherwise. Must stay ABOVE proxy_pass_request_headers on;.
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         # Pass all original headers (including Authorization and X-Body from Lua)
         proxy_pass_request_headers on;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -435,7 +435,9 @@ server {
         # the source in the auth-server MCP access audit (get_client_ip prefers
         # X-Real-IP). $remote_addr honours the realip module (set_real_ip_from),
         # so this is the real client behind a trusted proxy and non-spoofable
-        # otherwise. Must stay ABOVE proxy_pass_request_headers on;.
+        # otherwise. (proxy_set_header overrides the forwarded client header
+        # declaratively regardless of its position relative to
+        # proxy_pass_request_headers on.)
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -331,12 +331,22 @@ BIND_HOST="${BIND_HOST:-127.0.0.1}"
 
 # Only trust proxy headers (X-Forwarded-For / X-Forwarded-Proto) when the peer is
 # loopback. nginx is the sole client and reaches uvicorn over 127.0.0.1:7860 in
-# this same container, so scoping trust to loopback means uvicorn NEVER derives
-# request.client from a header supplied by a non-local caller. Using "*" made
-# uvicorn overwrite request.client with the left-most (client-controlled)
-# X-Forwarded-For entry, poisoning the direct-peer fallback in get_client_ip();
-# loopback-only keeps that fallback non-spoofable (defense-in-depth for the
-# audit client-IP resolver). ::1 covers the BIND_HOST=:: dual-stack case.
+# this same container. Scope of this setting: it governs ONLY whether uvicorn
+# overwrites request.client from a forwarded header. Using "*" made uvicorn set
+# request.client from the left-most (client-controlled) X-Forwarded-For entry;
+# loopback-only stops that. It is NOT what makes get_client_ip() safe — that
+# resolver reads X-Real-IP / X-Forwarded-For from the request headers directly
+# (tiers 1-2, whose trustworthiness depends on nginx overwriting those headers,
+# not on this flag) and only falls back to request.client as tier 3. So this is
+# a narrow hardening of that tier-3 fallback, not the primary control. ::1
+# covers the BIND_HOST=:: dual-stack case.
+#
+# NOTE: assumes nginx shares this container's network namespace (reaches uvicorn
+# over loopback). If nginx is ever run in a separate pod/container, its peer is
+# no longer loopback: request.client reverts to the nginx peer (still not
+# client-controlled) and uvicorn drops --proxy-headers scheme handling, but the
+# audit IP survives via X-Real-IP and scheme via the X-Forwarded-Proto header,
+# so it degrades gracefully. Revisit this value if that topology is adopted.
 FORWARDED_ALLOW_IPS="127.0.0.1,::1"
 
 echo "Starting MCP Registry in the background..."

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -38,6 +38,16 @@ DEFAULT_NGINX_CONFIG_MODE: int = 0o644
 MCP_PROXY_NGINX_READ_TIMEOUT_BUFFER_SECONDS: int = 30
 
 
+# Minimum sane prefix length for a TRUSTED_REAL_IP_CIDRS entry. A prefix shorter
+# than this (e.g. 0.0.0.0/1, 10.0.0.0/4) trusts an implausibly large peer range
+# for a proxy subnet and edges toward the catch-all footgun, so we warn (but still
+# honour it — unlike a /0, which is rejected outright). IPv4-scale; IPv6 prefixes
+# are compared on their IPv4-equivalent host-bit width so a normal /48–/64 proxy
+# subnet does not trip the warning.
+MIN_TRUSTED_REAL_IP_PREFIXLEN_V4: int = 8
+MIN_TRUSTED_REAL_IP_PREFIXLEN_V6: int = 32
+
+
 def _resolve_mcp_proxy_read_timeout_seconds() -> int:
     """Resolve nginx's proxy_read_timeout (seconds) for MCP location blocks.
 
@@ -126,6 +136,22 @@ def _render_real_ip_config() -> str:
                 candidate,
             )
             continue
+        # Warn (but honour) an implausibly broad, non-catch-all range. A proxy
+        # subnet is realistically a /16-/28 (v4) or /48-/64 (v6); anything much
+        # broader trusts far more peers than a real LB tier occupies and edges
+        # toward the same spoofing risk as a catch-all.
+        floor = (
+            MIN_TRUSTED_REAL_IP_PREFIXLEN_V6
+            if network.version == 6
+            else MIN_TRUSTED_REAL_IP_PREFIXLEN_V4
+        )
+        if network.prefixlen < floor:
+            logger.warning(
+                "TRUSTED_REAL_IP_CIDRS entry %r is very broad (/%d); trusting this "
+                "many peers is risky — narrow it to the proxy's actual subnet",
+                candidate,
+                network.prefixlen,
+            )
         valid_cidrs.append(str(network))
 
     if not valid_cidrs:

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -80,16 +80,25 @@ def _render_real_ip_config() -> str:
     directives are emitted, which is the correct behaviour for edge deployments
     (compose / single host) where nginx's peer already IS the client.
 
-    ``real_ip_recursive on`` walks the forwarded chain right-to-left skipping the
-    trusted CIDRs, stopping at the first untrusted address (the real client), so a
-    stacked-proxy topology (e.g. CloudFront in front of an ALB, once both ranges
-    are listed) resolves correctly. A spoofed left-most entry can never win
-    because it is not appended by a trusted hop.
+    ``real_ip_recursive`` walks the forwarded chain right-to-left skipping the
+    trusted CIDRs, stopping at the first untrusted address (the real client). It
+    is emitted as ``on`` ONLY when more than one trusted CIDR is configured (a
+    stacked-proxy topology, e.g. CloudFront in front of an ALB). For the common
+    single-hop case (one ALB) recursion is left off: nginx takes the single
+    right-most entry, which is what the one trusted proxy appended, and a spoofed
+    left-most entry can never win. Recursion + an over-broad trusted range would
+    let a client whose own source falls inside that range inject a left-most
+    entry, so we don't enable it unless the topology actually needs it.
+
+    Catch-all ranges (``0.0.0.0/0`` / ``::/0``) are rejected: they would make
+    nginx trust EVERY peer and take the spoofable left-most XFF entry — a
+    fail-open misconfiguration — so they are dropped with a warning like any other
+    invalid entry. Narrow the trust to the load balancer's specific subnet(s).
 
     Returns:
         The nginx directive block (``set_real_ip_from`` lines + ``real_ip_header``
-        + ``real_ip_recursive on``), or an empty string when no valid CIDRs are
-        configured.
+        + optional ``real_ip_recursive on``), or an empty string when no valid
+        CIDRs are configured.
     """
     raw = os.environ.get("TRUSTED_REAL_IP_CIDRS", "").strip()
     if not raw:
@@ -104,9 +113,20 @@ def _render_real_ip_config() -> str:
             # strict=False so a host address (e.g. 10.1.3.39) is accepted as a
             # /32 rather than rejected for having host bits set.
             network = ipaddress.ip_network(candidate, strict=False)
-            valid_cidrs.append(str(network))
         except ValueError:
             logger.warning("Ignoring malformed entry in TRUSTED_REAL_IP_CIDRS: %r", candidate)
+            continue
+        # Reject a catch-all range: trusting every peer defeats the guard and
+        # makes the spoofable left-most XFF entry win (fail-open). prefixlen == 0
+        # is 0.0.0.0/0 or ::/0.
+        if network.prefixlen == 0:
+            logger.warning(
+                "Refusing catch-all range %r in TRUSTED_REAL_IP_CIDRS "
+                "(would trust every peer); narrow it to the proxy's subnet",
+                candidate,
+            )
+            continue
+        valid_cidrs.append(str(network))
 
     if not valid_cidrs:
         logger.warning(
@@ -118,7 +138,10 @@ def _render_real_ip_config() -> str:
     logger.info("Configuring nginx realip trust for CIDRs: %s", ", ".join(valid_cidrs))
     lines = [f"set_real_ip_from {cidr};" for cidr in valid_cidrs]
     lines.append("real_ip_header X-Forwarded-For;")
-    lines.append("real_ip_recursive on;")
+    # Only recurse for stacked proxies (>1 trusted hop). A single trusted CIDR
+    # needs no recursion — the right-most entry is the one that proxy appended.
+    if len(valid_cidrs) > 1:
+        lines.append("real_ip_recursive on;")
     return "\n".join(lines)
 
 

--- a/registry/services/admin_safety.py
+++ b/registry/services/admin_safety.py
@@ -115,6 +115,23 @@ async def resolve_admin_group_names() -> set[str]:
                 if isinstance(mapped, str):
                     admin_names.add(_normalize(mapped))
 
+    # Fail closed on an empty result. A scope catalogue that lists groups but
+    # matches ZERO admin-conferring scopes means our privileged-scope predicate
+    # has drifted from the catalogue shape (or the catalogue is incomplete) — not
+    # that the deployment genuinely has no admin groups. Proceeding would make
+    # every user look non-admin and silently disable the last-admin guard, so we
+    # refuse rather than derive a lockout decision from an unverifiable picture.
+    if not admin_names:
+        logger.error(
+            "admin_safety: scope catalogue yielded ZERO admin-conferring groups "
+            "(%d groups scanned); refusing to derive admin population",
+            len(groups),
+        )
+        raise AdminSafetyError(
+            status_code=503,
+            detail="Unable to verify administrator population; operation refused",
+        )
+
     logger.debug("admin_safety: resolved %d admin-conferring group names", len(admin_names))
     return admin_names
 
@@ -165,6 +182,24 @@ async def list_admin_usernames() -> set[str]:
             continue
         if groups_confer_admin(user.get("groups"), admin_group_names):
             admins.add(_normalize(username))
+
+    # Fail closed on an empty admin set. We already know at least one
+    # admin-conferring group exists (resolve_admin_group_names raises otherwise),
+    # so finding NO admin users means the user listing didn't surface group
+    # membership (e.g. an IdP adapter that returned groupless users, or a
+    # truncated/empty listing) rather than a genuine zero-admin deployment.
+    # Deriving "target is not an admin, nothing to guard" from that would silently
+    # bypass the last-admin guard, so refuse instead.
+    if not admins:
+        logger.error(
+            "admin_safety: no administrator accounts found despite %d "
+            "admin-conferring group(s); refusing (user listing likely incomplete)",
+            len(admin_group_names),
+        )
+        raise AdminSafetyError(
+            status_code=503,
+            detail="Unable to verify administrator population; operation refused",
+        )
 
     logger.debug("admin_safety: %d administrator account(s) currently present", len(admins))
     return admins

--- a/registry/services/admin_safety.py
+++ b/registry/services/admin_safety.py
@@ -152,11 +152,64 @@ def groups_confer_admin(
     return False
 
 
+async def _m2m_admin_usernames(admin_group_names: set[str]) -> set[str]:
+    """Return admin M2M service-account usernames from the ``idp_m2m_clients`` store.
+
+    For non-Keycloak IdPs (Okta/Auth0/PingFederate) an M2M client's group
+    membership lives ONLY in the MongoDB ``idp_m2m_clients`` collection, not in the
+    IdP user listing. The user-management list handler merges this collection, so
+    the admin count must too — otherwise an M2M-only admin is invisible and the
+    last-admin guard both under-counts and (with the empty-set fail-closed) can
+    wrongly refuse legitimate operations. Mirrors the merge in
+    ``registry.api.management_routes.management_list_users``.
+
+    Best-effort: a datastore error is logged and treated as "no M2M admins found"
+    rather than raised, because the IdP listing is the primary source and the
+    empty-set guard in :func:`list_admin_usernames` still fails closed if the
+    combined result is empty.
+
+    Args:
+        admin_group_names: Case-folded admin-conferring group set.
+
+    Returns:
+        Case-folded usernames of M2M clients whose groups confer admin.
+    """
+    from ..repositories.documentdb.client import get_documentdb_client
+
+    m2m_admins: set[str] = set()
+    try:
+        db = await get_documentdb_client()
+        collection = db["idp_m2m_clients"]
+        cursor = collection.find({})
+        docs = await cursor.to_list(length=None)
+    except Exception as exc:
+        logger.warning(
+            "admin_safety: could not read idp_m2m_clients for admin count "
+            "(M2M admins not included): %s",
+            exc,
+        )
+        return m2m_admins
+
+    for doc in docs or []:
+        if not isinstance(doc, dict):
+            continue
+        name = doc.get("name") or doc.get("client_id")
+        if not name:
+            continue
+        if groups_confer_admin(doc.get("groups"), admin_group_names):
+            m2m_admins.add(_normalize(name))
+
+    logger.debug("admin_safety: %d M2M admin service-account(s) found", len(m2m_admins))
+    return m2m_admins
+
+
 async def list_admin_usernames() -> set[str]:
     """Return the case-folded usernames of all current administrators.
 
-    Cross-references the IdP/DB user listing against the admin-conferring group
-    set. Fails closed on any error.
+    Cross-references the IdP/DB user listing AND the MongoDB ``idp_m2m_clients``
+    store against the admin-conferring group set, so the admin population matches
+    what the user-management list handler shows (M2M-only admins included). Fails
+    closed on any error enumerating the primary IdP listing.
 
     Raises:
         AdminSafetyError: If users or admin groups cannot be enumerated.
@@ -182,6 +235,11 @@ async def list_admin_usernames() -> set[str]:
             continue
         if groups_confer_admin(user.get("groups"), admin_group_names):
             admins.add(_normalize(username))
+
+    # Merge M2M admins (stored only in idp_m2m_clients for non-Keycloak IdPs) so
+    # the count matches management_list_users and an M2M-only admin is not
+    # invisible to the last-admin guard.
+    admins |= await _m2m_admin_usernames(admin_group_names)
 
     # Fail closed on an empty admin set. We already know at least one
     # admin-conferring group exists (resolve_admin_group_names raises otherwise),

--- a/registry/services/admin_safety.py
+++ b/registry/services/admin_safety.py
@@ -152,8 +152,8 @@ def groups_confer_admin(
     return False
 
 
-async def _m2m_admin_usernames(admin_group_names: set[str]) -> set[str]:
-    """Return admin M2M service-account usernames from the ``idp_m2m_clients`` store.
+async def _m2m_admin_identities(admin_group_names: set[str]) -> list[frozenset[str]]:
+    """Return one alias-set per admin M2M service account from ``idp_m2m_clients``.
 
     For non-Keycloak IdPs (Okta/Auth0/PingFederate) an M2M client's group
     membership lives ONLY in the MongoDB ``idp_m2m_clients`` collection, not in the
@@ -163,20 +163,28 @@ async def _m2m_admin_usernames(admin_group_names: set[str]) -> set[str]:
     wrongly refuse legitimate operations. Mirrors the merge in
     ``registry.api.management_routes.management_list_users``.
 
+    Each admin is returned as a frozenset of ALL its identifiers (normalized
+    ``name`` and ``client_id``). ``management_delete_user`` resolves an M2M client
+    by ``{"$or": [{"client_id": ...}, {"name": ...}]}`` and the guard is called
+    with the raw path param (either key), so the guard must recognise a delete by
+    EITHER — but the two aliases are ONE admin, so they must count as one (a flat
+    set of identifiers would double-count and re-open the last-admin fail-open).
+    For Keycloak ``name == client_id`` so the set collapses to one element.
+
     Best-effort: a datastore error is logged and treated as "no M2M admins found"
     rather than raised, because the IdP listing is the primary source and the
-    empty-set guard in :func:`list_admin_usernames` still fails closed if the
-    combined result is empty.
+    empty-population guard in :func:`list_admin_identities` still fails closed if
+    the combined result is empty.
 
     Args:
         admin_group_names: Case-folded admin-conferring group set.
 
     Returns:
-        Case-folded usernames of M2M clients whose groups confer admin.
+        One alias frozenset per M2M client whose groups confer admin.
     """
     from ..repositories.documentdb.client import get_documentdb_client
 
-    m2m_admins: set[str] = set()
+    m2m_admins: list[frozenset[str]] = []
     try:
         db = await get_documentdb_client()
         collection = db["idp_m2m_clients"]
@@ -193,26 +201,35 @@ async def _m2m_admin_usernames(admin_group_names: set[str]) -> set[str]:
     for doc in docs or []:
         if not isinstance(doc, dict):
             continue
-        name = doc.get("name") or doc.get("client_id")
-        if not name:
+        if not groups_confer_admin(doc.get("groups"), admin_group_names):
             continue
-        if groups_confer_admin(doc.get("groups"), admin_group_names):
-            m2m_admins.add(_normalize(name))
+        aliases = {_normalize(key) for key in (doc.get("name"), doc.get("client_id")) if key}
+        if aliases:
+            m2m_admins.append(frozenset(aliases))
 
-    logger.debug("admin_safety: %d M2M admin service-account(s) found", len(m2m_admins))
+    logger.debug("admin_safety: %d M2M admin account(s) found", len(m2m_admins))
     return m2m_admins
 
 
-async def list_admin_usernames() -> set[str]:
-    """Return the case-folded usernames of all current administrators.
+async def list_admin_identities() -> list[frozenset[str]]:
+    """Return one alias-set per current administrator.
+
+    Each element is the set of case-folded identifiers by which one admin can be
+    addressed: a single username for an IdP user, or ``{name, client_id}`` for an
+    M2M service account (which a delete may target by either). Returning one entry
+    PER ADMIN — rather than a flat set of identifiers — is what lets the guards
+    both (a) recognise the target by any of its aliases and (b) count distinct
+    admins correctly (a flat identifier set would count a two-alias M2M admin
+    twice and re-open the last-admin fail-open).
 
     Cross-references the IdP/DB user listing AND the MongoDB ``idp_m2m_clients``
-    store against the admin-conferring group set, so the admin population matches
-    what the user-management list handler shows (M2M-only admins included). Fails
-    closed on any error enumerating the primary IdP listing.
+    store against the admin-conferring group set, so the population matches what
+    the user-management list handler shows (M2M-only admins included). Fails closed
+    on any error enumerating the primary IdP listing, and on an empty population.
 
     Raises:
-        AdminSafetyError: If users or admin groups cannot be enumerated.
+        AdminSafetyError: If users/groups cannot be enumerated, or the resolved
+            population is empty (treated as unverifiable, not a genuine zero).
     """
     admin_group_names = await resolve_admin_group_names()
 
@@ -226,7 +243,7 @@ async def list_admin_usernames() -> set[str]:
             detail="Unable to verify administrator population; operation refused",
         ) from exc
 
-    admins: set[str] = set()
+    admins: list[frozenset[str]] = []
     for user in users or []:
         if not isinstance(user, dict):
             continue
@@ -234,20 +251,20 @@ async def list_admin_usernames() -> set[str]:
         if not username:
             continue
         if groups_confer_admin(user.get("groups"), admin_group_names):
-            admins.add(_normalize(username))
+            admins.append(frozenset({_normalize(username)}))
 
     # Merge M2M admins (stored only in idp_m2m_clients for non-Keycloak IdPs) so
     # the count matches management_list_users and an M2M-only admin is not
     # invisible to the last-admin guard.
-    admins |= await _m2m_admin_usernames(admin_group_names)
+    admins.extend(await _m2m_admin_identities(admin_group_names))
 
-    # Fail closed on an empty admin set. We already know at least one
+    # Fail closed on an empty admin population. We already know at least one
     # admin-conferring group exists (resolve_admin_group_names raises otherwise),
-    # so finding NO admin users means the user listing didn't surface group
-    # membership (e.g. an IdP adapter that returned groupless users, or a
-    # truncated/empty listing) rather than a genuine zero-admin deployment.
-    # Deriving "target is not an admin, nothing to guard" from that would silently
-    # bypass the last-admin guard, so refuse instead.
+    # so finding NO admin means the listing didn't surface group membership (e.g.
+    # an IdP adapter that returned groupless users, or a truncated/empty listing)
+    # rather than a genuine zero-admin deployment. Deriving "target is not an
+    # admin, nothing to guard" from that would silently bypass the guard, so
+    # refuse instead.
     if not admins:
         logger.error(
             "admin_safety: no administrator accounts found despite %d "
@@ -261,6 +278,24 @@ async def list_admin_usernames() -> set[str]:
 
     logger.debug("admin_safety: %d administrator account(s) currently present", len(admins))
     return admins
+
+
+def _would_empty_admins(
+    admins: list[frozenset[str]],
+    target: str,
+) -> bool:
+    """Return True if removing ``target`` leaves zero administrators.
+
+    ``target`` is a normalized identifier. An admin is "the target" if that
+    identifier is one of its aliases; the removal empties the population only if
+    NO OTHER admin (a different alias-set) remains. Counting distinct admins —
+    not identifiers — is what prevents a two-alias M2M admin from masking itself.
+    """
+    is_target_admin = any(target in aliases for aliases in admins)
+    if not is_target_admin:
+        return False
+    remaining = [aliases for aliases in admins if target not in aliases]
+    return not remaining
 
 
 async def assert_not_last_admin(target_username: str) -> None:
@@ -278,16 +313,10 @@ async def assert_not_last_admin(target_username: str) -> None:
         AdminSafetyError: If the target is the only remaining administrator, or
             the admin population cannot be determined (fail closed).
     """
-    admins = await list_admin_usernames()
+    admins = await list_admin_identities()
     target = _normalize(target_username)
 
-    if target not in admins:
-        # Target is not an admin (or an unverifiable edge) — removing it cannot
-        # empty the admin population. Nothing to guard.
-        return
-
-    remaining = admins - {target}
-    if not remaining:
+    if _would_empty_admins(admins, target):
         raise AdminSafetyError(
             status_code=409,
             detail=(
@@ -322,14 +351,10 @@ async def would_remove_last_admin_via_groups(
     if groups_confer_admin(desired_groups, admin_group_names):
         return
 
-    admins = await list_admin_usernames()
+    admins = await list_admin_identities()
     target = _normalize(target_username)
 
-    if target not in admins:
-        return
-
-    remaining = admins - {target}
-    if not remaining:
+    if _would_empty_admins(admins, target):
         raise AdminSafetyError(
             status_code=409,
             detail=(

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -222,6 +222,36 @@ def test_render_real_ip_config_drops_catch_all_keeps_valid():
 
 
 @pytest.mark.unit
+def test_render_real_ip_config_warns_but_honours_broad_range(caplog):
+    """A broad non-catch-all range (e.g. /1) is warned about but still emitted.
+
+    Unlike /0 (rejected outright), a /1 is honoured — an operator may have a
+    reason — but a warning flags that it trusts an implausibly large peer range.
+    """
+    import logging
+
+    with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "0.0.0.0/1"}):
+        with caplog.at_level(logging.WARNING, logger="registry.core.nginx_service"):
+            out = nginx_module._render_real_ip_config()
+
+    assert "set_real_ip_from 0.0.0.0/1;" in out
+    assert any("very broad" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
+def test_render_real_ip_config_normal_v6_subnet_no_broad_warning(caplog):
+    """A normal IPv6 proxy subnet (/48) must NOT trip the broad-range warning."""
+    import logging
+
+    with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "2001:db8::/48"}):
+        with caplog.at_level(logging.WARNING, logger="registry.core.nginx_service"):
+            out = nginx_module._render_real_ip_config()
+
+    assert "set_real_ip_from 2001:db8::/48;" in out
+    assert not any("very broad" in r.message for r in caplog.records)
+
+
+@pytest.mark.unit
 def test_nginx_service_init_http_only():
     """Test NginxConfigService initialization with HTTP-only template."""
     with patch("registry.core.nginx_service.Path") as mock_path_class:

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -129,13 +129,31 @@ def test_render_real_ip_config_empty_when_blank():
 
 
 @pytest.mark.unit
-def test_render_real_ip_config_single_cidr():
-    """A single VPC CIDR renders set_real_ip_from + recursive directives."""
+def test_render_real_ip_config_single_cidr_no_recursion():
+    """A single VPC CIDR renders set_real_ip_from + header, but NOT recursion.
+
+    One trusted hop needs no recursion — nginx takes the single right-most entry
+    (what that proxy appended). Recursion is reserved for stacked proxies.
+    """
     with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "10.0.0.0/16"}):
         out = nginx_module._render_real_ip_config()
 
     assert "set_real_ip_from 10.0.0.0/16;" in out
     assert "real_ip_header X-Forwarded-For;" in out
+    assert "real_ip_recursive" not in out
+
+
+@pytest.mark.unit
+def test_render_real_ip_config_multiple_enables_recursion():
+    """More than one trusted CIDR (stacked proxies) enables real_ip_recursive on."""
+    with patch.dict(
+        "os.environ",
+        {"TRUSTED_REAL_IP_CIDRS": "10.0.0.0/16, 130.176.0.0/16"},
+    ):
+        out = nginx_module._render_real_ip_config()
+
+    assert "set_real_ip_from 10.0.0.0/16;" in out
+    assert "set_real_ip_from 130.176.0.0/16;" in out
     assert "real_ip_recursive on;" in out
 
 
@@ -172,6 +190,35 @@ def test_render_real_ip_config_all_invalid_emits_nothing():
     """When every entry is malformed, emit nothing rather than a broken directive."""
     with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "garbage, also-bad"}):
         assert nginx_module._render_real_ip_config() == ""
+
+
+@pytest.mark.unit
+def test_render_real_ip_config_rejects_ipv4_catch_all():
+    """0.0.0.0/0 is rejected (would trust every peer -> spoofable, fail-open)."""
+    with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "0.0.0.0/0"}):
+        assert nginx_module._render_real_ip_config() == ""
+
+
+@pytest.mark.unit
+def test_render_real_ip_config_rejects_ipv6_catch_all():
+    """::/0 is rejected for the same reason as the IPv4 catch-all."""
+    with patch.dict("os.environ", {"TRUSTED_REAL_IP_CIDRS": "::/0"}):
+        assert nginx_module._render_real_ip_config() == ""
+
+
+@pytest.mark.unit
+def test_render_real_ip_config_drops_catch_all_keeps_valid():
+    """A catch-all mixed with a valid CIDR drops only the catch-all."""
+    with patch.dict(
+        "os.environ",
+        {"TRUSTED_REAL_IP_CIDRS": "0.0.0.0/0, 10.0.0.0/16"},
+    ):
+        out = nginx_module._render_real_ip_config()
+
+    assert "set_real_ip_from 10.0.0.0/16;" in out
+    assert "0.0.0.0/0" not in out
+    # Only one valid CIDR survived -> no recursion.
+    assert "real_ip_recursive" not in out
 
 
 @pytest.mark.unit

--- a/tests/unit/services/test_admin_safety.py
+++ b/tests/unit/services/test_admin_safety.py
@@ -140,8 +140,8 @@ def _mongo_m2m_mock(docs):
 
 
 @pytest.mark.asyncio
-class TestListAdminUsernames:
-    """Tests for counting admin users."""
+class TestListAdminIdentities:
+    """Tests for enumerating admin accounts (one alias-set per admin)."""
 
     async def test_counts_only_admin_users(self):
         users = [
@@ -163,8 +163,8 @@ class TestListAdminUsernames:
                 new=_mongo_m2m_mock([]),
             ),
         ):
-            admins = await admin_safety.list_admin_usernames()
-        assert admins == {"admin1", "admin2"}
+            admins = await admin_safety.list_admin_identities()
+        assert set(admins) == {frozenset({"admin1"}), frozenset({"admin2"})}
 
     async def test_counts_m2m_only_admin_from_mongo(self):
         # The IdP listing has NO admin (M2M group membership lives only in
@@ -189,8 +189,41 @@ class TestListAdminUsernames:
                 new=_mongo_m2m_mock(m2m_docs),
             ),
         ):
-            admins = await admin_safety.list_admin_usernames()
-        assert admins == {"svc-admin"}
+            admins = await admin_safety.list_admin_identities()
+        assert admins == [frozenset({"svc-admin"})]
+
+    async def test_m2m_admin_aliases_are_ONE_admin_not_two(self):
+        # Okta/Auth0 case: client_id (opaque IdP id) != name (friendly label), and
+        # the M2M account is NOT in the IdP listing. Both aliases identify ONE
+        # admin, so the entry is a single frozenset carrying both keys. This is
+        # what lets the guard (a) recognise a delete by EITHER key AND (b) count it
+        # as one admin — a flat two-element identifier set would double-count and
+        # re-open the last-admin fail-open.
+        users = [{"username": "regular", "groups": ["readers"]}]
+        m2m_docs = [
+            {
+                "client_id": "0oa1b2c3d4e5",
+                "name": "break-glass-admin",
+                "groups": ["mcp-registry-admin"],
+            },
+        ]
+        with (
+            patch(
+                "registry.services.admin_safety.resolve_admin_group_names",
+                new=AsyncMock(return_value={"mcp-registry-admin"}),
+            ),
+            patch(
+                "registry.services.admin_safety.get_iam_manager",
+                return_value=_iam_mock(users),
+            ),
+            patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new=_mongo_m2m_mock(m2m_docs),
+            ),
+        ):
+            admins = await admin_safety.list_admin_identities()
+        # ONE admin, addressable by either identifier.
+        assert admins == [frozenset({"0oa1b2c3d4e5", "break-glass-admin"})]
 
     async def test_m2m_store_error_does_not_raise_when_idp_admin_present(self):
         # A datastore error reading idp_m2m_clients is best-effort: it must not
@@ -211,8 +244,8 @@ class TestListAdminUsernames:
                 new=broken,
             ),
         ):
-            admins = await admin_safety.list_admin_usernames()
-        assert admins == {"admin1"}
+            admins = await admin_safety.list_admin_identities()
+        assert admins == [frozenset({"admin1"})]
 
     async def test_fails_closed_when_users_unavailable(self):
         mock = MagicMock()
@@ -228,7 +261,7 @@ class TestListAdminUsernames:
             ),
         ):
             with pytest.raises(AdminSafetyError) as exc:
-                await admin_safety.list_admin_usernames()
+                await admin_safety.list_admin_identities()
         assert exc.value.status_code == 503
 
     async def test_fails_closed_when_no_admins_found(self):
@@ -255,7 +288,7 @@ class TestListAdminUsernames:
             ),
         ):
             with pytest.raises(AdminSafetyError) as exc:
-                await admin_safety.list_admin_usernames()
+                await admin_safety.list_admin_identities()
         assert exc.value.status_code == 503
 
 
@@ -265,16 +298,16 @@ class TestAssertNotLastAdmin:
 
     async def test_allows_when_other_admins_remain(self):
         with patch(
-            "registry.services.admin_safety.list_admin_usernames",
-            new=AsyncMock(return_value={"admin1", "admin2"}),
+            "registry.services.admin_safety.list_admin_identities",
+            new=AsyncMock(return_value=[frozenset({"admin1"}), frozenset({"admin2"})]),
         ):
             # Should not raise.
             await admin_safety.assert_not_last_admin("admin1")
 
     async def test_rejects_last_admin(self):
         with patch(
-            "registry.services.admin_safety.list_admin_usernames",
-            new=AsyncMock(return_value={"admin1"}),
+            "registry.services.admin_safety.list_admin_identities",
+            new=AsyncMock(return_value=[frozenset({"admin1"})]),
         ):
             with pytest.raises(AdminSafetyError) as exc:
                 await admin_safety.assert_not_last_admin("admin1")
@@ -282,19 +315,50 @@ class TestAssertNotLastAdmin:
 
     async def test_noop_when_target_not_admin(self):
         with patch(
-            "registry.services.admin_safety.list_admin_usernames",
-            new=AsyncMock(return_value={"admin1"}),
+            "registry.services.admin_safety.list_admin_identities",
+            new=AsyncMock(return_value=[frozenset({"admin1"})]),
         ):
             # Deleting a non-admin cannot empty the admin population.
             await admin_safety.assert_not_last_admin("regular-user")
 
     async def test_fails_closed_when_population_unknown(self):
         with patch(
-            "registry.services.admin_safety.list_admin_usernames",
+            "registry.services.admin_safety.list_admin_identities",
             new=AsyncMock(side_effect=AdminSafetyError(503, "unknown")),
         ):
             with pytest.raises(AdminSafetyError):
                 await admin_safety.assert_not_last_admin("admin1")
+
+    async def test_rejects_last_admin_deleted_by_either_m2m_key(self):
+        # The sole admin is ONE M2M client whose alias-set carries both client_id
+        # and name. Deleting by EITHER identifier must be refused. This is the case
+        # a flat identifier set got wrong: two aliases must count as one admin so
+        # removing either empties the population.
+        sole_admin = [frozenset({"0oa1b2c3d4e5", "break-glass-admin"})]
+        for target in ("0oa1b2c3d4e5", "break-glass-admin"):
+            with patch(
+                "registry.services.admin_safety.list_admin_identities",
+                new=AsyncMock(return_value=list(sole_admin)),
+            ):
+                with pytest.raises(AdminSafetyError) as exc:
+                    await admin_safety.assert_not_last_admin(target)
+            assert exc.value.status_code == 409
+
+    async def test_allows_when_another_distinct_admin_remains_alongside_m2m(self):
+        # Two DISTINCT admins: a two-alias M2M client and a regular user. Deleting
+        # the M2M admin (by either alias) is allowed because the regular admin
+        # remains. Guards against over-counting the aliases as "the only admin".
+        admins = [
+            frozenset({"0oa1b2c3d4e5", "break-glass-admin"}),
+            frozenset({"human-admin"}),
+        ]
+        for target in ("0oa1b2c3d4e5", "break-glass-admin"):
+            with patch(
+                "registry.services.admin_safety.list_admin_identities",
+                new=AsyncMock(return_value=list(admins)),
+            ):
+                # Must NOT raise — another distinct admin remains.
+                await admin_safety.assert_not_last_admin(target)
 
 
 @pytest.mark.asyncio
@@ -316,8 +380,8 @@ class TestWouldRemoveLastAdminViaGroups:
                 new=AsyncMock(return_value={"mcp-registry-admin"}),
             ),
             patch(
-                "registry.services.admin_safety.list_admin_usernames",
-                new=AsyncMock(return_value={"admin1"}),
+                "registry.services.admin_safety.list_admin_identities",
+                new=AsyncMock(return_value=[frozenset({"admin1"})]),
             ),
         ):
             with pytest.raises(AdminSafetyError) as exc:
@@ -331,8 +395,8 @@ class TestWouldRemoveLastAdminViaGroups:
                 new=AsyncMock(return_value={"mcp-registry-admin"}),
             ),
             patch(
-                "registry.services.admin_safety.list_admin_usernames",
-                new=AsyncMock(return_value={"admin1", "admin2"}),
+                "registry.services.admin_safety.list_admin_identities",
+                new=AsyncMock(return_value=[frozenset({"admin1"}), frozenset({"admin2"})]),
             ),
         ):
             await admin_safety.would_remove_last_admin_via_groups("admin1", ["readers"])

--- a/tests/unit/services/test_admin_safety.py
+++ b/tests/unit/services/test_admin_safety.py
@@ -127,6 +127,18 @@ def _iam_mock(users):
     return mock
 
 
+def _mongo_m2m_mock(docs):
+    """Patch target: get_documentdb_client returning a db whose idp_m2m_clients
+    collection yields ``docs`` from ``find({}).to_list()``."""
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=docs)
+    collection = MagicMock()
+    collection.find = MagicMock(return_value=cursor)
+    db = MagicMock()
+    db.__getitem__ = MagicMock(return_value=collection)
+    return AsyncMock(return_value=db)
+
+
 @pytest.mark.asyncio
 class TestListAdminUsernames:
     """Tests for counting admin users."""
@@ -146,9 +158,61 @@ class TestListAdminUsernames:
                 "registry.services.admin_safety.get_iam_manager",
                 return_value=_iam_mock(users),
             ),
+            patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new=_mongo_m2m_mock([]),
+            ),
         ):
             admins = await admin_safety.list_admin_usernames()
         assert admins == {"admin1", "admin2"}
+
+    async def test_counts_m2m_only_admin_from_mongo(self):
+        # The IdP listing has NO admin (M2M group membership lives only in
+        # idp_m2m_clients for non-Keycloak IdPs). The M2M admin must be counted so
+        # the population is not falsely empty and the guard does not 503-brick.
+        users = [{"username": "regular", "groups": ["readers"]}]
+        m2m_docs = [
+            {"client_id": "svc-admin", "name": "svc-admin", "groups": ["mcp-registry-admin"]},
+            {"client_id": "svc-reader", "name": "svc-reader", "groups": ["readers"]},
+        ]
+        with (
+            patch(
+                "registry.services.admin_safety.resolve_admin_group_names",
+                new=AsyncMock(return_value={"mcp-registry-admin"}),
+            ),
+            patch(
+                "registry.services.admin_safety.get_iam_manager",
+                return_value=_iam_mock(users),
+            ),
+            patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new=_mongo_m2m_mock(m2m_docs),
+            ),
+        ):
+            admins = await admin_safety.list_admin_usernames()
+        assert admins == {"svc-admin"}
+
+    async def test_m2m_store_error_does_not_raise_when_idp_admin_present(self):
+        # A datastore error reading idp_m2m_clients is best-effort: it must not
+        # raise as long as the IdP listing already surfaced an admin.
+        users = [{"username": "admin1", "groups": ["mcp-registry-admin"]}]
+        broken = AsyncMock(side_effect=Exception("mongo down"))
+        with (
+            patch(
+                "registry.services.admin_safety.resolve_admin_group_names",
+                new=AsyncMock(return_value={"mcp-registry-admin"}),
+            ),
+            patch(
+                "registry.services.admin_safety.get_iam_manager",
+                return_value=_iam_mock(users),
+            ),
+            patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new=broken,
+            ),
+        ):
+            admins = await admin_safety.list_admin_usernames()
+        assert admins == {"admin1"}
 
     async def test_fails_closed_when_users_unavailable(self):
         mock = MagicMock()
@@ -168,10 +232,10 @@ class TestListAdminUsernames:
         assert exc.value.status_code == 503
 
     async def test_fails_closed_when_no_admins_found(self):
-        # Admin-conferring groups exist, but the user listing surfaces NO admin
-        # (e.g. an IdP adapter that returned groupless users, or a truncated
-        # listing). Deriving "no admins, nothing to guard" would bypass the
-        # last-admin guard, so this must fail closed instead of returning set().
+        # Admin-conferring groups exist, but neither the user listing NOR the M2M
+        # store surfaces an admin (e.g. an IdP adapter that returned groupless
+        # users, or a truncated listing). Deriving "no admins, nothing to guard"
+        # would bypass the last-admin guard, so this must fail closed.
         users = [
             {"username": "regular1", "groups": ["readers"]},
             {"username": "regular2", "groups": []},
@@ -184,6 +248,10 @@ class TestListAdminUsernames:
             patch(
                 "registry.services.admin_safety.get_iam_manager",
                 return_value=_iam_mock(users),
+            ),
+            patch(
+                "registry.repositories.documentdb.client.get_documentdb_client",
+                new=_mongo_m2m_mock([]),
             ),
         ):
             with pytest.raises(AdminSafetyError) as exc:

--- a/tests/unit/services/test_admin_safety.py
+++ b/tests/unit/services/test_admin_safety.py
@@ -104,6 +104,22 @@ class TestResolveAdminGroupNames:
             with pytest.raises(AdminSafetyError):
                 await admin_safety.resolve_admin_group_names()
 
+    async def test_fails_closed_on_empty_admin_group_set(self):
+        # Catalogue lists groups but NONE match the privileged-scope predicate
+        # (predicate/catalogue drift). Must refuse rather than return an empty set
+        # that would silently disable the last-admin guard.
+        groups = {
+            "readers": {"ui_scopes": {"list_service": ["some-server"]}, "mappings": []},
+            "viewers": {"ui_scopes": {"list_service": ["another-server"]}, "mappings": []},
+        }
+        with patch(
+            "registry.services.admin_safety.scope_service.list_groups",
+            new=AsyncMock(return_value=groups),
+        ):
+            with pytest.raises(AdminSafetyError) as exc:
+                await admin_safety.resolve_admin_group_names()
+        assert exc.value.status_code == 503
+
 
 def _iam_mock(users):
     mock = MagicMock()
@@ -145,6 +161,29 @@ class TestListAdminUsernames:
             patch(
                 "registry.services.admin_safety.get_iam_manager",
                 return_value=mock,
+            ),
+        ):
+            with pytest.raises(AdminSafetyError) as exc:
+                await admin_safety.list_admin_usernames()
+        assert exc.value.status_code == 503
+
+    async def test_fails_closed_when_no_admins_found(self):
+        # Admin-conferring groups exist, but the user listing surfaces NO admin
+        # (e.g. an IdP adapter that returned groupless users, or a truncated
+        # listing). Deriving "no admins, nothing to guard" would bypass the
+        # last-admin guard, so this must fail closed instead of returning set().
+        users = [
+            {"username": "regular1", "groups": ["readers"]},
+            {"username": "regular2", "groups": []},
+        ]
+        with (
+            patch(
+                "registry.services.admin_safety.resolve_admin_group_names",
+                new=AsyncMock(return_value={"mcp-registry-admin"}),
+            ),
+            patch(
+                "registry.services.admin_safety.get_iam_manager",
+                return_value=_iam_mock(users),
             ),
         ):
             with pytest.raises(AdminSafetyError) as exc:


### PR DESCRIPTION
Follow up to #1428 
## What the follow-up adds

### 1. Non-spoofable client IP on the `auth_request /validate` path
The audit client-IP resolver preferred `X-Real-IP`, but an nginx `auth_request`
subrequest does **not** inherit the parent location's `proxy_set_header`
directives, and the `/validate` blocks set neither `X-Real-IP` nor a sanitized
`X-Forwarded-For` while enabling `proxy_pass_request_headers on`. A client
sending `X-Real-IP: 8.8.8.8` therefore had it forwarded verbatim to the
auth-server and recorded as the source in the **MCP tool-invocation audit**
(`log_mcp_access`) — the highest-value attribution trail in the system. Fixed by
setting `X-Real-IP $remote_addr` + `X-Forwarded-For $proxy_add_x_forwarded_for`
inside **all three** `/validate` blocks (both nginx templates, including the
`:8443` TLS listener), so the recorded value is nginx's realip-resolved peer, not
a client header. This complements the registry-side fix from the base PR, where
every client-facing location already set `X-Real-IP`.

### 2. `--forwarded-allow-ips` scoped to loopback on both services
uvicorn ran with `--forwarded-allow-ips=*`, letting `ProxyHeadersMiddleware`
overwrite `request.client` from the spoofable left-most `X-Forwarded-For` entry
(the tier-3 fallback in `get_client_ip()`, and anything else reading
`request.client`). Scoped to `127.0.0.1,::1` on the registry and auth-server
(container entrypoints and the `__main__` dev runners). nginx is the sole client
and reaches uvicorn over loopback in the same container; the real client IP still
arrives via `X-Real-IP` and HTTPS/OAuth scheme detection reads
`X-Forwarded-Proto` directly, so both are unaffected. This is defense-in-depth
for the resolver, which already ignores the left-most entry.

### 3. Admin population is fail-closed and counts admins by identity
Two problems in the intra-admin last-admin guard:
- **Fail-open on an empty admin set.** `resolve_admin_group_names()` returned a
  valid-but-empty set on predicate/catalogue drift, and `list_admin_usernames()`
  could return empty when a user listing didn't surface group membership; the
  guard then treated the target as "not an admin, nothing to guard" and allowed
  the delete. Both now raise `AdminSafetyError(503)` on an empty result, matching
  the module's fail-closed contract.
- **M2M admins were invisible, then mis-counted.** M2M service-account admins
  live only in the MongoDB `idp_m2m_clients` store for non-Keycloak IdPs and were
  not counted, so an M2M-only admin was invisible (and with the empty-set
  fail-closed could 503-brick user management). Merging them exposed a subtler
  bug: M2M clients are addressable by **two** identifiers (`client_id` and
  `name`, which differ on Okta/Auth0) and a delete resolves by either, so a flat
  `set[str]` either missed a delete-by-the-other-key (fail-open) or double-counted
  the sole admin's two aliases (also fail-open). Fixed by modelling the population
  as one entry **per admin** — `list_admin_usernames` → `list_admin_identities`
  returning `list[frozenset[str]]` (each set is one admin's aliases) — plus a
  `_would_empty_admins()` helper that matches the target by any alias and reports
  empty only when no *other* admin remains. The admin enumeration now mirrors the
  M2M merge already used by the user-management list handler.

### 4. `set_real_ip_from` hardening
`_render_real_ip_config()` rejects the catch-all ranges `0.0.0.0/0` and `::/0`
(which trust every peer and let the spoofable left-most `X-Forwarded-For` win),
warns on an implausibly broad non-catch-all range (broader than `/8` IPv4 / `/32`
IPv6), and emits `real_ip_recursive on` only when more than one trusted CIDR is
configured (a single-ALB hop needs no recursion).

## Testing (follow-up)
Added coverage for: empty-admin-group and empty-admin-user fail-closed; M2M-only
admin counted; an M2M admin's two aliases counted as one and refused on delete by
either key; delete allowed when a second distinct admin remains; realip catch-all
and broad-range handling; single- vs multi-CIDR recursion. All three `/validate`
blocks are asserted to carry the source-header overwrite. The affected unit
suites and the helm registry suite pass; ruff clean. An independent adversarial
review over four rounds signed off with no remaining fail-open.

## Known gaps (follow-up, deferred)
- The admin enumeration reads `iam.list_users(max_results=1000, ...)`; on an IdP
  realm with >1000 users the scan can truncate. This interacts **fail-closed**
  (worst case is a spurious refusal, never a lockout), so it is deferred as a
  separate change; full pagination is the eventual fix.
- The last-admin count is read-then-act with no lock; two concurrent admin
  deletions could race. Admin ops are rare; serialization is a follow-up.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
