### PR TITLE
fix(a2a): pass dict to update_agent in security-pending-tag path

### DIFF
--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -155,11 +155,11 @@ async def _perform_agent_security_scan_on_registration(
                     # the warning it earned.
                     agent_info = await agent_service.get_agent_info(path)
                     if agent_info:
-                        updated_card = agent_info.model_dump()
-                        updated_card["tags"] = current_tags
-                        from ..schemas.agent_models import AgentCard as AgentCardModel
-
-                        await agent_service.update_agent(path, AgentCardModel(**updated_card))
+                        # update_agent takes a dict of fields to merge (it calls
+                        # updates.get(...)); pass the dict directly, not an
+                        # AgentCard instance (which has no .get and raises
+                        # AttributeError). Only the changed field is needed.
+                        await agent_service.update_agent(path, {"tags": current_tags})
                     logger.info(f"Added 'security-pending' tag to agent {path}")
 
             # Disable agent if configured

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -1897,9 +1897,14 @@ class TestRunSecurityScanOnRegistrationUpdatesViaUpdateAgent:
         # tag. register_agent must NOT be called inside this helper because
         # the agent was already inserted by the caller.
         assert service_mock.update_agent.await_count == 1
-        called_path, called_card = service_mock.update_agent.await_args.args
+        called_path, called_updates = service_mock.update_agent.await_args.args
         assert called_path == path
-        assert "security-pending" in called_card.tags
+        # update_agent takes a DICT of fields to merge (it calls updates.get()).
+        # Passing an AgentCard instance raised
+        # "'AgentCard' object has no attribute 'get'". Regression: must be a dict
+        # whose tags include the security-pending marker.
+        assert isinstance(called_updates, dict)
+        assert "security-pending" in called_updates["tags"]
         assert service_mock.register_agent.await_count == 0
 
         # block_unsafe_agents was False, so the scan helper does not toggle


### PR DESCRIPTION
## Summary

Fixes the remaining sibling of the `AttributeError: 'AgentCard' object has no attribute 'get'` bug. A 1.26.0 user hit this on agent update from the registry UI (the PUT endpoint), which was fixed in #1434. This PR fixes the last call site that still passes an `AgentCard` where `agent_service.update_agent()` expects a dict: the post-registration security scan's security-pending-tag path.

## Root cause

`update_agent(path, updates)` merges `updates` as a dict (`updates.get("url")`, `agent_dict.update(updates)`). The scan path called it with `AgentCardModel(**updated_card)`, so `.get()` raised `AttributeError`. This fires whenever `add_security_pending_tag` is enabled and an agent fails its registration scan.

## Change

- `registry/api/agent_routes.py`: pass `{"tags": current_tags}` (a partial-merge dict) instead of an `AgentCard` instance; drop the now-unused local `AgentCardModel` import.
- Update the #1033 regression test to assert `update_agent` receives a dict whose tags include `security-pending` (the old assertion `called_card.tags` encoded the buggy contract).

## Testing

- `tests/unit/api/test_agent_routes.py` — 70 passed, 2 skipped; ruff clean.