### PR TITLE
Redact URLs

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1511,45 +1511,49 @@ async def validate_server_tool_access(
         True if access is allowed, False otherwise
     """
     try:
-        # Verbose logging: Print input parameters
-        logger.info("=== VALIDATE_SERVER_TOOL_ACCESS START ===")
-        logger.info(f"Requested server: '{server_name}'")
-        logger.info(f"Requested method: '{method}'")
-        logger.info(f"Requested tool: '{tool_name}'")
-        logger.info(f"User scopes: {user_scopes}")
+        # Verbose per-request trace. Kept at DEBUG (never INFO): this runs on the
+        # hot /validate path for every MCP proxy request, and user_scopes /
+        # scope_config carry the full authorization policy. The single audit
+        # record is the one INFO "Access granted/denied" line emitted at each
+        # return point below.
+        logger.debug("=== VALIDATE_SERVER_TOOL_ACCESS START ===")
+        logger.debug(f"Requested server: '{server_name}'")
+        logger.debug(f"Requested method: '{method}'")
+        logger.debug(f"Requested tool: '{tool_name}'")
+        logger.debug(f"User scopes: {user_scopes}")
 
         # Query DocumentDB directly for server access rules
         scope_repo = get_scope_repository()
 
         # Check each user scope to see if it grants access
         for scope in user_scopes:
-            logger.info(f"--- Checking scope: '{scope}' ---")
+            logger.debug(f"--- Checking scope: '{scope}' ---")
 
             # Query DocumentDB for this scope's server access rules
             scope_config = await scope_repo.get_server_scopes(scope)
 
             if not scope_config:
-                logger.info(f"Scope '{scope}' not found in DocumentDB")
+                logger.debug(f"Scope '{scope}' not found in DocumentDB")
                 continue
 
-            logger.info(f"Scope '{scope}' config: {scope_config}")
+            logger.debug(f"Scope '{scope}' config: {scope_config}")
 
             # The scope_config is directly a list of server configurations
             # since the permission type is already encoded in the scope name
             for server_config in scope_config:
-                logger.info(f"  Examining server config: {server_config}")
+                logger.debug(f"  Examining server config: {server_config}")
                 server_config_name = server_config.get("server")
-                logger.info(
+                logger.debug(
                     f"  Server name in config: '{server_config_name}' vs requested: '{server_name}'"
                 )
 
                 if _server_names_match(server_config_name, server_name):
-                    logger.info("  ✓ Server name matches!")
+                    logger.debug("  Server name matches")
 
                     # Check methods first
                     allowed_methods = server_config.get("methods", [])
-                    logger.info(f"  Allowed methods for server '{server_name}': {allowed_methods}")
-                    logger.info(f"  Checking if method '{method}' is in allowed methods...")
+                    logger.debug(f"  Allowed methods for server '{server_name}': {allowed_methods}")
+                    logger.debug(f"  Checking if method '{method}' is in allowed methods...")
 
                     # Check if all methods are allowed (wildcard support)
                     has_wildcard_methods = "all" in allowed_methods or "*" in allowed_methods
@@ -1560,58 +1564,60 @@ async def validate_server_tool_access(
                     if (
                         method in allowed_methods or has_wildcard_methods
                     ) and method != "tools/call":
-                        logger.info(f"  ✓ Method '{method}' found in allowed methods!")
+                        logger.debug(f"  Method '{method}' found in allowed methods")
+                        logger.debug(f"scope '{scope}' allows access to {server_name}.{method}")
                         logger.info(
-                            f"Access granted: scope '{scope}' allows access to {server_name}.{method}"
+                            f"Access granted: server='{server_name}' method='{method}' "
+                            f"tool='{tool_name}'"
                         )
-                        logger.info("=== VALIDATE_SERVER_TOOL_ACCESS END: GRANTED ===")
                         return True
 
                     # Check tools if method not found in methods
                     allowed_tools = server_config.get("tools", [])
-                    logger.info(f"  Allowed tools for server '{server_name}': {allowed_tools}")
+                    logger.debug(f"  Allowed tools for server '{server_name}': {allowed_tools}")
 
                     # Check if all tools are allowed (wildcard support)
                     has_wildcard_tools = "all" in allowed_tools or "*" in allowed_tools
 
                     # For tools/call, check if the specific tool is allowed
                     if method == "tools/call" and tool_name:
-                        logger.info(
+                        logger.debug(
                             f"  Checking if tool '{tool_name}' is in allowed tools for tools/call..."
                         )
                         if tool_name in allowed_tools or has_wildcard_tools:
-                            logger.info(f"  ✓ Tool '{tool_name}' found in allowed tools!")
-                            logger.info(
-                                f"Access granted: scope '{scope}' allows access to {server_name}.{method} for tool {tool_name}"
+                            logger.debug(f"  Tool '{tool_name}' found in allowed tools")
+                            logger.debug(
+                                f"scope '{scope}' allows access to {server_name}.{method} for tool {tool_name}"
                             )
-                            logger.info("=== VALIDATE_SERVER_TOOL_ACCESS END: GRANTED ===")
+                            logger.info(
+                                f"Access granted: server='{server_name}' method='{method}' "
+                                f"tool='{tool_name}'"
+                            )
                             return True
                         else:
-                            logger.info(f"  ✗ Tool '{tool_name}' NOT found in allowed tools")
+                            logger.debug(f"  Tool '{tool_name}' NOT found in allowed tools")
                     else:
                         # For other methods, check if method is in tools list (backward compatibility)
-                        logger.info(f"  Checking if method '{method}' is in allowed tools...")
+                        logger.debug(f"  Checking if method '{method}' is in allowed tools...")
                         if method in allowed_tools or has_wildcard_tools:
-                            logger.info(f"  ✓ Method '{method}' found in allowed tools!")
+                            logger.debug(f"  Method '{method}' found in allowed tools")
+                            logger.debug(f"scope '{scope}' allows access to {server_name}.{method}")
                             logger.info(
-                                f"Access granted: scope '{scope}' allows access to {server_name}.{method}"
+                                f"Access granted: server='{server_name}' method='{method}' "
+                                f"tool='{tool_name}'"
                             )
-                            logger.info("=== VALIDATE_SERVER_TOOL_ACCESS END: GRANTED ===")
                             return True
                         else:
-                            logger.info(f"  ✗ Method '{method}' NOT found in allowed tools")
+                            logger.debug(f"  Method '{method}' NOT found in allowed tools")
                 else:
-                    logger.info("  ✗ Server name does not match")
+                    logger.debug("  Server name does not match")
 
-        logger.warning(
-            f"Access denied: no scope allows access to {server_name}.{method} (tool: {tool_name}) for user scopes: {user_scopes}"
-        )
-        logger.info("=== VALIDATE_SERVER_TOOL_ACCESS END: DENIED ===")
+        logger.info(f"Access denied: server='{server_name}' method='{method}' tool='{tool_name}'")
         return False
 
     except Exception as e:
         logger.error(f"Error validating server/tool access: {e}")
-        logger.info("=== VALIDATE_SERVER_TOOL_ACCESS END: ERROR ===")
+        logger.info(f"Access denied: server='{server_name}' method='{method}' tool='{tool_name}'")
         return False  # Deny access on error
 
 
@@ -2435,7 +2441,9 @@ async def validate_a2a_agent_access(
     try:
         scope_rules = await scope_repo.get_server_scopes_bulk(user_scopes)
     except Exception as exc:
-        logger.warning(f"A2A access: failed to resolve scopes {user_scopes}: {exc}")
+        # Log the scope COUNT, not the scope list: the user's scopes are the
+        # caller's full authorization policy and must not land in logs.
+        logger.warning(f"A2A access: failed to resolve {len(user_scopes)} scope(s): {exc}")
         return False
 
     for scope_config in scope_rules.values():

--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -86,7 +86,24 @@ sanitizer that isn't called) is equivalent to no check.
   the standard `error` code + status. (c) **IdP group-name lists** — group names
   are organizational PII (org units, teams, cost centers); log the count, not the
   names. A "masked" token prefix is still a leak — a base64 JWT header/signature
-  fragment is reconstructable; log `<token len=N>`, not `token[:10]`.
+  fragment is reconstructable; log `<token len=N>`, not `token[:10]`. (d) **A
+  registrant/backend URL** (`proxy_pass_url`, an MCP/SSE endpoint, an agent
+  `base_url`, an inbound `request.url`) can carry credentials in userinfo
+  (`user:pass@host`) or a secret in the query (`?access_token=...`); route every
+  such URL through `registry/common/log_redaction.py` `redact_url` (keeps
+  `scheme://host[:port]/path`, drops userinfo/query/fragment, fails closed) at
+  EVERY log site, not just the reported one. (e) **The caller's own authorization
+  policy** (`user_scopes`, `scope_config`, `accessible_services`, `ui_permissions`)
+  is sensitive and must never sit at INFO — especially on a hot per-request path
+  (the `/validate` subrequest, list-servers): keep the verbose policy trace at
+  DEBUG and emit exactly ONE INFO allow/deny audit line carrying only
+  server/method/tool identifiers, at every return including the fail-closed
+  exception branch. Watch for developer traces mislabeled by LEVEL, not just by
+  content — a `logger.info(f"DEBUG: ...")` or `[TRACE]` line is still emitted at
+  INFO in production; the `# TODO: replace with debug` marker means it was never
+  meant to ship at that level. After fixing the reported site, grep the whole
+  package for the same variable/pattern — these leaks travel in packs across
+  health-check, connection, and registration code paths.
 - **Never reflect an exception/stack trace into a response the caller sees**
   (CWE-209, CodeQL `py/stack-trace-exposure`). `HTTPException(detail=str(e))`,
   `return {"error": str(e)}` from a route, and `HTMLResponse(f"...{exc}...")` all
@@ -612,7 +629,8 @@ the drift between copies is the hole.
   var, never `verify=False`. `guarded_client`/`guarded_async_client` take
   `verify=` and default it to `True`.
 - **Log redaction → `registry/common/log_redaction.py`** (`redact_headers`,
-  `redact_mapping`) and, for OIDC identity, `safe_identity_summary()` in
+  `redact_mapping`, `redact_url` for a single URL string) and, for OIDC identity,
+  `safe_identity_summary()` in
   `auth_server/server.py`. NEVER log a raw header dict, a request/response body
   dict, a `user_context`, `updates`, or decoded id_token claims — route it
   through the redactor (masks any `*token*`/`*secret*`/`*credential*`/auth/cookie

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, ValidationError
 from ..audit import set_audit_action
 from ..auth.csrf import verify_csrf_token_flexible
 from ..auth.dependencies import nginx_proxied_auth
-from ..common.log_redaction import redact_headers, redact_mapping
+from ..common.log_redaction import redact_headers, redact_mapping, redact_url
 from ..core.config import settings
 from ..exceptions import UrlValidationError
 from ..repositories.factory import get_search_repository
@@ -282,24 +282,30 @@ async def _probe_agent_backend_health(
             if response.status_code == 200:
                 status_label = "healthy"
                 detail = None
-                logger.info(f"Agent health check for {path} succeeded via GET on {url}")
+                logger.info(f"Agent health check for {path} succeeded via GET on {redact_url(url)}")
                 break
             detail = f"Agent responded with HTTP {response.status_code}"
-            logger.debug(f"Agent health check for {path} got HTTP {response.status_code} on {url}")
+            logger.debug(
+                f"Agent health check for {path} got HTTP {response.status_code} on {redact_url(url)}"
+            )
         except httpx.TimeoutException:
             detail = f"Health check timed out on {url}"
-            logger.debug(f"Agent health check for {path} timed out on {url}")
+            logger.debug(f"Agent health check for {path} timed out on {redact_url(url)}")
         except httpx.HTTPError as exc:
             detail = f"Health check failed on {url}"
-            logger.debug(f"Agent health check for {path} failed on {url}: {exc}")
+            logger.debug(f"Agent health check for {path} failed on {redact_url(url)}: {exc}")
         except Exception as exc:
             detail = f"Unexpected health check error on {url}"
-            logger.debug(f"Agent health check for {path} unexpected error on {url}: {exc}")
+            logger.debug(
+                f"Agent health check for {path} unexpected error on {redact_url(url)}: {exc}"
+            )
 
     # Fallback: if GET-based checks failed, try HEAD on the base URL. A
     # non-connection-error response (even 401/403) means the server is reachable.
     if status_label == "unhealthy":
-        logger.info(f"Agent {path} GET checks failed, falling back to HEAD ping on {base_url}")
+        logger.info(
+            f"Agent {path} GET checks failed, falling back to HEAD ping on {redact_url(base_url)}"
+        )
         try:
             start_time = datetime.now(UTC)
             async with guarded_async_client(
@@ -316,11 +322,13 @@ async def _probe_agent_backend_health(
                 f"(HTTP {response.status_code})"
             )
         except httpx.TimeoutException:
-            logger.debug(f"Agent {path} HEAD ping timed out on {base_url}")
+            logger.debug(f"Agent {path} HEAD ping timed out on {redact_url(base_url)}")
         except httpx.HTTPError as exc:
-            logger.debug(f"Agent {path} HEAD ping failed on {base_url}: {exc}")
+            logger.debug(f"Agent {path} HEAD ping failed on {redact_url(base_url)}: {exc}")
         except Exception as exc:
-            logger.debug(f"Agent {path} HEAD ping unexpected error on {base_url}: {exc}")
+            logger.debug(
+                f"Agent {path} HEAD ping unexpected error on {redact_url(base_url)}: {exc}"
+            )
 
     last_checked = datetime.now(UTC)
     return {
@@ -986,7 +994,7 @@ async def register_agent(
         )
 
     logger.info(f"Agent registration request from user '{user_context['username']}'")
-    logger.info(f"Name: {request.name}, Path: {request.path}, URL: {request.url}")
+    logger.info(f"Name: {request.name}, Path: {request.path}, URL: {redact_url(request.url)}")
 
     path = _normalize_path(request.path, request.name)
 

--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -31,7 +31,7 @@ from ..auth.csrf import (
 from ..auth.dependencies import enhanced_auth, nginx_proxied_auth
 from ..auth.internal import validate_internal_auth
 from ..auth.tool_filter import filter_tools_for_user
-from ..common.log_redaction import redact_mapping
+from ..common.log_redaction import redact_mapping, redact_url
 from ..constants import VALID_AUTH_SCHEMES, DeploymentType, HealthStatus
 from ..core.config import DeploymentMode, settings
 from ..core.schemas import AuthCredentialUpdateRequest
@@ -624,13 +624,14 @@ async def read_root(
     accessible_services = user_context.get("accessible_services", [])
     # Normalize accessible_services by stripping slashes for comparison
     normalized_accessible_services = [s.strip("/") for s in accessible_services]
-    logger.info(
-        f"DEBUG: User {user_context['username']} accessible_services: {accessible_services}"
+    # Per-user authorization policy (accessible services, UI permissions, scopes)
+    # is a verbose trace, kept at DEBUG: this runs on the list-servers path and
+    # dumps the caller's full authz policy, which must not land in logs at INFO.
+    logger.debug(f"User {user_context['username']} accessible_services: {accessible_services}")
+    logger.debug(
+        f"User {user_context['username']} ui_permissions: {user_context.get('ui_permissions', {})}"
     )
-    logger.info(
-        f"DEBUG: User {user_context['username']} ui_permissions: {user_context.get('ui_permissions', {})}"
-    )
-    logger.info(f"DEBUG: User {user_context['username']} scopes: {user_context.get('scopes', [])}")
+    logger.debug(f"User {user_context['username']} scopes: {user_context.get('scopes', [])}")
 
     for path in sorted_server_paths:
         server_info = all_servers[path]
@@ -1682,26 +1683,25 @@ async def internal_register_service(
     allowed_groups: Annotated[str | None, Form()] = None,
 ):
     """Internal service registration endpoint for mcpgw-server (requires admin authentication)."""
-    logger.warning(
-        "INTERNAL REGISTER: Function called - starting execution"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Function called - starting execution")
 
     from ..health.service import health_service
 
-    logger.warning(
-        f"INTERNAL REGISTER: Request parameters - name={name}, path={path}, proxy_pass_url={proxy_pass_url}"
-    )  # TODO: replace with debug
+    logger.debug(
+        f"INTERNAL REGISTER: Request parameters - name={name}, path={path}, "
+        f"proxy_pass_url={redact_url(proxy_pass_url)}"
+    )
 
     logger.info(f"Internal service registration request from caller '{caller}'")
 
     # Validate path format
     if not path.startswith("/"):
         path = "/" + path
-    logger.warning(f"INTERNAL REGISTER: Validated path: {path}")  # TODO: replace with debug
+    logger.debug(f"INTERNAL REGISTER: Validated path: {path}")
 
     # Process tags
     tag_list = [tag.strip() for tag in tags.split(",") if tag.strip()] if tags else []
-    logger.warning(f"INTERNAL REGISTER: Processed tags: {tag_list}")  # TODO: replace with debug
+    logger.debug(f"INTERNAL REGISTER: Processed tags: {tag_list}")
 
     # Process supported_transports
     if supported_transports:
@@ -1845,19 +1845,13 @@ async def internal_register_service(
                 content={"error": "Failed to encrypt custom headers"},
             )
 
-    logger.warning(
-        f"INTERNAL REGISTER: Created server entry for path: {path}"
-    )  # TODO: replace with debug
-    logger.warning(
-        f"INTERNAL REGISTER: Overwrite parameter: {overwrite}"
-    )  # TODO: replace with debug
+    logger.debug(f"INTERNAL REGISTER: Created server entry for path: {path}")
+    logger.debug(f"INTERNAL REGISTER: Overwrite parameter: {overwrite}")
 
     # Check if server exists and handle overwrite logic
     existing_server = await server_service.get_server_info(path)
     if existing_server and not overwrite:
-        logger.warning(
-            f"INTERNAL REGISTER: Server exists and overwrite=False for path {path}"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL REGISTER: Server exists and overwrite=False for path {path}")
         return JSONResponse(
             status_code=409,  # Conflict status code for existing resource
             content={
@@ -1868,13 +1862,9 @@ async def internal_register_service(
         )
 
     # Register the server (this will overwrite if server exists and overwrite=True)
-    logger.warning(
-        "INTERNAL REGISTER: Calling server_service.register_server"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Calling server_service.register_server")
     if existing_server and overwrite:
-        logger.warning(
-            f"INTERNAL REGISTER: Overwriting existing server at path {path}"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL REGISTER: Overwriting existing server at path {path}")
         success = await server_service.update_server(path, server_entry)
         is_new_version = False
     else:
@@ -1895,9 +1885,7 @@ async def internal_register_service(
             },
         )
 
-    logger.warning(
-        "INTERNAL REGISTER: Auto-enabling newly registered server"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Auto-enabling newly registered server")
 
     # Automatically enable the newly registered server before search indexing
     try:
@@ -1910,9 +1898,7 @@ async def internal_register_service(
         logger.error(f"Error auto-enabling server {path}: {e}")
         # Non-fatal error - server is registered but not enabled
 
-    logger.warning(
-        "INTERNAL REGISTER: Server registered successfully, updating search index"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Server registered successfully, updating search index")
 
     # Index in DocumentDB search with current enabled state (should be True after auto-enable)
     is_enabled = await server_service.is_service_enabled(path)
@@ -1929,14 +1915,12 @@ async def internal_register_service(
 
     nginx_reload_scheduler.mark_dirty()
 
-    logger.warning(
-        "INTERNAL REGISTER: Broadcasting health status update"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Broadcasting health status update")
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(path)
 
-    logger.warning("INTERNAL REGISTER: Updating scopes for new server")  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Updating scopes for new server")
 
     # Update scopes with the new server's tools
     from ..services.scope_service import update_server_scopes
@@ -1962,9 +1946,7 @@ async def internal_register_service(
         _perform_security_scan_on_registration(path, proxy_pass_url, server_entry, headers_list)
     )
 
-    logger.warning(
-        "INTERNAL REGISTER: Registration complete, returning success response"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REGISTER: Registration complete, returning success response")
     logger.info(
         f"New service registered via internal endpoint: '{name}' at path '{path}' by caller '{caller}'"
     )
@@ -2051,9 +2033,7 @@ async def internal_remove_service(
     """Internal service removal endpoint for mcpgw-server (requires admin authentication)."""
     from ..health.service import health_service
 
-    logger.warning(
-        "INTERNAL REMOVE: Function called - starting execution"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Function called - starting execution")
 
     logger.info(
         f"Internal service removal request from caller '{caller}' for service '{service_path}'"
@@ -2063,16 +2043,12 @@ async def internal_remove_service(
     if not service_path.startswith("/"):
         service_path = "/" + service_path
 
-    logger.warning(
-        f"INTERNAL REMOVE: Normalized service path: {service_path}"
-    )  # TODO: replace with debug
+    logger.debug(f"INTERNAL REMOVE: Normalized service path: {service_path}")
 
     # Check if server exists
     server_info = await server_service.get_server_info(service_path)
     if not server_info:
-        logger.warning(
-            f"INTERNAL REMOVE: Service not found at path '{service_path}'"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL REMOVE: Service not found at path '{service_path}'")
         return JSONResponse(
             status_code=404,
             content={
@@ -2082,17 +2058,13 @@ async def internal_remove_service(
             },
         )
 
-    logger.warning(
-        "INTERNAL REMOVE: Service found, proceeding with removal"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Service found, proceeding with removal")
 
     # Remove the server
     success = await server_service.remove_server(service_path)
 
     if not success:
-        logger.warning(
-            f"INTERNAL REMOVE: Failed to remove service at path '{service_path}'"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL REMOVE: Failed to remove service at path '{service_path}'")
         return JSONResponse(
             status_code=500,
             content={
@@ -2102,9 +2074,7 @@ async def internal_remove_service(
             },
         )
 
-    logger.warning(
-        "INTERNAL REMOVE: Service removed successfully, updating search index"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Service removed successfully, updating search index")
 
     # Remove from DocumentDB search index
     try:
@@ -2115,7 +2085,7 @@ async def internal_remove_service(
     except Exception as e:
         logger.warning(f"Failed to remove search index for {service_path}: {e}")
 
-    logger.warning("INTERNAL REMOVE: Regenerating Nginx configuration")  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Regenerating Nginx configuration")
 
     # Flush nginx config immediately (delete must take effect before response)
     from ..core.nginx_service import nginx_reload_scheduler
@@ -2123,12 +2093,12 @@ async def internal_remove_service(
     nginx_reload_scheduler.mark_dirty()
     await nginx_reload_scheduler.flush_now()
 
-    logger.warning("INTERNAL REMOVE: Broadcasting health status update")  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Broadcasting health status update")
 
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(service_path)
 
-    logger.warning("INTERNAL REMOVE: Removing server from scopes")  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Removing server from scopes")
 
     # Remove server from scopes and reload auth server
     from ..services.scope_service import remove_server_scopes
@@ -2140,9 +2110,7 @@ async def internal_remove_service(
         logger.error(f"Failed to remove server {service_path} from scopes: {e}")
         # Non-fatal error - server is removed but scopes not updated
 
-    logger.warning(
-        "INTERNAL REMOVE: Removal complete, returning success response"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL REMOVE: Removal complete, returning success response")
     logger.info(f"Service removed via internal endpoint: '{service_path}' by caller '{caller}'")
 
     return JSONResponse(
@@ -2163,9 +2131,7 @@ async def internal_toggle_service(
     """Internal service toggle endpoint for mcpgw-server (requires admin authentication)."""
     from ..health.service import health_service
 
-    logger.warning(
-        "INTERNAL TOGGLE: Function called - starting execution"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL TOGGLE: Function called - starting execution")
 
     # Ensure service_path starts with /
     if not service_path.startswith("/"):
@@ -2174,9 +2140,7 @@ async def internal_toggle_service(
     # Check if server exists
     server_info = await server_service.get_server_info(service_path)
     if not server_info:
-        logger.warning(
-            f"INTERNAL TOGGLE: Service not found at path '{service_path}'"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL TOGGLE: Service not found at path '{service_path}'")
         return JSONResponse(
             status_code=404,
             content={
@@ -2186,9 +2150,7 @@ async def internal_toggle_service(
             },
         )
 
-    logger.warning(
-        "INTERNAL TOGGLE: Service found, proceeding with toggle"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL TOGGLE: Service found, proceeding with toggle")
 
     # Get current state and toggle it
     current_state = await server_service.is_service_enabled(service_path)
@@ -2196,9 +2158,7 @@ async def internal_toggle_service(
     success = await server_service.toggle_service(service_path, new_state)
 
     if not success:
-        logger.warning(
-            f"INTERNAL TOGGLE: Failed to toggle service at path '{service_path}'"
-        )  # TODO: replace with debug
+        logger.debug(f"INTERNAL TOGGLE: Failed to toggle service at path '{service_path}'")
         return JSONResponse(
             status_code=500,
             content={
@@ -2248,9 +2208,7 @@ async def internal_toggle_service(
     # Broadcast health status update to WebSocket clients
     await health_service.broadcast_health_update(service_path)
 
-    logger.warning(
-        "INTERNAL TOGGLE: Toggle complete, returning success response"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL TOGGLE: Toggle complete, returning success response")
     return JSONResponse(
         status_code=200,
         content={
@@ -2272,9 +2230,7 @@ async def internal_healthcheck(
     """Internal health check endpoint for mcpgw-server (requires admin authentication)."""
     from ..health.service import health_service
 
-    logger.warning(
-        "INTERNAL HEALTHCHECK: Function called - starting execution"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL HEALTHCHECK: Function called - starting execution")
 
     logger.info(f"Internal healthcheck request from caller '{caller}'")
 
@@ -2947,7 +2903,7 @@ async def get_service_tools(
     if not proxy_pass_url:
         raise HTTPException(status_code=500, detail="Service has no proxy URL configured")
 
-    logger.info(f"Fetching live tools for {service_path} from {proxy_pass_url}")
+    logger.info(f"Fetching live tools for {service_path} from {redact_url(proxy_pass_url)}")
 
     try:
         # Call MCP client to fetch fresh tools using server configuration
@@ -3102,7 +3058,8 @@ async def refresh_service(service_path: str, user_context: Annotated[dict, Depen
         raise HTTPException(status_code=500, detail="Service has no proxy URL configured")
 
     logger.info(
-        f"Refreshing service {service_path} at {proxy_pass_url} by user '{user_context['username']}'"
+        f"Refreshing service {service_path} at {redact_url(proxy_pass_url)} "
+        f"by user '{user_context['username']}'"
     )
 
     try:
@@ -3287,16 +3244,14 @@ async def internal_list_services(
     caller: Annotated[str, Depends(validate_internal_auth)],
 ):
     """Internal service listing endpoint for mcpgw-server (requires admin authentication)."""
-    logger.warning(
-        "INTERNAL LIST: Function called - starting execution"
-    )  # TODO: replace with debug
+    logger.debug("INTERNAL LIST: Function called - starting execution")
 
     logger.info(f"Internal service list request from caller '{caller}'")
 
     # Get all servers (admin access - no permission filtering)
     all_servers = await server_service.get_all_servers()
 
-    logger.warning(f"INTERNAL LIST: Found {len(all_servers)} servers")  # TODO: replace with debug
+    logger.debug(f"INTERNAL LIST: Found {len(all_servers)} servers")
 
     # Transform the data to include enabled status and health information
     services = []
@@ -3327,7 +3282,7 @@ async def internal_list_services(
         }
         services.append(service_data)
 
-    logger.warning(f"INTERNAL LIST: Returning {len(services)} services")  # TODO: replace with debug
+    logger.debug(f"INTERNAL LIST: Returning {len(services)} services")
     logger.info(
         f"Internal service list completed for caller '{caller}' - returned {len(services)} services"
     )

--- a/registry/common/log_redaction.py
+++ b/registry/common/log_redaction.py
@@ -18,6 +18,7 @@ redact.
 """
 
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 REDACTED: str = "[REDACTED]"
 
@@ -147,6 +148,36 @@ def redact_headers(headers: Any) -> dict[str, str]:
         else:
             redacted[name] = value
     return redacted
+
+
+def redact_url(url: str | None) -> str:
+    """Return a URL safe to log, stripped of any credential-bearing parts.
+
+    A backend URL (e.g. a server ``proxy_pass_url``) can carry credentials in
+    its userinfo component (``user:pass@host``) or secrets in its query string
+    (``?access_token=...``). Keep only ``scheme://host[:port]/path`` and drop
+    the userinfo, query, and fragment. Non-parseable input is masked entirely
+    (fail closed) rather than logged raw.
+
+    Args:
+        url: The URL to redact. ``None`` and empty strings pass through as an
+            empty string.
+
+    Returns:
+        The URL reduced to ``scheme://host[:port]/path``, an empty string for
+        falsy input, or ``[REDACTED]`` when it cannot be parsed.
+    """
+    if not url:
+        return ""
+    try:
+        parts = urlsplit(url)
+        # ``hostname``/``port`` drop any ``user:pass@`` userinfo prefix.
+        netloc = parts.hostname or ""
+        if parts.port is not None:
+            netloc = f"{netloc}:{parts.port}"
+        return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    except ValueError:
+        return REDACTED
 
 
 def redact_mapping(

--- a/registry/core/endpoint_utils.py
+++ b/registry/core/endpoint_utils.py
@@ -10,6 +10,8 @@ from typing import (
     Any,
 )
 
+from ..common.log_redaction import redact_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -57,17 +59,17 @@ def get_endpoint_url(
     if transport_type == "sse":
         # Priority 1: Explicit sse_endpoint
         if sse_endpoint:
-            logger.debug(f"Using explicit sse_endpoint: {sse_endpoint}")
+            logger.debug(f"Using explicit sse_endpoint: {redact_url(sse_endpoint)}")
             return sse_endpoint
 
         # Priority 2: URL already contains transport path
         if base_url.endswith("/sse") or "/sse/" in base_url:
-            logger.debug(f"URL already contains /sse: {base_url}")
+            logger.debug(f"URL already contains /sse: {redact_url(base_url)}")
             return base_url
 
         # Priority 3: Append default suffix
         endpoint = f"{base_url}/sse"
-        logger.debug(f"Appending /sse suffix: {endpoint}")
+        logger.debug(f"Appending /sse suffix: {redact_url(endpoint)}")
         return endpoint
 
     else:
@@ -79,12 +81,12 @@ def get_endpoint_url(
 
         # Priority 2: URL already contains transport path
         if _url_contains_transport_path(base_url):
-            logger.debug(f"URL already contains transport path: {base_url}")
+            logger.debug(f"URL already contains transport path: {redact_url(base_url)}")
             return base_url
 
         # Priority 3: Append default suffix
         endpoint = f"{base_url}/mcp"
-        logger.debug(f"Appending /mcp suffix: {endpoint}")
+        logger.debug(f"Appending /mcp suffix: {redact_url(endpoint)}")
         return endpoint
 
 

--- a/registry/core/mcp_client.py
+++ b/registry/core/mcp_client.py
@@ -18,6 +18,8 @@ from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
 
+from ..common.log_redaction import redact_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,10 +51,10 @@ def _assert_mcp_url_fetchable(
         validate_url(url, profile=PROXY_PROFILE)
         return True
     except UrlValidationError as e:
-        logger.warning("MCP connection blocked by SSRF guard for %s: %s", url, e)
+        logger.warning("MCP connection blocked by SSRF guard for %s: %s", redact_url(url), e)
         return False
     except Exception as e:  # pragma: no cover - defensive, fail closed
-        logger.warning("MCP connection blocked (validation error) for %s: %s", url, e)
+        logger.warning("MCP connection blocked (validation error) for %s: %s", redact_url(url), e)
         return False
 
 
@@ -96,7 +98,9 @@ def normalize_sse_endpoint_url(endpoint_url: str) -> str:
         mount_path = match.group(1)  # e.g., "/currenttime"
         rest_of_url = match.group(2)  # e.g., "/messages/?session_id=123"
 
-        logger.debug(f"Stripping mount path '{mount_path}' from endpoint URL: {endpoint_url}")
+        logger.debug(
+            f"Stripping mount path '{mount_path}' from endpoint URL: {redact_url(endpoint_url)}"
+        )
         return rest_of_url
 
     # If no mount path pattern detected, return as-is
@@ -256,10 +260,10 @@ async def detect_server_transport_aware(base_url: str, server_info: dict = None)
     """
     # If URL already has a transport endpoint, detect from it
     if base_url.endswith("/sse") or "/sse/" in base_url:
-        logger.debug(f"Server URL {base_url} already has SSE endpoint")
+        logger.debug(f"Server URL {redact_url(base_url)} already has SSE endpoint")
         return "sse"
     elif base_url.endswith("/mcp") or "/mcp/" in base_url:
-        logger.debug(f"Server URL {base_url} already has MCP endpoint")
+        logger.debug(f"Server URL {redact_url(base_url)} already has MCP endpoint")
         return "streamable-http"
 
     # Use server configuration if available
@@ -293,10 +297,10 @@ async def detect_server_transport(base_url: str) -> str:
     """
     # If URL already has a transport endpoint, detect from it
     if base_url.endswith("/sse") or "/sse/" in base_url:
-        logger.debug(f"Server URL {base_url} already has SSE endpoint")
+        logger.debug(f"Server URL {redact_url(base_url)} already has SSE endpoint")
         return "sse"
     elif base_url.endswith("/mcp") or "/mcp/" in base_url:
-        logger.debug(f"Server URL {base_url} already has MCP endpoint")
+        logger.debug(f"Server URL {redact_url(base_url)} already has MCP endpoint")
         return "streamable-http"
 
     # Fail closed on SSRF before probing the target with the (unpinnable) SDK
@@ -309,22 +313,24 @@ async def detect_server_transport(base_url: str) -> str:
     try:
         mcp_url = base_url.rstrip("/") + "/mcp/"
         async with streamablehttp_client(url=mcp_url) as connection:
-            logger.debug(f"Server at {base_url} supports streamable-http transport")
+            logger.debug(f"Server at {redact_url(base_url)} supports streamable-http transport")
             return "streamable-http"
     except Exception as e:
-        logger.debug(f"Streamable-HTTP test failed for {base_url}: {e}")
+        logger.debug(f"Streamable-HTTP test failed for {redact_url(base_url)}: {e}")
 
     # Fallback to SSE
     try:
         sse_url = base_url.rstrip("/") + "/sse"
         async with sse_client(sse_url) as connection:
-            logger.debug(f"Server at {base_url} supports SSE transport")
+            logger.debug(f"Server at {redact_url(base_url)} supports SSE transport")
             return "sse"
     except Exception as e:
-        logger.debug(f"SSE test failed for {base_url}: {e}")
+        logger.debug(f"SSE test failed for {redact_url(base_url)}: {e}")
 
     # Default to streamable-http if detection fails
-    logger.warning(f"Could not detect transport for {base_url}, defaulting to streamable-http")
+    logger.warning(
+        f"Could not detect transport for {redact_url(base_url)}, defaulting to streamable-http"
+    )
     return "streamable-http"
 
 
@@ -349,7 +355,9 @@ async def get_tools_from_server_with_transport(
     if transport == "auto":
         transport = await detect_server_transport(base_url)
 
-    logger.info(f"Attempting to connect to MCP server at {base_url} using {transport} transport...")
+    logger.info(
+        f"Attempting to connect to MCP server at {redact_url(base_url)} using {transport} transport..."
+    )
 
     try:
         if transport == "streamable-http":
@@ -362,7 +370,7 @@ async def get_tools_from_server_with_transport(
 
     except Exception as e:
         logger.error(
-            f"MCP Check Error: Failed to get tool list from {base_url} with {transport}: {type(e).__name__} - {e}"
+            f"MCP Check Error: Failed to get tool list from {redact_url(base_url)} with {transport}: {type(e).__name__} - {e}"
         )
         return None
 
@@ -386,7 +394,7 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
     # If explicit endpoint is provided, use it directly (single attempt)
     if explicit_endpoint:
         mcp_url = explicit_endpoint
-        logger.info(f"MCP Client: Using explicit mcp_endpoint: {mcp_url}")
+        logger.info(f"MCP Client: Using explicit mcp_endpoint: {redact_url(mcp_url)}")
 
         # Handle servers imported from anthropic by adding required query parameter
         if (
@@ -411,7 +419,9 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
                     result = _extract_tool_details(tools_response)
                     return result
         except Exception as e:
-            logger.error(f"MCP Check Error: Streamable-HTTP connection failed to {mcp_url}: {e}")
+            logger.error(
+                f"MCP Check Error: Streamable-HTTP connection failed to {redact_url(mcp_url)}: {e}"
+            )
             return None
 
     # If URL already has MCP endpoint, use it directly
@@ -430,9 +440,9 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
             elif "instance_id=" not in mcp_url:
                 mcp_url += "&instance_id=default"
         else:
-            logger.info(f"DEBUG: Not a Strata server, URL unchanged: {mcp_url}")
+            logger.debug(f"Not a Strata server, URL unchanged: {redact_url(mcp_url)}")
 
-        logger.info(f"DEBUG: About to connect to: {mcp_url}")
+        logger.debug(f"About to connect to: {redact_url(mcp_url)}")
         try:
             async with streamablehttp_client(url=mcp_url, headers=headers) as (
                 read,
@@ -446,7 +456,9 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
                     result = _extract_tool_details(tools_response)
                     return result
         except Exception as e:
-            logger.error(f"MCP Check Error: Streamable-HTTP connection failed to {base_url}: {e}")
+            logger.error(
+                f"MCP Check Error: Streamable-HTTP connection failed to {redact_url(base_url)}: {e}"
+            )
 
             return None
     else:
@@ -455,7 +467,7 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
 
         for mcp_url in endpoints_to_try:
             try:
-                logger.info(f"MCP Client: Trying streamable-http endpoint: {mcp_url}")
+                logger.info(f"MCP Client: Trying streamable-http endpoint: {redact_url(mcp_url)}")
                 async with streamablehttp_client(url=mcp_url, headers=headers) as (
                     read,
                     write,
@@ -465,19 +477,19 @@ async def _get_tools_streamable_http(base_url: str, server_info: dict = None) ->
                         await asyncio.wait_for(session.initialize(), timeout=10.0)
                         tools_response = await asyncio.wait_for(session.list_tools(), timeout=15.0)
 
-                        logger.info(f"MCP Client: Successfully connected to {mcp_url}")
+                        logger.info(f"MCP Client: Successfully connected to {redact_url(mcp_url)}")
                         return _extract_tool_details(tools_response)
 
             except TimeoutError:
                 logger.error(
-                    f"MCP Check Error: Timeout during streamable-http session with {mcp_url}."
+                    f"MCP Check Error: Timeout during streamable-http session with {redact_url(mcp_url)}."
                 )
                 if mcp_url == endpoints_to_try[0]:
                     continue
                 return None
             except Exception as e:
                 logger.error(
-                    f"MCP Check Error: Streamable-HTTP connection failed to {mcp_url}: {e}"
+                    f"MCP Check Error: Streamable-HTTP connection failed to {redact_url(mcp_url)}: {e}"
                 )
                 if mcp_url == endpoints_to_try[0]:
                     continue
@@ -494,7 +506,7 @@ async def _get_tools_sse(base_url: str, server_info: dict = None) -> list[dict] 
     # Resolve SSE endpoint URL
     if explicit_endpoint:
         sse_url = explicit_endpoint
-        logger.info(f"MCP Client: Using explicit sse_endpoint: {sse_url}")
+        logger.info(f"MCP Client: Using explicit sse_endpoint: {redact_url(sse_url)}")
     elif base_url.endswith("/sse") or "/sse/" in base_url:
         sse_url = base_url
     else:
@@ -539,10 +551,10 @@ async def _get_tools_sse(base_url: str, server_info: dict = None) -> list[dict] 
             httpx.AsyncClient.request = original_request  # type: ignore[method-assign]  # restore monkeypatch
 
     except TimeoutError:
-        logger.error(f"MCP Check Error: Timeout during SSE session with {base_url}.")
+        logger.error(f"MCP Check Error: Timeout during SSE session with {redact_url(base_url)}.")
         return None
     except Exception as e:
-        logger.error(f"MCP Check Error: SSE connection failed to {base_url}: {e}")
+        logger.error(f"MCP Check Error: SSE connection failed to {redact_url(base_url)}: {e}")
         return None
 
 
@@ -653,7 +665,7 @@ async def get_tools_from_server_with_server_info(
     transport = await detect_server_transport_aware(base_url, server_info)
 
     logger.info(
-        f"Attempting to connect to MCP server at {base_url} using {transport} transport (server-info aware)..."
+        f"Attempting to connect to MCP server at {redact_url(base_url)} using {transport} transport (server-info aware)..."
     )
 
     try:
@@ -667,7 +679,7 @@ async def get_tools_from_server_with_server_info(
 
     except Exception as e:
         logger.error(
-            f"MCP Check Error: Failed to get tool list from {base_url} with {transport}: {type(e).__name__} - {e}"
+            f"MCP Check Error: Failed to get tool list from {redact_url(base_url)} with {transport}: {type(e).__name__} - {e}"
         )
         return None
 
@@ -710,7 +722,9 @@ async def get_mcp_connection_result(
     # Use transport-aware detection
     transport = await detect_server_transport_aware(base_url, server_info)
 
-    logger.info(f"Getting MCP connection result from {base_url} using {transport} transport...")
+    logger.info(
+        f"Getting MCP connection result from {redact_url(base_url)} using {transport} transport..."
+    )
 
     # Build headers for the server (destination re-validated inside before any
     # decrypted secret is attached).
@@ -762,7 +776,7 @@ async def get_mcp_connection_result(
 
                     if mcp_server_info:
                         logger.info(
-                            f"MCP Server Info from {base_url}: "
+                            f"MCP Server Info from {redact_url(base_url)}: "
                             f"name={mcp_server_info.get('name')}, "
                             f"version={mcp_server_info.get('version')}"
                         )
@@ -799,7 +813,7 @@ async def get_mcp_connection_result(
 
                     if mcp_server_info:
                         logger.info(
-                            f"MCP Server Info from {base_url}: "
+                            f"MCP Server Info from {redact_url(base_url)}: "
                             f"name={mcp_server_info.get('name')}, "
                             f"version={mcp_server_info.get('version')}"
                         )
@@ -811,11 +825,11 @@ async def get_mcp_connection_result(
             return None
 
     except TimeoutError:
-        logger.error(f"MCP Check Error: Timeout connecting to {mcp_url}")
+        logger.error(f"MCP Check Error: Timeout connecting to {redact_url(mcp_url)}")
         return None
     except Exception as e:
         logger.error(
-            f"MCP Check Error: Failed to get connection result from {base_url}: "
+            f"MCP Check Error: Failed to get connection result from {redact_url(base_url)}: "
             f"{type(e).__name__} - {e}"
         )
         return None

--- a/registry/health/service.py
+++ b/registry/health/service.py
@@ -10,7 +10,7 @@ from fastapi import WebSocket
 
 from registry.constants import DeploymentType, HealthStatus
 
-from ..common.log_redaction import redact_headers
+from ..common.log_redaction import redact_headers, redact_url
 from ..core.config import settings
 from ..core.endpoint_utils import get_endpoint_url_from_server_info
 from ..exceptions import UrlValidationError
@@ -597,7 +597,7 @@ class HealthMonitoringService:
             # Check if initialize succeeded
             if response.status_code not in [200, 201]:
                 logger.warning(
-                    f"MCP initialize failed for {endpoint}: "
+                    f"MCP initialize failed for {redact_url(endpoint)}: "
                     f"Status {response.status_code}, Response: {response.text[:200]}"
                 )
                 return None
@@ -618,7 +618,7 @@ class HealthMonitoringService:
                 return client_session_id
 
         except Exception as e:
-            logger.warning(f"MCP initialize failed for {endpoint}: {e}")
+            logger.warning(f"MCP initialize failed for {redact_url(endpoint)}: {e}")
             return None
 
     async def _try_ping_without_auth(self, client: httpx.AsyncClient, endpoint: str) -> bool:
@@ -655,17 +655,19 @@ class HealthMonitoringService:
             # Check if we get any valid response (even auth errors indicate server is up)
             if response.status_code in [200, 400, 401, 403]:
                 logger.info(
-                    f"Ping without auth succeeded for {endpoint} - server is reachable but auth may have expired"
+                    f"Ping without auth succeeded for {redact_url(endpoint)} - server is reachable but auth may have expired"
                 )
                 return True
             else:
                 logger.warning(
-                    f"Ping without auth failed for {endpoint}: Status {response.status_code}"
+                    f"Ping without auth failed for {redact_url(endpoint)}: Status {response.status_code}"
                 )
                 return False
 
         except Exception as e:
-            logger.warning(f"Ping without auth failed for {endpoint}: {type(e).__name__} - {e}")
+            logger.warning(
+                f"Ping without auth failed for {redact_url(endpoint)}: {type(e).__name__} - {e}"
+            )
             return False
 
     async def _check_server_endpoint_transport_aware(
@@ -690,7 +692,7 @@ class HealthMonitoringService:
         except UrlValidationError as e:
             logger.warning(
                 "Health check blocked by SSRF guard for %s: %s (credentials NOT sent)",
-                proxy_pass_url,
+                redact_url(proxy_pass_url),
                 e,
             )
             return False, HealthStatus.UNHEALTHY_URL_BLOCKED
@@ -708,7 +710,7 @@ class HealthMonitoringService:
         )
 
         if has_transport_in_url and "streamable-http" not in supported_transports:
-            logger.info(f"[TRACE] Found transport endpoint in URL: {proxy_pass_url}")
+            logger.debug(f"[TRACE] Found transport endpoint in URL: {redact_url(proxy_pass_url)}")
             logger.info(
                 f"[TRACE] URL contains /mcp: {'/mcp' in proxy_pass_url}, URL contains /sse: {'/sse' in proxy_pass_url}"
             )
@@ -717,7 +719,9 @@ class HealthMonitoringService:
                 headers = self._build_headers_for_server(server_info)
                 # For SSE endpoints, use a shorter timeout since they start streaming immediately
                 if proxy_pass_url.endswith("/sse") or "/sse/" in proxy_pass_url:
-                    logger.info("[TRACE] Detected SSE endpoint in URL, using SSE-specific handling")
+                    logger.debug(
+                        "[TRACE] Detected SSE endpoint in URL, using SSE-specific handling"
+                    )
                     timeout = httpx.Timeout(connect=5.0, read=2.0, write=5.0, pool=5.0)
                     try:
                         response = await client.get(
@@ -729,19 +733,19 @@ class HealthMonitoringService:
                     except (TimeoutError, httpx.TimeoutException) as e:
                         # For SSE endpoints, timeout while reading streaming response is normal after getting 200 OK
                         logger.debug(
-                            f"SSE endpoint {proxy_pass_url} timed out while streaming (expected): {e}"
+                            f"SSE endpoint {redact_url(proxy_pass_url)} timed out while streaming (expected): {e}"
                         )
                         # If we can extract status code from response, check if it was 200
                         if hasattr(e, "response") and e.response and e.response.status_code == 200:
                             logger.debug(
-                                f"SSE endpoint {proxy_pass_url} returned 200 OK before timeout - considering healthy"
+                                f"SSE endpoint {redact_url(proxy_pass_url)} returned 200 OK before timeout - considering healthy"
                             )
                             return True, HealthStatus.HEALTHY
                         # For SSE, timeout after initial connection usually means server is responding
                         return True, HealthStatus.HEALTHY
                     except Exception as e:
                         logger.warning(
-                            f"SSE endpoint {proxy_pass_url} failed with exception: {type(e).__name__} - {e}"
+                            f"SSE endpoint {redact_url(proxy_pass_url)} failed with exception: {type(e).__name__} - {e}"
                         )
                         return False, f"unhealthy: {type(e).__name__}"
                 else:
@@ -755,7 +759,7 @@ class HealthMonitoringService:
                     # Check for auth failures first
                     if response.status_code in [401, 403]:
                         logger.info(
-                            f"[TRACE] Auth failure detected ({response.status_code}) for {proxy_pass_url}, trying ping without auth"
+                            f"[TRACE] Auth failure detected ({response.status_code}) for {redact_url(proxy_pass_url)}, trying ping without auth"
                         )
                         if await self._try_ping_without_auth(client, proxy_pass_url):
                             return True, HealthStatus.HEALTHY
@@ -768,22 +772,24 @@ class HealthMonitoringService:
                         return False, f"unhealthy: status {response.status_code}"
             except Exception as e:
                 logger.warning(
-                    f"Health check failed for {proxy_pass_url}: {type(e).__name__} - {e}"
+                    f"Health check failed for {redact_url(proxy_pass_url)}: {type(e).__name__} - {e}"
                 )
                 return False, f"unhealthy: {type(e).__name__}"
 
         # Skip health checks for stdio transport (as requested)
         if supported_transports == ["stdio"]:
-            logger.info(f"[TRACE] Skipping health check for stdio transport: {proxy_pass_url}")
+            logger.debug(
+                f"[TRACE] Skipping health check for stdio transport: {redact_url(proxy_pass_url)}"
+            )
             return True, HealthStatus.UNKNOWN
 
         # Try endpoints based on supported transports, prioritizing streamable-http
-        logger.info(f"[TRACE] No transport endpoint in URL: {proxy_pass_url}")
-        logger.info(f"[TRACE] Supported transports: {supported_transports}")
+        logger.debug(f"[TRACE] No transport endpoint in URL: {redact_url(proxy_pass_url)}")
+        logger.debug(f"[TRACE] Supported transports: {supported_transports}")
 
         # Try streamable-http first (default preference)
         if "streamable-http" in supported_transports:
-            logger.info("[TRACE] Trying streamable-http transport")
+            logger.debug("[TRACE] Trying streamable-http transport")
             # Build base headers without session ID
             headers = self._build_headers_for_server(server_info, include_session_id=False)
 
@@ -792,18 +798,20 @@ class HealthMonitoringService:
             endpoint = get_endpoint_url_from_server_info(
                 server_info, transport_type="streamable-http"
             )
-            logger.info(f"[TRACE] Resolved streamable-http endpoint: {endpoint}")
+            logger.debug(f"[TRACE] Resolved streamable-http endpoint: {redact_url(endpoint)}")
 
             try:
                 # Step 1: Initialize session to get session ID
-                logger.info(f"[TRACE] Initializing MCP session for endpoint: {endpoint}")
+                logger.debug(
+                    f"[TRACE] Initializing MCP session for endpoint: {redact_url(endpoint)}"
+                )
                 session_id = await self._initialize_mcp_session(client, endpoint, headers)
 
                 # If initialize failed, check if it was due to auth (401/403)
                 # Try ping without auth before giving up
                 if not session_id:
                     logger.warning(
-                        f"Failed to initialize MCP session for {endpoint}, trying ping without auth"
+                        f"Failed to initialize MCP session for {redact_url(endpoint)}, trying ping without auth"
                     )
                     if await self._try_ping_without_auth(client, endpoint):
                         return True, HealthStatus.HEALTHY
@@ -817,17 +825,17 @@ class HealthMonitoringService:
                 headers["Mcp-Session-Id"] = session_id
                 ping_payload = '{ "jsonrpc": "2.0", "id": "0", "method": "ping" }'
 
-                logger.info(f"[TRACE] Sending ping to endpoint: {endpoint}")
-                logger.info(f"[TRACE] Headers being sent: {self._mask_sensitive_headers(headers)}")
+                logger.debug(f"[TRACE] Sending ping to endpoint: {redact_url(endpoint)}")
+                logger.debug(f"[TRACE] Headers being sent: {self._mask_sensitive_headers(headers)}")
                 response = await client.post(
                     endpoint, headers=headers, content=ping_payload, follow_redirects=True
                 )
-                logger.info(f"[TRACE] Response status: {response.status_code}")
+                logger.debug(f"[TRACE] Response status: {response.status_code}")
 
                 # Check for auth failures first
                 if response.status_code in [401, 403]:
                     logger.info(
-                        f"[TRACE] Auth failure detected ({response.status_code}) for {endpoint}, trying ping without auth"
+                        f"[TRACE] Auth failure detected ({response.status_code}) for {redact_url(endpoint)}, trying ping without auth"
                     )
                     if await self._try_ping_without_auth(client, endpoint):
                         # ============================================================================
@@ -859,26 +867,28 @@ class HealthMonitoringService:
 
                 # Check normal health status
                 if self._is_mcp_endpoint_healthy_streamable(response):
-                    logger.info(f"Health check succeeded at {endpoint}")
+                    logger.info(f"Health check succeeded at {redact_url(endpoint)}")
                     return True, HealthStatus.HEALTHY
                 else:
                     logger.warning(
-                        f"Health check failed for {endpoint}: Status {response.status_code}, Response: {response.text}"
+                        f"Health check failed for {redact_url(endpoint)}: Status {response.status_code}, Response: {response.text}"
                     )
                     return False, f"unhealthy: status {response.status_code}"
 
             except Exception as e:
-                logger.warning(f"Health check failed for {endpoint}: {type(e).__name__} - {e}")
+                logger.warning(
+                    f"Health check failed for {redact_url(endpoint)}: {type(e).__name__} - {e}"
+                )
                 return False, f"unhealthy: {type(e).__name__}"
 
         # Fallback to SSE
         if "sse" in supported_transports:
-            logger.info("[TRACE] Trying SSE transport")
+            logger.debug("[TRACE] Trying SSE transport")
             try:
                 # Resolve SSE endpoint URL using centralized utility
                 # Priority: explicit sse_endpoint > URL detection > append /sse
                 sse_endpoint = get_endpoint_url_from_server_info(server_info, transport_type="sse")
-                logger.info(f"[TRACE] Resolved SSE endpoint: {sse_endpoint}")
+                logger.debug(f"[TRACE] Resolved SSE endpoint: {redact_url(sse_endpoint)}")
                 # Build headers including server-specific headers
                 headers = self._build_headers_for_server(server_info)
                 # Use shorter timeout for SSE since it starts streaming immediately
@@ -891,56 +901,60 @@ class HealthMonitoringService:
             except (TimeoutError, httpx.TimeoutException) as e:
                 # For SSE endpoints, timeout while reading streaming response is normal after getting 200 OK
                 logger.info(
-                    f"SSE endpoint {sse_endpoint} timed out while streaming (expected): {e}"
+                    f"SSE endpoint {redact_url(sse_endpoint)} timed out while streaming (expected): {e}"
                 )
                 # If we can extract status code from response, check if it was 200
                 if hasattr(e, "response") and e.response and e.response.status_code == 200:
                     logger.info(
-                        f"SSE endpoint {sse_endpoint} returned 200 OK before timeout - considering healthy"
+                        f"SSE endpoint {redact_url(sse_endpoint)} returned 200 OK before timeout - considering healthy"
                     )
                     return True, HealthStatus.HEALTHY
                 # For SSE, timeout after initial connection usually means server is responding
                 return True, "healthy"
             except Exception as e:
                 logger.error(
-                    f"SSE endpoint {sse_endpoint} failed with exception: {type(e).__name__} - {e}"
+                    f"SSE endpoint {redact_url(sse_endpoint)} failed with exception: {type(e).__name__} - {e}"
                 )
                 pass
 
         # If no specific transports, try default streamable-http then sse
         if not supported_transports or supported_transports == []:
-            logger.info("[TRACE] No specific transports defined, trying defaults")
+            logger.debug("[TRACE] No specific transports defined, trying defaults")
             headers = self._build_headers_for_server(server_info)
 
             # Resolve default streamable-http endpoint using centralized utility
             endpoint = get_endpoint_url_from_server_info(
                 server_info, transport_type="streamable-http"
             )
-            logger.info(f"[TRACE] Resolved default streamable-http endpoint: {endpoint}")
+            logger.debug(
+                f"[TRACE] Resolved default streamable-http endpoint: {redact_url(endpoint)}"
+            )
             ping_payload = '{ "jsonrpc": "2.0", "id": "0", "method": "ping" }'
 
             try:
-                logger.info(f"[TRACE] Trying default endpoint: {endpoint}")
-                logger.info(f"[TRACE] Headers being sent: {self._mask_sensitive_headers(headers)}")
+                logger.debug(f"[TRACE] Trying default endpoint: {redact_url(endpoint)}")
+                logger.debug(f"[TRACE] Headers being sent: {self._mask_sensitive_headers(headers)}")
                 response = await client.post(
                     endpoint, headers=headers, content=ping_payload, follow_redirects=True
                 )
-                logger.info(f"[TRACE] Response status: {response.status_code}")
+                logger.debug(f"[TRACE] Response status: {response.status_code}")
                 if self._is_mcp_endpoint_healthy_streamable(response):
-                    logger.info(f"Health check succeeded at {endpoint}")
+                    logger.info(f"Health check succeeded at {redact_url(endpoint)}")
                     return True, HealthStatus.HEALTHY
                 else:
                     logger.warning(
-                        f"Health check failed for {endpoint}: Status {response.status_code}, Response: {response.text}"
+                        f"Health check failed for {redact_url(endpoint)}: Status {response.status_code}, Response: {response.text}"
                     )
                     return False, f"unhealthy: status {response.status_code}"
             except Exception as e:
-                logger.warning(f"Health check failed for {endpoint}: {type(e).__name__} - {e}")
+                logger.warning(
+                    f"Health check failed for {redact_url(endpoint)}: {type(e).__name__} - {e}"
+                )
 
             try:
                 # Resolve default SSE endpoint using centralized utility
                 sse_endpoint = get_endpoint_url_from_server_info(server_info, transport_type="sse")
-                logger.info(f"[TRACE] Resolved default SSE endpoint: {sse_endpoint}")
+                logger.debug(f"[TRACE] Resolved default SSE endpoint: {redact_url(sse_endpoint)}")
                 # Build headers including server-specific headers
                 headers = self._build_headers_for_server(server_info)
                 # Use shorter timeout for SSE since it starts streaming immediately
@@ -953,19 +967,19 @@ class HealthMonitoringService:
             except (TimeoutError, httpx.TimeoutException) as e:
                 # For SSE endpoints, timeout while reading streaming response is normal after getting 200 OK
                 logger.info(
-                    f"SSE endpoint {sse_endpoint} timed out while streaming (expected): {e}"
+                    f"SSE endpoint {redact_url(sse_endpoint)} timed out while streaming (expected): {e}"
                 )
                 # If we can extract status code from response, check if it was 200
                 if hasattr(e, "response") and e.response and e.response.status_code == 200:
                     logger.info(
-                        f"SSE endpoint {sse_endpoint} returned 200 OK before timeout - considering healthy"
+                        f"SSE endpoint {redact_url(sse_endpoint)} returned 200 OK before timeout - considering healthy"
                     )
                     return True, HealthStatus.HEALTHY
                 # For SSE, timeout after initial connection usually means server is responding
                 return True, "healthy"
             except Exception as e:
                 logger.error(
-                    f"SSE endpoint {sse_endpoint} failed with exception: {type(e).__name__} - {e}"
+                    f"SSE endpoint {redact_url(sse_endpoint)} failed with exception: {type(e).__name__} - {e}"
                 )
                 pass
 
@@ -1097,7 +1111,7 @@ class HealthMonitoringService:
             server_info = await server_service.get_server_info(
                 service_path, include_credentials=True
             )
-            logger.info(f"Fetching tools from {proxy_pass_url} for {service_path}")
+            logger.info(f"Fetching tools from {redact_url(proxy_pass_url)} for {service_path}")
 
             # Use the new connection result function to get both tools and server info
             connection_result = await mcp_client_service.get_mcp_connection_result(
@@ -1240,7 +1254,7 @@ class HealthMonitoringService:
 
         # Set status to 'checking' before performing the check
         logger.info(
-            f"Setting status to '{HealthStatus.CHECKING}' for {service_path} ({proxy_pass_url})..."
+            f"Setting status to '{HealthStatus.CHECKING}' for {service_path} ({redact_url(proxy_pass_url)})..."
         )
         previous_status = self.server_health_status.get(service_path, HealthStatus.UNKNOWN)
         self.server_health_status[service_path] = HealthStatus.CHECKING
@@ -1258,7 +1272,7 @@ class HealthMonitoringService:
                 if is_healthy:
                     current_status = status_detail  # Could be "healthy" or "healthy-auth-expired"
                     logger.info(
-                        f"Health check successful for {service_path} ({proxy_pass_url}): {status_detail}"
+                        f"Health check successful for {service_path} ({redact_url(proxy_pass_url)}): {status_detail}"
                     )
 
                     # Schedule tool list fetch in background only for fully healthy status
@@ -1284,7 +1298,7 @@ class HealthMonitoringService:
                 else:
                     current_status = status_detail  # Detailed error from transport check
                     logger.info(
-                        f"Health check failed for {service_path} ({proxy_pass_url}): {status_detail}"
+                        f"Health check failed for {service_path} ({redact_url(proxy_pass_url)}): {status_detail}"
                     )
 
         except httpx.TimeoutException:

--- a/registry/services/federation/ai_catalog_client.py
+++ b/registry/services/federation/ai_catalog_client.py
@@ -27,6 +27,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 from pydantic import ValidationError
 
+from ...common.log_redaction import redact_url
 from ...exceptions import UrlValidationError
 from ...schemas.ard_models import AICatalogManifest
 from ...utils.url_guard import SKILL_PROFILE, guarded_client
@@ -98,7 +99,7 @@ class AiCatalogFederationClient:
         if depth > self.max_depth:
             return
         if url in visited:
-            logger.debug("ARD ingestion: skipping already-visited catalog URL %s", url)
+            logger.debug("ARD ingestion: skipping already-visited catalog URL %s", redact_url(url))
             return
         visited.add(url)
 
@@ -109,7 +110,9 @@ class AiCatalogFederationClient:
         try:
             manifest = self._fetch_one(url, root_domain)
         except Exception as e:
-            logger.warning("ARD ingestion: skipping catalog URL %s after error: %s", url, e)
+            logger.warning(
+                "ARD ingestion: skipping catalog URL %s after error: %s", redact_url(url), e
+            )
             return
         if manifest is None:
             return
@@ -132,7 +135,7 @@ class AiCatalogFederationClient:
         try:
             assert_fetchable(url, allowed)
         except ArdValidationError as e:
-            logger.warning("ARD ingestion: refusing catalog URL %s: %s", url, e)
+            logger.warning("ARD ingestion: refusing catalog URL %s: %s", redact_url(url), e)
             return None
 
         if self.polite_interval_ms:
@@ -153,7 +156,7 @@ class AiCatalogFederationClient:
                 if 300 <= response.status_code < 400:
                     logger.warning(
                         "ARD ingestion: catalog %s returned redirect status %d, skipping",
-                        url,
+                        redact_url(url),
                         response.status_code,
                     )
                     return None
@@ -161,7 +164,7 @@ class AiCatalogFederationClient:
                 if declared and declared.isdigit() and int(declared) > _MAX_BYTES:
                     logger.warning(
                         "ARD ingestion: catalog %s Content-Length %s exceeds %d cap, skipping",
-                        url,
+                        redact_url(url),
                         declared,
                         _MAX_BYTES,
                     )
@@ -173,7 +176,7 @@ class AiCatalogFederationClient:
                     if total > _MAX_BYTES:
                         logger.warning(
                             "ARD ingestion: catalog %s exceeds %d byte cap, aborting",
-                            url,
+                            redact_url(url),
                             _MAX_BYTES,
                         )
                         return None
@@ -184,16 +187,18 @@ class AiCatalogFederationClient:
             # at connect time (and on every redirect hop). A hostname that
             # passed assert_fetchable() but rebinds to a private/metadata IP
             # before the connect is blocked here — skip and log, never fatal.
-            logger.warning("ARD ingestion: refusing rebound/unsafe catalog URL %s: %s", url, e)
+            logger.warning(
+                "ARD ingestion: refusing rebound/unsafe catalog URL %s: %s", redact_url(url), e
+            )
             return None
         except httpx.HTTPError as e:
-            logger.warning("ARD ingestion: fetch failed for %s: %s", url, e)
+            logger.warning("ARD ingestion: fetch failed for %s: %s", redact_url(url), e)
             return None
 
         try:
             payload = json.loads(content)
         except (ValueError, UnicodeDecodeError) as e:
-            logger.warning("ARD ingestion: catalog %s is not valid JSON: %s", url, e)
+            logger.warning("ARD ingestion: catalog %s is not valid JSON: %s", redact_url(url), e)
             return None
 
         try:

--- a/registry/services/federation/asor_client.py
+++ b/registry/services/federation/asor_client.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from registry.core.config import settings
 
+from ...common.log_redaction import redact_url
 from ...schemas.federation_schema import AsorAgentConfig
 from .base_client import BaseFederationClient
 
@@ -221,7 +222,7 @@ class AsorFederationClient(BaseFederationClient):
             logger.error("Failed to authenticate with Workday")
             return []
 
-        logger.debug(f"ASOR DEBUG - URL: {url}")
+        logger.debug(f"ASOR DEBUG - URL: {redact_url(url)}")
         logger.debug(f"ASOR DEBUG - Endpoint: {self.endpoint}")
 
         # Build headers - match working test script format

--- a/registry/services/federation/base_client.py
+++ b/registry/services/federation/base_client.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 
+from ...common.log_redaction import redact_url
 from ...utils.url_guard import FEDERATION_PROFILE, guarded_client
 
 logging.basicConfig(
@@ -116,13 +117,14 @@ class BaseFederationClient(ABC):
         try:
             validate_url(url, profile=FEDERATION_PROFILE)
         except UrlValidationError as exc:
-            logger.error(f"Refusing federation request to unsafe URL {url!r}: {exc}")
+            logger.error(f"Refusing federation request to unsafe URL {redact_url(url)}: {exc}")
             return None
 
         for attempt in range(self.retry_attempts):
             try:
                 logger.debug(
-                    f"Making {method} request to {url} (attempt {attempt + 1}/{self.retry_attempts})"
+                    f"Making {method} request to {redact_url(url)} "
+                    f"(attempt {attempt + 1}/{self.retry_attempts})"
                 )
 
                 response = self.client.request(
@@ -133,7 +135,7 @@ class BaseFederationClient(ABC):
                 return response.json()
 
             except httpx.HTTPStatusError as e:
-                logger.error(f"HTTP error {e.response.status_code} for {url}: {e}")
+                logger.error(f"HTTP error {e.response.status_code} for {redact_url(url)}: {e}")
                 if e.response.status_code in [404, 401, 403]:
                     # Don't retry for these errors
                     return None
@@ -141,12 +143,12 @@ class BaseFederationClient(ABC):
                     return None
 
             except httpx.RequestError as e:
-                logger.error(f"Request error for {url}: {e}")
+                logger.error(f"Request error for {redact_url(url)}: {e}")
                 if attempt == self.retry_attempts - 1:
                     return None
 
             except Exception as e:
-                logger.error(f"Unexpected error for {url}: {e}")
+                logger.error(f"Unexpected error for {redact_url(url)}: {e}")
                 if attempt == self.retry_attempts - 1:
                     return None
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 
 import httpx
 
+from ..common.log_redaction import redact_url
 from ..core.config import settings
 from ..exceptions import (
     SkillUrlValidationError,
@@ -356,7 +357,8 @@ async def _discover_skill_resources(
     tree_info = _resolve_tree_api(skill_md_url)
     if not tree_info:
         logger.debug(
-            "Cannot derive tree API URL from %s — skipping resource discovery", skill_md_url
+            "Cannot derive tree API URL from %s — skipping resource discovery",
+            redact_url(skill_md_url),
         )
         return None
 
@@ -377,7 +379,9 @@ async def _discover_skill_resources(
             resp = await client.get(tree_url, headers=merged_headers)
             if resp.status_code >= 400:
                 logger.warning(
-                    "Resource discovery failed: HTTP %s for %s", resp.status_code, tree_url
+                    "Resource discovery failed: HTTP %s for %s",
+                    resp.status_code,
+                    redact_url(tree_url),
                 )
                 return None
             payload = resp.json()
@@ -405,7 +409,7 @@ async def _discover_skill_resources(
                         tree_url,
                     )
     except Exception as e:
-        logger.warning("Resource discovery error for %s: %s", tree_url, e)
+        logger.warning("Resource discovery error for %s: %s", redact_url(tree_url), e)
         return None
 
     # GitHub's Trees API returns {"sha": ..., "url": ..., "tree": [...], "truncated": bool}.
@@ -537,7 +541,7 @@ async def _validate_skill_md_url(
             final_url = str(response.url)
             if final_url != fetch_url and not _is_safe_url(final_url):
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {url} to unsafe URL {final_url}"
+                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(final_url)}"
                 )
                 raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {final_url}")
 
@@ -635,7 +639,7 @@ async def _parse_skill_md_content(
             final_url = str(response.url)
             if final_url != str(raw_url) and not _is_safe_url(final_url):
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {raw_url} to unsafe URL {final_url}"
+                    f"SSRF protection: Blocked redirect from {redact_url(raw_url)} to unsafe URL {redact_url(final_url)}"
                 )
                 raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {final_url}")
 
@@ -761,7 +765,7 @@ async def _parse_skill_md_content(
                 result["name_slug"] = name_slug
 
             logger.info(
-                f"Parsed SKILL.md from {user_url} (raw: {raw_url}): "
+                f"Parsed SKILL.md from {redact_url(user_url)} (raw: {redact_url(raw_url)}): "
                 f"name={result.get('name')}, has_description={bool(result.get('description'))}"
             )
             return result
@@ -831,7 +835,7 @@ async def _check_skill_health(
             final_url = str(response.url)
             if final_url != str(url) and not _is_safe_url(final_url):
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {url} to unsafe URL {final_url}"
+                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(final_url)}"
                 )
                 response_time_ms = (time.perf_counter() - start_time) * 1000
                 return {
@@ -851,7 +855,9 @@ async def _check_skill_health(
             }
 
     except UrlValidationError as e:
-        logger.warning("Skill health check blocked by SSRF guard for URL %s: %s", url, e)
+        logger.warning(
+            "Skill health check blocked by SSRF guard for URL %s: %s", redact_url(url), e
+        )
         response_time_ms = (time.perf_counter() - start_time) * 1000
         return {
             "healthy": False,
@@ -861,7 +867,7 @@ async def _check_skill_health(
         }
     except httpx.RequestError as e:
         # Log detailed exception on the server, but return a generic message to the client
-        logger.error("Error while checking skill health for URL %s: %s", url, e)
+        logger.error("Error while checking skill health for URL %s: %s", redact_url(url), e)
         response_time_ms = (time.perf_counter() - start_time) * 1000
         return {
             "healthy": False,
@@ -1032,10 +1038,10 @@ async def _fetch_authenticated_content(
 
             return response
     except UrlValidationError as e:
-        logger.warning("Skill content fetch blocked by SSRF guard for %s: %s", url, e)
+        logger.warning("Skill content fetch blocked by SSRF guard for %s: %s", redact_url(url), e)
         raise SkillContentSSRFError(url) from e
     except httpx.RequestError as e:
-        logger.error("Failed to fetch from %s: %s", url, e)
+        logger.error("Failed to fetch from %s: %s", redact_url(url), e)
         raise SkillContentFetchError(url, str(e))
 
 

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -15,6 +15,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel
 
+from registry.common.log_redaction import redact_url
 from registry.schemas.agent_models import (
     AgentCard,
     SecurityScheme,
@@ -228,15 +229,15 @@ def _check_endpoint_reachability(
         return (False, f"Endpoint returned status {response.status_code}")
 
     except UrlValidationError as e:
-        logger.warning(f"Endpoint blocked by SSRF guard for {url}: {e}")
+        logger.warning(f"Endpoint blocked by SSRF guard for {redact_url(url)}: {e}")
         return (False, "Endpoint URL failed SSRF validation")
 
     except httpx.TimeoutException:
-        logger.warning(f"Endpoint timeout for {url}")
+        logger.warning(f"Endpoint timeout for {redact_url(url)}")
         return (False, "Endpoint request timed out")
 
     except Exception as e:
-        logger.warning(f"Could not reach endpoint {url}: {e}")
+        logger.warning(f"Could not reach endpoint {redact_url(url)}: {e}")
         return (False, str(e))
 
 

--- a/registry/utils/url_normalize.py
+++ b/registry/utils/url_normalize.py
@@ -10,6 +10,8 @@ import logging
 from typing import Literal
 from urllib.parse import urlparse
 
+from registry.common.log_redaction import redact_url
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
@@ -50,7 +52,7 @@ def _parse_url(
     try:
         parsed = urlparse(url.strip())
     except Exception as exc:
-        logger.debug("Failed to parse url for normalization: %s (%s)", url, exc)
+        logger.debug("Failed to parse url for normalization: %s (%s)", redact_url(url), exc)
         return None
     if not parsed.scheme or not parsed.hostname:
         return None

--- a/registry/utils/url_utils.py
+++ b/registry/utils/url_utils.py
@@ -9,6 +9,8 @@ import logging
 import re
 from urllib.parse import urlparse
 
+from registry.common.log_redaction import redact_url
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -126,7 +128,7 @@ def _translate_github_url_to_raw(
 
     if not match:
         # If not a blob URL, return as-is
-        logger.debug(f"URL path doesn't match blob pattern, returning as-is: {url}")
+        logger.debug(f"URL path doesn't match blob pattern, returning as-is: {redact_url(url)}")
         return url
 
     owner, repo, branch, file_path = match.groups()
@@ -146,7 +148,7 @@ def _translate_github_url_to_raw(
         raw_hostname = f"raw.{hostname_lower}"
         raw_url = f"https://{raw_hostname}/{owner}/{repo}/refs/heads/{branch}/{file_path}"
 
-    logger.debug(f"Translated GitHub URL: {url} -> {raw_url}")
+    logger.debug(f"Translated GitHub URL: {redact_url(url)} -> {redact_url(raw_url)}")
     return raw_url
 
 
@@ -174,18 +176,18 @@ def translate_skill_url(
     hostname = parsed.hostname or ""
 
     if not hostname:
-        logger.warning(f"URL has no hostname: {url}")
+        logger.warning(f"URL has no hostname: {redact_url(url)}")
         return (url, url)
 
     # Check if it's a GitHub-related hostname
     if not _is_github_hostname(hostname):
         # Non-GitHub URL: use same URL for both
-        logger.debug(f"Non-GitHub URL, using as-is: {url}")
+        logger.debug(f"Non-GitHub URL, using as-is: {redact_url(url)}")
         return (url, url)
 
     # Already a raw URL: keep as-is
     if _is_raw_github_url(hostname):
-        logger.debug(f"Already a raw GitHub URL: {url}")
+        logger.debug(f"Already a raw GitHub URL: {redact_url(url)}")
         return (url, url)
 
     # GitHub URL: translate to raw

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -436,6 +436,129 @@ class TestScopeValidation:
             # Assert
             assert result is True
 
+    @pytest.mark.asyncio
+    async def test_allow_does_not_log_scopes_or_config_at_info(
+        self, mock_scope_repository_with_data, caplog
+    ):
+        """An allow does not leak user_scopes/scope_config at INFO.
+
+        The verbose per-request trace (user scopes, the full scope_config
+        authorization policy) must stay at DEBUG. Exactly one INFO line, the
+        access decision, is emitted and it must not carry the scopes list.
+        """
+        from auth_server.server import validate_server_tool_access
+
+        with patch(
+            "auth_server.server.get_scope_repository",
+            return_value=mock_scope_repository_with_data,
+        ):
+            caplog.set_level(logging.INFO, logger="auth_server.server")
+            server_name = "test-server"
+            method = "initialize"
+            user_scopes = ["read:servers"]
+
+            result = await validate_server_tool_access(server_name, method, None, user_scopes)
+
+        assert result is True
+
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        info_text = "\n".join(r.getMessage() for r in info_records)
+
+        # The full scope config (its dict repr) and the raw scopes list must not
+        # appear at INFO.
+        assert "'methods'" not in info_text
+        assert str(user_scopes) not in info_text
+        assert "User scopes" not in info_text
+
+        # Exactly one INFO decision line, and it records the grant.
+        decision_lines = [line for line in info_text.splitlines() if "Access " in line]
+        assert len(decision_lines) == 1
+        assert "Access granted" in decision_lines[0]
+        assert "test-server" in decision_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_deny_does_not_log_scopes_or_config_at_info(
+        self, mock_scope_repository_with_data, caplog
+    ):
+        """A deny emits exactly one INFO decision line, no scopes dump."""
+        from auth_server.server import validate_server_tool_access
+
+        with patch(
+            "auth_server.server.get_scope_repository",
+            return_value=mock_scope_repository_with_data,
+        ):
+            caplog.set_level(logging.INFO, logger="auth_server.server")
+            server_name = "other-server"
+            method = "initialize"
+            user_scopes = ["read:servers"]
+
+            result = await validate_server_tool_access(server_name, method, None, user_scopes)
+
+        assert result is False
+
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        info_text = "\n".join(r.getMessage() for r in info_records)
+
+        assert "'methods'" not in info_text
+        assert str(user_scopes) not in info_text
+
+        decision_lines = [line for line in info_text.splitlines() if "Access " in line]
+        assert len(decision_lines) == 1
+        assert "Access denied" in decision_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_scope_config_visible_only_at_debug(
+        self, mock_scope_repository_with_data, caplog
+    ):
+        """The scope_config dump still exists, but only at DEBUG."""
+        from auth_server.server import validate_server_tool_access
+
+        with patch(
+            "auth_server.server.get_scope_repository",
+            return_value=mock_scope_repository_with_data,
+        ):
+            caplog.set_level(logging.DEBUG, logger="auth_server.server")
+            await validate_server_tool_access("test-server", "initialize", None, ["read:servers"])
+
+        debug_text = "\n".join(r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG)
+        # The full authorization policy trace lands at DEBUG.
+        assert "'methods'" in debug_text
+        assert "User scopes" in debug_text
+
+    @pytest.mark.asyncio
+    async def test_exception_path_denies_with_one_info_line_no_scopes(self, caplog):
+        """The fail-closed exception branch denies, emits exactly one
+        INFO decision line, and never leaks user_scopes at INFO."""
+        from auth_server.server import validate_server_tool_access
+
+        # A scope repo whose lookup raises drives the except branch.
+        failing_repo = MagicMock()
+        failing_repo.get_server_scopes = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch(
+            "auth_server.server.get_scope_repository",
+            return_value=failing_repo,
+        ):
+            caplog.set_level(logging.INFO, logger="auth_server.server")
+            user_scopes = ["read:servers", "secret-scope-name"]
+
+            result = await validate_server_tool_access(
+                "test-server", "initialize", None, user_scopes
+            )
+
+        # Fail closed.
+        assert result is False
+
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        info_text = "\n".join(r.getMessage() for r in info_records)
+
+        # No scope list leaked at INFO, and exactly one decision line (deny).
+        assert str(user_scopes) not in info_text
+        assert "secret-scope-name" not in info_text
+        decision_lines = [line for line in info_text.splitlines() if "Access " in line]
+        assert len(decision_lines) == 1
+        assert "Access denied" in decision_lines[0]
+
     def test_validate_scope_subset_valid(self):
         """Test that requested scopes are subset of user scopes."""
         from auth_server.server import validate_scope_subset

--- a/tests/unit/api/test_server_routes.py
+++ b/tests/unit/api/test_server_routes.py
@@ -1391,6 +1391,75 @@ class TestInternalRegister:
             assert data["message"] == "Service registered successfully"
             mock_server_service.register_server.assert_called_once()
 
+    def test_internal_register_does_not_log_proxy_url_at_info_or_warning(
+        self,
+        test_client_no_auth,
+        mock_server_service,
+        mock_nginx_service,
+        mock_health_service,
+        caplog,
+    ):
+        """The internal-register trace lines are DEBUG, and any URL is redacted.
+
+        The developer trace lines (previously WARNING with a TODO marker) must
+        not emit the backend proxy_pass_url at INFO/WARNING, and where the URL
+        is logged at DEBUG its credential userinfo and query secret must be
+        stripped.
+        """
+        mock_server_service.register_server.return_value = {
+            "success": True,
+            "message": "Server registered successfully",
+            "is_new_version": False,
+        }
+
+        # userinfo credentials + a query-string secret that must never be logged.
+        proxy_url = "http://user:s3cr3t@backend.internal:9000/mcp?token=leakme"
+
+        with (
+            patch.dict("os.environ", {"SECRET_KEY": "testpass"}),
+            patch("registry.utils.scopes_manager.update_server_scopes", new_callable=AsyncMock),
+        ):
+            token = generate_internal_token(subject="test-service", purpose="test")
+            caplog.set_level(logging.DEBUG, logger="registry.api.server_routes")
+            response = test_client_no_auth.post(
+                "/api/internal/register",
+                data={
+                    "name": "Internal Server",
+                    "description": "Registered internally",
+                    "path": "/internal-server",
+                    "proxy_pass_url": proxy_url,
+                    "tags": "internal",
+                    "num_tools": 3,
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 201
+
+        higher_records = [
+            r
+            for r in caplog.records
+            if r.name == "registry.api.server_routes" and r.levelno >= logging.INFO
+        ]
+        higher_text = "\n".join(r.getMessage() for r in higher_records)
+        # The raw URL, its userinfo, and its query secret must never surface at
+        # INFO or WARNING.
+        assert proxy_url not in higher_text
+        assert "s3cr3t" not in higher_text
+        assert "leakme" not in higher_text
+
+        # At DEBUG the URL may appear, but only in redacted form: scheme://host/path,
+        # with no credentials or query string.
+        debug_records = [
+            r
+            for r in caplog.records
+            if r.name == "registry.api.server_routes" and r.levelno == logging.DEBUG
+        ]
+        debug_text = "\n".join(r.getMessage() for r in debug_records)
+        assert "s3cr3t" not in debug_text
+        assert "leakme" not in debug_text
+        assert "http://backend.internal:9000/mcp" in debug_text
+
     def test_internal_register_missing_auth_header(self, test_client_no_auth):
         """Test internal registration fails without Authorization header."""
         # Act

--- a/tests/unit/common/test_log_redaction.py
+++ b/tests/unit/common/test_log_redaction.py
@@ -10,6 +10,7 @@ from registry.common.log_redaction import (
     REDACTED,
     redact_headers,
     redact_mapping,
+    redact_url,
 )
 
 
@@ -161,3 +162,35 @@ class TestRedactMapping:
         assert redact_mapping("plain") == "plain"
         assert redact_mapping(42) == 42
         assert redact_mapping(None) is None
+
+
+class TestRedactUrl:
+    """redact_url must strip credential-bearing parts from a URL."""
+
+    def test_strips_userinfo_query_and_fragment(self):
+        # user:pass@ userinfo, ?secret query, and #frag must all be dropped;
+        # scheme, host, port, and path are preserved for diagnostics.
+        result = redact_url("https://user:pass@host.example:8443/path?secret=1#frag")
+        assert result == "https://host.example:8443/path"
+        assert "user" not in result
+        assert "pass" not in result
+        assert "secret" not in result
+
+    def test_drops_query_token(self):
+        result = redact_url("https://backend.internal/mcp?access_token=abc123")
+        assert result == "https://backend.internal/mcp"
+        assert "abc123" not in result
+
+    def test_plain_url_unchanged(self):
+        assert redact_url("http://backend.internal:9000/mcp") == "http://backend.internal:9000/mcp"
+
+    def test_empty_and_none_pass_through(self):
+        assert redact_url("") == ""
+        assert redact_url(None) == ""
+
+    def test_unparseable_port_fails_closed(self):
+        # A non-numeric port makes .port raise ValueError -> fail closed to
+        # [REDACTED] rather than logging the raw (possibly credentialed) string.
+        result = redact_url("http://user:pass@host:notaport/path")
+        assert result == REDACTED
+        assert "pass" not in result


### PR DESCRIPTION
# Redact URLs and log outputs

## Problem

Two residual sensitive-logging sites (missed by the earlier logging sweep):

- the internal server-registration endpoints in
  `registry/api/server_routes.py` carried 33 developer-trace lines at
  `logger.warning(...)  # TODO: replace with debug`, two of which logged a raw
  `proxy_pass_url`. A backend URL can carry credentials in its userinfo
  (`user:pass@host`) or a secret in its query string, so this leaked them to logs
  at WARNING on every internal registration.
- `auth_server/server.py` `validate_server_tool_access` logged a full
  verbose block at INFO on the hot per-request `/validate` path, dumping the
  caller's `user_scopes` and the entire matched `scope_config` (the whole
  authorization policy), plus a WARNING deny line that also included `user_scopes`.

## Fix

- Added a canonical **`redact_url()`** to `registry/common/log_redaction.py`
  (alongside `redact_headers`/`redact_mapping`): keeps `scheme://host[:port]/path`
  and drops userinfo, query, and fragment; fails closed to `[REDACTED]` on an
  unparseable URL. One shared implementation, imported by every consumer.
- The 33 trace lines are now `logger.debug(...)` (the TODO marker is
  removed — that was always the intent), and `proxy_pass_url` is passed through
  `redact_url()` wherever it is logged. The single INFO caller-audit line is kept.
- The verbose trace is now DEBUG; every return path (grant, deny, and
  the fail-closed exception branch) emits exactly one INFO decision line
  `Access granted/denied: server=... method=... tool=...` with no scopes or
  policy. The scopes/config dumps remain available at DEBUG.

## Repo-wide sweep

A grep for the same leak class turned it up across the package; all are fixed
here so the guarantee is uniform rather than per-reported-site:

- Authorization policy dumps: `auth_server/server.py` `validate_a2a_agent_access`
  (full `user_scopes` at WARNING -> count) and
  `registry/api/server_routes.py` list-servers (`accessible_services` /
  `ui_permissions` / `scopes` at INFO -> DEBUG). (`auth_server` is a separate
  deployable and cannot import the registry helper, so its scope leak is fixed
  inline by logging a count.)
- Registrant/federation URL logs routed through `redact_url` (all levels):
  `registry/core/mcp_client.py`, `registry/health/service.py`,
  `registry/api/agent_routes.py`, `registry/utils/agent_validator.py`,
  `registry/utils/url_utils.py`, `registry/utils/url_normalize.py`,
  `registry/core/endpoint_utils.py`, `registry/services/skill_service.py`,
  `registry/services/federation/{base_client,ai_catalog_client,asor_client}.py`,
  and `registry/api/server_routes.py`. Mislabeled `[TRACE]` / `"DEBUG:"` lines
  logging at INFO were also corrected to DEBUG.

Operator-configured infrastructure URLs (IdP/Okta/Auth0/gate endpoints) are not
in this class (no per-user secret; set by the operator) and are left as-is.

## Tests

New/updated: `redact_url` (including the fail-closed `[REDACTED]` path)
allow/deny/debug-visibility and the fail-closed exception branch, each asserting
exactly one INFO decision line and no raw scope list; internal-register asserting
`proxy_pass_url` is absent from INFO/WARNING and redacted where logged at DEBUG.
Touched-area run: 521 passed, 5 skipped.

## Notes

- No new config parameters; no deployment-surface changes.
- Behavior change is log level + redaction only; the single INFO audit line for
  each access decision and each registration is preserved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
