### PR TITLE
fix(readme): replace PAT-gated star-history chart with shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,15 +183,11 @@ The registry collects **anonymous, non-sensitive** usage telemetry (version, OS,
 
 ### Star History
 
-<a href="https://star-history.com/#agentic-community/mcp-gateway-registry&Date" title="View the interactive star history on star-history.com">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=agentic-community/mcp-gateway-registry&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=agentic-community/mcp-gateway-registry&type=Date" />
-    <img alt="Star History Chart for agentic-community/mcp-gateway-registry (click to view)" src="https://api.star-history.com/svg?repos=agentic-community/mcp-gateway-registry&type=Date" width="720" />
-  </picture>
-</a>
+[![Stars](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/stargazers)
+[![Forks](https://img.shields.io/github/forks/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/network/members)
+[![Contributors](https://img.shields.io/github/contributors/agentic-community/mcp-gateway-registry?style=flat&logo=github)](https://github.com/agentic-community/mcp-gateway-registry/graphs/contributors)
 
-If the chart above does not render (star-history.com occasionally rate-limits or times out), view it directly at [star-history.com](https://star-history.com/#agentic-community/mcp-gateway-registry&Date).
+View the full interactive star-growth chart at [star-history.com](https://star-history.com/#agentic-community/mcp-gateway-registry&Date).
 
 ## License
 


### PR DESCRIPTION
The star-history.com embedded SVG now requires a GitHub PAT, so the anonymous embed renders broken. Replace it with a live Stars/Forks/ Contributors badge row (shields.io, anonymous) plus a link to the full interactive chart for anyone who wants the richer view.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
