### PR TITLE
Validate override endpoint fields through the canonical SSRF guard

### DIFF
--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -103,6 +103,16 @@ sanitizer that isn't called) is equivalent to no check.
   loopback, link-local, reserved, multicast, unspecified, and cloud-metadata
   (`169.254.169.254` — never allowlistable); unwrap IPv4-mapped IPv6; require
   http/https. Fail closed. Do not create per-call-site `_is_safe_url` variants.
+- **Don't rely on the language runtime's `is_private` to cover reserved ranges —
+  block them explicitly and pin the range in a test.** Ranges like CGNAT / shared
+  address space (`100.64.0.0/10`, RFC 6598) are only classified private on newer
+  runtimes; depending on interpreter semantics means a downgrade or a stdlib
+  change silently re-opens an SSRF pivot. Add the range to the guard's explicit
+  block list (treated like the other private ranges — operator-CIDR-allowlistable,
+  never for metadata) and add a unit test asserting both a sample IP is blocked
+  AND the exact network is pinned, so a semantics change fails loudly instead of
+  quietly. Apply to every guard implementation, including any legacy one still in
+  use.
 - **Validate at registration (structural) AND pin the resolved IP at fetch
   time.** A pre-fetch check followed by a separate client call re-resolves DNS =
   TOCTOU / DNS-rebinding. Pin the validated public IP into the transport
@@ -145,6 +155,20 @@ sanitizer that isn't called) is equivalent to no check.
   via an explicit CA bundle env var (fail closed if the configured bundle is
   missing); any insecure escape hatch must be explicit opt-in, logged, default
   off.
+- **Every alternate/override URL field is a bypass — validate the whole family,
+  not just the primary field.** A server record often carries a main backend URL
+  (`proxy_pass_url`) plus optional override endpoints (`mcp_endpoint`,
+  `sse_endpoint`) that are fetched and interpolated into config exactly like the
+  main URL. If only the primary field goes through the canonical guard, the
+  override field is an unguarded SSRF / config-injection sink. At EVERY write path
+  (register, edit, internal-register, version-add), run each present override
+  field through the SAME `validate_proxy_pass_url()` as the primary; empty/unset
+  is fine, present-but-invalid is rejected. Then RE-validate the resolved URL at
+  fetch time (`resolve=True`) on each fetch path (health check, tool discovery,
+  and especially before handing the URL to an external subprocess the pinned
+  guarded client cannot protect — e.g. a scanner CLI) so a value that was rebound
+  after registration, or that reached the connect through the override field, is
+  still blocked before any credential is attached or process spawned.
 
 ## Injection (nginx config generation, NoSQL/regex)
 

--- a/registry/core/mcp_client.py
+++ b/registry/core/mcp_client.py
@@ -470,7 +470,11 @@ async def _get_tools_sse(base_url: str, server_info: dict = None) -> list[dict] 
     secure_prefix = "s" if sse_url.startswith("https://") else ""
     mcp_server_url = f"http{secure_prefix}://{sse_url[len(f'http{secure_prefix}://') :]}"
 
-    # Fail closed on SSRF BEFORE decrypting/building credential headers.
+    # Fail closed on SSRF BEFORE decrypting/building credential headers. This
+    # validates the ACTUAL connection target (mcp_server_url), whose host is
+    # taken verbatim from the explicit sse_endpoint when one is set, so an
+    # sse_endpoint pointing at a private/metadata/loopback address is rejected
+    # before any credential is built or attached.
     if not _assert_mcp_url_fetchable(mcp_server_url):
         return None
 
