### PR TITLE
fix(cdk): enable WAF path and restore built-in MCP server flow

### DIFF
--- a/infra/config.yaml
+++ b/infra/config.yaml
@@ -50,7 +50,7 @@ registry:
   deploymentMode: with-gateway
   registryMode: full
   enableObservability: true
-  enableWaf: false
+  enableWaf: true
   createCodebuild: false
   disableAiRegistryToolsServer: "false"
 
@@ -86,7 +86,7 @@ registry:
     authServer: "mcpgateway/auth-server:latest"
     keycloak: "quay.io/keycloak/keycloak:26.2.4"
     currenttime: ""
-    mcpgw: ""
+    mcpgw: "public.ecr.aws/p3v1o3c6/mcpgw:1.26.0"
     realserverfaketools: ""
     flightBookingAgent: ""
     travelAssistantAgent: ""

--- a/infra/docs/WAF-AND-MCP-FLOW.md
+++ b/infra/docs/WAF-AND-MCP-FLOW.md
@@ -1,0 +1,470 @@
+# WAF and MCP Auth Flow
+
+Reference for how WAFv2 is configured on this stack and how a Claude Code (or any MCP) client goes from `/mcp` invocation to a tool response, including where each WAF rule evaluates and what it blocks.
+
+## Table of contents
+
+- [WAF primer](#waf-primer)
+- [WAF setup in this stack](#waf-setup-in-this-stack)
+- [Sub-rule overrides we apply](#sub-rule-overrides-we-apply)
+- [End-to-end MCP flow](#end-to-end-mcp-flow)
+- [WAF evaluation order for a DCR request](#waf-evaluation-order-for-a-dcr-request)
+- [WAF evaluation order for an MCP tool call](#waf-evaluation-order-for-an-mcp-tool-call)
+
+## WAF primer
+
+AWS WAFv2 sits in front of a resource (ALB / CloudFront / API Gateway). Every request runs through a **Web ACL** — an ordered list of rules — until one rule takes a **terminating action** (`Allow` or `Block`).
+
+Each rule has:
+
+- **Statement** — the match condition (byte match, rate-based, managed rule group reference, regex, etc.)
+- **Action** — `Allow` / `Block` / `Count` / `CAPTCHA` / `Challenge` (used on your own rules)
+- **OverrideAction** — `None` or `Count` (used only when the rule references a managed rule group)
+
+**Terminating vs non-terminating:**
+
+- `Allow` and `Block` are terminating — evaluation stops.
+- `Count` is non-terminating — it records the match in CloudWatch metrics and sampled requests, then keeps evaluating the remaining rules.
+
+**Managed rule groups** are AWS-authored rule bundles (for example `AWSManagedRulesCommonRuleSet` contains around 50 sub-rules covering SQLi, XSS, LFI, RFI, SSRF, size limits, bad bots). You reference them by name; you do not own the internals. Two ways to tune them:
+
+1. **`overrideAction: { count: {} }`** — downgrade the **whole group** from block-mode to count-mode. Everything in the group becomes visibility-only.
+2. **`ruleActionOverrides[]`** — **per sub-rule** action override. Leaves the rest of the group at Block, changes only named sub-rules to (usually) `Count`. Cannot narrow by request path.
+
+**`scopeDownStatement`** — an extra condition that gates a rule (managed group or rate-based). The rule only evaluates when the scope-down condition matches. Rate-based rules with `aggregateKeyType=CONSTANT` require a scope-down clause; without it AWS rejects the WebACL at create time. **`ManagedRuleGroupStatement` must be a rule's top-level statement** — it cannot be nested inside `AndStatement` / `NotStatement`. To gate a managed group by path, put the path condition inside the group's own `scopeDownStatement`, not wrapped around it.
+
+**Sampled requests** — AWS records up to ~5000 matched requests per rule in a rolling window (typically 3h). The console shows them as forensic evidence for what fired. This is separate from full logs, which go to CloudWatch / S3 / Kinesis when `LoggingConfiguration` is attached.
+
+## WAF setup in this stack
+
+Two Web ACLs, one per ALB — both REGIONAL scope, us-east-1:
+
+- `mcp-gateway-mcp-gateway-waf` — attached to the registry ALB
+- `mcp-gateway-keycloak-waf` — attached to the Keycloak ALB
+
+Both ACLs share the same 5-rule chain (built in `infra/lib/registry/constructs/waf-rules.ts`):
+
+| Priority | Rule | Type | Scope-down | Purpose |
+|---|---|---|---|---|
+| 1 | `CommonRuleSet` | managed group at Block | path is **NOT** `starts_with(/realms/mcp-gateway/clients-registrations/)` | Full CRS protection everywhere except the anonymous DCR endpoint. |
+| 2 | `CommonRuleSetForDcr` | managed group with `EC2MetaDataSSRF_BODY` + `GenericRFI_BODY` set to Count | path **starts_with** `/realms/mcp-gateway/clients-registrations/` | Same managed group, DCR path only, with the two false-positive body rules downgraded to Count. All other CRS sub-rules still Block on this path. |
+| 3 | `AWSManagedRulesKnownBadInputsRuleSet` | managed group at Block | — | Known exploit signatures. |
+| 4 | `IPRateLimitRule` | rate-based (`aggregateKeyType=IP`) | — | 100 req / 5 min per client IP. |
+| 5 | `GlobalRateLimitRule` | rate-based (`aggregateKeyType=CONSTANT`) | `uriPath CONTAINS "/"` (match-all) | 2000 req / 5 min total across all clients. |
+
+Rules 1 and 2 are the same managed rule group referenced twice with **mutually exclusive** scope-down paths. WAF evaluates rules in priority order and stops at the first terminating action (Allow / Block). Because the scope-downs are disjoint, at most one of {Rule 1, Rule 2} matches per request — no double-charging.
+
+Both ACLs also attach a `LoggingConfiguration` that streams matches to CloudWatch log groups `aws-waf-logs-mcp-gateway` and `aws-waf-logs-keycloak`, with `redactedFields: [{ singleHeader: { Name: "authorization" } }]` so bearer tokens do not land in the log.
+
+## Sub-rule overrides we apply
+
+The `CommonRuleSetForDcr` rule (priority 2) downgrades two body-inspection sub-rules from Block to Count, and only applies to Keycloak's anonymous DCR endpoint (`/realms/mcp-gateway/clients-registrations/*`):
+
+| Sub-rule | Matches when… | Override |
+|---|---|---|
+| `EC2MetaDataSSRF_BODY` | SSRF tokens (`localhost`, `127.0.0.1`, `169.254.169.254`, cloud metadata IPs) appear in the request body | Count |
+| `GenericRFI_BODY` | `127.0.0.1` / `169.254.169.254` / other RFI-shaped tokens appear in the body | Count |
+
+**Why** — OAuth Dynamic Client Registration (RFC 7591) for native / CLI clients (Claude Code, Kiro, gcloud, `aws sso login`, GitHub CLI, VS Code) always registers a **loopback callback URI** (RFC 8252):
+
+```json
+{"redirect_uris":["http://localhost:1234/callback"], ...}
+```
+
+The `localhost` token in the JSON body matches `EC2MetaDataSSRF_BODY`, so at Block the DCR request terminated with an HTML `403 Forbidden` page — which broke every MCP client's OAuth flow. Downgrading to Count lets the DCR reach Keycloak; metric + sample still recorded for observability.
+
+`GenericRFI_BODY` is included because it was **shadowed** by `EC2MetaDataSSRF_BODY` — once the latter was downgraded to Count, `GenericRFI_BODY` became the next terminating match on bodies containing `127.0.0.1` / `169.254.169.254`. Claude Code defaults to `localhost` (which `GenericRFI_BODY` does not match) but clients that emit `127.0.0.1` literals would still trip it without this second override.
+
+**What stays at Block:**
+
+- On the DCR endpoint: `EC2MetaDataSSRF_COOKIE` / `_URIPATH` / `_QUERYARGUMENTS`, all LFI / XSS / SQLi / bad-bots / size-limits / restricted-extensions sub-rules, plus everything else in the managed group.
+- On every other path (including registry `/api/*`, MCP `/airegistry-tools/mcp`, `/oauth2/*`, Keycloak `/protocol/openid-connect/token`): the entire CRS runs at full Block via Rule 1, including all 4 `EC2MetaDataSSRF_*` sub-rules.
+- Rules 3 (`KnownBadInputs`), 4 (per-IP rate limit), 5 (global rate limit) — untouched.
+
+## End-to-end MCP flow
+
+Full trace of a Claude Code `/mcp` invocation reaching the built-in `ai-registry-tools` MCP server. Sequence diagram first; per-hop payloads below.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant CC as Claude Code<br/>(MCP client)
+    participant B as System browser
+    participant CF as CloudFront
+    participant NGX as nginx<br/>(registry ALB)
+    participant AS as auth-server<br/>FastAPI
+    participant MG as mcpgw<br/>FastMCP
+    participant REG as registry<br/>FastAPI + DocumentDB
+    participant KC as Keycloak<br/>(mcp-gateway realm)
+
+    Note over CC,KC: Hop 1 — Discovery (unauth POST → 401)
+    CC->>NGX: POST /airegistry-tools/mcp<br/>(no Authorization)
+    NGX->>AS: auth_request /validate
+    AS-->>NGX: 401
+    NGX-->>CC: 401<br/>www-authenticate: Bearer<br/>resource_metadata=".../.well-known/oauth-protected-resource"
+
+    Note over CC,KC: Hop 2 — Fetch PRM (RFC 9728)
+    CC->>NGX: GET /.well-known/oauth-protected-resource
+    NGX->>REG: proxy_pass
+    REG-->>CC: { resource, authorization_servers, scopes_supported: [openid,email,profile,offline_access] }
+
+    Note over CC,KC: Hop 3 — Fetch AS metadata (RFC 8414)
+    CC->>KC: GET /realms/mcp-gateway/.well-known/openid-configuration
+    KC-->>CC: { registration_endpoint, authorization_endpoint, token_endpoint, jwks_uri }
+
+    Note over CC,KC: Hop 4 — Anonymous DCR (RFC 7591) — WAF interception
+    CC->>KC: POST /clients-registrations/openid-connect<br/>{redirect_uris:["http://localhost:1234/callback"], scope:"openid profile email"}
+    Note right of KC: WAF Rule 1 (CommonRuleSet) skipped — scope-down excludes DCR path<br/>WAF Rule 2 (CommonRuleSetForDcr) matches:<br/>  EC2MetaDataSSRF_BODY = Count<br/>  GenericRFI_BODY = Count<br/>Keycloak DCR: Trusted Hosts allows "localhost"<br/>Keycloak DCR: Allowed Client Scopes includes "openid"
+    KC-->>CC: { client_id: "518efe22-…", redirect_uris }
+
+    Note over CC,KC: Hop 5 — Browser OAuth code + PKCE
+    CC->>B: open system browser
+    B->>KC: GET /protocol/openid-connect/auth?...&code_challenge=...&state=...
+    KC->>B: login form → user consent
+    B->>KC: submit credentials
+    KC->>B: 302 http://localhost:1234/callback?code=…&state=…
+    B->>CC: browser hits localhost listener
+
+    Note over CC,KC: Hop 6 — Token exchange
+    CC->>KC: POST /protocol/openid-connect/token<br/>grant=authorization_code&code=…&code_verifier=…
+    KC-->>CC: { access_token: JWT, refresh_token, expires_in: 300 }
+
+    Note over CC,KC: Hop 7 — Client retries /mcp with Bearer
+    CC->>NGX: POST /airegistry-tools/mcp<br/>Authorization: Bearer JWT<br/>{initialize}
+    NGX->>AS: auth_request /validate
+    AS->>KC: JWKS lookup (cached)
+    AS->>AS: verify sig, map groups → scopes,<br/>check method allowed
+    AS-->>NGX: 200 + X-Internal-Token (auth-server signed JWT)
+    NGX->>AS: proxy_pass /mcp-proxy/airegistry-tools/mcp<br/>(X-Internal-Token injected)
+    AS->>MG: POST http://mcpgw-server:8003/mcp<br/>(Service Connect)
+
+    Note over CC,KC: Hop 8 — MCP initialize response
+    MG-->>AS: SSE: {serverInfo:{name:"AI Registry", version:"3.4.2"}, ...}
+    AS-->>NGX: stream
+    NGX-->>CC: stream
+
+    Note over CC,KC: Hop 9 — tools/list
+    CC->>NGX: POST /airegistry-tools/mcp<br/>{tools/list}
+    NGX->>AS: /validate + /mcp-proxy
+    AS->>MG: forward
+    MG-->>CC: 7 tools: list_services, list_agents, list_skills,<br/>get_skill_content, search_registry,<br/>intelligent_tool_finder, healthcheck
+
+    Note over CC,KC: Hop 10 — tools/call list_agents
+    CC->>NGX: POST /airegistry-tools/mcp<br/>{tools/call, name:list_agents}
+    NGX->>AS: /validate (scope + tool_filter check)
+    AS->>MG: forward
+    MG->>REG: GET http://registry:8080/api/agents
+    REG-->>MG: [{name:"customer-support-agent", ...}]
+    MG-->>CC: {structuredContent:{agents:[...], total_count:1}}
+    CC-->>U: renders tool output
+```
+
+### Hop 1 — Client POST /mcp without auth
+
+Client:
+
+```http
+POST /airegistry-tools/mcp HTTP/2
+Host: d2iekp3sw064ee.cloudfront.net
+Content-Type: application/json
+Accept: application/json, text/event-stream
+
+{"jsonrpc":"2.0","id":1,"method":"initialize", ...}
+```
+
+Server (nginx → auth-server `/validate` subrequest → 401):
+
+```http
+HTTP/2 401
+www-authenticate: Bearer realm="mcp",
+                  resource_metadata="https://d2iekp3sw064ee.cloudfront.net/.well-known/oauth-protected-resource"
+
+{"error":"Authentication required"}
+```
+
+Client extracts the `resource_metadata` URL.
+
+### Hop 2 — Client GET Protected Resource Metadata (RFC 9728)
+
+Server (registry FastAPI, `MCP_ADVERTISED_SCOPES` env forces the OIDC-universal scope list):
+
+```json
+{
+  "resource": "https://d2iekp3sw064ee.cloudfront.net",
+  "authorization_servers": ["https://d3oekhpchzd13n.cloudfront.net/realms/mcp-gateway"],
+  "scopes_supported": ["openid","email","profile","offline_access"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "https://d2iekp3sw064ee.cloudfront.net/docs/oauth"
+}
+```
+
+### Hop 3 — Client GET Authorization Server metadata (RFC 8414)
+
+Keycloak returns the OIDC discovery document. Relevant fields:
+
+```json
+{
+  "issuer": "https://d3oekhpchzd13n.cloudfront.net/realms/mcp-gateway",
+  "authorization_endpoint": ".../protocol/openid-connect/auth",
+  "token_endpoint":         ".../protocol/openid-connect/token",
+  "registration_endpoint":  ".../clients-registrations/openid-connect",
+  "jwks_uri":               ".../protocol/openid-connect/certs"
+}
+```
+
+### Hop 4 — Anonymous DCR (RFC 7591) — WAF interception point
+
+Client POST to `registration_endpoint`:
+
+```http
+POST /realms/mcp-gateway/clients-registrations/openid-connect
+Host: d3oekhpchzd13n.cloudfront.net
+Content-Type: application/json
+User-Agent: node
+
+{
+  "redirect_uris": ["http://localhost:1234/callback"],
+  "client_name": "Claude Code",
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code","refresh_token"],
+  "response_types": ["code"],
+  "scope": "openid profile email"
+}
+```
+
+Request path: CloudFront → ALB → keycloak WAF Web ACL → Keycloak container. See "WAF evaluation order for a DCR request" below for what happens inside the ACL.
+
+If the WAF passes it, Keycloak's DCR policies run:
+
+- `Trusted Hosts` — `localhost` is on the allowlist (relaxed by `keycloak/setup/init-keycloak.sh` `configure_dcr_trusted_hosts`).
+- `Allowed Client Scopes` — includes every realm client-scope plus `openid` (appended by `configure_dcr_allowed_scopes`).
+- `Consent Required`, `Full Scope Disabled`, etc. — pass.
+
+Keycloak issues:
+
+```json
+{
+  "client_id": "518efe22-8f96-4d6f-acd6-adddfb60a143",
+  "redirect_uris": ["http://localhost:1234/callback"],
+  "token_endpoint_auth_method": "none",
+  "grant_types": ["authorization_code","refresh_token"],
+  "scope": "profile email"
+}
+```
+
+### Hop 5 — Browser-based authorization_code + PKCE flow
+
+Client opens the system browser at:
+
+```
+https://d3oekhpchzd13n.cloudfront.net/realms/mcp-gateway/protocol/openid-connect/auth
+  ?response_type=code
+  &client_id=518efe22-...
+  &redirect_uri=http://localhost:1234/callback
+  &scope=openid+profile+email
+  &state=<csrf>
+  &code_challenge=<pkce-hash>
+  &code_challenge_method=S256
+```
+
+User authenticates. Keycloak redirects the browser to:
+
+```
+http://localhost:1234/callback?code=<auth-code>&state=<csrf>
+```
+
+The client's local HTTP listener captures the code.
+
+### Hop 6 — Token exchange
+
+Client:
+
+```http
+POST /realms/mcp-gateway/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code=<auth-code>
+&client_id=518efe22-...
+&redirect_uri=http://localhost:1234/callback
+&code_verifier=<pkce-verifier>
+```
+
+Keycloak returns:
+
+```json
+{
+  "access_token": "eyJhbGci...",
+  "expires_in": 300,
+  "refresh_token": "eyJhbGci...",
+  "id_token": "eyJhbGci...",
+  "token_type": "Bearer",
+  "scope": "profile email"
+}
+```
+
+Access token payload (relevant claims):
+
+```json
+{
+  "iss": "https://d3oekhpchzd13n.cloudfront.net/realms/mcp-gateway",
+  "sub": "c385eea8-...",
+  "preferred_username": "admin",
+  "groups": ["mcp-registry-admin","mcp-servers-unrestricted"],
+  "scope": "profile email",
+  "exp": 1784...
+}
+```
+
+### Hop 7 — Client POST /mcp with Bearer
+
+Client retries the original `initialize` call, now with the access token:
+
+```http
+POST /airegistry-tools/mcp
+Authorization: Bearer <access_token>
+
+{"jsonrpc":"2.0","id":1,"method":"initialize", ...}
+```
+
+`auth-server /validate` verifies the JWT signature against Keycloak's JWKS, maps `groups` → registry scopes, and checks the requested MCP method against that scope set. On success nginx `proxy_pass`es the body to `/mcp-proxy/airegistry-tools/mcp`, and auth-server forwards it to `http://mcpgw-server:8003/mcp` over Service Connect (with an `X-Internal-Token` header that mcpgw's own auth guard checks).
+
+### Hop 8 — MCP initialize response
+
+mcpgw returns an SSE frame:
+
+```
+event: message
+data: {"jsonrpc":"2.0","id":1,"result":{
+  "protocolVersion":"2025-03-26",
+  "capabilities":{"tools":{"listChanged":true}, ...},
+  "serverInfo":{"name":"AI Registry","version":"3.4.2"},
+  "instructions":"..."
+}}
+```
+
+### Hop 9 — tools/list
+
+Client:
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+```
+
+mcpgw:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{"tools":[
+  {"name":"list_services", ...},
+  {"name":"list_agents",   ...},
+  {"name":"list_skills",   ...},
+  {"name":"get_skill_content", ...},
+  {"name":"search_registry",   ...},
+  {"name":"intelligent_tool_finder", ...},
+  {"name":"healthcheck",   ...}
+]}}
+```
+
+### Hop 10 — tools/call
+
+Client:
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
+  "name":"list_agents",
+  "arguments":{}
+}}
+```
+
+Auth-server's `tool_filter` checks `airegistry-tools.list_agents` against the scopes derived from the JWT `groups` claim (`mcp-servers-unrestricted` → `.../execute`). If allowed, the request forwards to mcpgw, whose `list_agents()` handler calls the registry HTTP API. Registry queries DocumentDB and returns:
+
+```json
+{"jsonrpc":"2.0","id":3,"result":{
+  "content":[{"type":"text","text":"..."}],
+  "structuredContent":{
+    "agents":[{
+      "name":"customer-support-agent",
+      "description":"Handles customer inquiries via chat",
+      "tags":["team:retail-banking","domain:banking","compliance:sox","security-pending"]
+    }],
+    "total_count":1,
+    "status":"success"
+  },
+  "isError":false
+}}
+```
+
+Claude Code renders the tool output to the user.
+
+## WAF evaluation order for a DCR request
+
+Detail for Hop 4. Web ACL: `mcp-gateway-keycloak-waf`. Request: POST `/realms/mcp-gateway/clients-registrations/openid-connect`, body contains `http://localhost:1234/callback`.
+
+```mermaid
+flowchart TD
+    A["DCR POST arrives<br/>path: /realms/mcp-gateway/clients-registrations/openid-connect<br/>body: redirect_uris=[http://localhost:1234/callback]"] --> P1
+
+    P1["Priority 1: CommonRuleSet<br/>scope-down: NOT starts_with '/realms/*/clients-registrations/'"]
+    P1 -->|"path DOES start with DCR prefix<br/>→ scope-down does not match<br/>→ rule skipped entirely"| P2
+
+    P2["Priority 2: CommonRuleSetForDcr<br/>scope-down: starts_with '/realms/*/clients-registrations/'<br/>→ matches, managed group evaluates"]
+
+    P2 --> S1["BadBots_HEADER, NoUserAgent, SizeRestrictions_*,<br/>RestrictedExtensions_*, XSS_*, SQLi_*, LFI_*<br/>→ no match"]
+    S1 --> S2{"EC2MetaDataSSRF_BODY<br/>regex hits 'localhost'"}
+    S2 -->|"OVERRIDE: Count<br/>(non-terminating)"| S3["metric + sample recorded<br/>continue"]
+    S3 --> S4{"GenericRFI_BODY<br/>tries 127.0.0.1 / 169.254.169.254"}
+    S4 -->|"'localhost' does not match<br/>→ pass through"| S5["group exhausted, no Block"]
+
+    S5 --> P3["Priority 3: KnownBadInputsRuleSet<br/>→ no match"]
+    P3 --> P4["Priority 4: IPRateLimitRule 100/5min per IP<br/>→ under limit"]
+    P4 --> P5["Priority 5: GlobalRateLimitRule 2000/5min<br/>scopeDown uriPath CONTAINS '/'<br/>→ under limit"]
+    P5 --> DA["defaultAction: Allow"]
+    DA --> KC["Request reaches Keycloak"]
+
+    S2 -.->|"OVERRIDE: Count preserves flow<br/>(was Block, would have terminated here)"| BLK1["what would have happened<br/>before the override"]
+    S4 -.->|"if body had 127.0.0.1<br/>→ OVERRIDE: Count<br/>→ still passes through"| S5
+
+    classDef pass fill:#d4f4dd,stroke:#2d7a3e,color:#000
+    classDef count fill:#fff3c4,stroke:#8a6b00,color:#000
+    classDef skip fill:#e8e8e8,stroke:#666,color:#000
+    classDef hypothetical fill:#f0d4ff,stroke:#6b2d7a,color:#000
+    class KC,DA,S1,S5,P3,P4,P5 pass
+    class S2,S3,S4 count
+    class P1 skip
+    class BLK1 hypothetical
+```
+
+Legend: grey = rule skipped (scope-down did not match), yellow = matched-but-Count, green = pass, purple = counterfactual reference. Both `EC2MetaDataSSRF_BODY` and `GenericRFI_BODY` are Count-only on the DCR path, so bodies containing `localhost`, `127.0.0.1`, or `169.254.169.254` all pass here — and only here.
+
+**On any other path** (registry API, `/oauth2/*`, MCP endpoint, etc.), Rule 1's scope-down matches and runs the same managed group at full Block, so `EC2MetaDataSSRF_BODY` and `GenericRFI_BODY` still terminate on those tokens.
+
+## WAF evaluation order for an MCP tool call
+
+Detail for Hop 10. Web ACL: `mcp-gateway-mcp-gateway-waf`. Request: POST `/airegistry-tools/mcp`, body is a JSON-RPC `tools/call` payload.
+
+```mermaid
+flowchart TD
+    A["Bearer POST arrives<br/>path: /airegistry-tools/mcp<br/>body: JSON-RPC tools/call<br/>Authorization: Bearer JWT"] --> P1
+
+    P1["Priority 1: CommonRuleSet<br/>scope-down: NOT DCR path<br/>→ matches (MCP path is not DCR)<br/>→ managed group evaluates at FULL BLOCK"]
+    P1 --> C1["all CRS sub-rules evaluate:<br/>SSRF (all 4) / LFI / RFI / SizeRestrictions /<br/>BadBots / RestrictedExtensions / XSS / SQLi<br/>→ no match (JSON-RPC body has no SSRF tokens<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;or user-controlled URLs / paths)"]
+    C1 --> C2["Authorization header redacted from WAF logs<br/>(singleHeader.Name=authorization)"]
+
+    C2 --> P2["Priority 2: CommonRuleSetForDcr<br/>scope-down: DCR path<br/>→ does NOT match → rule skipped"]
+    P2 --> P3["Priority 3: KnownBadInputsRuleSet<br/>→ no match"]
+    P3 --> P4["Priority 4: IPRateLimitRule 100/5min per IP<br/>→ under limit"]
+    P4 --> P5["Priority 5: GlobalRateLimitRule 2000/5min<br/>→ under limit"]
+    P5 --> DA["defaultAction: Allow"]
+    DA --> NGX["nginx"]
+    NGX --> AS["auth-server /validate<br/>JWT sig + scope + tool_filter"]
+    AS --> MG["mcpgw:8003/mcp<br/>(Service Connect)"]
+    MG --> REG["registry:8080/api/agents"]
+
+    classDef pass fill:#d4f4dd,stroke:#2d7a3e,color:#000
+    classDef skip fill:#e8e8e8,stroke:#666,color:#000
+    class P1,C1,C2,P3,P4,P5,DA,NGX,AS,MG,REG pass
+    class P2 skip
+```
+
+MCP traffic runs against the full-Block CRS via Rule 1 (its scope-down excludes only the Keycloak DCR path). Rule 2 is skipped because the MCP path is not under `/realms/*/clients-registrations/`. JSON-RPC bodies have no user-controlled URLs or filesystem paths, so no CRS sub-rule fires. Active defences on MCP traffic: full CRS (Rule 1), KnownBadInputs (Rule 3), and both rate limiters (Rules 4–5).

--- a/infra/docs/WAF-AND-MCP-FLOW.md
+++ b/infra/docs/WAF-AND-MCP-FLOW.md
@@ -405,10 +405,10 @@ Detail for Hop 4. Web ACL: `mcp-gateway-keycloak-waf`. Request: POST `/realms/mc
 flowchart TD
     A["DCR POST arrives<br/>path: /realms/mcp-gateway/clients-registrations/openid-connect<br/>body: redirect_uris=[http://localhost:1234/callback]"] --> P1
 
-    P1["Priority 1: CommonRuleSet<br/>scope-down: NOT starts_with '/realms/*/clients-registrations/'"]
+    P1["Priority 1: CommonRuleSet<br/>scope-down: NOT starts_with '/realms/mcp-gateway/clients-registrations/'"]
     P1 -->|"path DOES start with DCR prefix<br/>→ scope-down does not match<br/>→ rule skipped entirely"| P2
 
-    P2["Priority 2: CommonRuleSetForDcr<br/>scope-down: starts_with '/realms/*/clients-registrations/'<br/>→ matches, managed group evaluates"]
+    P2["Priority 2: CommonRuleSetForDcr<br/>scope-down: starts_with '/realms/mcp-gateway/clients-registrations/'<br/>→ matches, managed group evaluates"]
 
     P2 --> S1["BadBots_HEADER, NoUserAgent, SizeRestrictions_*,<br/>RestrictedExtensions_*, XSS_*, SQLi_*, LFI_*<br/>→ no match"]
     S1 --> S2{"EC2MetaDataSSRF_BODY<br/>regex hits 'localhost'"}
@@ -422,20 +422,17 @@ flowchart TD
     P5 --> DA["defaultAction: Allow"]
     DA --> KC["Request reaches Keycloak"]
 
-    S2 -.->|"OVERRIDE: Count preserves flow<br/>(was Block, would have terminated here)"| BLK1["what would have happened<br/>before the override"]
-    S4 -.->|"if body had 127.0.0.1<br/>→ OVERRIDE: Count<br/>→ still passes through"| S5
-
     classDef pass fill:#d4f4dd,stroke:#2d7a3e,color:#000
     classDef count fill:#fff3c4,stroke:#8a6b00,color:#000
     classDef skip fill:#e8e8e8,stroke:#666,color:#000
-    classDef hypothetical fill:#f0d4ff,stroke:#6b2d7a,color:#000
     class KC,DA,S1,S5,P3,P4,P5 pass
     class S2,S3,S4 count
     class P1 skip
-    class BLK1 hypothetical
 ```
 
-Legend: grey = rule skipped (scope-down did not match), yellow = matched-but-Count, green = pass, purple = counterfactual reference. Both `EC2MetaDataSSRF_BODY` and `GenericRFI_BODY` are Count-only on the DCR path, so bodies containing `localhost`, `127.0.0.1`, or `169.254.169.254` all pass here — and only here.
+Legend: grey = rule skipped (scope-down did not match), yellow = matched-but-Count, green = pass. Both `EC2MetaDataSSRF_BODY` and `GenericRFI_BODY` are Count-only on the DCR path, so bodies containing `localhost`, `127.0.0.1`, or `169.254.169.254` all pass here — and only here.
+
+**Counterfactual (before this refactor):** with `EC2MetaDataSSRF_BODY` at Block, evaluation would have terminated at S2 with an HTML 403 page. With the sub-rule at Count-but-Block-scoped-globally (the earlier iteration of this PR), `GenericRFI_BODY` at S4 would have terminated with the same 403 for `127.0.0.1` / `169.254.169.254` bodies.
 
 **On any other path** (registry API, `/oauth2/*`, MCP endpoint, etc.), Rule 1's scope-down matches and runs the same managed group at full Block, so `EC2MetaDataSSRF_BODY` and `GenericRFI_BODY` still terminate on those tokens.
 

--- a/infra/lib/registry/constructs/waf-rules.ts
+++ b/infra/lib/registry/constructs/waf-rules.ts
@@ -124,6 +124,9 @@ export class WafRules extends Construct {
 function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
   return [
     // Rule 1: AWS Managed Rules - Common Rule Set
+    // EC2MetaDataSSRF_BODY excluded: blocks legitimate OAuth DCR bodies that
+    // contain "localhost"/"127.0.0.1" as redirect_uri (false positive; the DCR
+    // is against Keycloak on a different host and cannot exfiltrate metadata).
     {
       name: 'AWSManagedRulesCommonRuleSet',
       priority: 1,
@@ -132,6 +135,12 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
         managedRuleGroupStatement: {
           name: 'AWSManagedRulesCommonRuleSet',
           vendorName: 'AWS',
+          ruleActionOverrides: [
+            { name: 'EC2MetaDataSSRF_BODY', actionToUse: { count: {} } },
+            { name: 'EC2MetaDataSSRF_COOKIE', actionToUse: { count: {} } },
+            { name: 'EC2MetaDataSSRF_URIPATH', actionToUse: { count: {} } },
+            { name: 'EC2MetaDataSSRF_QUERYARGUMENTS', actionToUse: { count: {} } },
+          ],
         },
       },
       visibilityConfig: {
@@ -174,7 +183,10 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
         sampledRequestsEnabled: true,
       },
     },
-    // Rule 4: Global rate limiting (2000 req / 5 min total)
+    // Rule 4: Global rate limiting (2000 req / 5 min total across all clients).
+    // WAF requires a scopeDownStatement when aggregateKeyType=CONSTANT. Match-all
+    // achieved via byte_match on URI path containing "/" — every HTTP request
+    // has a URI, so all traffic counts toward the global bucket.
     {
       name: 'GlobalRateLimitRule',
       priority: 4,
@@ -183,6 +195,14 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
         rateBasedStatement: {
           limit: GLOBAL_RATE_LIMIT,
           aggregateKeyType: 'CONSTANT',
+          scopeDownStatement: {
+            byteMatchStatement: {
+              fieldToMatch: { uriPath: {} },
+              positionalConstraint: 'CONTAINS',
+              searchString: '/',
+              textTransformations: [{ priority: 0, type: 'NONE' }],
+            },
+          },
         },
       },
       visibilityConfig: {
@@ -265,7 +285,7 @@ function _createWafLogging(
     logDestinationConfigs: [logGroup.logGroupArn],
     redactedFields: [
       {
-        singleHeader: { name: 'authorization' },
+        singleHeader: { Name: 'authorization' },
       },
     ],
   });

--- a/infra/lib/registry/constructs/waf-rules.ts
+++ b/infra/lib/registry/constructs/waf-rules.ts
@@ -4,11 +4,21 @@
  *
  * Translated from: terraform/aws-ecs/waf.tf
  *
- * Each Web ACL contains 4 rules:
- *   1. AWSManagedRulesCommonRuleSet (priority 1)
- *   2. AWSManagedRulesKnownBadInputsRuleSet (priority 2)
- *   3. IP-based rate limit: 100 requests / 5 minutes per IP (priority 3)
- *   4. Global rate limit: 2000 requests / 5 minutes (priority 4)
+ * Each Web ACL contains 5 rules:
+ *   1. AWSManagedRulesCommonRuleSet   (priority 1) — everywhere EXCEPT the
+ *      Keycloak anonymous DCR endpoint. Full block on all sub-rules.
+ *   2. AWSManagedRulesCommonRuleSet   (priority 2) — ONLY the Keycloak DCR
+ *      endpoint. Same managed group but with count-mode overrides on the
+ *      two sub-rules that false-positive on RFC 8252 loopback redirect_uris
+ *      (EC2MetaDataSSRF_BODY, GenericRFI_BODY).
+ *   3. AWSManagedRulesKnownBadInputsRuleSet (priority 3)
+ *   4. IP-based rate limit: 100 requests / 5 minutes per IP (priority 4)
+ *   5. Global rate limit: 2000 requests / 5 minutes (priority 5)
+ *
+ * Rules 1 and 2 share the same managed group but have mutually-exclusive
+ * scopeDownStatements. Together they preserve full CRS protection on every
+ * path except the one endpoint (Keycloak anonymous DCR) that has a documented
+ * false-positive on loopback callback URIs.
  *
  * This construct is a no-op when config.enableWaf is false.
  */
@@ -26,6 +36,12 @@ import { RegistryConfig } from '../registry-config';
 const IP_RATE_LIMIT = 100;
 const GLOBAL_RATE_LIMIT = 2000;
 const WAF_LOG_RETENTION_DAYS = 30;
+
+// Keycloak anonymous Dynamic Client Registration endpoint. Requests to this
+// path legitimately carry loopback callback URIs (http://localhost:<port>/...)
+// per RFC 8252, which trip EC2MetaDataSSRF_BODY (and, once that is downgraded,
+// GenericRFI_BODY as well). Elsewhere both rules stay at Block.
+const KEYCLOAK_DCR_PATH_PREFIX = '/realms/mcp-gateway/clients-registrations/';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -122,14 +138,58 @@ export class WafRules extends Construct {
  * Build the standard array of 4 WAF rules used by both MCP Gateway and Keycloak ACLs.
  */
 function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
+  // Reusable byte match: URI path starts with the Keycloak DCR endpoint.
+  const dcrPathMatch: wafv2.CfnWebACL.StatementProperty = {
+    byteMatchStatement: {
+      fieldToMatch: { uriPath: {} },
+      positionalConstraint: 'STARTS_WITH',
+      searchString: KEYCLOAK_DCR_PATH_PREFIX,
+      textTransformations: [{ priority: 0, type: 'NONE' }],
+    },
+  };
+
   return [
-    // Rule 1: AWS Managed Rules - Common Rule Set
-    // EC2MetaDataSSRF_BODY excluded: blocks legitimate OAuth DCR bodies that
-    // contain "localhost"/"127.0.0.1" as redirect_uri (false positive; the DCR
-    // is against Keycloak on a different host and cannot exfiltrate metadata).
+    // Rule 1: CommonRuleSet EVERYWHERE EXCEPT Keycloak DCR.
+    // Full managed group at Block. AWS requires ManagedRuleGroupStatement at
+    // the rule's top level (cannot nest under AndStatement/NotStatement), so
+    // the path exclusion goes via managedRuleGroupStatement.scopeDownStatement.
     {
-      name: 'AWSManagedRulesCommonRuleSet',
+      name: 'CommonRuleSet',
       priority: 1,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          name: 'AWSManagedRulesCommonRuleSet',
+          vendorName: 'AWS',
+          // Managed group only evaluates when scope-down matches.
+          // scope-down = NOT starts_with('/realms/*/clients-registrations/').
+          scopeDownStatement: {
+            notStatement: { statement: dcrPathMatch },
+          },
+        },
+      },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'CommonRuleSetMetric',
+        sampledRequestsEnabled: true,
+      },
+    },
+    // Rule 2: CommonRuleSet on Keycloak DCR endpoint ONLY, with count-mode
+    // overrides for the two sub-rules that false-positive on RFC 8252 loopback
+    // callback URIs. Every other CommonRuleSet sub-rule (LFI, XSS, SQLi, size,
+    // bad bots, etc.) still Blocks on this endpoint.
+    //
+    //   EC2MetaDataSSRF_BODY  — matches 'localhost' / '127.0.0.1' / '169.254.*'
+    //                           in the JSON body. DCR redirect_uris legitimately
+    //                           contain these per RFC 8252.
+    //   GenericRFI_BODY       — matches '127.0.0.1' / '169.254.*' in the body.
+    //                           Shadowed while _BODY was terminating; now that
+    //                           _BODY is Count on this path, GenericRFI_BODY
+    //                           becomes the next terminating match unless also
+    //                           downgraded.
+    {
+      name: 'CommonRuleSetForDcr',
+      priority: 2,
       overrideAction: { none: {} },
       statement: {
         managedRuleGroupStatement: {
@@ -137,22 +197,21 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
           vendorName: 'AWS',
           ruleActionOverrides: [
             { name: 'EC2MetaDataSSRF_BODY', actionToUse: { count: {} } },
-            { name: 'EC2MetaDataSSRF_COOKIE', actionToUse: { count: {} } },
-            { name: 'EC2MetaDataSSRF_URIPATH', actionToUse: { count: {} } },
-            { name: 'EC2MetaDataSSRF_QUERYARGUMENTS', actionToUse: { count: {} } },
+            { name: 'GenericRFI_BODY', actionToUse: { count: {} } },
           ],
+          scopeDownStatement: dcrPathMatch,
         },
       },
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
-        metricName: 'AWSManagedRulesCommonRuleSetMetric',
+        metricName: 'CommonRuleSetForDcrMetric',
         sampledRequestsEnabled: true,
       },
     },
-    // Rule 2: AWS Managed Rules - Known Bad Inputs
+    // Rule 3: AWS Managed Rules - Known Bad Inputs
     {
       name: 'AWSManagedRulesKnownBadInputsRuleSet',
-      priority: 2,
+      priority: 3,
       overrideAction: { none: {} },
       statement: {
         managedRuleGroupStatement: {
@@ -166,10 +225,10 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
         sampledRequestsEnabled: true,
       },
     },
-    // Rule 3: IP-based rate limiting (100 req / 5 min per IP)
+    // Rule 4: IP-based rate limiting (100 req / 5 min per IP)
     {
       name: 'IPRateLimitRule',
-      priority: 3,
+      priority: 4,
       action: { block: {} },
       statement: {
         rateBasedStatement: {
@@ -183,13 +242,13 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
         sampledRequestsEnabled: true,
       },
     },
-    // Rule 4: Global rate limiting (2000 req / 5 min total across all clients).
+    // Rule 5: Global rate limiting (2000 req / 5 min total across all clients).
     // WAF requires a scopeDownStatement when aggregateKeyType=CONSTANT. Match-all
     // achieved via byte_match on URI path containing "/" — every HTTP request
     // has a URI, so all traffic counts toward the global bucket.
     {
       name: 'GlobalRateLimitRule',
-      priority: 4,
+      priority: 5,
       action: { block: {} },
       statement: {
         rateBasedStatement: {
@@ -215,7 +274,7 @@ function _buildWafRules(): wafv2.CfnWebACL.RuleProperty[] {
 }
 
 /**
- * Create a WAFv2 Web ACL with the standard 4-rule set.
+ * Create a WAFv2 Web ACL with the standard 5-rule set (see file header).
  */
 function _createWebAcl(
   scope: Construct,

--- a/infra/lib/registry/registry-config.ts
+++ b/infra/lib/registry/registry-config.ts
@@ -397,7 +397,7 @@ export const DEFAULT_REGISTRY_CONFIG: RegistryConfig = {
   deploymentMode: 'with-gateway',
   registryMode: 'full',
   enableObservability: true,
-  enableWaf: false,
+  enableWaf: true,
   createCodebuild: false,
   idpGroupFilterPrefix: '',
   disableAiRegistryToolsServer: 'false',

--- a/infra/lib/registry/registry-service-stack.ts
+++ b/infra/lib/registry/registry-service-stack.ts
@@ -257,6 +257,12 @@ export class RegistryServiceStack extends cdk.Stack {
       MCP_TELEMETRY_HEARTBEAT_INTERVAL_MINUTES: config.telemetry.heartbeatIntervalMinutes,
       TELEMETRY_DEBUG: config.telemetry.debug,
       DISABLE_AI_REGISTRY_TOOLS_SERVER: config.disableAiRegistryToolsServer,
+      // PRM scopes_supported override. Live registry image advertises group-derived
+      // internal scope names (registry-admins, federation-service, etc.) that
+      // Keycloak DCR does not accept. Force the IdP-universal OIDC scopes so
+      // Claude/MCP client DCR succeeds. Access is still group-derived at token
+      // validation time, so this does not affect authorization.
+      MCP_ADVERTISED_SCOPES: 'openid email profile offline_access',
       SERVICE_CONNECT_NAMESPACE: `${namePrefix}.local`,
       GITHUB_PAT: config.github.pat,
       GITHUB_APP_ID: config.github.appId,
@@ -435,6 +441,7 @@ export class RegistryServiceStack extends cdk.Stack {
       serviceConnectPortName: 'mcpgw',
       environment: {
         PORT: '8003',
+        HOST: '0.0.0.0',
         REGISTRY_BASE_URL: 'http://registry:8080',
         REGISTRY_USERNAME: 'admin',
       },
@@ -456,6 +463,11 @@ export class RegistryServiceStack extends cdk.Stack {
           mcpgwService.securityGroup, ec2.Port.tcp(port), `Port ${port} from mcpgw`,
         );
       }
+      // Auth-server mcp-proxy forwards to mcpgw:8003 (parity with terraform
+      // auth_to_mcpgw rule at terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf:1965)
+      mcpgwService.securityGroup.addIngressRule(
+        authService.securityGroup, ec2.Port.tcp(8003), 'Allow auth-server mcp-proxy to reach mcpgw',
+      );
     }
 
     new McpServerService(this, 'RealServerFakeToolsSvc', {

--- a/keycloak/setup/init-keycloak.sh
+++ b/keycloak/setup/init-keycloak.sh
@@ -706,10 +706,12 @@ configure_dcr_allowed_scopes() {
         return 1
     fi
 
-    # Get the union of all realm client-scope NAMES
+    # Get the union of all realm client-scope NAMES, plus "openid" (which is
+    # the OIDC identifier scope Claude/MCP DCR clients always request but is
+    # not defined as a Keycloak client-scope; without it the policy 403s).
     local all_scope_names=$(curl -s -H "Authorization: Bearer ${token}" \
         "${KEYCLOAK_URL}/admin/realms/${REALM}/client-scopes" | \
-        jq -c '[.[].name]')
+        jq -c '[.[].name] + ["openid"] | unique')
 
     # Build the updated policy body. Keep `allow-default-scopes` true so the
     # built-in OIDC scopes still pass; explicitly include every realm scope

--- a/terraform/aws-ecs/waf.tf
+++ b/terraform/aws-ecs/waf.tf
@@ -2,6 +2,22 @@
 # WAFv2 Web ACL Configuration for MCP Gateway and Keycloak ALBs
 # Set enable_waf = false in terraform.tfvars if you don't have wafv2:* IAM permissions
 #
+# Both ACLs share the same 5-rule chain:
+#   1. AWSManagedRulesCommonRuleSet — full Block, everywhere EXCEPT the Keycloak
+#      anonymous DCR endpoint (scope-down excludes that path).
+#   2. AWSManagedRulesCommonRuleSet — DCR endpoint only, with count-mode
+#      overrides for EC2MetaDataSSRF_BODY and GenericRFI_BODY (both fire on
+#      loopback callback URIs per RFC 8252; documented false positives).
+#   3. AWSManagedRulesKnownBadInputsRuleSet — full Block.
+#   4. IP rate limit — 100 req/5min per IP.
+#   5. Global rate limit — 2000 req/5min total (scope-down = URI CONTAINS "/").
+
+locals {
+  # Keycloak anonymous Dynamic Client Registration endpoint. Requests here
+  # legitimately carry http://localhost:<port>/ callback URIs (RFC 8252).
+  keycloak_dcr_path_prefix = "/realms/mcp-gateway/clients-registrations/"
+}
+
 
 # WAFv2 Web ACL for MCP Gateway ALB
 resource "aws_wafv2_web_acl" "mcp_gateway" {
@@ -14,9 +30,12 @@ resource "aws_wafv2_web_acl" "mcp_gateway" {
     allow {}
   }
 
-  # AWS Managed Rules - Common Rule Set
+  # Rule 1: CommonRuleSet EVERYWHERE EXCEPT Keycloak DCR path.
+  # AWS requires managed_rule_group_statement at the rule's top level (cannot
+  # be nested under and_statement/not_statement). Path exclusion goes via the
+  # managed group's own scope_down_statement.
   rule {
-    name     = "AWSManagedRulesCommonRuleSet"
+    name     = "CommonRuleSet"
     priority = 1
 
     override_action {
@@ -27,20 +46,93 @@ resource "aws_wafv2_web_acl" "mcp_gateway" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                search_string         = local.keycloak_dcr_path_prefix
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
       }
     }
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "AWSManagedRulesCommonRuleSetMetric"
+      metric_name                = "CommonRuleSetMetric"
       sampled_requests_enabled   = true
     }
   }
 
-  # AWS Managed Rules - Known Bad Inputs
+  # Rule 2: CommonRuleSet on Keycloak DCR endpoint ONLY, with count-mode
+  # overrides for the sub-rules that false-positive on RFC 8252 loopback URIs.
+  rule {
+    name     = "CommonRuleSetForDcr"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        # 'localhost' / '127.0.0.1' / '169.254.*' in the body — legit for
+        # native-client DCR redirect_uris.
+        rule_action_override {
+          name = "EC2MetaDataSSRF_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        # Shadowed by _BODY until _BODY was downgraded; now it becomes the
+        # next terminating match on the same body content.
+        rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            search_string         = local.keycloak_dcr_path_prefix
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetForDcrMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rule 3: AWS Managed Rules - Known Bad Inputs
   rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 2
+    priority = 3
 
     override_action {
       none {}
@@ -60,10 +152,10 @@ resource "aws_wafv2_web_acl" "mcp_gateway" {
     }
   }
 
-  # IP-based rate limiting rule (100 req/5min per IP)
+  # Rule 4: IP-based rate limiting (100 req/5min per IP)
   rule {
     name     = "IPRateLimitRule"
-    priority = 3
+    priority = 4
 
     action {
       block {}
@@ -83,10 +175,13 @@ resource "aws_wafv2_web_acl" "mcp_gateway" {
     }
   }
 
-  # Global rate limiting rule (2000 req/5min globally)
+  # Rule 5: Global rate limiting (2000 req/5min globally).
+  # WAF requires a scope_down_statement when aggregate_key_type=CONSTANT. Match-all
+  # achieved via byte_match on URI path containing "/" — every HTTP request has a
+  # URI, so all traffic counts toward the global bucket.
   rule {
     name     = "GlobalRateLimitRule"
-    priority = 4
+    priority = 5
 
     action {
       block {}
@@ -96,6 +191,20 @@ resource "aws_wafv2_web_acl" "mcp_gateway" {
       rate_based_statement {
         limit              = 2000
         aggregate_key_type = "CONSTANT"
+
+        scope_down_statement {
+          byte_match_statement {
+            field_to_match {
+              uri_path {}
+            }
+            positional_constraint = "CONTAINS"
+            search_string         = "/"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
       }
     }
 
@@ -175,9 +284,12 @@ resource "aws_wafv2_web_acl" "keycloak" {
     allow {}
   }
 
-  # AWS Managed Rules - Common Rule Set
+  # Rule 1: CommonRuleSet EVERYWHERE EXCEPT Keycloak DCR path.
+  # AWS requires managed_rule_group_statement at the rule's top level (cannot
+  # be nested under and_statement/not_statement). Path exclusion goes via the
+  # managed group's own scope_down_statement.
   rule {
-    name     = "AWSManagedRulesCommonRuleSet"
+    name     = "CommonRuleSet"
     priority = 1
 
     override_action {
@@ -188,20 +300,89 @@ resource "aws_wafv2_web_acl" "keycloak" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        scope_down_statement {
+          not_statement {
+            statement {
+              byte_match_statement {
+                positional_constraint = "STARTS_WITH"
+                search_string         = local.keycloak_dcr_path_prefix
+                field_to_match {
+                  uri_path {}
+                }
+                text_transformation {
+                  priority = 0
+                  type     = "NONE"
+                }
+              }
+            }
+          }
+        }
       }
     }
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "AWSManagedRulesCommonRuleSetMetric"
+      metric_name                = "CommonRuleSetMetric"
       sampled_requests_enabled   = true
     }
   }
 
-  # AWS Managed Rules - Known Bad Inputs
+  # Rule 2: CommonRuleSet on Keycloak DCR endpoint ONLY, with count-mode
+  # overrides for the sub-rules that false-positive on RFC 8252 loopback URIs.
+  rule {
+    name     = "CommonRuleSetForDcr"
+    priority = 2
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          name = "EC2MetaDataSSRF_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+        rule_action_override {
+          name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
+        }
+
+        scope_down_statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            search_string         = local.keycloak_dcr_path_prefix
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CommonRuleSetForDcrMetric"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Rule 3: AWS Managed Rules - Known Bad Inputs
   rule {
     name     = "AWSManagedRulesKnownBadInputsRuleSet"
-    priority = 2
+    priority = 3
 
     override_action {
       none {}
@@ -221,10 +402,10 @@ resource "aws_wafv2_web_acl" "keycloak" {
     }
   }
 
-  # IP-based rate limiting rule (100 req/5min per IP)
+  # Rule 4: IP-based rate limiting (100 req/5min per IP)
   rule {
     name     = "IPRateLimitRule"
-    priority = 3
+    priority = 4
 
     action {
       block {}
@@ -244,10 +425,13 @@ resource "aws_wafv2_web_acl" "keycloak" {
     }
   }
 
-  # Global rate limiting rule (2000 req/5min globally)
+  # Rule 5: Global rate limiting (2000 req/5min globally).
+  # WAF requires a scope_down_statement when aggregate_key_type=CONSTANT. Match-all
+  # achieved via byte_match on URI path containing "/" — every HTTP request has a
+  # URI, so all traffic counts toward the global bucket.
   rule {
     name     = "GlobalRateLimitRule"
-    priority = 4
+    priority = 5
 
     action {
       block {}
@@ -257,6 +441,20 @@ resource "aws_wafv2_web_acl" "keycloak" {
       rate_based_statement {
         limit              = 2000
         aggregate_key_type = "CONSTANT"
+
+        scope_down_statement {
+          byte_match_statement {
+            field_to_match {
+              uri_path {}
+            }
+            positional_constraint = "CONTAINS"
+            search_string         = "/"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
       }
     }
 
@@ -266,6 +464,7 @@ resource "aws_wafv2_web_acl" "keycloak" {
       sampled_requests_enabled   = true
     }
   }
+
 
   visibility_config {
     cloudwatch_metrics_enabled = true


### PR DESCRIPTION
## Summary

Wire the mcpgw ECS service in Registry-Service (image URI, `HOST=0.0.0.0`, and auth-server → mcpgw:8003 SG rule) so the built-in airegistry-tools MCP server is reachable end-to-end. Fix WAF WebACL creation by using `CfnLoggingConfiguration.singleHeader.Name` (capital N) and by giving Rule 4 a match-all `scopeDownStatement`, and downgrade the managed `EC2MetaDataSSRF_*` sub-rules to count-only so OAuth DCR bodies with `localhost` redirect URIs are not blocked. Flip `enableWaf` to true in config and defaults, set `MCP_ADVERTISED_SCOPES` on the registry env so DCR only asks for scopes the anonymous policy accepts, and append `openid` to the DCR `Allowed Client Scopes` allowlist in `init-keycloak.sh` so the policy accepts the OIDC identifier scope every DCR client includes.

## Files changed

- `infra/config.yaml` — `enableWaf: true`, `images.mcpgw` populated
- `infra/lib/registry/registry-config.ts` — `enableWaf` default `true`
- `infra/lib/registry/registry-service-stack.ts` — `HOST=0.0.0.0` and `MCP_ADVERTISED_SCOPES` env; auth→mcpgw:8003 SG ingress
- `infra/lib/registry/constructs/waf-rules.ts` — `Name` casing on singleHeader; Rule 4 scopeDownStatement; EC2MetaDataSSRF_* count-only overrides
- `keycloak/setup/init-keycloak.sh` — append `openid` to DCR Allowed Client Scopes

## Verification on beta

### End-to-end via curl (bash)

```bash
# 1. Hydrate the registry token by password-grant against the mcp-gateway-web client
export CDK_KEYCLOAK_ADMIN_PASSWORD=$(aws secretsmanager get-secret-value   --region us-east-1 --secret-id AppSecretsKeycloakAdminPass-vxwFrFyuEkSE   --query SecretString --output text)

KEYCLOAK_URL="https://d3oekhpchzd13n.cloudfront.net"

ADMIN_TOKEN=$(curl -s -X POST "$KEYCLOAK_URL/realms/master/protocol/openid-connect/token"   -H "Content-Type: application/x-www-form-urlencoded"   -d "username=admin&password=$CDK_KEYCLOAK_ADMIN_PASSWORD&grant_type=password&client_id=admin-cli"   | jq -r .access_token)

WEB_UUID=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN"   "$KEYCLOAK_URL/admin/realms/mcp-gateway/clients?clientId=mcp-gateway-web" | jq -r '.[0].id')

WEB_SECRET=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN"   "$KEYCLOAK_URL/admin/realms/mcp-gateway/clients/$WEB_UUID/client-secret" | jq -r .value)

export CATALYST_REGISTRY_TOKEN=$(curl -s -X POST   "$KEYCLOAK_URL/realms/mcp-gateway/protocol/openid-connect/token"   -H "Content-Type: application/x-www-form-urlencoded"   -d "username=admin&password=$CDK_KEYCLOAK_ADMIN_PASSWORD&grant_type=password&client_id=mcp-gateway-web&client_secret=$WEB_SECRET"   | jq -r .access_token)

# 2. Register a new agent via catalyst
export CATALYST_REGISTRY_URL="https://d2iekp3sw064ee.cloudfront.net"
cd /path/to/catalyst-toolbox/agentcore-catalyst
uv run catalyst register examples/agent-definition.yaml   --target mcp-gateway --visibility org
# → Registered: customer-support-agent v1.0.0

# 3. Confirm the agent is listed in the registry
curl -s "$CATALYST_REGISTRY_URL/api/agents"   -H "Authorization: Bearer $CATALYST_REGISTRY_TOKEN"   | jq '.agents[] | {name, visibility}'
# → {"name":"customer-support-agent","visibility":"public"}

# 4. Full MCP round-trip against the built-in airegistry-tools server.
# Token below is the airegistry-tools static token (X-Authorization header),
# NOT the CATALYST_REGISTRY_TOKEN — that one is the Keycloak user JWT for
# the /api/* control plane. This one is minted from the registry UI:
# "Generate token for MCP configuration → AI Registry tools".

curl -s -X POST "$CATALYST_REGISTRY_URL/airegistry-tools/mcp"   -H "Content-Type: application/json"   -H "Accept: application/json, text/event-stream"   -H "X-Authorization: Bearer <airegistry-tools-mcp-token>"   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl-client","version":"1.0.0"}}}'
# → serverInfo {"name":"AI Registry","version":"3.4.2"}

curl -s -X POST "$CATALYST_REGISTRY_URL/airegistry-tools/mcp"   -H "Content-Type: application/json"   -H "Accept: application/json, text/event-stream"   -H "X-Authorization: Bearer <airegistry-tools-mcp-token>"   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
# → 7 tools: list_services, list_agents, list_skills, get_skill_content,
#            search_registry, intelligent_tool_finder, healthcheck
```

### Claude Code

`~/.claude.json` (or `claude mcp add --transport http`):

```json
{
  "mcpServers": {
    "ai-registry-tools": {
      "type": "http",
      "url": "https://<registry-host>/airegistry-tools/mcp",
      "headers": {
        "X-Authorization": "Bearer <airegistry-tools-mcp-token>"
      }
    }
  }
}
```

Then `/mcp` inside Claude Code → completes OAuth DCR against Keycloak, negotiates protocol, and registers the 7 airegistry-tools MCP tools (`mcp__ai-registry-tools__list_agents`, `..._list_services`, etc.). Calling `list_agents` returns the newly registered `customer-support-agent`.

## Test plan

- [x] `cdk synth Registry-Auth Registry-Service` clean
- [x] `cdk deploy` succeeds (no CFN validation error on WAF resources)
- [x] mcpgw ECS service reaches `runningCount=1` / `healthStatus=HEALTHY`
- [x] Registry health check flips airegistry-tools to `healthy`
- [x] curl MCP `initialize` returns 200 + serverInfo
- [x] curl MCP `tools/list` returns the 7 registry tools
- [x] curl MCP `tools/call list_services` returns real registry data
- [x] Claude Code `/mcp` completes DCR + connects
- [x] catalyst CLI publishes `customer-support-agent` and it appears in `GET /api/agents`