### PR TITLE
fix(cdk): use rds:* actions for DocumentDB rotation IAM (Terraform parity)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1457,7 +1457,7 @@
         "filename": "terraform/aws-ecs/secret-rotation.tf",
         "hashed_secret": "e4f82e1b6821416cecc631b9daa67b3389af8fbb",
         "is_verified": false,
-        "line_number": 338
+        "line_number": 340
       }
     ],
     "terraform/aws-ecs/setup-documentdb-env.sh": [
@@ -1605,5 +1605,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-14T01:34:29Z"
+  "generated_at": "2026-07-14T03:48:45Z"
 }

--- a/infra/lib/registry/registry-ops-stack.ts
+++ b/infra/lib/registry/registry-ops-stack.ts
@@ -232,9 +232,11 @@ function _createRotationRole(
     new iam.PolicyStatement({
       sid: 'DocumentDBAccess',
       effect: iam.Effect.ALLOW,
+      // Amazon DocumentDB shares the RDS control-plane API; boto3 docdb
+      // calls are authorized as rds:* actions against the DocDB cluster ARN.
       actions: [
-        'docdb:DescribeDBClusters',
-        'docdb:ModifyDBCluster',
+        'rds:DescribeDBClusters',
+        'rds:ModifyDBCluster',
       ],
       resources: [documentDbClusterArn],
     }),

--- a/terraform/aws-ecs/lambda/README.md
+++ b/terraform/aws-ecs/lambda/README.md
@@ -33,8 +33,8 @@ Rotates DocumentDB cluster master password.
 - `secretsmanager:GetRandomPassword`
 - `kms:Decrypt`
 - `kms:GenerateDataKey`
-- `docdb:DescribeDBClusters`
-- `docdb:ModifyDBCluster`
+- `rds:DescribeDBClusters` (DocumentDB shares the RDS control-plane API)
+- `rds:ModifyDBCluster` (DocumentDB shares the RDS control-plane API)
 - VPC networking permissions for private subnet access
 
 **Network Configuration:**


### PR DESCRIPTION
## Summary

Follow-up to #1406, which fixed the DocumentDB rotation Lambda IAM policy in the Terraform `aws-ecs` stack. The CDK ops stack carried the identical bug and was not covered by that PR, so CDK deployments remained broken.

The rotation Lambda uses a boto3 `docdb` client, but Amazon DocumentDB shares the RDS control-plane API, so those calls are authorized under the `rds:` action namespace. Granting `docdb:DescribeDBClusters` / `docdb:ModifyDBCluster` never matches the evaluated `rds:*` actions, which produces the latent, destructive rotation failure described in #1348 (the ~30-day scheduled rotation changes the live password at `setSecret`, then `testSecret` fails with `AccessDenied` and `finishSecret` never promotes the new secret).

This PR brings CDK into parity with Terraform:

- `infra/lib/registry/registry-ops-stack.ts`: swap `docdb:DescribeDBClusters` / `docdb:ModifyDBCluster` to `rds:DescribeDBClusters` / `rds:ModifyDBCluster` on the same DocumentDB cluster ARN (the ARN is already RDS-namespaced). Scope is unchanged; only the action namespace is corrected.
- `terraform/aws-ecs/lambda/README.md`: update the documented Lambda IAM permissions, which still listed the old `docdb:*` actions.

The action set matches exactly what the Lambda calls (`modify_db_cluster`, `describe_db_clusters`) — least privilege, no `rds:DescribeDBInstances` added.

## Checks
- `npx tsc --noEmit -p infra/tsconfig.json` passes
- Repo-wide grep confirms no `docdb:DescribeDBClusters` / `docdb:ModifyDBCluster` grants remain in any `.tf`, `.ts`, or `.md`

## Notes
- No parameter-carrying files touched; unified parameter reference not applicable.
- Post-merge, the destructive rotation path is best validated on a real DocumentDB deployment via `aws secretsmanager rotate-secret`, confirming all four rotation steps complete and `AWSCURRENT` is promoted.

Relates to #1348.