@@ -656,11 +660,17 @@ async def get_mcp_connection_result(
 
     # Determine the MCP endpoint URL
     explicit_endpoint = server_info.get("mcp_endpoint") if server_info else None
+    explicit_sse_endpoint = server_info.get("sse_endpoint") if server_info else None
 
     # Fail closed on SSRF BEFORE any transport probe or credential build: a
     # target that resolves to a private/metadata address must never receive the
-    # server's decrypted backend credentials.
+    # server's decrypted backend credentials. Validate BOTH override endpoint
+    # fields (mcp_endpoint and sse_endpoint) here because either one can be the
+    # actual connection target below depending on the negotiated transport; the
+    # SDK client is unpinnable, so this is the fetch-time re-validation.
     if not _assert_mcp_url_fetchable(explicit_endpoint or base_url):
+        return None
+    if explicit_sse_endpoint and not _assert_mcp_url_fetchable(explicit_sse_endpoint):
         return None
 
     # Use transport-aware detection

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1573,7 +1573,14 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 parsed_url = urlparse(proxy_pass_url)
                 upstream_host = parsed_url.netloc
 
-                # Build MCP endpoint URL from the server's mcp_endpoint or proxy_pass_url
+                # Build MCP endpoint URL from the server's mcp_endpoint or proxy_pass_url.
+                # mcp_endpoint is defended by two layers: (1) registration-time
+                # validation rejects an mcp_endpoint containing nginx
+                # metacharacters (including "$") via the same canonical guard as
+                # proxy_pass_url, so a "$" can never legitimately be stored; and
+                # (2) the render-time _sanitize_for_nginx_set below strips "$"
+                # and escapes quotes/backslashes as defense in depth for any
+                # legacy value persisted before validation existed.
                 mcp_endpoint = server_info.get("mcp_endpoint", "")
                 if mcp_endpoint:
                     mcp_parsed = urlparse(mcp_endpoint)

--- a/registry/services/ard_net_guard.py
+++ b/registry/services/ard_net_guard.py
@@ -31,12 +31,18 @@ logger = logging.getLogger(__name__)
 # ``is_loopback`` / ``is_link_local`` / ``is_reserved`` / ``is_multicast`` cover
 # most of these already; the explicit list documents intent and guards the cloud
 # metadata endpoint (169.254.169.254) and IPv6 unique-local / link-local ranges.
+#
+# 100.64.0.0/10 is carrier-grade NAT / shared address space (RFC 6598). It is
+# pinned here explicitly rather than relying on ``is_private``, which only
+# classifies it as private on newer Python runtimes -- a downgrade or semantics
+# change would otherwise silently re-open it as an SSRF pivot.
 _BLOCKED_NETS: list[ipaddress._BaseNetwork] = [
     ipaddress.ip_network(n)
     for n in (
         "10.0.0.0/8",
         "172.16.0.0/12",
         "192.168.0.0/16",
+        "100.64.0.0/10",
         "127.0.0.0/8",
         "169.254.0.0/16",
         "::1/128",

--- a/registry/services/security_scanner.py
+++ b/registry/services/security_scanner.py
@@ -203,6 +203,7 @@ class SecurityScannerService:
         # in depth against stored data predating validation, and a live
         # resolve catches a host that has since been pointed at an internal
         # address). Raises UrlValidationError -> surfaced by the caller.
+        from ..exceptions import UrlValidationError
         from ..utils.url_guard import PROXY_PROFILE, validate_url
 
         validate_url(server_url, profile=PROXY_PROFILE)
@@ -226,6 +227,19 @@ class SecurityScannerService:
         logger.info(f"Starting security scan for {server_url} with analyzers: {analyzers}")
 
         try:
+            # Re-validate the FINAL resolved URL before spawning the scanner.
+            # get_endpoint_url() may return an operator-supplied mcp_endpoint
+            # verbatim, which is a different host/URL than the proxy_pass_url
+            # validated above. The scanner runs in an external subprocess that
+            # the pinned guarded client cannot protect, so this is the only
+            # place we can block an mcp_endpoint that points at a
+            # private/metadata/loopback address (or that has since been rebound
+            # there). resolve=True forces a live DNS lookup so a rebind is
+            # caught at fetch time. Fail closed: a validation failure is treated
+            # like any other scan failure below (recorded as unsafe, subprocess
+            # never spawned).
+            validate_url(server_url, profile=PROXY_PROFILE)
+
             # Run the scan in a thread pool to avoid blocking
             raw_output = await asyncio.to_thread(
                 self._run_mcp_scanner,
@@ -271,6 +285,7 @@ class SecurityScannerService:
             subprocess.CalledProcessError,
             ValueError,
             RuntimeError,
+            UrlValidationError,
         ) as e:
             logger.error(f"Security scan failed for {server_url}: {e}")
 

--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -13,6 +13,31 @@ from ..utils.url_guard import validate_proxy_pass_url, validate_server_path
 logger = logging.getLogger(__name__)
 
 
+def _validate_endpoint_fields(
+    server_info: dict[str, Any],
+) -> None:
+    """Validate optional override endpoint fields at every write path.
+
+    ``mcp_endpoint`` and ``sse_endpoint`` are user-supplied alternate targets
+    that are later fetched (health checks, tool discovery, the scanner
+    subprocess) and interpolated into generated nginx config, exactly like
+    ``proxy_pass_url``. They therefore MUST pass the same canonical guard as
+    ``proxy_pass_url`` so an attacker cannot use them to smuggle a
+    private/metadata/loopback target or an nginx metacharacter past the check
+    on the primary URL field. Empty/unset is allowed (they are optional); a
+    present-but-invalid value is rejected with the same error shape as an
+    invalid ``proxy_pass_url`` (fail closed).
+
+    Raises:
+        UrlValidationError: If a present endpoint field fails scheme, host,
+            metacharacter, or private/metadata-IP validation.
+    """
+    for field_name in ("mcp_endpoint", "sse_endpoint"):
+        value = server_info.get(field_name)
+        if value:
+            validate_proxy_pass_url(value)
+
+
 class ServerService:
     """Service for managing server registration and state."""
 
@@ -77,6 +102,10 @@ class ServerService:
         proxy_pass_url = server_info.get("proxy_pass_url")
         if proxy_pass_url:
             validate_proxy_pass_url(proxy_pass_url)
+
+        # Alternate/override endpoint fields are fetched and interpolated into
+        # config just like proxy_pass_url, so they go through the SAME guard.
+        _validate_endpoint_fields(server_info)
 
         # The path is interpolated into nginx location directives; reject any
         # nginx metacharacters so a crafted path cannot inject config.
@@ -166,6 +195,9 @@ class ServerService:
         # Fail-closed URL validation on edit paths that change the backend URL.
         if server_info.get("proxy_pass_url"):
             validate_proxy_pass_url(server_info["proxy_pass_url"])
+
+        # Alternate/override endpoint fields get the same guard on edit paths.
+        _validate_endpoint_fields(server_info)
 
         result = await self._repo.update(path, server_info)
 

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -59,6 +59,18 @@ _DEFAULT_TIMEOUT_SECONDS: float = 15.0
 # The cloud metadata endpoint can never be reached, regardless of allowlists.
 _CLOUD_METADATA_IPS: frozenset[str] = frozenset({"169.254.169.254", "fd00:ec2::254"})
 
+# Carrier-grade NAT / shared address space (RFC 6598). Blocked explicitly rather
+# than relying on ipaddress.is_private: is_private only classifies this range as
+# private on newer Python runtimes, so depending on the runtime is fragile -- a
+# downgrade or a semantics change would silently re-open it as an SSRF pivot to
+# an internal/CGNAT host. Blocking it here pins the behavior regardless of the
+# interpreter version. It is treated exactly like the other reserved private
+# ranges: an operator CIDR allowlist can re-permit it (same as 10/8 etc.), but
+# it is denied by default.
+_CGNAT_NETS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("100.64.0.0/10"),
+)
+
 # The gateway's own bundled registry-tools MCP server (airegistry-tools ->
 # mcpgw-server), reached over private container/service DNS (Docker Compose
 # service name, ECS Service Connect alias, Kubernetes service name). This is a
@@ -244,6 +256,9 @@ def _is_blocked_ip(
         or ip.is_reserved
         or ip.is_multicast
         or ip.is_unspecified
+        # Explicit CGNAT (RFC 6598) block so this does not depend on the Python
+        # runtime's is_private semantics for the 100.64.0.0/10 range.
+        or any(ip in net for net in _CGNAT_NETS)
     )
     if not is_dangerous:
         return False

--- a/tests/unit/core/test_mcp_client.py
+++ b/tests/unit/core/test_mcp_client.py
@@ -921,3 +921,65 @@ class TestMcpClientSsrfGuard:
             assert result is None
             mock_headers.assert_not_called()
             mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sse_explicit_endpoint_to_blocked_host_refused(self):
+        """An explicit sse_endpoint that resolves to a private host is refused.
+
+        The base_url is a public host, but the override sse_endpoint points at
+        a private target; the actual connection target must be validated so no
+        credential is attached to the private host.
+        """
+        from registry.core.mcp_client import _get_tools_sse
+
+        server_info = {
+            "sse_endpoint": "https://internal.evil.example/sse",
+            "headers": [],
+        }
+
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.sse_client") as mock_client,
+            patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve,
+        ):
+            mock_resolve.return_value = [(None, None, None, None, ("10.0.0.9", 443))]
+
+            result = await _get_tools_sse("https://public.example", server_info)
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connection_result_blocks_private_sse_endpoint(self):
+        """get_mcp_connection_result refuses a private-IP explicit sse_endpoint.
+
+        Only the sse_endpoint override is malicious here; the base_url resolves
+        public. The sse_endpoint must be validated because it can become the
+        actual connection target for the SSE transport.
+        """
+        from registry.core.mcp_client import get_mcp_connection_result
+
+        server_info = {
+            "sse_endpoint": "https://internal.evil.example/sse",
+            "headers": [],
+        }
+
+        def _resolve(host, port, **kw):
+            # base_url host is public; the sse_endpoint host is private.
+            if "internal.evil.example" in host:
+                return [(None, None, None, None, ("10.1.2.3", 443))]
+            return [(None, None, None, None, ("93.184.216.34", 443))]
+
+        with (
+            patch("registry.core.mcp_client._build_headers_for_server") as mock_headers,
+            patch("registry.core.mcp_client.streamablehttp_client") as mock_stream,
+            patch("registry.core.mcp_client.sse_client") as mock_sse,
+            patch("registry.utils.url_guard.socket.getaddrinfo", side_effect=_resolve),
+        ):
+            result = await get_mcp_connection_result("https://public.example", server_info)
+
+            assert result is None
+            mock_headers.assert_not_called()
+            mock_stream.assert_not_called()
+            mock_sse.assert_not_called()

--- a/tests/unit/services/test_ard_net_guard.py
+++ b/tests/unit/services/test_ard_net_guard.py
@@ -48,6 +48,18 @@ class TestAssertFetchable:
             with pytest.raises(ArdValidationError):
                 g.assert_fetchable("https://evil.example/x")
 
+    def test_blocks_cgnat_shared_address_space(self):
+        """Carrier-grade NAT (100.64.0.0/10, RFC 6598) must be blocked."""
+        with patch.object(g.socket, "getaddrinfo", _resolve_to("100.64.0.1")):
+            with pytest.raises(ArdValidationError):
+                g.assert_fetchable("https://evil.example/x")
+
+    def test_cgnat_range_pinned_in_blocked_nets(self):
+        """Pin the exact CGNAT range so a runtime-semantics change fails loudly."""
+        import ipaddress
+
+        assert ipaddress.ip_network("100.64.0.0/10") in g._BLOCKED_NETS
+
     def test_same_domain_allows_subdomain(self):
         with patch.object(g.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
             assert g.assert_fetchable("https://sub.acme.com/x", allowed_domain="acme.com")

--- a/tests/unit/services/test_security_scanner_ssrf.py
+++ b/tests/unit/services/test_security_scanner_ssrf.py
@@ -1,0 +1,115 @@
+"""Unit tests for SSRF re-validation in the security-scanner service.
+
+The scanner runs an external subprocess (mcp-scanner) against a target URL.
+That URL may be an operator-supplied ``mcp_endpoint`` override, which is a
+different host than the ``proxy_pass_url`` validated earlier. Because the
+external subprocess cannot use the registry's IP-pinned guarded client, the
+FINAL resolved URL must be re-validated before the subprocess is spawned, and
+the scan must fail closed (no subprocess) when it points at a
+private/metadata/loopback target.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_service():
+    """Build a SecurityScannerService with its repository dependency mocked."""
+    with patch("registry.services.security_scanner.get_security_scan_repository"):
+        from registry.services.security_scanner import SecurityScannerService
+
+        service = SecurityScannerService()
+        service._scan_repo = MagicMock()
+        service._scan_repo.create = AsyncMock(return_value=None)
+        return service
+
+
+def _resolve_to(*ips: str):
+    def _stub(host, port, **kw):
+        return [(2, 1, 6, "", (ip, port)) for ip in ips]
+
+    return _stub
+
+
+@pytest.mark.asyncio
+async def test_scan_blocked_when_mcp_endpoint_targets_private_host():
+    """An mcp_endpoint override resolving to a private host does NOT run the scanner."""
+    service = _make_service()
+
+    def _resolve(host, port, **kw):
+        # proxy_pass_url host resolves public; the mcp_endpoint override is private.
+        if "internal.evil.example" in host:
+            return [(2, 1, 6, "", ("10.0.0.5", port))]
+        return [(2, 1, 6, "", ("93.184.216.34", port))]
+
+    with (
+        patch("registry.services.security_scanner.subprocess.run") as mock_run,
+        patch("registry.utils.url_guard.socket.getaddrinfo", side_effect=_resolve),
+    ):
+        # proxy_pass_url is public, but the mcp_endpoint override is private.
+        # The block must be attributable to the mcp_endpoint re-check.
+        result = await service.scan_server(
+            server_url="https://public.example",
+            server_path="/x",
+            mcp_endpoint="https://internal.evil.example/mcp",
+        )
+
+        # Fail closed: subprocess never runs, scan is recorded as unsafe/failed.
+        mock_run.assert_not_called()
+        assert result.is_safe is False
+        assert result.scan_failed is True
+
+
+@pytest.mark.asyncio
+async def test_scan_blocked_when_mcp_endpoint_is_metadata_literal():
+    """A metadata-IP literal mcp_endpoint is refused with no subprocess."""
+    service = _make_service()
+
+    with (
+        patch("registry.services.security_scanner.subprocess.run") as mock_run,
+        patch(
+            "registry.utils.url_guard.socket.getaddrinfo",
+            side_effect=_resolve_to("93.184.216.34"),
+        ),
+    ):
+        result = await service.scan_server(
+            server_url="https://public.example",
+            server_path="/x",
+            mcp_endpoint="http://169.254.169.254/latest/meta-data/",
+        )
+
+        mock_run.assert_not_called()
+        assert result.is_safe is False
+        assert result.scan_failed is True
+
+
+@pytest.mark.asyncio
+async def test_scan_runs_for_valid_public_endpoint():
+    """A valid public mcp_endpoint proceeds to run the scanner subprocess."""
+    service = _make_service()
+
+    completed = MagicMock()
+    completed.stdout = "[]"
+    completed.stderr = ""
+
+    with (
+        patch(
+            "registry.services.security_scanner.subprocess.run", return_value=completed
+        ) as mock_run,
+        patch(
+            "registry.utils.url_guard.socket.getaddrinfo",
+            side_effect=_resolve_to("93.184.216.34"),
+        ),
+    ):
+        result = await service.scan_server(
+            server_url="https://public.example",
+            server_path="/x",
+            mcp_endpoint="https://good.example.com/mcp",
+        )
+
+        mock_run.assert_called_once()
+        # The subprocess was invoked against the validated public endpoint.
+        cmd = mock_run.call_args.args[0]
+        assert "https://good.example.com/mcp" in cmd
+        assert result.scan_failed is False

--- a/tests/unit/services/test_server_service.py
+++ b/tests/unit/services/test_server_service.py
@@ -283,6 +283,99 @@ class TestRegisterServerUrlValidation:
         assert result is True
         mock_server_repository.update.assert_called_once()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field_name", ["mcp_endpoint", "sse_endpoint"])
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata literal
+            "http://10.0.0.1:8080/mcp",  # RFC-1918 literal
+            "http://127.0.0.1:8080/sse",  # loopback literal
+            "http://100.64.0.1/mcp",  # CGNAT (RFC 6598) literal
+            "ftp://acme.com/mcp",  # disallowed scheme
+            'http://acme.com/";} location /x { proxy_pass http://evil;',  # nginx injection
+            "http://acme.com/${SOME_VAR}",  # nginx variable sigil
+            "http://acme.com/a;b",  # directive terminator
+        ],
+    )
+    async def test_register_rejects_unsafe_endpoint_field(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+        field_name,
+        bad_url,
+    ):
+        """An mcp_endpoint/sse_endpoint override gets the same guard as proxy_pass_url."""
+        from registry.exceptions import UrlValidationError
+
+        mock_server_repository.get.return_value = None
+        payload = {**sample_server_dict, field_name: bad_url}
+
+        with pytest.raises(UrlValidationError):
+            await server_service.register_server(payload)
+
+        mock_server_repository.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field_name", ["mcp_endpoint", "sse_endpoint"])
+    async def test_update_rejects_unsafe_endpoint_field(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+        field_name,
+    ):
+        """Editing an endpoint override to a private target is rejected."""
+        from registry.exceptions import UrlValidationError
+
+        payload = {**sample_server_dict, field_name: "http://192.168.1.5/mcp"}
+
+        with pytest.raises(UrlValidationError):
+            await server_service.update_server(sample_server_dict["path"], payload)
+
+        mock_server_repository.update.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("field_name", ["mcp_endpoint", "sse_endpoint"])
+    async def test_register_accepts_public_https_endpoint_field(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+        mock_search_repository,
+        field_name,
+    ):
+        """A valid public https endpoint override is accepted."""
+        mock_server_repository.get.return_value = None
+        mock_server_repository.create.return_value = True
+        mock_server_repository.get_state.return_value = False
+
+        payload = {**sample_server_dict, field_name: "https://acme.example.com/mcp"}
+        result = await server_service.register_server(payload)
+
+        assert result["success"] is True
+        mock_server_repository.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_register_accepts_empty_endpoint_fields(
+        self,
+        server_service: ServerService,
+        sample_server_dict: dict[str, Any],
+        mock_server_repository,
+        mock_search_repository,
+    ):
+        """Empty/unset endpoint override fields are allowed (they are optional)."""
+        mock_server_repository.get.return_value = None
+        mock_server_repository.create.return_value = True
+        mock_server_repository.get_state.return_value = False
+
+        payload = {**sample_server_dict, "mcp_endpoint": "", "sse_endpoint": None}
+        result = await server_service.register_server(payload)
+
+        assert result["success"] is True
+        mock_server_repository.create.assert_called_once()
+
 
 class TestRegisterServer:
     """Test server registration functionality."""

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -138,6 +138,59 @@ class TestPrivateAndMetadata:
 
 
 # ---------------------------------------------------------------------------
+# Carrier-grade NAT (RFC 6598) explicit block
+# ---------------------------------------------------------------------------
+
+
+class TestCgnatBlock:
+    """CGNAT (100.64.0.0/10) must be blocked independently of Python's is_private.
+
+    These pin the exact range so a runtime/semantics change fails loudly here
+    rather than silently re-opening an SSRF pivot to a shared-address-space host.
+    """
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "100.64.0.1",
+            "100.64.0.0",
+            "100.100.50.1",
+            "100.127.255.254",
+            "::ffff:100.64.0.1",  # IPv4-mapped IPv6 form
+        ],
+    )
+    def test_cgnat_ip_is_blocked(self, ip):
+        assert url_guard._is_blocked_ip(ip, url_guard._Allowlist()) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "100.63.255.255",  # just below the range
+            "100.128.0.1",  # just above the range
+        ],
+    )
+    def test_addresses_adjacent_to_cgnat_range_are_public(self, ip):
+        assert url_guard._is_blocked_ip(ip, url_guard._Allowlist()) is False
+
+    def test_cgnat_range_pinned_exactly(self):
+        """The pinned network must be exactly 100.64.0.0/10 (RFC 6598)."""
+        import ipaddress
+
+        assert ipaddress.ip_network("100.64.0.0/10") in url_guard._CGNAT_NETS
+
+    def test_cgnat_literal_host_rejected(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_url("https://100.64.0.1/x")
+
+    def test_cgnat_resolution_rejected(self):
+        with patch.object(url_guard, "settings", _settings()):
+            with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("100.64.0.1")):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url("https://sneaky.example/x")
+
+
+# ---------------------------------------------------------------------------
 # nginx metacharacters
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Validate override endpoint URL fields through the canonical SSRF guard

## What changed

Server registrations accept optional override endpoint fields (`mcp_endpoint`,
`sse_endpoint`) in addition to the primary backend URL (`proxy_pass_url`). Only
`proxy_pass_url` was routed through the canonical URL guard; the override fields
were stored and later fetched / interpolated into generated nginx config without
validation. This closes that gap.

- Validate override endpoint fields at every write path. A new
  `_validate_endpoint_fields` helper in the server service runs each present
  `mcp_endpoint` / `sse_endpoint` through the same `validate_proxy_pass_url()`
  used for `proxy_pass_url`. It is invoked from `register_server` and
  `update_server`, which every registration/edit route (dashboard, internal,
  A2A, version-add) funnels through, so the whole write family is covered by one
  chokepoint. Empty/unset is allowed; a present-but-invalid value is rejected
  with the same error as an invalid `proxy_pass_url`.
- Re-validate the resolved URL before the scanner subprocess. The security
  scanner resolves the target with the override `mcp_endpoint` and then spawns an
  external process that the registry's IP-pinned HTTP client cannot protect. The
  final resolved URL is now re-validated (with live DNS resolution) before the
  subprocess is built; a failure is recorded as a fail-closed scan result and the
  subprocess is never run.
- Validate the override SSE endpoint before connecting. The MCP connection path
  now validates an explicit `sse_endpoint` before any credential is decrypted or
  attached, matching the streamable-http path.
- Block carrier-grade NAT (100.64.0.0/10, RFC 6598) explicitly. Both the current
  URL guard and the legacy ingestion guard now pin this range instead of relying
  on the interpreter's `is_private` semantics.

The render-time nginx sanitizer that strips `$` and escapes quotes/backslashes is
kept unchanged as defense in depth for any value persisted before validation
existed.

## Why it is safer

- Validation is additive and fail-closed: empty/unset override fields behave
  exactly as before; only a present, malicious value (private/metadata/loopback/
  CGNAT target, non-http(s) scheme, or nginx metacharacter) is now rejected.
- The scanner re-validation runs inside the existing error path, so a blocked URL
  produces the same fail-closed scan result the scanner already emits for other
  failures - no subprocess, server marked unsafe.
- The override fields use the identical canonical guard as `proxy_pass_url`, so
  there is one trust boundary and no new validation logic to drift.
- The CGNAT block reuses the existing allowlist and IPv4-mapped-IPv6 unwrap, so it
  behaves like the other reserved ranges (operator-CIDR-allowlistable, never for
  metadata).

## How it was tested

- New unit tests for endpoint-field validation at register and edit (rejects
  private/metadata/loopback/CGNAT/metacharacter/bad-scheme values across both
  fields; accepts a valid public https endpoint; accepts empty/unset).
- New unit tests for the scanner: a private or metadata override endpoint does not
  spawn the subprocess and returns a failed scan; a valid public endpoint runs.
- New unit tests for the SSE override path: an explicit `sse_endpoint` resolving
  to a private host does not connect and does not build credentials.
- New unit tests pinning the CGNAT range in both guards.
- Full affected suites pass: `tests/unit/utils`, `tests/unit/services`,
  `tests/unit/core`, `tests/unit/api` - no regressions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
