### PR TITLE
Harden legacy static admin token

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -86,7 +86,7 @@ from registry.audit.models import Identity, MCPServer, TokenMintAuditRecord
 from registry.audit.service import AuditLogger, NonDurableAuditError, enforce_durable_audit_sink
 from registry.audit.sink import emit_audit_event
 from registry.common.scopes_loader import reload_scopes_config
-from registry.common.secret_key import validate_secret_key
+from registry.common.secret_key import validate_secret_key, validate_signing_secret
 from registry.core.config import settings
 from registry.repositories.factory import get_scope_repository
 
@@ -510,8 +510,21 @@ _registry_static_token_requested: bool = (
     os.environ.get("REGISTRY_STATIC_TOKEN_AUTH_ENABLED", "false").lower() == "true"
 )
 
-# Static API key for Registry API (must match Bearer token value when enabled)
-REGISTRY_API_TOKEN: str = os.environ.get("REGISTRY_API_TOKEN", "")
+# Static API key for Registry API (must match Bearer token value when enabled).
+#
+# When set, this token is promoted to a legacy admin entry with unrestricted
+# scopes (see _build_static_token_map), so it grants the highest privilege in
+# the system. It must therefore clear the same strength bar as the application
+# signing secret: presence is optional (an unset token simply means no legacy
+# entry is created), but a value that IS present must be strong. Validating
+# through the canonical signing-secret helper fails closed at startup on an
+# empty/whitespace-only, too-short, or known-weak/placeholder value rather than
+# silently accepting a weak admin credential.
+REGISTRY_API_TOKEN: str = validate_signing_secret(
+    os.environ.get("REGISTRY_API_TOKEN"),
+    "REGISTRY_API_TOKEN",
+    required=False,
+)
 
 # Issue #779: multiple static API keys with per-key groups.
 _REGISTRY_API_KEYS_RAW: str = os.environ.get("REGISTRY_API_KEYS", "").strip()
@@ -594,6 +607,26 @@ class _RegistryApiKeyEntry(BaseModel):
                 f"Key name '{v}' is reserved (legacy/internal). Pick a different name."
             )
         return v
