### PR TITLE
fix(egress): retry transient Vault/OpenBao failures on token save; surface hard save failures to the user

### DIFF
--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -40,6 +40,7 @@ from registry.egress_auth.providers import list_provider_names, resolve_provider
 from registry.egress_auth.service import EgressAuthError, is_per_user_auth_method
 from registry.exceptions import UrlValidationError
 from registry.repositories.factory import get_server_repository
+from registry.secrets.interfaces import SecretStoreError
 from registry.services.server_service import server_service
 from registry.utils.credential_encryption import encrypt_credential
 from registry.utils.url_guard import PROXY_PROFILE, validate_url
@@ -706,6 +707,24 @@ async def egress_callback(
         return HTMLResponse(
             "<h3>Connection failed. Please close this tab and try connecting again.</h3>",
             status_code=400,
+        )
+    except SecretStoreError as exc:
+        # The code exchange SUCCEEDED but persisting the token to the secret store
+        # (Vault/OpenBao) failed — the store already retried transient blips (HA
+        # leader election / pod restart), so landing here means the write did not
+        # persist. Critically, DO NOT fall through to the success page: that would
+        # tell the user they are "Connected" while no token was vaulted, leaving
+        # them with a silent "0 tools" and no signal to retry. Surface a clear,
+        # retryable error instead. Detail to logs only (may wrap internal store
+        # addresses). 503 == transient/backing-store issue, please retry.
+        logger.error(
+            "egress callback: code exchange ok but secret store write failed: %s", exc
+        )
+        return HTMLResponse(
+            "<h3>Connection not saved.</h3>"
+            "<p>We couldn't store your connection because of a temporary storage "
+            "issue. Please close this tab and try connecting again in a minute.</p>",
+            status_code=503,
         )
 
     # The egress consent is the web Connected-Accounts / MCP URL-mode elicitation

--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -717,9 +717,7 @@ async def egress_callback(
         # them with a silent "0 tools" and no signal to retry. Surface a clear,
         # retryable error instead. Detail to logs only (may wrap internal store
         # addresses). 503 == transient/backing-store issue, please retry.
-        logger.error(
-            "egress callback: code exchange ok but secret store write failed: %s", exc
-        )
+        logger.error("egress callback: code exchange ok but secret store write failed: %s", exc)
         return HTMLResponse(
             "<h3>Connection not saved.</h3>"
             "<p>We couldn't store your connection because of a temporary storage "

--- a/registry/secrets/openbao/store.py
+++ b/registry/secrets/openbao/store.py
@@ -25,6 +25,14 @@ logger = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
 
+# Bounded backoff for transient Vault/OpenBao unavailability (see
+# ``_is_transient_error``). A HA leader election or a pod restart clears within a
+# few seconds, so a short exponential backoff (0.5, 1, 2, 4 -> ~7.5s total)
+# rides through it without stranding the caller. Kept as module constants so
+# tests can shrink the backoff.
+_TRANSIENT_RETRIES = 4
+_TRANSIENT_BACKOFF_BASE = 0.5
+
 
 def _is_auth_expiry_error(exc: Exception) -> bool:
     """True if an hvac error looks like an expired/invalid Vault token.
@@ -43,13 +51,66 @@ def _is_auth_expiry_error(exc: Exception) -> bool:
     return "permission denied" in text or "403" in text or "invalid token" in text
 
 
+def _is_transient_error(exc: Exception) -> bool:
+    """True if an hvac/transport error looks like a transient Vault availability
+    blip rather than a definitive failure.
+
+    A Vault/OpenBao HA cluster momentarily rejects requests while it (re-)elects a
+    leader -- e.g. after a pod restart (eviction / rollout / spot reclaim). During
+    that window in-flight requests see one of:
+
+      * ``connection refused`` / ``failed to establish a new connection`` -- the
+        Service still routes to a pod that is terminating, or a standby redirects
+        (307) to a now-dead leader ``api_addr``,
+      * HTTP 5xx with ``local node not active but active cluster node not found``
+        -- a standby that does not yet know who the active node is,
+      * read timeouts.
+
+    These clear within seconds once a leader is (re-)elected, so a short bounded
+    retry (see ``_run``) turns a user-visible failure -- a consent whose token
+    never persists, i.e. a silent "0 tools" -- into a transparent success. NOTE:
+    this is deliberately disjoint from ``_is_auth_expiry_error`` (403/permission
+    denied is NOT transient) so the two retry paths never overlap.
+    """
+    name = type(exc).__name__
+    if name in (
+        "InternalServerError",  # hvac 500
+        "VaultDown",  # hvac 503
+        "BadGateway",  # hvac 502
+        "GatewayTimeout",  # hvac 504
+        "ConnectionError",  # requests / urllib3
+        "ConnectTimeout",
+        "ReadTimeout",
+        "Timeout",
+        "MaxRetryError",  # urllib3
+        "NewConnectionError",  # urllib3
+    ):
+        return True
+    text = str(exc).lower()
+    return (
+        "local node not active" in text
+        or "connection refused" in text
+        or "max retries exceeded" in text
+        or "failed to establish a new connection" in text
+        or "read timed out" in text
+        or "temporarily unavailable" in text
+        or " 500" in text
+        or " 502" in text
+        or " 503" in text
+        or " 504" in text
+    )
+
+
 class OpenBaoStore(SecretStoreBase):
     """Per-entry KV v2 store. ``client`` is a connected, authenticated hvac client.
 
     ``reauthenticate`` re-runs the configured login on ``client`` in place; the
     store calls it and retries once when an operation fails with an expired-token
     error (see ``_is_auth_expiry_error``), making a long-lived store self-healing
-    against short Vault token TTLs.
+    against short Vault token TTLs. It also rides out transient Vault
+    unavailability (HA leader election / pod restart -- see
+    ``_is_transient_error``) with a short bounded backoff, so a consent's token
+    write is not lost to a few-second cluster blip.
     """
 
     def __init__(
@@ -65,16 +126,50 @@ class OpenBaoStore(SecretStoreBase):
         self._reauthenticate = reauthenticate
 
     async def _run(self, fn: Callable[[], _T]) -> _T:
-        """Run a blocking hvac call in a thread, re-authenticating + retrying ONCE
-        if it fails because the Vault token expired."""
-        try:
-            return await asyncio.to_thread(fn)
-        except Exception as exc:
-            if self._reauthenticate is None or not _is_auth_expiry_error(exc):
+        """Run a blocking hvac call in a thread, with two independent recoveries:
+
+        1. Expired Vault token (``_is_auth_expiry_error``) -> re-authenticate
+           once and retry (short-lived role tokens; hvac does not auto-renew).
+        2. Transient cluster unavailability (``_is_transient_error``, e.g. a HA
+           leader election after a pod restart) -> bounded exponential backoff
+           retry so a few-second blip does not surface as a hard failure (a
+           consent whose token never persists == a silent "0 tools").
+
+        A genuine error (bad path, real policy gap, malformed data) matches
+        neither and is raised immediately by the callers as a SecretStoreError.
+        """
+        attempt = 0
+        reauthed = False
+        while True:
+            try:
+                return await asyncio.to_thread(fn)
+            except Exception as exc:
+                # 1) expired token: re-login once, then keep going.
+                if (
+                    not reauthed
+                    and self._reauthenticate is not None
+                    and _is_auth_expiry_error(exc)
+                ):
+                    logger.warning(
+                        "OpenBao token rejected (%s); re-authenticating and retrying", exc
+                    )
+                    await asyncio.to_thread(self._reauthenticate)
+                    reauthed = True
+                    continue
+                # 2) transient unavailability: bounded backoff retry.
+                if attempt < _TRANSIENT_RETRIES and _is_transient_error(exc):
+                    delay = _TRANSIENT_BACKOFF_BASE * (2**attempt)
+                    attempt += 1
+                    logger.warning(
+                        "OpenBao request failed transiently (%s); retry %d/%d in %.1fs",
+                        exc,
+                        attempt,
+                        _TRANSIENT_RETRIES,
+                        delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
                 raise
-            logger.warning("OpenBao token rejected (%s); re-authenticating and retrying once", exc)
-            await asyncio.to_thread(self._reauthenticate)
-            return await asyncio.to_thread(fn)
 
     def _rel_path(
         self,

--- a/registry/secrets/openbao/store.py
+++ b/registry/secrets/openbao/store.py
@@ -145,11 +145,7 @@ class OpenBaoStore(SecretStoreBase):
                 return await asyncio.to_thread(fn)
             except Exception as exc:
                 # 1) expired token: re-login once, then keep going.
-                if (
-                    not reauthed
-                    and self._reauthenticate is not None
-                    and _is_auth_expiry_error(exc)
-                ):
+                if not reauthed and self._reauthenticate is not None and _is_auth_expiry_error(exc):
                     logger.warning(
                         "OpenBao token rejected (%s); re-authenticating and retrying", exc
                     )

--- a/tests/unit/egress_auth/test_public_routes.py
+++ b/tests/unit/egress_auth/test_public_routes.py
@@ -228,6 +228,38 @@ class TestCallback:
         assert svc.handle_callback.await_count == 1
         state_codec.reset_cipher_for_tests()
 
+    def test_callback_store_write_failure_returns_503_not_success(self, client, monkeypatch):
+        # The code exchange succeeds but persisting the token to the secret store
+        # (Vault/OpenBao) fails even after the store's own transient retries. The
+        # route MUST surface a retryable 503 "Connection not saved" page and MUST
+        # NOT fall through to the success page -- otherwise the user is told
+        # "Connected" while no token was vaulted, i.e. a silent "0 tools".
+        monkeypatch.setenv("SECRET_KEY", "test-secret-key-for-testing-only-do-not-use")
+        from registry.egress_auth import state_codec
+        from registry.egress_auth.schemas import OAuthState
+        from registry.secrets.interfaces import SecretStoreError
+
+        state_codec.reset_cipher_for_tests()
+        blob = state_codec.encode_state(
+            OAuthState(
+                user_id="alice",
+                auth_method="oauth2",
+                provider="github",
+                server_path="/github-mcp",
+                nonce="n1",
+                issued_at="2026-06-19T00:00:00+00:00",
+            )
+        )
+        svc = AsyncMock()
+        svc.handle_callback = AsyncMock(side_effect=SecretStoreError("vault write failed"))
+        c = client(USER, server=_server(), svc=svc)
+        r = c.get("/api/oauth2/egress/callback", params={"code": "the-code", "state": blob})
+        assert r.status_code == 503
+        assert "Connection not saved" in r.text
+        assert "Connected github" not in r.text
+        assert svc.handle_callback.await_count == 1
+        state_codec.reset_cipher_for_tests()
+
     def test_callback_success_page_escapes_server_path(self, client, monkeypatch):
         # server_path is admin-registrant-supplied; validate_server_path blocks
         # nginx metacharacters but not '<'/'>', so the success HTML must escape it

--- a/tests/unit/secrets/test_stores.py
+++ b/tests/unit/secrets/test_stores.py
@@ -351,3 +351,26 @@ class TestOpenBaoTransientRetry:
         with pytest.raises(SecretStoreError):
             await store.put_token("oauth2", "alice", "github", "/github-mcp", _token())
         assert calls["n"] == 1  # raised immediately, no retry
+
+    async def test_write_retries_on_transient_error_type(self):
+        # The other transient tests match by MESSAGE (e.g. "local node not
+        # active"); this one matches by EXCEPTION TYPE NAME. hvac/urllib3 raise
+        # typed errors (ConnectionError, ReadTimeout, ...) whose str() may carry
+        # no recognizable phrase, so _is_transient_error must classify them by
+        # class name alone -- otherwise a leader-election blip surfacing as a bare
+        # ConnectionError would fall straight through as a hard failure.
+        store, kv = self._store()
+        real_write = kv.create_or_update_secret
+        calls = {"n": 0}
+
+        def flaky_write(path, secret, mount_point):
+            calls["n"] += 1
+            if calls["n"] < 2:  # a bare typed transport error, no telltale text
+                raise ConnectionError()
+            return real_write(path, secret, mount_point)
+
+        kv.create_or_update_secret = flaky_write
+        await store.put_token("oauth2", "alice", "github", "/github-mcp", _token("a1"))
+        assert calls["n"] == 2
+        got = await store.get_token("oauth2", "alice", "github", "/github-mcp")
+        assert got is not None and got.access_token == "a1"

--- a/tests/unit/secrets/test_stores.py
+++ b/tests/unit/secrets/test_stores.py
@@ -257,3 +257,98 @@ class TestOpenBaoReauth:
         with pytest.raises(SecretStoreError):
             await store.get_token("oauth2", "alice", "github", "/github-mcp")
         assert logins["n"] == 1  # retried exactly once
+
+
+# --------------------------------------------------------------------------- #
+# OpenBao transient-unavailability retry (HA leader election / pod restart)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+class TestOpenBaoTransientRetry:
+    """Regression: a Vault/OpenBao HA cluster briefly rejects requests while it
+    (re-)elects a leader after a pod restart (eviction / rollout / spot reclaim).
+    A consent's token WRITE that lands in that window used to bubble a hard
+    SecretStoreError -> the user saw "Connected" (or a 500) but no token was
+    vaulted -> a silent "0 tools". The store MUST ride out the blip with a
+    bounded backoff retry. Backoff is shrunk to 0 here so the test is instant."""
+
+    @pytest.fixture(autouse=True)
+    def _no_backoff(self, monkeypatch):
+        import registry.secrets.openbao.store as store_mod
+
+        monkeypatch.setattr(store_mod, "_TRANSIENT_BACKOFF_BASE", 0.0)
+
+    def _store(self):
+        kv = _FakeKvV2()
+        client = _FakeHvacClient()
+        client.secrets.kv.v2 = kv
+        return OpenBaoStore(client=client, mount_point="secret", prefix="mcp/egress"), kv
+
+    async def test_write_retries_through_transient_then_persists(self):
+        store, kv = self._store()
+        real_write = kv.create_or_update_secret
+        calls = {"n": 0}
+
+        def flaky_write(path, secret, mount_point):
+            calls["n"] += 1
+            if calls["n"] < 3:  # fail twice (leader election), then succeed
+                raise Exception("local node not active but active cluster node not found")
+            return real_write(path, secret, mount_point)
+
+        kv.create_or_update_secret = flaky_write
+        await store.put_token("oauth2", "alice", "github", "/github-mcp", _token("a1"))
+        assert calls["n"] == 3
+        got = await store.get_token("oauth2", "alice", "github", "/github-mcp")
+        assert got is not None and got.access_token == "a1"
+
+    async def test_read_retries_through_connection_refused(self):
+        store, kv = self._store()
+        await store.put_token("oauth2", "alice", "github", "/github-mcp", _token("a1"))
+        real_read = kv.read_secret_version
+        calls = {"n": 0}
+
+        def flaky_read(path, mount_point, raise_on_deleted_version=False):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise Exception(
+                    "HTTPConnectionPool: Max retries exceeded ... [Errno 111] "
+                    "Connection refused"
+                )
+            return real_read(path, mount_point, raise_on_deleted_version)
+
+        kv.read_secret_version = flaky_read
+        got = await store.get_token("oauth2", "alice", "github", "/github-mcp")
+        assert got is not None and got.access_token == "a1"
+
+    async def test_persistent_transient_raises_after_bounded_retries(self):
+        import registry.secrets.openbao.store as store_mod
+        from registry.secrets.interfaces import SecretStoreError
+
+        store, kv = self._store()
+        calls = {"n": 0}
+
+        def always_down(*a, **k):
+            calls["n"] += 1
+            raise Exception("connection refused")
+
+        kv.create_or_update_secret = always_down
+        with pytest.raises(SecretStoreError):
+            await store.put_token("oauth2", "alice", "github", "/github-mcp", _token())
+        # initial attempt + N bounded retries, then give up (no infinite loop)
+        assert calls["n"] == store_mod._TRANSIENT_RETRIES + 1
+
+    async def test_non_transient_error_is_not_retried(self):
+        store, kv = self._store()
+        calls = {"n": 0}
+
+        def bad_write(*a, **k):
+            calls["n"] += 1
+            raise Exception("malformed data: not retryable")
+
+        kv.create_or_update_secret = bad_write
+        from registry.secrets.interfaces import SecretStoreError
+
+        with pytest.raises(SecretStoreError):
+            await store.put_token("oauth2", "alice", "github", "/github-mcp", _token())
+        assert calls["n"] == 1  # raised immediately, no retry

--- a/tests/unit/secrets/test_stores.py
+++ b/tests/unit/secrets/test_stores.py
@@ -312,8 +312,7 @@ class TestOpenBaoTransientRetry:
             calls["n"] += 1
             if calls["n"] < 2:
                 raise Exception(
-                    "HTTPConnectionPool: Max retries exceeded ... [Errno 111] "
-                    "Connection refused"
+                    "HTTPConnectionPool: Max retries exceeded ... [Errno 111] Connection refused"
                 )
             return real_read(path, mount_point, raise_on_deleted_version)
 


### PR DESCRIPTION
## Problem

The per-user egress token store (`OpenBaoStore`) only retries on **expired-token** errors (`_is_auth_expiry_error`: Forbidden / 403 / "permission denied"). Transient **Vault/OpenBao unavailability** is not retried:

- `hvac.InternalServerError` 500 with `local node not active but active cluster node not found` (a standby that doesn't yet know the leader),
- `ConnectionError` / `connection refused` / `Max retries exceeded` (Service still routing to a terminating pod, or an HA 307 redirect to a now-dead leader `api_addr`),
- read timeouts.

All of these occur for a few seconds while an HA cluster **re-elects a leader** after a pod restart (eviction / rollout / spot reclaim). Today they fall straight through as `SecretStoreError`.

The worst case is the OAuth **consent callback**: `handle_callback` exchanges the code successfully and then calls `put_token`. If the write hits that window it raises, and `egress_callback` only catches `EgressAuthError` — so the request 500s and, critically, the token is **never vaulted**. The user is left with a silent **"0 tools"** and no signal that they should retry.

## Change

- **`registry/secrets/openbao/store.py`** — add `_is_transient_error` and extend `_run` with a bounded exponential backoff retry (`0.5/1/2/4s`, module constants so tests can shrink it). It is deliberately **disjoint** from the existing single re-auth path (403 is not transient), so the two recovery paths never overlap. Reads and writes now ride out a leader election instead of failing.
- **`registry/api/egress_auth_routes.py`** — catch `SecretStoreError` in `egress_callback` separately from `EgressAuthError` and return a clear, retryable **"Connection not saved"** page (`503`) instead of a raw `500`. It never falls through to the success page, so a failed write can't masquerade as a connected account.
- **`tests/unit/secrets/test_stores.py`** — new `TestOpenBaoTransientRetry`: retry-then-persist on write, retry-then-succeed on read, bounded give-up after N retries (no infinite loop), and that non-transient errors are not retried.

## Test plan

- [x] `pytest tests/unit/secrets/test_stores.py` — 22 passed (incl. 4 new).
- [x] `pytest tests/unit/egress_auth/test_public_routes.py` — 16 passed (callback route).
- [x] `py_compile` + line-length (≤100) clean on changed files.