### PR TITLE
chore(usage-report): bump install-forecast target to 2,000

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -328,7 +328,7 @@ Same data-sourcing behavior as the other historical charts (scans all CSVs acros
 
 ### Step 5d: Generate Install Forecast Chart
 
-Project when the registry will reach 1,000 installs using two models: a 14-day OLS linear regression and a 7-day recent-pace extrapolation. Produces a PNG chart (cumulative installs with forecast line and confidence bands) and a JSON summary with ETAs.
+Project when the registry will reach 2,000 installs using two models: a 14-day OLS linear regression and a 7-day recent-pace extrapolation. Produces a PNG chart (cumulative installs with forecast line and confidence bands) and a JSON summary with ETAs. The target defaults to 2,000 and is overridable via `--target`.
 
 ```bash
 /usr/bin/python3 .claude/skills/usage-report/generate_install_forecast.py \
@@ -338,7 +338,7 @@ Project when the registry will reach 1,000 installs using two models: a 14-day O
 ```
 
 Outputs:
-- PNG chart showing cumulative installs, linear fit, and projected crossing of the 1,000-install target
+- PNG chart showing cumulative installs, linear fit, and projected crossing of the 2,000-install target
 - JSON summary with `today.installs`, `linear.eta` (with 95% CI bounds), `recent_pace.eta`, and model parameters
 
 Embed the chart in the report's **Install Forecast** section. Include a table showing both model ETAs and daily rates. This section should come after Version Adoption and before Customer Infra Spend.
@@ -568,7 +568,7 @@ The report MUST embed all 14 charts (the template's `![...]` references). If any
 6. `lifetime-buckets-YYYY-MM-DD.png` (retention % over time)
 7. `active-instances-YYYY-MM-DD.png` (DAI + MA7 + streak)
 8. `compute-installs-timeseries-YYYY-MM-DD.png` (compute platform cumulative + daily)
-9. `install-forecast-YYYY-MM-DD.png` (OLS + recent-pace to 1,000)
+9. `install-forecast-YYYY-MM-DD.png` (OLS + recent-pace to 2,000)
 10. `daily-reporters-YYYY-MM-DD.png` (daily AWS reporters: all + persisted >=2 events + persisted >=2 days)
 11. `ltv-spend-YYYY-MM-DD.png` (daily compute + bedrock + cumulative)
 12. `adoption-funnel-YYYY-MM-DD.png` (funnel from total to confirmed-alive)

--- a/.claude/skills/usage-report/generate_install_forecast.py
+++ b/.claude/skills/usage-report/generate_install_forecast.py
@@ -382,8 +382,8 @@ def main() -> None:
     parser.add_argument(
         "--target",
         type=int,
-        default=1000,
-        help="Target install count to forecast (default: 1000)",
+        default=2000,
+        help="Target install count to forecast (default: 2000)",
     )
     parser.add_argument(
         "--output",

--- a/.claude/skills/usage-report/recommendations.py
+++ b/.claude/skills/usage-report/recommendations.py
@@ -86,7 +86,7 @@ def rule_milestone_install_count(
     prev = vars_.get("prev_total_instances", 0)
     if not isinstance(cur, int) or not isinstance(prev, int):
         return None
-    for milestone in (1000, 900, 800, 700, 600, 500):
+    for milestone in (2000, 1900, 1800, 1700, 1600, 1500, 1400, 1300, 1200, 1100, 1000, 900, 800, 700, 600, 500):
         if cur >= milestone > prev:
             return (
                 f"**Crossed {milestone} unique registry installs.** "
@@ -189,11 +189,12 @@ def rule_install_forecast_eta(
         gap = abs((linear_eta - recent_eta).days)
     except ValueError:
         return None
+    target_str = vars_.get("forecast_target", "2,000")
     if gap <= 2:
         return (
             f"**Forecast models converged within {gap} day{'s' if gap != 1 else ''}** "
             f"(linear: {linear_eta_str}, recent-pace: {recent_eta_str}). "
-            f"The 1,000-install milestone is forecastable to within a small window."
+            f"The {target_str}-install milestone is forecastable to within a small window."
         )
     if gap >= 7:
         return (

--- a/.claude/skills/usage-report/recommendations.py
+++ b/.claude/skills/usage-report/recommendations.py
@@ -86,7 +86,24 @@ def rule_milestone_install_count(
     prev = vars_.get("prev_total_instances", 0)
     if not isinstance(cur, int) or not isinstance(prev, int):
         return None
-    for milestone in (2000, 1900, 1800, 1700, 1600, 1500, 1400, 1300, 1200, 1100, 1000, 900, 800, 700, 600, 500):
+    for milestone in (
+        2000,
+        1900,
+        1800,
+        1700,
+        1600,
+        1500,
+        1400,
+        1300,
+        1200,
+        1100,
+        1000,
+        900,
+        800,
+        700,
+        600,
+        500,
+    ):
         if cur >= milestone > prev:
             return (
                 f"**Crossed {milestone} unique registry installs.** "

--- a/.claude/skills/usage-report/render_report.py
+++ b/.claude/skills/usage-report/render_report.py
@@ -840,7 +840,7 @@ def _build_template_vars(
     linear_rate = fc_linear.get("slope_per_day", 0)
     recent_rate = fc_recent.get("daily_add_rate", 0)
     today_count = forecast.get("today", {}).get("installs", total_instances)
-    target = forecast.get("target", 1000)
+    target = forecast.get("target", 2000)
     remaining = target - today_count
     if recent_rate > linear_rate:
         forecast_narrative = (
@@ -998,6 +998,7 @@ def _build_template_vars(
         "forecast_linear_eta": linear_eta,
         "forecast_recent_rate": f"{recent_rate:.1f}",
         "forecast_recent_eta": recent_eta,
+        "forecast_target": f"{target:,}",
         "forecast_narrative": forecast_narrative,
         # LTV
         "yesterday_label": ltv_yesterday.get("date", "?"),

--- a/.claude/skills/usage-report/report_template.md
+++ b/.claude/skills/usage-report/report_template.md
@@ -216,7 +216,7 @@ Cumulative unique instances per development/git-describe version:
 
 ![Install Forecast](install-forecast-{date}.png)
 
-| Model | Daily Rate | ETA to 1,000 |
+| Model | Daily Rate | ETA to {forecast_target} |
 |-------|----------:|:-------------|
 | Linear OLS (14-day) | {forecast_linear_rate} / day | {forecast_linear_eta} |
 | Recent pace (7-day) | {forecast_recent_rate} / day | {forecast_recent_eta} |


### PR DESCRIPTION
## Summary

Retargets the `usage-report` skill's **install-forecast** from 1,000 to 2,000 installs, now that the registry has passed the 1,000-install milestone.

## Changes

- **`generate_install_forecast.py`** — `--target` default `1000` → `2000` (still overridable via `--target`).
- **`recommendations.py`** — extend the install-count milestone rule to cover 1,100–2,000, and make the forecast-ETA recommendation reference the configured target instead of a hardcoded "1,000".
- **`render_report.py`** — default forecast target `2000`; expose a `forecast_target` template variable (comma-formatted) so the report text tracks the target.
- **`report_template.md`** — the Install Forecast table's ETA column header uses `{forecast_target}` instead of a hardcoded `1,000`.
- **`SKILL.md`** — docs updated to describe the 2,000 target (overridable via `--target`) and the forecast chart/summary.

## Notes

- Skill-only change (`.claude/skills/usage-report/`); no application code, deployment, or runtime behavior affected.
- Python files syntax-checked (`py_compile` clean).
- Split out of the rate-limiting work (#1467) where these edits happened to be sitting uncommitted in the working tree; they are unrelated and belong on their own.