+
+    @field_validator("key")
+    @classmethod
+    def _validate_key(
+        cls,
+        v: str,
+    ) -> str:
+        # A keyed entry grants the scopes mapped from its groups (which may
+        # include admin), so the key bypasses IdP JWT validation and must clear
+        # the same weak-value bar as every other privilege-granting credential.
+        # The min_length=32 Field constraint alone accepts a >=32-char known
+        # placeholder (e.g. the .env.example value); route the key through the
+        # canonical validator to reject well-known literals too. Pydantic
+        # validators must raise ValueError, so re-wrap the validator's
+        # RuntimeError -- the error then flows through _parse_registry_api_keys'
+        # fail-closed path (invalid REGISTRY_API_KEYS disables the feature).
+        try:
+            return validate_signing_secret(v, "REGISTRY_API_KEYS key", required=True)
+        except RuntimeError as e:
+            raise ValueError(str(e)) from e
 
 
 def _repair_stripped_json(
@@ -783,17 +816,30 @@ if _federation_static_token_requested and not FEDERATION_STATIC_TOKEN:
 else:
     FEDERATION_STATIC_TOKEN_AUTH_ENABLED = _federation_static_token_requested
 
-# Warn if token is too short (weak entropy)
 MIN_FEDERATION_TOKEN_LENGTH: int = 32
-if (
-    FEDERATION_STATIC_TOKEN_AUTH_ENABLED
-    and len(FEDERATION_STATIC_TOKEN) < MIN_FEDERATION_TOKEN_LENGTH
-):
-    logging.warning(
-        f"FEDERATION_STATIC_TOKEN is only {len(FEDERATION_STATIC_TOKEN)} characters. "
-        f"Recommended minimum is {MIN_FEDERATION_TOKEN_LENGTH} characters. "
-        'Generate a stronger token with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"'
-    )
+
+# The federation static token bypasses IdP JWT validation, so it must be held to
+# the same strength bar as every other signing/marker secret: a short OR
+# well-known placeholder value must never be armed for authentication. The
+# operator explicitly enabled the feature, so the token is required=True here.
+# This is an optional feature, so on a weak/invalid token we degrade gracefully
+# (disable the feature) rather than crash the whole process -- mirroring the
+# missing-token branch above. Failing closed means the weak token is NOT armed.
+if FEDERATION_STATIC_TOKEN_AUTH_ENABLED:
+    try:
+        FEDERATION_STATIC_TOKEN = validate_signing_secret(
+            FEDERATION_STATIC_TOKEN,
+            "FEDERATION_STATIC_TOKEN",
+            required=True,
+        )
+    except RuntimeError as e:
+        logging.error(
+            "FEDERATION_STATIC_TOKEN_AUTH_ENABLED=true but FEDERATION_STATIC_TOKEN is weak: %s "
+            "Federation static token auth is DISABLED. Set a strong FEDERATION_STATIC_TOKEN or "
+            "disable the feature. Falling back to standard IdP JWT validation.",
+            e,
+        )
+        FEDERATION_STATIC_TOKEN_AUTH_ENABLED = False
 
 # Federation endpoint path patterns (scoped access for federation static token)
 # REGISTRY_ROOT_PATH is prepended so pattern matching works when hosted on a base path
@@ -2611,9 +2657,15 @@ async def validate_request(request: Request):
             if hmac.compare_digest(bearer_token, FEDERATION_STATIC_TOKEN):
                 logger.info(f"Federation static token: Authenticated for {original_url}")
 
+                # The federation static token is a long-lived, non-expiring
+                # credential intended for federation DATA SYNC. It is therefore
+                # least-privilege READ-ONLY: it grants only "federation/read".
+                # Peer/federation-config management (create/update/delete) is a
+                # privileged operation and must be driven by a real admin
+                # credential, not this static token, so "federation/peers" is
+                # deliberately NOT granted here.
                 federation_scopes = [
                     "federation/read",
-                    "federation/peers",
                 ]
                 response_data: dict[str, Any] = {
                     "valid": True,
@@ -3611,17 +3663,29 @@ async def manage_federation_token(request: Request):
     body = await request.json()
     new_token = body.get("new_token")
 
-    # Validate minimum token length if a new token is provided
-    if new_token and len(new_token) < MIN_FEDERATION_TOKEN_LENGTH:
-        return JSONResponse(
-            content={
-                "detail": (
-                    f"Token must be at least {MIN_FEDERATION_TOKEN_LENGTH} characters. "
-                    'Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"'
-                )
-            },
-            status_code=400,
-        )
+    # A rotated token arms the same privileged static credential as startup, so
+    # it must clear the same strength bar. Run it through the canonical validator
+    # (rejects too-short AND known-weak/placeholder values, weak-check before
+    # length) rather than a bare length check -- otherwise an admin could rotate
+    # to a long-but-well-known placeholder and silently undo the startup
+    # hardening.
+    if new_token:
+        try:
+            new_token = validate_signing_secret(
+                new_token,
+                "FEDERATION_STATIC_TOKEN",
+                required=True,
+            )
+        except RuntimeError as e:
+            return JSONResponse(
+                content={
+                    "detail": (
+                        f"{e} "
+                        'Generate with: python3 -c "import secrets; print(secrets.token_urlsafe(32))"'
+                    )
+                },
+                status_code=400,
+            )
 
     if new_token:
         FEDERATION_STATIC_TOKEN = new_token

--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -36,6 +36,27 @@ sanitizer that isn't called) is equivalent to no check.
   right error. Normalize (strip) and reuse the same value everywhere so all
   services derive an identical key (avoids cross-replica signature mismatches).
   Wire the validator into EVERY signing entrypoint — grep for all of them.
+- **Every credential that grants privilege must go through the ONE canonical
+  signing-secret validator at its startup entrypoint — the legacy/backward-compat
+  path is where this check gets skipped.** When a newer keyed scheme enforces a
+  minimum length/weak-value bar but an older single-value credential is read raw
+  (`os.environ.get("TOKEN", "")`) and then promoted to a privileged (often admin,
+  unrestricted-scope) entry, that legacy credential is asymmetrically weaker than
+  both the keyed entries and the app signing secret. Run it through the SAME
+  `validate_signing_secret` helper (missing AND weak: unset/empty/whitespace,
+  `< 32` stripped chars, known-weak literals, weak-check before length) at the
+  point it is read/built, and fail closed. Presence may be optional (unset simply
+  means the legacy entry is not created — that is the safe outcome), but a value
+  that IS present must be strong; never silently accept a weak privilege-granting
+  credential just because it predates the current key scheme. This applies to ALL
+  sibling credential paths, not only the reported one — a federation/static bypass
+  token, each per-key entry in a keyed scheme, and any other value that bypasses
+  IdP validation must each run through the SAME validator. A `min_length`-only
+  Pydantic constraint or a `logging.warning(...)` on a short value is NOT fail
+  closed: a weak privilege-granting token that is merely warned about is still
+  armed. Reject it — raise where a raise is safe, or (for an optional feature that
+  degrades gracefully) disable the feature so the weak token is never armed —
+  never merely warn.
 - **Match placeholder markers as substrings ANYWHERE, not just as a prefix.** An
   operator rarely leaves the `.env.example` value verbatim — they prepend a
   prefix or edit the middle (`internal-CHANGE-ME-...`, `prod-generate-with-openssl-...`).
@@ -176,6 +197,14 @@ sanitizer that isn't called) is equivalent to no check.
 - **Attach a shared/global credential only on explicit opt-in.** Make the
   privileged code path default to not attaching it and gate its use behind an
   admin check.
+- **A static, long-lived, non-expiring token must be least-privilege.** Never
+  bundle a management/write scope onto a token whose purpose is read/data-sync.
+  A token meant for federation (or any) data sync should grant only the read
+  scope (`.../read`); create/update/delete of peers or config is a management
+  operation that must stay behind a real admin credential, not the shared static
+  token. The blast radius of a leaked never-expiring token is exactly the union
+  of the scopes it carries, so keep that union minimal and audit any grant that
+  couples a read scope with a management scope on the same static token.
 - **Never forward the caller's inbound credential to a proxied/untrusted
   destination.** When the gateway proxies to a registrant-controlled upstream (or
   an agent calls a discovered remote agent), strip `Authorization`/`Cookie` from

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -4926,3 +4926,434 @@ class TestValidateA2AAgentAccess:
         repo = self._repo({})
         with patch("auth_server.server.get_scope_repository", return_value=repo):
             assert await validate_a2a_agent_access("/travel", ["missing-scope"]) is False
+
+
+# =============================================================================
+# LEGACY STATIC ADMIN TOKEN STRENGTH VALIDATION AT STARTUP
+# =============================================================================
+
+
+class TestLegacyRegistryTokenStrengthValidation:
+    """Startup strength validation for the legacy REGISTRY_API_TOKEN.
+
+    When set, REGISTRY_API_TOKEN is promoted to an unrestricted admin entry, so
+    it grants the highest privilege in the system. It must therefore clear the
+    same strength bar as the application signing secret: an unset token is fine
+    (the feature simply has no legacy entry), but a token that is present must
+    be strong (non-empty after stripping, at least the minimum length, and not a
+    known-weak placeholder). A present-but-weak value must fail closed at
+    startup rather than silently arm a weak admin credential.
+
+    These tests reload the server module under a patched environment so the
+    real module-level validation runs, then restore a known-good module state
+    for the rest of the suite.
+    """
+
+    _STRONG = "x" * 40
+    _RESTORE_ENV = {
+        "SECRET_KEY": "test-secret-key-that-is-definitely-long-enough-32b",
+        "DOCUMENTDB_HOST": "localhost",
+    }
+
+    def _reload_with_token(self, token_value):
+        """Reload auth_server.server with REGISTRY_API_TOKEN set to token_value.
+
+        A ``None`` token_value means the variable is unset entirely. Returns the
+        freshly reloaded module. Raises whatever the module raises at import.
+        """
+        import importlib
+        import os
+
+        import auth_server.server as server_module
+
+        env = dict(self._RESTORE_ENV)
+        if token_value is not None:
+            env["REGISTRY_API_TOKEN"] = token_value
+
+        # patch.dict(clear=False) plus explicit pop keeps unrelated env intact
+        # while giving us precise control over REGISTRY_API_TOKEN.
+        with patch.dict(os.environ, env, clear=False):
+            if token_value is None:
+                os.environ.pop("REGISTRY_API_TOKEN", None)
+            return importlib.reload(server_module)
+
+    def teardown_method(self):
+        """Restore a valid module state so later tests see a sane module."""
+        import importlib
+        import os
+
+        import auth_server.server as server_module
+
+        with patch.dict(os.environ, self._RESTORE_ENV, clear=False):
+            os.environ.pop("REGISTRY_API_TOKEN", None)
+            importlib.reload(server_module)
+
+    def test_unset_token_is_accepted_and_empty(self):
+        """An unset token is fine: no legacy admin credential, no raise."""
+        reloaded = self._reload_with_token(None)
+        assert reloaded.REGISTRY_API_TOKEN == ""
+
+    def test_strong_token_is_accepted(self):
+        """A sufficiently long, non-placeholder token is accepted verbatim."""
+        reloaded = self._reload_with_token(self._STRONG)
+        assert reloaded.REGISTRY_API_TOKEN == self._STRONG
+
+    def test_short_token_fails_closed(self):
+        """A present but too-short token must raise at startup."""
+        with pytest.raises(RuntimeError):
+            self._reload_with_token("short")
+
+    def test_whitespace_only_token_is_treated_as_unset(self):
+        """A whitespace-only token is equivalent to unset: no admin credential.
+
+        The canonical validator treats a whitespace-only value as unset when the
+        secret is optional, which is the fail-closed outcome here: no legacy
+        admin entry is armed. A whitespace-only value is never accepted as a
+        usable credential (it strips to empty), so no weak admin token results.
+        """
+        reloaded = self._reload_with_token("   " * 20)
+        assert reloaded.REGISTRY_API_TOKEN == ""
+
+    def test_known_weak_literal_token_fails_closed(self):
+        """A present but known-weak placeholder literal must raise at startup."""
+        with pytest.raises(RuntimeError):
+            self._reload_with_token("change-this-immediately-use-a-strong-random-key-in-production")
+
+
+# =============================================================================
+# FEDERATION STATIC TOKEN IS LEAST-PRIVILEGE READ-ONLY
+# =============================================================================
+
+
+class TestFederationStaticTokenReadOnly:
+    """The federation static token grants read-only access.
+
+    The federation static token is a long-lived, non-expiring credential meant
+    for federation data sync. It must be least-privilege: it grants only
+    ``federation/read`` and must NOT carry a peer/federation management scope.
+    Peer management stays behind a real admin credential.
+    """
+
+    _TOKEN = "f" * 40
+
+    def test_validate_grants_only_read_scope(self):
+        """A matching federation token yields scopes == ['federation/read']."""
+        import auth_server.server as server_module
+
+        with (
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN_AUTH_ENABLED", True),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN", self._TOKEN),
+        ):
+            client = TestClient(server_module.app)
+            response = client.get(
+                "/validate",
+                headers={
+                    "Authorization": f"Bearer {self._TOKEN}",
+                    "X-Original-URL": "https://example.com/api/federation/peers",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["method"] == "federation-static"
+        assert data["scopes"] == ["federation/read"]
+
+    def test_validate_does_not_grant_peer_management_scope(self):
+        """The federation token must not carry the peer-management scope."""
+        import auth_server.server as server_module
+
+        with (
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN_AUTH_ENABLED", True),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN", self._TOKEN),
+        ):
+            client = TestClient(server_module.app)
+            response = client.get(
+                "/validate",
+                headers={
+                    "Authorization": f"Bearer {self._TOKEN}",
+                    "X-Original-URL": "https://example.com/api/federation/peers",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "federation/peers" not in data["scopes"]
+        assert "federation/peers" not in response.headers.get("X-Scopes", "")
+
+
+# =============================================================================
+# FEDERATION STATIC TOKEN STRENGTH VALIDATION (FAIL CLOSED ON WEAK TOKEN)
+# =============================================================================
+
+
+class TestFederationStaticTokenStrengthValidation:
+    """Startup strength validation for FEDERATION_STATIC_TOKEN.
+
+    The federation static token bypasses IdP JWT validation when armed, so it
+    must clear the same weak-value bar as every other privilege-granting
+    credential. When the operator explicitly enables the feature, the token is
+    required and must be strong: a short OR known-weak placeholder value must
+    NOT be armed. Because this is an optional feature, a weak token degrades
+    gracefully -- the feature is DISABLED (fail closed) rather than crashing the
+    process -- mirroring the missing-token branch. Warn-only is not fail closed.
+
+    These tests reload the server module under a patched environment so the real
+    module-level validation runs, then restore a known-good module state for the
+    rest of the suite.
+    """
+
+    _STRONG = "f" * 40
+    _RESTORE_ENV = {
+        "SECRET_KEY": "test-secret-key-that-is-definitely-long-enough-32b",
+        "DOCUMENTDB_HOST": "localhost",
+    }
+
+    def _reload_with_federation_token(self, token_value):
+        """Reload auth_server.server with the feature enabled and a given token.
+
+        A ``None`` token_value means FEDERATION_STATIC_TOKEN is unset entirely.
+        Returns the freshly reloaded module.
+        """
+        import importlib
+        import os
+
+        import auth_server.server as server_module
+
+        env = dict(self._RESTORE_ENV)
+        env["FEDERATION_STATIC_TOKEN_AUTH_ENABLED"] = "true"
+        if token_value is not None:
+            env["FEDERATION_STATIC_TOKEN"] = token_value
+
+        with patch.dict(os.environ, env, clear=False):
+            if token_value is None:
+                os.environ.pop("FEDERATION_STATIC_TOKEN", None)
+            return importlib.reload(server_module)
+
+    def teardown_method(self):
+        """Restore a valid module state (feature disabled) for later tests."""
+        import importlib
+        import os
+
+        import auth_server.server as server_module
+
+        with patch.dict(os.environ, self._RESTORE_ENV, clear=False):
+            os.environ.pop("FEDERATION_STATIC_TOKEN", None)
+            os.environ.pop("FEDERATION_STATIC_TOKEN_AUTH_ENABLED", None)
+            importlib.reload(server_module)
+
+    def test_strong_token_stays_enabled_and_armed(self):
+        """A strong token keeps the feature enabled and arms the token."""
+        reloaded = self._reload_with_federation_token(self._STRONG)
+        assert reloaded.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is True
+        assert reloaded.FEDERATION_STATIC_TOKEN == self._STRONG
+
+    def test_short_token_disables_feature(self):
+        """A short token disables the feature (fail closed), does not raise."""
+        reloaded = self._reload_with_federation_token("short")
+        assert reloaded.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+
+    def test_known_weak_literal_disables_feature(self):
+        """A known-weak >=32-char placeholder disables the feature."""
+        reloaded = self._reload_with_federation_token(
+            "change-this-immediately-use-a-strong-random-key-in-production"
+        )
+        assert reloaded.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+
+    def test_unset_token_disables_feature(self):
+        """Enabling the feature without a token disables it (fail closed)."""
+        reloaded = self._reload_with_federation_token(None)
+        assert reloaded.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+
+    def test_validate_does_not_authenticate_weak_token(self):
+        """A weak token is not armed: the /validate federation path rejects it."""
+        weak = "short"
+        reloaded = self._reload_with_federation_token(weak)
+        assert reloaded.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+
+        client = TestClient(reloaded.app)
+        response = client.get(
+            "/validate",
+            headers={
+                "Authorization": f"Bearer {weak}",
+                "X-Original-URL": "https://example.com/api/federation/peers",
+            },
+        )
+        # The weak token is not armed, so it never authenticates via the
+        # federation-static path (it falls through to standard JWT validation,
+        # which rejects a non-JWT bearer).
+        assert response.status_code != 200 or response.json().get("method") != ("federation-static")
+
+
+# =============================================================================
+# REGISTRY_API_KEYS ENTRY WEAK-VALUE REJECTION (FAIL CLOSED)
+# =============================================================================
+
+
+class TestRegistryApiKeyEntryStrengthValidation:
+    """Per-key REGISTRY_API_KEYS entries must reject weak key values.
+
+    A keyed entry grants the scopes mapped from its groups (which may include
+    admin), so its key bypasses IdP JWT validation and must clear the same
+    weak-value bar as every other privilege-granting credential. The Pydantic
+    ``min_length=32`` constraint alone accepts a >=32-char known placeholder, so
+    the key is additionally routed through the canonical validator, which
+    rejects short AND known-weak literals. A weak key must fail closed: the
+    entry is rejected and the parse path disables the feature rather than arming
+    a weak keyed credential.
+    """
+
+    _STRONG = "x" * 40
+
+    def test_strong_key_validates(self):
+        """A strong, non-placeholder key builds a valid entry."""
+        import auth_server.server as server_module
+
+        entry = server_module._RegistryApiKeyEntry(
+            name="deploy-pipeline",
+            key=self._STRONG,
+            groups=["mcp-registry-admin"],
+        )
+        assert entry.key == self._STRONG
+
+    def test_short_key_raises(self):
+        """A key shorter than the minimum raises a validation error."""
+        import pydantic
+
+        import auth_server.server as server_module
+
+        with pytest.raises((pydantic.ValidationError, ValueError)):
+            server_module._RegistryApiKeyEntry(
+                name="deploy-pipeline",
+                key="short",
+                groups=["mcp-registry-admin"],
+            )
+
+    def test_known_weak_literal_key_raises(self):
+        """A >=32-char known-weak placeholder key raises a validation error."""
+        import pydantic
+
+        import auth_server.server as server_module
+
+        with pytest.raises((pydantic.ValidationError, ValueError)):
+            server_module._RegistryApiKeyEntry(
+                name="deploy-pipeline",
+                key="change-this-immediately-use-a-strong-random-key-in-production",
+                groups=["mcp-registry-admin"],
+            )
+
+    def test_parse_rejects_weak_key_entry(self):
+        """A >=32-char weak-literal key fails the parser (fail closed)."""
+        import json
+
+        import auth_server.server as server_module
+
+        raw = json.dumps(
+            {
+                "deploy-pipeline": {
+                    "key": "change-this-immediately-use-a-strong-random-key-in-production",
+                    "groups": ["mcp-registry-admin"],
+                }
+            }
+        )
+        with pytest.raises(ValueError, match="Invalid entry"):
+            server_module._parse_registry_api_keys(raw)
+
+    async def test_build_static_token_map_disabled_on_weak_key(self):
+        """A weak keyed entry disables static-token auth (matches malformed-JSON)."""
+        import json
+
+        import auth_server.server as server_module
+
+        raw = json.dumps(
+            {
+                "deploy-pipeline": {
+                    "key": "change-this-immediately-use-a-strong-random-key-in-production",
+                    "groups": ["mcp-registry-admin"],
+                }
+            }
+        )
+        with (
+            patch.object(server_module, "REGISTRY_STATIC_TOKEN_AUTH_ENABLED", True),
+            patch.object(server_module, "_REGISTRY_API_KEYS_RAW", raw),
+            patch.object(server_module, "REGISTRY_API_TOKEN", ""),
+            patch.object(server_module, "_STATIC_TOKEN_MAP", {}),
+        ):
+            await server_module._build_static_token_map()
+            assert server_module.REGISTRY_STATIC_TOKEN_AUTH_ENABLED is False
+            assert server_module._STATIC_TOKEN_MAP == {}
+
+
+# =============================================================================
+# RUNTIME FEDERATION-TOKEN ROTATION MUST ENFORCE THE SAME STRENGTH BAR
+# =============================================================================
+
+
+class TestFederationTokenRotationStrength:
+    """The runtime rotation endpoint must reject weak new tokens.
+
+    Rotating the federation static token arms the same privileged credential as
+    startup, so the rotation endpoint must clear the same weak-value bar: a short
+    OR known-weak placeholder value must be rejected with 400 and must NOT arm
+    the token, otherwise an admin could rotate to a long-but-well-known
+    placeholder and silently undo the startup hardening.
+    """
+
+    _ADMIN = "a" * 40
+    _STRONG = "f" * 40
+
+    def _client_and_module(self):
+        import auth_server.server as server_module
+
+        return TestClient(server_module.app), server_module
+
+    def test_short_new_token_rejected(self):
+        """A short rotation token is rejected (400) and does not arm the token."""
+        client, server_module = self._client_and_module()
+        with (
+            patch.object(server_module, "REGISTRY_API_TOKEN", self._ADMIN),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN", ""),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN_AUTH_ENABLED", False),
+        ):
+            response = client.post(
+                "/admin/federation-token",
+                headers={"Authorization": f"Bearer {self._ADMIN}"},
+                json={"new_token": "short"},
+            )
+            assert response.status_code == 400
+            assert server_module.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+            assert server_module.FEDERATION_STATIC_TOKEN == ""
+
+    def test_known_weak_literal_new_token_rejected(self):
+        """A long-but-known-placeholder rotation token is rejected (400)."""
+        client, server_module = self._client_and_module()
+        with (
+            patch.object(server_module, "REGISTRY_API_TOKEN", self._ADMIN),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN", ""),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN_AUTH_ENABLED", False),
+        ):
+            response = client.post(
+                "/admin/federation-token",
+                headers={"Authorization": f"Bearer {self._ADMIN}"},
+                json={"new_token": "change-this-immediately-use-a-strong-random-key-in-production"},
+            )
+            assert response.status_code == 400
+            assert server_module.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is False
+            assert server_module.FEDERATION_STATIC_TOKEN == ""
+
+    def test_strong_new_token_rotates(self):
+        """A strong rotation token is accepted and arms the feature."""
+        client, server_module = self._client_and_module()
+        with (
+            patch.object(server_module, "REGISTRY_API_TOKEN", self._ADMIN),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN", ""),
+            patch.object(server_module, "FEDERATION_STATIC_TOKEN_AUTH_ENABLED", False),
+        ):
+            response = client.post(
+                "/admin/federation-token",
+                headers={"Authorization": f"Bearer {self._ADMIN}"},
+                json={"new_token": self._STRONG},
+            )
+            assert response.status_code == 200
+            assert response.json()["action"] == "rotated"
+            assert server_module.FEDERATION_STATIC_TOKEN == self._STRONG
+            assert server_module.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is True


### PR DESCRIPTION
# Harden legacy static admin token and scope the federation static token to read-only

## What changed

This builds on the merged multi-key static-token work (PR #876) and hardens two
residuals that work left in place. It does not change the multi-key behavior.

1. **Legacy `REGISTRY_API_TOKEN` now goes through the canonical signing-secret
   validator.** Previously the legacy single-value token was read raw and, when
   set, promoted to an unrestricted admin entry with no length or weak-value
   check — asymmetrically weaker than both the keyed `REGISTRY_API_KEYS` entries
   (32-char Pydantic minimum) and the application `SECRET_KEY`. It is now
   validated through `validate_signing_secret(..., required=False)` at the same
   startup entrypoint where the legacy entry is built. Presence stays optional
   (an unset token simply means no legacy entry), but a present value must be
   strong; an empty/whitespace-only, too-short, or known-weak placeholder value
   fails closed at startup instead of silently arming a weak admin credential.

2. **The federation static token is now least-privilege read-only.** It
   previously granted `["federation/read", "federation/peers"]`; the
   `federation/peers` scope authorizes peer create/update/delete and federation
   config changes. A static, long-lived, non-expiring token meant for data sync
   should not carry a management scope, so the token now grants only
   `["federation/read"]`. Peer/federation management stays behind a real admin
   credential.

Changes are confined to `auth_server/server.py` (import, the token read, and the
federation scope list), with a lesson added to `docs/SECURITY_GUIDELINES.md` and
new unit tests.

## Why it's safer

- The legacy-token change reuses the single canonical validator already used for
  `SECRET_KEY` (`registry/common/secret_key.py`); no validation logic is copied
  or reinvented. It fails closed: unset is fine, present-but-weak raises.
- The federation-scope change only removes a management scope from a static
  token. The registry-side enforcement (`peer_management_routes.py`,
  `federation_routes.py`) is unchanged and still honors `federation/peers` for
  genuine admin identities. A repo-wide grep confirmed the auth-server line was
  the only place the static token received that scope.
- Behavior change: callers that used the static federation token for peer
  management now get 403 (intended). Peer management requires an admin
  credential.

## How it was tested

- New table-driven unit tests for the legacy-token validation (unset -> no
  entry, strong -> accepted, too-short -> raises, whitespace-only -> treated as
  unset, known-weak literal -> raises), reloading the module under a patched
  environment so the real startup validation runs.
- New unit tests asserting the federation `/validate` path returns scopes
  `["federation/read"]` and never includes `federation/peers`.
- Full `tests/auth_server/unit/` suite passes (558 passed), confirming no
  regression in the existing static-token and federation flows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
