### PR TITLE
Add per-type authorization scopes for custom entities

### DIFF
--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -421,6 +421,39 @@ sanitizer that isn't called) is equivalent to no check.
   skills. Filter each resource by ITS OWN access check (skill access for skills,
   server access for servers); the only universal bypass is real admin. Fail
   closed (omit) when access is unclear.
+- **A dynamically-minted permission name must not collide with a
+  privilege-derivation rule.** Admin here is derived from holding any
+  `ui_permission` whose action starts with a mutating prefix
+  (`create_/modify_/delete_/...`) granted for `["all"]`. Minting a per-type scope
+  named `create_<type>_entity` would therefore SILENTLY PROMOTE anyone granted it
+  to full admin. When you add a new family of dynamic scopes that reuse the
+  system's `{action}_{resource}` convention: (a) put the admin-derivation rule
+  behind ONE shared predicate (`is_admin_conferring_action`) in the dependency-free
+  constants module, and make EVERY consumer (`_user_is_admin`, the privileged-write
+  `_grants_admin`) call it — grep for stray `.startswith(PREFIXES)` checks that
+  bypass it; (b) exclude the new dynamic family from admin-derivation there
+  (exact regex, e.g. `^(create|modify|delete)_.+_entity$`), and keep the minted
+  action set EXACTLY equal to the excluded set (add a runtime `assert not
+  is_admin_conferring_action(x)` invariant so they can't drift); (c) constrain the
+  `<type>`/resource name charset at the source (`^[a-z0-9_-]+$`) so the minted key
+  is safe to use as a Mongo `$set` dotted field path (no `.`/`$` injection) and no
+  crafted name can slip a real admin action past the exclusion. NOTE the drift
+  trap: a *separate* privileged-WRITE guard that flags "any `["all"]` grant" (not
+  routed through the shared predicate) will disagree with the admin-derivation
+  rule about the excluded family — that disagreement is safe only if it fails
+  CLOSED (over-restrictive), and any admin-population counter that consumes it will
+  over-count; audit both directions.
+- **Bring a new first-class asset to authorization parity across its WHOLE
+  surface, not just the reported gap.** A custom/extensible entity type that has
+  per-record ownership but no per-type permission layer is missing create-gating
+  AND type-scoped discovery. Fixing only the ungated CREATE leaves enumeration
+  open; gate list/get/create/modify/delete/rate uniformly (view gate hides
+  existence with 404, mutate gate denies with 403), layer the per-type scope ON
+  TOP of the existing per-record owner/visibility checks (defense-in-depth, don't
+  replace them), and wire the SAME type-level gate into every discovery projection
+  (search, catalog) BEFORE per-record filtering so a caller with no list scope
+  sees zero records — including public ones — exactly as the equivalent
+  server/agent list scope behaves.
 - **Authorize the exact bytes you act on — never a separately-captured copy.** If
   one component captures a request body for the authz decision and another
   forwards a different copy to the sink, they can diverge (size-triggered

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -28,6 +28,7 @@ import { useRegistryConfig } from '../hooks/useRegistryConfig';
 import DeleteConfirmation from './DeleteConfirmation';
 import SearchableSelect from './SearchableSelect';
 import ListStateBoundary from './iam/ListStateBoundary';
+import CustomTypeListPicker from './iam/CustomTypeListPicker';
 
 interface IAMGroupsProps {
   onShowToast: (message: string, type: 'success' | 'error' | 'info') => void;
@@ -62,8 +63,10 @@ const UI_PERMISSION_KEYS = [
 // scopes. These are enumerated from the current type set (via /api/config) so an
 // admin can grant them proactively, before any record of the type exists. The
 // keys mirror registry/services/custom_entity_scopes.entity_scope() exactly.
-const ENTITY_SCOPE_ACTIONS: { action: string; verb: string }[] = [
-  { action: 'list', verb: 'List' },
+// Mutation actions render as free-text grants; the read action (`list`) renders
+// as a record picker (CustomTypeListPicker) since its grant supports specific
+// record paths, not just "all".
+const ENTITY_MUTATION_ACTIONS: { action: string; verb: string }[] = [
   { action: 'create', verb: 'Create' },
   { action: 'modify', verb: 'Modify' },
   { action: 'delete', verb: 'Delete' },
@@ -72,7 +75,8 @@ const ENTITY_SCOPE_ACTIONS: { action: string; verb: string }[] = [
 interface EntityScopeGroup {
   typeName: string;
   displayName: string;
-  keys: { key: string; label: string }[];
+  listKey: string;
+  mutationKeys: { key: string; label: string }[];
 }
 
 function buildEntityScopeGroups(
@@ -81,7 +85,8 @@ function buildEntityScopeGroups(
   return customTypes.map((t) => ({
     typeName: t.name,
     displayName: t.display_name || t.name,
-    keys: ENTITY_SCOPE_ACTIONS.map(({ action, verb }) => ({
+    listKey: `list_${t.name}_entity`,
+    mutationKeys: ENTITY_MUTATION_ACTIONS.map(({ action, verb }) => ({
       key: `${action}_${t.name}_entity`,
       label: `${verb} ${t.display_name || t.name}`,
     })),
@@ -982,8 +987,14 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                   <p className="text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide">
                     Custom Type: {group.displayName}
                   </p>
+                  <CustomTypeListPicker
+                    typeName={group.typeName}
+                    displayName={group.displayName}
+                    value={uiPermissions[group.listKey] || ''}
+                    onChange={(csv) => setPermValue(group.listKey, csv)}
+                  />
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                    {group.keys.map(({ key, label }) => (
+                    {group.mutationKeys.map(({ key, label }) => (
                       <div key={key}>
                         <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
                         <input
@@ -1325,8 +1336,14 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                       <p className="text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide">
                         Custom Type: {group.displayName}
                       </p>
+                      <CustomTypeListPicker
+                        typeName={group.typeName}
+                        displayName={group.displayName}
+                        value={uiPermissions[group.listKey] || ''}
+                        onChange={(csv) => setPermValue(group.listKey, csv)}
+                      />
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        {group.keys.map(({ key, label }) => (
+                        {group.mutationKeys.map(({ key, label }) => (
                           <div key={key}>
                             <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
                             <input

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -24,6 +24,7 @@ import {
 } from '../hooks/useIAM';
 import { useServerList, useServerTools } from '../hooks/useToolCatalog';
 import { useAgentList } from '../hooks/useAgentList';
+import { useRegistryConfig } from '../hooks/useRegistryConfig';
 import DeleteConfirmation from './DeleteConfirmation';
 import SearchableSelect from './SearchableSelect';
 import ListStateBoundary from './iam/ListStateBoundary';
@@ -55,6 +56,37 @@ const UI_PERMISSION_KEYS = [
   { key: 'modify_agent', label: 'Modify Agent' },
   { key: 'delete_agent', label: 'Delete Agent' },
 ];
+
+// ─── Per-type custom-entity ui_permissions ────────
+// Each admin-defined custom type mints list/create/modify/delete_<type>_entity
+// scopes. These are enumerated from the current type set (via /api/config) so an
+// admin can grant them proactively, before any record of the type exists. The
+// keys mirror registry/services/custom_entity_scopes.entity_scope() exactly.
+const ENTITY_SCOPE_ACTIONS: { action: string; verb: string }[] = [
+  { action: 'list', verb: 'List' },
+  { action: 'create', verb: 'Create' },
+  { action: 'modify', verb: 'Modify' },
+  { action: 'delete', verb: 'Delete' },
+];
+
+interface EntityScopeGroup {
+  typeName: string;
+  displayName: string;
+  keys: { key: string; label: string }[];
+}
+
+function buildEntityScopeGroups(
+  customTypes: { name: string; display_name: string }[],
+): EntityScopeGroup[] {
+  return customTypes.map((t) => ({
+    typeName: t.name,
+    displayName: t.display_name || t.name,
+    keys: ENTITY_SCOPE_ACTIONS.map(({ action, verb }) => ({
+      key: `${action}_${t.name}_entity`,
+      label: `${verb} ${t.display_name || t.name}`,
+    })),
+  }));
+}
 
 const COMMON_METHODS = [
   'initialize',
@@ -329,6 +361,17 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
   const { groups, isLoading, error, refetch } = useIAMGroups();
   const { servers: availableServers, isLoading: serversLoading } = useServerList();
   const { agents: availableAgents, isLoading: agentsLoading } = useAgentList();
+  const { config } = useRegistryConfig();
+
+  // Dynamic per-type entity scope keys, enabled only when the custom-types
+  // feature is on. Enumerated from the current type set so admins can grant
+  // before any record exists. Memoized so the render sites are stable.
+  const customTypesEnabled = config?.features?.custom_types ?? false;
+  const entityScopeGroups = useMemo(
+    () =>
+      customTypesEnabled ? buildEntityScopeGroups(config?.custom_types ?? []) : [],
+    [customTypesEnabled, config?.custom_types],
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [view, setView] = useState<View>('list');
 
@@ -917,22 +960,47 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
             </span>
           </button>
           {showUiPermissions && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pl-6">
-              {UI_PERMISSION_KEYS.map(({ key, label }) => (
-                <div key={key}>
-                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
-                  <input
-                    type="text"
-                    value={uiPermissions[key] || ''}
-                    onChange={(e) => setPermValue(key, e.target.value)}
-                    placeholder="e.g. all or currenttime, mcpgw"
-                    className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
-                               bg-white dark:bg-gray-900 text-gray-900 dark:text-white
-                               focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                  />
+            <>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pl-6">
+                {UI_PERMISSION_KEYS.map(({ key, label }) => (
+                  <div key={key}>
+                    <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
+                    <input
+                      type="text"
+                      value={uiPermissions[key] || ''}
+                      onChange={(e) => setPermValue(key, e.target.value)}
+                      placeholder="e.g. all or currenttime, mcpgw"
+                      className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
+                                 bg-white dark:bg-gray-900 text-gray-900 dark:text-white
+                                 focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                    />
+                  </div>
+                ))}
+              </div>
+              {entityScopeGroups.map((group) => (
+                <div key={group.typeName} className="pl-6 space-y-2">
+                  <p className="text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide">
+                    Custom Type: {group.displayName}
+                  </p>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {group.keys.map(({ key, label }) => (
+                      <div key={key}>
+                        <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
+                        <input
+                          type="text"
+                          value={uiPermissions[key] || ''}
+                          onChange={(e) => setPermValue(key, e.target.value)}
+                          placeholder="e.g. all or a comma-separated list"
+                          className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
+                                     bg-white dark:bg-gray-900 text-gray-900 dark:text-white
+                                     focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                        />
+                      </div>
+                    ))}
+                  </div>
                 </div>
               ))}
-            </div>
+            </>
           )}
         </div>
 
@@ -1235,22 +1303,47 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
                 </span>
               </button>
               {showUiPermissions && (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pl-6">
-                  {UI_PERMISSION_KEYS.map(({ key, label }) => (
-                    <div key={key}>
-                      <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
-                      <input
-                        type="text"
-                        value={uiPermissions[key] || ''}
-                        onChange={(e) => setPermValue(key, e.target.value)}
-                        placeholder="e.g. all or currenttime, mcpgw"
-                        className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
-                                   bg-white dark:bg-gray-900 text-gray-900 dark:text-white
-                                   focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-                      />
+                <>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-3 pl-6">
+                    {UI_PERMISSION_KEYS.map(({ key, label }) => (
+                      <div key={key}>
+                        <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
+                        <input
+                          type="text"
+                          value={uiPermissions[key] || ''}
+                          onChange={(e) => setPermValue(key, e.target.value)}
+                          placeholder="e.g. all or currenttime, mcpgw"
+                          className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
+                                     bg-white dark:bg-gray-900 text-gray-900 dark:text-white
+                                     focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                  {entityScopeGroups.map((group) => (
+                    <div key={group.typeName} className="pl-6 space-y-2">
+                      <p className="text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wide">
+                        Custom Type: {group.displayName}
+                      </p>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        {group.keys.map(({ key, label }) => (
+                          <div key={key}>
+                            <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">{label}</label>
+                            <input
+                              type="text"
+                              value={uiPermissions[key] || ''}
+                              onChange={(e) => setPermValue(key, e.target.value)}
+                              placeholder="e.g. all or a comma-separated list"
+                              className="w-full px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg
+                                         bg-white dark:bg-gray-900 text-gray-900 dark:text-white
+                                         focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+                            />
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   ))}
-                </div>
+                </>
               )}
             </div>
 

--- a/frontend/src/components/iam/CustomTypeListPicker.tsx
+++ b/frontend/src/components/iam/CustomTypeListPicker.tsx
@@ -1,0 +1,171 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import axios from 'axios';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import SearchableSelect from '../SearchableSelect';
+
+/**
+ * Grant control for a custom type's ``list_<type>_entity`` discovery scope.
+ *
+ * The discovery grant is interpreted by the backend in three tiers (mirroring
+ * ``list_agents``): ``"all"`` opens the whole type; a record path ``/type/uuid``
+ * opens just that record. This control surfaces those two tiers:
+ *
+ * - an "All" toggle (writes ``all``), and
+ * - a multi-select of specific records (writes their PATHS; the record NAME is
+ *   shown for readability), fetched from ``GET /api/custom/{type}``.
+ *
+ * Granting one record does NOT expose other records of the type — the backend
+ * matches each record's path, so this stays consistent with server/agent access.
+ * The value is stored as a comma-separated string in the shared uiPermissions
+ * state (``setValue``), exactly like the other permission inputs.
+ */
+
+interface CustomTypeListPickerProps {
+  typeName: string;
+  displayName: string;
+  /** Current CSV value of list_<type>_entity (e.g. "all" or "/type/uuid, ..."). */
+  value: string;
+  /** Persist a new CSV value (empty string clears the grant). */
+  onChange: (csv: string) => void;
+}
+
+interface RecordOption {
+  path: string;
+  name: string;
+}
+
+function _csvToList(csv: string): string[] {
+  return csv
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+const CustomTypeListPicker: React.FC<CustomTypeListPickerProps> = ({
+  typeName,
+  displayName,
+  value,
+  onChange,
+}) => {
+  const [records, setRecords] = useState<RecordOption[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Load the type's records so specific ones can be picked by name. Admins hit
+  // this editor, so the list returns every record of the type. Best-effort: a
+  // failure just leaves the picker empty (the All toggle + free-text still work).
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    axios
+      .get<{ records: RecordOption[] }>(`/api/custom/${typeName}`, {
+        params: { limit: 1000 },
+      })
+      .then((res) => {
+        if (cancelled) return;
+        setRecords(
+          (res.data.records ?? []).map((r) => ({ path: r.path, name: r.name })),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setRecords([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [typeName]);
+
+  const items = _csvToList(value);
+  const grantsAll = items.includes('all');
+  const selectedPaths = useMemo(() => items.filter((v) => v !== 'all'), [items]);
+
+  // Map a stored path back to a display label (name), falling back to the raw
+  // path if the record is gone or not yet loaded.
+  const labelForPath = useMemo(() => {
+    const byPath = new Map(records.map((r) => [r.path, r.name]));
+    return (path: string) => byPath.get(path) || path;
+  }, [records]);
+
+  const options = useMemo(
+    () =>
+      records
+        .filter((r) => !selectedPaths.includes(r.path))
+        .map((r) => ({ value: r.path, label: r.name, description: r.path })),
+    [records, selectedPaths],
+  );
+
+  const setAll = (checked: boolean) => {
+    // "All" is exclusive: it supersedes any specific-record selections.
+    onChange(checked ? 'all' : selectedPaths.join(', '));
+  };
+  const addPath = (path: string) => {
+    if (!path || selectedPaths.includes(path)) return;
+    onChange([...selectedPaths, path].join(', '));
+  };
+  const removePath = (path: string) => {
+    onChange(selectedPaths.filter((p) => p !== path).join(', '));
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-300">
+          List {displayName}
+        </label>
+        <label
+          htmlFor={`all-list_${typeName}_entity`}
+          className="flex items-center space-x-1.5 text-xs text-gray-500 dark:text-gray-400 cursor-pointer"
+        >
+          <input
+            id={`all-list_${typeName}_entity`}
+            type="checkbox"
+            checked={grantsAll}
+            onChange={(e) => setAll(e.target.checked)}
+            className="h-3.5 w-3.5 rounded border-gray-300 dark:border-gray-600 text-purple-600 focus:ring-purple-500"
+          />
+          <span>All</span>
+        </label>
+      </div>
+      {!grantsAll && (
+        <>
+          {selectedPaths.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {selectedPaths.map((path) => (
+                <span
+                  key={path}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded-full
+                             bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+                  title={path}
+                >
+                  {labelForPath(path)}
+                  <button
+                    type="button"
+                    onClick={() => removePath(path)}
+                    className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                    aria-label={`Remove ${labelForPath(path)}`}
+                  >
+                    <XMarkIcon className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <SearchableSelect
+            options={options}
+            value=""
+            onChange={addPath}
+            placeholder={
+              records.length > 0 ? 'Add a specific record…' : 'No records yet'
+            }
+            isLoading={loading}
+            allowCustom={false}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CustomTypeListPicker;

--- a/registry/api/custom_entity_routes.py
+++ b/registry/api/custom_entity_routes.py
@@ -22,7 +22,7 @@ from fastapi import (
 from pydantic import BaseModel
 
 from ..audit.context import set_audit_action
-from ..auth.dependencies import nginx_proxied_auth
+from ..auth.dependencies import nginx_proxied_auth, user_has_ui_permission_for_service
 from ..schemas.custom_entity_models import (
     CustomEntityCreate,
     CustomEntityRecord,
@@ -34,6 +34,7 @@ from ..services.custom_entity_errors import (
     CustomTypeRecordCapError,
     UnknownCustomTypeError,
 )
+from ..services.custom_entity_scopes import entity_scope
 from ..services.custom_entity_service import CustomEntityService
 
 # Configure logging
@@ -68,6 +69,81 @@ def _get_service() -> CustomEntityService:
     return get_custom_entity_service()
 
 
+def _has_type_scope(
+    action: str,
+    type_name: str,
+    user_context: dict,
+) -> bool:
+    """Return True if the caller holds the per-type scope, or is admin.
+
+    Admin is the catch-all bypass (matching server/agent routes). Otherwise the
+    caller must hold ``<action>_<type>_entity`` for this type (or "all") in their
+    ui_permissions. Fails closed: a missing/absent ui_permissions dict denies.
+
+    Args:
+        action: One of list/create/modify/delete.
+        type_name: The custom type being accessed.
+        user_context: The authenticated request context.
+
+    Returns:
+        True if access is permitted, False otherwise.
+    """
+    if user_context.get("is_admin", False):
+        return True
+    ui_permissions = user_context.get("ui_permissions") or {}
+    return user_has_ui_permission_for_service(
+        entity_scope(action, type_name), type_name, ui_permissions
+    )
+
+
+def _require_view_scope(
+    type_name: str,
+    user_context: dict,
+) -> None:
+    """Raise 404 (hide the type's existence) if the caller lacks the list scope.
+
+    Read gate for list/get/search/rating: holding no ``list_<type>_entity`` hides
+    even PUBLIC records (full parity with ``list_service``), so a non-holder is
+    told the type does not exist rather than that access is denied.
+    """
+    if not _has_type_scope("list", type_name, user_context):
+        logger.info(
+            "User %s denied list access to custom type %s (no list scope) -> 404",
+            user_context.get("username"),
+            type_name,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown custom type: {type_name}",
+        )
+
+
+def _require_mutate_scope(
+    action: str,
+    type_name: str,
+    user_context: dict,
+) -> None:
+    """Raise 403 if the caller lacks the ``<action>_<type>_entity`` scope.
+
+    Mutation gate for create/modify/delete. Unlike the read gate, existence is
+    not concealed (the caller can already see the type via the list scope), so a
+    non-holder gets a 403.
+    """
+    if not _has_type_scope(action, type_name, user_context):
+        logger.warning(
+            "User %s denied %s on custom type %s (no %s_%s_entity scope) -> 403",
+            user_context.get("username"),
+            action,
+            type_name,
+            action,
+            type_name,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"You do not have permission to {action} {type_name} records",
+        )
+
+
 @router.get("/{type}", summary="List records of a custom type")
 async def list_custom_entities(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
@@ -76,6 +152,7 @@ async def list_custom_entities(
     limit: int = Query(100, ge=1, le=1000, description="Max records to return"),
 ) -> dict:
     """List records of a type, filtered to those the caller may see."""
+    _require_view_scope(type, user_context)
     service = _get_service()
     try:
         items, total = await service.list_records(type, skip, limit, user_context)
@@ -101,6 +178,7 @@ async def get_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> CustomEntityRecord:
     """Get a single record by type and uuid (404 if not viewable)."""
+    _require_view_scope(type, user_context)
     service = _get_service()
     path = f"/{type}/{uuid}"
     try:
@@ -122,6 +200,7 @@ async def create_custom_entity(
     type: str = TYPE_PARAM,
 ) -> CustomEntityRecord:
     """Create a record of the given custom type."""
+    _require_mutate_scope("create", type, user_context)
     service = _get_service()
     owner = user_context.get("username")  # server-derived, never from body
     try:
@@ -157,6 +236,8 @@ async def update_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> CustomEntityRecord:
     """Update a record (owner or admin only; partial-update semantics)."""
+    # Type-level gate first; the service still enforces per-record owner-or-admin.
+    _require_mutate_scope("modify", type, user_context)
     service = _get_service()
     path = f"/{type}/{uuid}"
     try:
@@ -190,6 +271,8 @@ async def delete_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> None:
     """Delete a record (owner or admin only)."""
+    # Type-level gate first; the service still enforces per-record owner-or-admin.
+    _require_mutate_scope("delete", type, user_context)
     service = _get_service()
     path = f"/{type}/{uuid}"
     try:
@@ -215,6 +298,7 @@ async def rate_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> dict:
     """Add or update the caller's 1-5 rating on a record they can view."""
+    _require_view_scope(type, user_context)
     service = _get_service()
     path = f"/{type}/{uuid}"
     set_audit_action(
@@ -243,6 +327,7 @@ async def get_custom_entity_rating(
     uuid: str = UUID_PARAM,
 ) -> dict:
     """Return {num_stars, rating_details} for a record the caller can view."""
+    _require_view_scope(type, user_context)
     service = _get_service()
     path = f"/{type}/{uuid}"
     try:

--- a/registry/api/custom_entity_routes.py
+++ b/registry/api/custom_entity_routes.py
@@ -34,7 +34,11 @@ from ..services.custom_entity_errors import (
     CustomTypeRecordCapError,
     UnknownCustomTypeError,
 )
-from ..services.custom_entity_scopes import entity_scope
+from ..services.custom_entity_scopes import (
+    entity_scope,
+    list_grant_allows_type,
+    list_grant_record_paths,
+)
 from ..services.custom_entity_service import CustomEntityService
 
 # Configure logging
@@ -74,14 +78,16 @@ def _has_type_scope(
     type_name: str,
     user_context: dict,
 ) -> bool:
-    """Return True if the caller holds the per-type scope, or is admin.
+    """Return True if the caller holds the per-type MUTATION scope, or is admin.
 
-    Admin is the catch-all bypass (matching server/agent routes). Otherwise the
-    caller must hold ``<action>_<type>_entity`` for this type (or "all") in their
-    ui_permissions. Fails closed: a missing/absent ui_permissions dict denies.
+    Used for the mutation actions (create/modify/delete), which stay type-level:
+    the caller must hold ``<action>_<type>_entity`` for this type (or "all").
+    Admin is the catch-all bypass. Fails closed on a missing ui_permissions dict.
+    The read/list gate is per-record aware and lives in ``_require_view_scope`` /
+    ``user_can_list_custom_entity_type`` instead.
 
     Args:
-        action: One of list/create/modify/delete.
+        action: One of create/modify/delete.
         type_name: The custom type being accessed.
         user_context: The authenticated request context.
 
@@ -99,18 +105,29 @@ def _has_type_scope(
 def _require_view_scope(
     type_name: str,
     user_context: dict,
+    record_path: str | None = None,
 ) -> None:
-    """Raise 404 (hide the type's existence) if the caller lacks the list scope.
+    """Raise 404 (hide existence) if the caller lacks list access.
 
-    Read gate for list/get/search/rating: holding no ``list_<type>_entity`` hides
-    even PUBLIC records (full parity with ``list_service``), so a non-holder is
-    told the type does not exist rather than that access is denied.
+    Read gate for list/get/search/rating. The ``list_<type>_entity`` grant is
+    per-record aware (parity with ``list_agents``): ``"all"``/type-name open the
+    whole type; a record path opens just that record.
+
+    - On the COLLECTION list (``record_path=None``): passes if the caller can see
+      ANY record of the type (whole-type OR at least one granted record), so a
+      record-scoped grant does NOT 404 the type — the list then filters to the
+      granted records. Holding nothing 404s (hides existence, incl. public).
+    - On a SINGLE record (``record_path`` given): passes only if the grant covers
+      that specific record; otherwise 404 (indistinguishable from not-found).
     """
-    if not _has_type_scope("list", type_name, user_context):
+    from ..auth.dependencies import user_can_list_custom_entity_type
+
+    if not user_can_list_custom_entity_type(type_name, user_context, record_path):
         logger.info(
-            "User %s denied list access to custom type %s (no list scope) -> 404",
+            "User %s denied list access to custom type %s (record=%s) -> 404",
             user_context.get("username"),
             type_name,
+            record_path or "<collection>",
         )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -144,6 +161,29 @@ def _require_mutate_scope(
         )
 
 
+def _list_restrict_paths(
+    type_name: str,
+    user_context: dict,
+) -> list[str] | None:
+    """Return the record-path restriction for the collection list.
+
+    - ``None`` — whole-type access (admin, or a ``"all"``/type-name grant): the
+      list is bounded only by per-record visibility.
+    - ``list[str]`` — the caller holds only specific records of this type; the
+      list must be restricted to those paths (intersected with the per-record
+      visibility filter).
+
+    Assumes ``_require_view_scope`` already passed, so a non-whole-type caller
+    holds at least one record path here.
+    """
+    if user_context.get("is_admin", False):
+        return None
+    granted = (user_context.get("ui_permissions") or {}).get(entity_scope("list", type_name)) or []
+    if list_grant_allows_type(type_name, granted):
+        return None
+    return list_grant_record_paths(type_name, granted)
+
+
 @router.get("/{type}", summary="List records of a custom type")
 async def list_custom_entities(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
@@ -153,9 +193,17 @@ async def list_custom_entities(
 ) -> dict:
     """List records of a type, filtered to those the caller may see."""
     _require_view_scope(type, user_context)
+    # SECURITY: restrict_paths MUST be derived from _list_restrict_paths and
+    # passed to list_records. _require_view_scope passes a record-scoped caller
+    # (they hold at least one record path), so a whole-type read here would leak
+    # every record. _list_restrict_paths returns None only for whole-type/admin;
+    # a non-admin without the scope yields [] -> empty $in -> no records.
+    restrict_paths = _list_restrict_paths(type, user_context)
     service = _get_service()
     try:
-        items, total = await service.list_records(type, skip, limit, user_context)
+        items, total = await service.list_records(
+            type, skip, limit, user_context, restrict_paths=restrict_paths
+        )
     except UnknownCustomTypeError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
@@ -178,9 +226,9 @@ async def get_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> CustomEntityRecord:
     """Get a single record by type and uuid (404 if not viewable)."""
-    _require_view_scope(type, user_context)
-    service = _get_service()
     path = f"/{type}/{uuid}"
+    _require_view_scope(type, user_context, record_path=path)
+    service = _get_service()
     try:
         return await service.get_record(path, user_context)
     except CustomEntityNotFoundError as e:
@@ -298,9 +346,9 @@ async def rate_custom_entity(
     uuid: str = UUID_PARAM,
 ) -> dict:
     """Add or update the caller's 1-5 rating on a record they can view."""
-    _require_view_scope(type, user_context)
-    service = _get_service()
     path = f"/{type}/{uuid}"
+    _require_view_scope(type, user_context, record_path=path)
+    service = _get_service()
     set_audit_action(
         http_request,
         "rate",
@@ -327,9 +375,9 @@ async def get_custom_entity_rating(
     uuid: str = UUID_PARAM,
 ) -> dict:
     """Return {num_stars, rating_details} for a record the caller can view."""
-    _require_view_scope(type, user_context)
-    service = _get_service()
     path = f"/{type}/{uuid}"
+    _require_view_scope(type, user_context, record_path=path)
+    service = _get_service()
     try:
         return await service.get_rating(path, user_context)
     except CustomEntityNotFoundError as e:

--- a/registry/api/custom_type_routes.py
+++ b/registry/api/custom_type_routes.py
@@ -144,15 +144,27 @@ async def create_custom_type(
 
     # Mint the per-type scope set to the admin group so admins can manage this
     # type's records immediately. FATAL: a type whose scopes could not be granted
-    # is unusable, so surface the failure (the descriptor already exists; the
-    # admin can retry create after resolving the scope-store issue).
+    # is unusable. Roll back the just-created descriptor so the type-create stays
+    # atomic -- otherwise the orphaned descriptor makes an identical retry fail
+    # with 409 (already-exists) even though its scopes were never provisioned.
     try:
         await mint_custom_type_scopes(created.name)
     except ScopeMintError as e:
         logger.error(f"Failed to mint scopes for custom type {created.name}: {e}")
+        try:
+            # No records can exist yet (the type was created moments ago), so a
+            # non-forced delete is sufficient and leaves the scope store untouched.
+            await service.delete_type(created.name, force=False)
+            logger.info(f"Rolled back custom type {created.name} after scope-mint failure")
+        except Exception:
+            logger.exception(
+                "Failed to roll back custom type %s after scope-mint failure; "
+                "the descriptor is orphaned and a retry may 409",
+                created.name,
+            )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Custom type created but scope provisioning failed: {e}",
+            detail=f"Custom type scope provisioning failed and the type was rolled back: {e}",
         )
 
     # Reload is non-fatal: the auth server self-heals on its next periodic reload.

--- a/registry/api/custom_type_routes.py
+++ b/registry/api/custom_type_routes.py
@@ -31,6 +31,12 @@ from ..services.custom_entity_errors import (
     CustomTypeLimitError,
 )
 from ..services.custom_entity_service import CustomEntityService
+from ..services.scope_service import (
+    ScopeMintError,
+    cleanup_custom_type_scopes,
+    mint_custom_type_scopes,
+    trigger_auth_server_reload,
+)
 
 # Configure logging
 logging.basicConfig(
@@ -136,6 +142,27 @@ async def create_custom_type(
     except CustomEntityValidationError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=e.errors)
 
+    # Mint the per-type scope set to the admin group so admins can manage this
+    # type's records immediately. FATAL: a type whose scopes could not be granted
+    # is unusable, so surface the failure (the descriptor already exists; the
+    # admin can retry create after resolving the scope-store issue).
+    try:
+        await mint_custom_type_scopes(created.name)
+    except ScopeMintError as e:
+        logger.error(f"Failed to mint scopes for custom type {created.name}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Custom type created but scope provisioning failed: {e}",
+        )
+
+    # Reload is non-fatal: the auth server self-heals on its next periodic reload.
+    try:
+        await trigger_auth_server_reload()
+    except Exception:
+        logger.warning(
+            "Auth-server reload after minting scopes for %s failed (self-heals)", created.name
+        )
+
     logger.info(f"Custom type defined: {created.name} by {user_context.get('username')}")
     return created
 
@@ -202,6 +229,16 @@ async def delete_custom_type(
         count = await service.delete_type(name, force=force)
     except CustomTypeHasRecordsError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+
+    # Scope cleanup runs AFTER record/descriptor teardown (matches the existing
+    # embeddings -> records -> descriptor order). Non-fatal: a dangling scope on a
+    # deleted type is harmless (no records remain), and the backfill/sweep can
+    # re-run. Sweep ALL groups so a granted non-admin loses the scope too.
+    try:
+        await cleanup_custom_type_scopes(name)
+        await trigger_auth_server_reload()
+    except Exception:
+        logger.warning("Scope cleanup/reload after deleting custom type %s failed", name)
 
     set_audit_action(
         http_request,

--- a/registry/api/search_routes.py
+++ b/registry/api/search_routes.py
@@ -10,6 +10,9 @@ from pydantic import BaseModel, Field
 
 from ..audit import set_audit_action
 from ..auth.dependencies import nginx_proxied_auth
+from ..auth.dependencies import (
+    user_can_list_custom_entity_type as _user_can_list_custom_entity_type,
+)
 from ..auth.tool_filter import filter_tools_for_user, tool_allowed_for_user
 from ..constants import DeploymentType
 from ..core.config import DeploymentMode, RegistryMode, settings
@@ -848,9 +851,21 @@ async def semantic_search(
     # agreement: off = feature invisible, existing records dormant.
     custom_results = raw_results.get("custom", []) if settings.custom_entity_types_enabled else []
     filtered_custom: list[CustomEntitySearchResult] = []
+    # Type-level gate first: a caller with no list_<type>_entity sees no
+    # records of that type. A disallowed type is dropped before the per-record visibility check.
+    # Cache the decision per type so a many-hit type is only evaluated once.
+    type_allowed_cache: dict[str, bool] = {}
     for record in custom_results:
         record_path = record.get("path", "")
         if not record_path:
+            continue
+
+        entity_type = record.get("entity_type", "")
+        allowed = type_allowed_cache.get(entity_type)
+        if allowed is None:
+            allowed = _user_can_list_custom_entity_type(entity_type, user_context)
+            type_allowed_cache[entity_type] = allowed
+        if not allowed:
             continue
 
         visibility = record.get("visibility", "private")

--- a/registry/api/search_routes.py
+++ b/registry/api/search_routes.py
@@ -10,15 +10,15 @@ from pydantic import BaseModel, Field
 
 from ..audit import set_audit_action
 from ..auth.dependencies import nginx_proxied_auth
-from ..auth.dependencies import (
-    user_can_list_custom_entity_type as _user_can_list_custom_entity_type,
-)
 from ..auth.tool_filter import filter_tools_for_user, tool_allowed_for_user
 from ..constants import DeploymentType
 from ..core.config import DeploymentMode, RegistryMode, settings
 from ..repositories.factory import get_search_repository
 from ..repositories.interfaces import SearchRepositoryBase
 from ..services.agent_service import agent_service
+from ..services.custom_entity_scopes import entity_scope as _entity_scope
+from ..services.custom_entity_scopes import list_grant_allows_type as _list_grant_allows_type
+from ..services.custom_entity_scopes import list_grant_record_paths as _list_grant_record_paths
 from ..services.server_service import server_service
 from ..services.virtual_server_service import get_virtual_server_service
 
@@ -851,21 +851,33 @@ async def semantic_search(
     # agreement: off = feature invisible, existing records dormant.
     custom_results = raw_results.get("custom", []) if settings.custom_entity_types_enabled else []
     filtered_custom: list[CustomEntitySearchResult] = []
-    # Type-level gate first: a caller with no list_<type>_entity sees no
-    # records of that type. A disallowed type is dropped before the per-record visibility check.
-    # Cache the decision per type so a many-hit type is only evaluated once.
-    type_allowed_cache: dict[str, bool] = {}
+    # Discovery check first (per-record aware): the list_<type>_entity grant may
+    # open the whole type ("all"/type name) or only specific record paths. Resolve
+    # the grant ONCE per type into (whole, paths) — the grant is constant per type,
+    # so this avoids re-reading ui_permissions and re-extracting paths on every
+    # hit. Each hit then passes discovery iff the type is whole-open OR its own
+    # path is in the granted set (so granting one record surfaces only that
+    # record, never every public record of the type). Runs before the per-record
+    # visibility check.
+    is_admin = bool(user_context.get("is_admin", False))
+    ui_permissions = user_context.get("ui_permissions") or {}
+    # entity_type -> (whole_type_open, granted_record_paths)
+    discovery_cache: dict[str, tuple[bool, set[str]]] = {}
     for record in custom_results:
         record_path = record.get("path", "")
         if not record_path:
             continue
 
         entity_type = record.get("entity_type", "")
-        allowed = type_allowed_cache.get(entity_type)
-        if allowed is None:
-            allowed = _user_can_list_custom_entity_type(entity_type, user_context)
-            type_allowed_cache[entity_type] = allowed
-        if not allowed:
+        decision = discovery_cache.get(entity_type)
+        if decision is None:
+            granted = ui_permissions.get(_entity_scope("list", entity_type)) or []
+            whole = is_admin or _list_grant_allows_type(entity_type, granted)
+            paths = set() if whole else set(_list_grant_record_paths(entity_type, granted))
+            decision = (whole, paths)
+            discovery_cache[entity_type] = decision
+        whole_open, granted_paths = decision
+        if not whole_open and record_path not in granted_paths:
             continue
 
         visibility = record.get("visibility", "private")

--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -290,29 +290,54 @@ def get_accessible_agents_for_user(user_ui_permissions: dict[str, list[str]]) ->
 def user_can_list_custom_entity_type(
     type_name: str,
     user_context: dict,
+    record_path: str | None = None,
 ) -> bool:
     """Return True if the caller may see records of a custom type.
 
-    Type-level discovery gate for custom entities, mirroring the
-    ``list_service`` / ``list_agents`` projection: admin sees all types, a
-    non-admin must hold ``list_<type>_entity`` (or "all") in their
-    ui_permissions. Fails closed on a missing ui_permissions dict.
+    Discovery gate for custom entities, mirroring ``list_agents``: the
+    ``list_<type>_entity`` grant is interpreted in three tiers — ``"all"`` or the
+    bare type name open the WHOLE type; a record path ``/type/uuid`` opens just
+    that record. Admin bypasses. Fails closed on a missing ui_permissions dict.
+
+    Two call shapes:
+
+    - ``record_path=None`` (discovery pre-check for search/collection): True if
+      the caller can see ANY record of the type — the whole type OR at least one
+      specific record. This only decides whether the type is reachable at all;
+      per-record filtering still happens downstream (search checks each hit's
+      path; the collection list intersects the granted paths).
+    - ``record_path`` given (single-record gate): True only if the grant covers
+      that specific record (whole-type, or that exact path).
+
+    This discovery gate is layered ON TOP of the per-record visibility check;
+    both must pass.
 
     Args:
         type_name: The custom type name.
         user_context: The authenticated request context.
+        record_path: Optional specific record path ``/type/uuid`` to check.
 
     Returns:
-        True if the caller may list/search this type's records, False otherwise.
+        True if the caller may list/search the type (or the given record).
     """
-    from ..services.custom_entity_scopes import entity_scope
+    from ..services.custom_entity_scopes import (
+        entity_scope,
+        list_grant_allows_type,
+        list_grant_record_paths,
+    )
 
     if user_context.get("is_admin", False):
         return True
     ui_permissions = user_context.get("ui_permissions") or {}
-    return user_has_ui_permission_for_service(
-        entity_scope("list", type_name), type_name, ui_permissions
-    )
+    granted = ui_permissions.get(entity_scope("list", type_name)) or []
+
+    if list_grant_allows_type(type_name, granted):
+        return True
+    record_paths = list_grant_record_paths(type_name, granted)
+    if record_path is not None:
+        return record_path in record_paths
+    # Discovery pre-check: reachable if the caller holds any specific record.
+    return len(record_paths) > 0
 
 
 async def get_servers_for_scope(scope: str) -> list[str]:

--- a/registry/auth/dependencies.py
+++ b/registry/auth/dependencies.py
@@ -10,7 +10,7 @@ from .access_resolver import (
     get_user_accessible_tools,  # noqa: F401 - re-exported for external callers
     resolve_scope_access,
 )
-from .privileged_constants import ADMIN_ACTION_PREFIXES
+from .privileged_constants import ADMIN_ACTION_PREFIXES, is_admin_conferring_action
 from .proxied_token import (
     _api_auth_request_enabled,
     verify_registry_ui_token,
@@ -287,6 +287,34 @@ def get_accessible_agents_for_user(user_ui_permissions: dict[str, list[str]]) ->
     return list_permissions
 
 
+def user_can_list_custom_entity_type(
+    type_name: str,
+    user_context: dict,
+) -> bool:
+    """Return True if the caller may see records of a custom type.
+
+    Type-level discovery gate for custom entities, mirroring the
+    ``list_service`` / ``list_agents`` projection: admin sees all types, a
+    non-admin must hold ``list_<type>_entity`` (or "all") in their
+    ui_permissions. Fails closed on a missing ui_permissions dict.
+
+    Args:
+        type_name: The custom type name.
+        user_context: The authenticated request context.
+
+    Returns:
+        True if the caller may list/search this type's records, False otherwise.
+    """
+    from ..services.custom_entity_scopes import entity_scope
+
+    if user_context.get("is_admin", False):
+        return True
+    ui_permissions = user_context.get("ui_permissions") or {}
+    return user_has_ui_permission_for_service(
+        entity_scope("list", type_name), type_name, ui_permissions
+    )
+
+
 async def get_servers_for_scope(scope: str) -> list[str]:
     """
     Get list of server names that a scope provides access to - queries repository directly.
@@ -356,7 +384,11 @@ def _user_is_admin(
 
     Mutating actions are identified by prefix: register_, modify_, toggle_,
     delete_, publish_, create_. Read-only actions (list_, get_, health_check_)
-    do not grant admin status.
+    do not grant admin status. Per-type custom-entity mutation scopes
+    (create_/modify_/delete_<type>_entity) are also excluded via
+    is_admin_conferring_action: they gate one custom type's records, not
+    registry administration, so granting a non-admin group such a scope for
+    "all" resources does not silently promote it to admin.
 
     See GitHub issue #663 for the motivation behind this design.
 
@@ -368,7 +400,7 @@ def _user_is_admin(
         True if user has admin-level management permissions, False otherwise.
     """
     for action, resources in ui_permissions.items():
-        if action.startswith(_ADMIN_ACTION_PREFIXES) and "all" in resources:
+        if is_admin_conferring_action(action) and "all" in resources:
             logger.debug(f"Admin check: action '{action}' with 'all' grants admin status")
             return True
 

--- a/registry/auth/privileged_constants.py
+++ b/registry/auth/privileged_constants.py
@@ -22,6 +22,8 @@ so the privileged-write guard cannot silently drift out of sync with the
 admin-derivation rule.
 """
 
+import re
+
 # Mutating (management) UI-Scopes action prefixes. A user with any action whose
 # name starts with one of these, granted for "all" resources, is an admin.
 # Read-only prefixes (list_, get_, health_check_) are intentionally excluded.
@@ -41,6 +43,50 @@ ADMIN_ACTION_PREFIXES: tuple[str, ...] = (
 # Grant value that makes a mutating action admin-conferring. See the note above
 # on why "*" is deliberately excluded.
 PRIVILEGED_GRANTS: frozenset[str] = frozenset({"all"})
+
+# Per-type custom-entity mutation scopes (create_/modify_/delete_<type>_entity)
+# match the mutating prefixes above, but they are NOT admin-conferring: they gate
+# a single custom type's records, not registry management. Excluding them here
+# lets an admin grant a non-admin group ``create_dataset_entity: ["all"]`` without
+# silently promoting that user to full registry admin. This intentionally MODIFIES
+# the prefix-only admin-derivation contract from PR #717/#663 -- ``list_`` scopes
+# are read-only-prefixed and already excluded, so only the mutating forms need it.
+#
+# SECURITY BOUNDARY: this exclusion is the single source of truth for "a per-type
+# entity scope is not admin". ``is_admin_conferring_action`` (below) is the ONLY
+# supported way to apply the admin-derivation rule; both the per-request
+# ``_user_is_admin`` (dependencies.py) and the privileged-write ``_grants_admin``
+# (scope_repository.py) call it so they cannot drift apart.
+_PER_TYPE_ENTITY_SCOPE_RE = re.compile(r"^(create|modify|delete)_.+_entity$")
+
+
+def is_admin_conferring_action(action: str) -> bool:
+    """Return True if holding ``action`` for "all" resources confers admin.
+
+    An action confers admin when it starts with a mutating management prefix
+    (``ADMIN_ACTION_PREFIXES``) AND is not an excluded per-type custom-entity
+    scope (``create_/modify_/delete_<type>_entity``). Read-only prefixed actions
+    (``list_``/``get_``/``health_check_``) never match a mutating prefix and so
+    are non-conferring by construction.
+
+    This is the sole gate for the admin-derivation rule; both the per-request
+    admin check and the privileged-write guard defer to it so the exclusion
+    cannot be honored by one consumer and ignored by the other.
+
+    Args:
+        action: A UI-Scopes action name (e.g. ``register_service``,
+            ``create_dataset_entity``).
+
+    Returns:
+        True if the action is admin-conferring (subject to a "all" grant),
+        False otherwise.
+    """
+    if not action.startswith(ADMIN_ACTION_PREFIXES):
+        return False
+    if _PER_TYPE_ENTITY_SCOPE_RE.match(action):
+        return False
+    return True
+
 
 # Scope/group names that confer administrative access by membership. Naming a
 # scope one of these, or mapping a group to one of these, elevates whoever holds

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -11,6 +11,7 @@ from ...auth.privileged_constants import (
     ADMIN_ACTION_PREFIXES,
     PRIVILEGED_GRANTS,
     PRIVILEGED_SCOPE_NAMES,
+    is_admin_conferring_action,
 )
 from ..interfaces import ScopeRepositoryBase
 from .client import get_collection_name, get_documentdb_client
@@ -59,10 +60,13 @@ def _grants_admin(
 ) -> bool:
     """Return True if ui_permissions would confer admin privileges.
 
-    Admin is conferred by any mutating UI action (see
-    _PRIVILEGED_ACTION_PREFIXES) granted with "all" access. This is the same
-    rule _user_is_admin uses to derive admin status per request, so a group
-    carrying such permissions promotes its members to admin.
+    Admin is conferred by any mutating UI action granted with "all" access,
+    EXCEPT per-type custom-entity scopes (create_/modify_/delete_<type>_entity),
+    which is_admin_conferring_action excludes. This is the same rule
+    _user_is_admin uses to derive admin status per request (both defer to the
+    shared is_admin_conferring_action so the write guard and the admin check
+    cannot drift), so a group carrying such permissions promotes its members
+    to admin.
 
     Args:
         ui_permissions: Dict mapping UI actions to lists of allowed resources.
@@ -73,9 +77,7 @@ def _grants_admin(
     if not ui_permissions:
         return False
     for action, resources in ui_permissions.items():
-        if action.startswith(_PRIVILEGED_ACTION_PREFIXES) and (
-            _PRIVILEGED_GRANTS & set(resources or [])
-        ):
+        if is_admin_conferring_action(action) and (_PRIVILEGED_GRANTS & set(resources or [])):
             return True
     return False
 
@@ -769,6 +771,126 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                 f"Failed to remove server from UI scopes in DocumentDB: {e}", exc_info=True
             )
             return False
+
+    async def merge_ui_permissions(
+        self,
+        group_name: str,
+        ui_permissions: dict[str, list[str]],
+    ) -> bool:
+        """Merge ui_permission keys into a group's ui_permissions ($set per key)."""
+        if not ui_permissions:
+            return False
+        try:
+            collection = await self._get_collection()
+
+            set_fields: dict[str, Any] = {
+                f"ui_permissions.{key}": value for key, value in ui_permissions.items()
+            }
+            set_fields["updated_at"] = datetime.utcnow()
+
+            result = await collection.update_one(
+                {"_id": group_name},
+                {"$set": set_fields},
+            )
+
+            if result.matched_count == 0:
+                logger.error(f"Group '{group_name}' not found")
+                return False
+
+            # Keep the in-memory cache aligned so a subsequent read reflects the merge.
+            cached = self._scopes_cache.setdefault("UI-Scopes", {}).setdefault(group_name, {})
+            cached.update(ui_permissions)
+
+            logger.info(
+                "Merged %d ui_permission key(s) into group '%s': %s",
+                len(ui_permissions),
+                group_name,
+                sorted(ui_permissions.keys()),
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to merge ui_permissions in DocumentDB: {e}", exc_info=True)
+            return False
+
+    async def remove_ui_permission_keys(
+        self,
+        group_name: str,
+        permission_keys: list[str],
+    ) -> bool:
+        """Unset ui_permission keys from a single group."""
+        if not permission_keys:
+            return False
+        try:
+            collection = await self._get_collection()
+
+            unset_fields = {f"ui_permissions.{key}": "" for key in permission_keys}
+            result = await collection.update_one(
+                {"_id": group_name},
+                {
+                    "$unset": unset_fields,
+                    "$set": {"updated_at": datetime.utcnow()},
+                },
+            )
+
+            if result.matched_count == 0:
+                logger.error(f"Group '{group_name}' not found")
+                return False
+
+            cached = self._scopes_cache.get("UI-Scopes", {}).get(group_name)
+            if isinstance(cached, dict):
+                for key in permission_keys:
+                    cached.pop(key, None)
+
+            logger.info(
+                "Removed %d ui_permission key(s) from group '%s': %s",
+                len(permission_keys),
+                group_name,
+                sorted(permission_keys),
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to remove ui_permission keys in DocumentDB: {e}", exc_info=True)
+            return False
+
+    async def remove_ui_permission_keys_from_all_groups(
+        self,
+        permission_keys: list[str],
+    ) -> int:
+        """Unset ui_permission keys from every group that holds any of them."""
+        if not permission_keys:
+            return 0
+        try:
+            collection = await self._get_collection()
+
+            unset_fields = {f"ui_permissions.{key}": "" for key in permission_keys}
+            # Only touch groups that actually carry at least one of the keys.
+            match_filter = {
+                "$or": [{f"ui_permissions.{key}": {"$exists": True}} for key in permission_keys]
+            }
+            result = await collection.update_many(
+                match_filter,
+                {
+                    "$unset": unset_fields,
+                    "$set": {"updated_at": datetime.utcnow()},
+                },
+            )
+
+            ui_cache = self._scopes_cache.get("UI-Scopes", {})
+            for cached in ui_cache.values():
+                if isinstance(cached, dict):
+                    for key in permission_keys:
+                        cached.pop(key, None)
+
+            logger.info(
+                "Swept %d ui_permission key(s) from %d group(s): %s",
+                len(permission_keys),
+                result.modified_count,
+                sorted(permission_keys),
+            )
+            return result.modified_count
+        except Exception as e:
+            logger.error(f"Failed to sweep ui_permission keys in DocumentDB: {e}", exc_info=True)
+            return 0
 
     async def add_group_mapping(
         self,

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -811,6 +811,69 @@ class ScopeRepositoryBase(ABC):
         pass
 
     @abstractmethod
+    async def merge_ui_permissions(
+        self,
+        group_name: str,
+        ui_permissions: dict[str, list[str]],
+    ) -> bool:
+        """
+        Merge a set of ui_permission keys into a group's ui_permissions.
+
+        Targeted read-modify-write of individual permission keys, used to grant
+        a group per-type custom-entity scopes on type-create without
+        round-tripping the whole group document through import_group. Existing
+        keys are overwritten with the provided value; keys not present are added.
+
+        Args:
+            group_name: Name of the group to update.
+            ui_permissions: Mapping of permission name -> allowed resources to
+                merge into the group's ui_permissions.
+
+        Returns:
+            True if the group existed and was updated, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    async def remove_ui_permission_keys(
+        self,
+        group_name: str,
+        permission_keys: list[str],
+    ) -> bool:
+        """
+        Remove a set of ui_permission keys from a group's ui_permissions.
+
+        Used to clean up per-type custom-entity scopes on type-delete.
+
+        Args:
+            group_name: Name of the group to update.
+            permission_keys: Permission names to unset from ui_permissions.
+
+        Returns:
+            True if the group existed and was updated, False otherwise.
+        """
+        pass
+
+    @abstractmethod
+    async def remove_ui_permission_keys_from_all_groups(
+        self,
+        permission_keys: list[str],
+    ) -> int:
+        """
+        Remove a set of ui_permission keys from EVERY group that holds them.
+
+        Sweeps all groups so a granted non-admin does not keep a dangling
+        per-type scope after its type is deleted.
+
+        Args:
+            permission_keys: Permission names to unset from every group.
+
+        Returns:
+            The number of group documents modified.
+        """
+        pass
+
+    @abstractmethod
     async def add_group_mapping(
         self,
         group_name: str,

--- a/registry/services/custom_entity_scopes.py
+++ b/registry/services/custom_entity_scopes.py
@@ -15,22 +15,14 @@ The scope set per type ``<type>`` is exactly:
 
 The mutating three match ``ADMIN_ACTION_PREFIXES`` but are intentionally
 EXCLUDED from the admin-derivation rule by ``is_admin_conferring_action`` in
-``registry.auth.privileged_constants`` (the security boundary lives there, so
-this module imports the predicate rather than redefining the exclusion regex).
+``registry.auth.privileged_constants``. That module owns the single copy of the
+exclusion regex (the security boundary), so this module does not redefine it.
 """
-
-import re
-
-from ..auth.privileged_constants import is_admin_conferring_action
 
 # The four actions minted per type. Ordering is stable so callers that iterate
 # (mint/cleanup) produce a deterministic scope set. ``get`` is folded into
 # ``list`` (a single list scope gates both list and get).
 _ENTITY_SCOPE_ACTIONS: tuple[str, ...] = ("list", "create", "modify", "delete")
-
-# Mutating per-type entity scopes only (list_ is read-only and excluded). Mirrors
-# the exclusion regex in privileged_constants; used by is_per_type_entity_scope.
-_MUTATING_ENTITY_SCOPE_RE = re.compile(r"^(create|modify|delete)_.+_entity$")
 
 
 def entity_scope(
@@ -121,29 +113,3 @@ def list_grant_record_paths(
     """
     prefix = f"/{type_name}/"
     return [g for g in granted if isinstance(g, str) and g.startswith(prefix)]
-
-
-def is_per_type_entity_scope(
-    action: str,
-) -> bool:
-    """Return True if ``action`` is a MUTATING per-type entity scope.
-
-    A mutating per-type entity scope matches ``^(create|modify|delete)_.+_entity$``
-    -- exactly the set the admin-derivation rule excludes. Read-only
-    ``list_<type>_entity`` returns False here (it is never admin-conferring, so it
-    needs no exclusion). This is cross-checked against the boundary predicate:
-    every action matched here MUST be non-admin-conferring, which asserts the
-    exclusion regex in privileged_constants stays in sync with this one.
-
-    Args:
-        action: A UI-Scopes action name.
-
-    Returns:
-        True if the action is a mutating per-type entity scope, False otherwise.
-    """
-    if not _MUTATING_ENTITY_SCOPE_RE.match(action):
-        return False
-    # Invariant: a mutating entity scope must be excluded from admin derivation.
-    # If this ever fails, the two regexes have drifted apart.
-    assert not is_admin_conferring_action(action)  # nosec B101 - boundary invariant
-    return True

--- a/registry/services/custom_entity_scopes.py
+++ b/registry/services/custom_entity_scopes.py
@@ -1,0 +1,95 @@
+"""Single source of truth for per-type custom-entity UI-Scope naming.
+
+Each custom entity TYPE, when created, mints a per-type UI-Scope set that gates
+discovery and mutation of that type's records, bringing custom entities to
+parity with servers/agents. The scope-name convention lives here so it
+is never duplicated across the mint path (custom_type_routes), the route gates
+(custom_entity_routes), the search filter (search_routes), and the backfill migration.
+
+The scope set per type ``<type>`` is exactly:
+
+- ``list_<type>_entity``   -- gates list/get/search + rating view (read-only).
+- ``create_<type>_entity`` -- gates record create.
+- ``modify_<type>_entity`` -- gates record update.
+- ``delete_<type>_entity`` -- gates record delete.
+
+The mutating three match ``ADMIN_ACTION_PREFIXES`` but are intentionally
+EXCLUDED from the admin-derivation rule by ``is_admin_conferring_action`` in
+``registry.auth.privileged_constants`` (the security boundary lives there, so
+this module imports the predicate rather than redefining the exclusion regex).
+"""
+
+import re
+
+from ..auth.privileged_constants import is_admin_conferring_action
+
+# The four actions minted per type. Ordering is stable so callers that iterate
+# (mint/cleanup) produce a deterministic scope set. ``get`` is folded into
+# ``list`` (a single list scope gates both list and get); see D5 in the LLD.
+_ENTITY_SCOPE_ACTIONS: tuple[str, ...] = ("list", "create", "modify", "delete")
+
+# Mutating per-type entity scopes only (list_ is read-only and excluded). Mirrors
+# the exclusion regex in privileged_constants; used by is_per_type_entity_scope.
+_MUTATING_ENTITY_SCOPE_RE = re.compile(r"^(create|modify|delete)_.+_entity$")
+
+
+def entity_scope(
+    action: str,
+    type_name: str,
+) -> str:
+    """Return the UI-Scope name for an action on a custom type.
+
+    Args:
+        action: One of ``_ENTITY_SCOPE_ACTIONS`` (list/create/modify/delete).
+        type_name: The custom type name (already constrained to
+            ``^[a-z0-9_-]+$`` at the route layer).
+
+    Returns:
+        The scope name, e.g. ``entity_scope("create", "dataset")`` ->
+        ``"create_dataset_entity"``.
+    """
+    return f"{action}_{type_name}_entity"
+
+
+def all_entity_scopes(
+    type_name: str,
+) -> dict[str, list[str]]:
+    """Return the full per-type scope set granted to a group's ui_permissions.
+
+    Each scope is granted for ``["all"]`` (all records of that type). The result
+    is shaped like a ui_permissions fragment and is merged into a group document
+    on type-create (minted to ``mcp-registry-admin``).
+
+    Args:
+        type_name: The custom type name.
+
+    Returns:
+        Mapping of scope name -> ``["all"]`` for every action in the set.
+    """
+    return {entity_scope(action, type_name): ["all"] for action in _ENTITY_SCOPE_ACTIONS}
+
+
+def is_per_type_entity_scope(
+    action: str,
+) -> bool:
+    """Return True if ``action`` is a MUTATING per-type entity scope.
+
+    A mutating per-type entity scope matches ``^(create|modify|delete)_.+_entity$``
+    -- exactly the set the admin-derivation rule excludes. Read-only
+    ``list_<type>_entity`` returns False here (it is never admin-conferring, so it
+    needs no exclusion). This is cross-checked against the boundary predicate:
+    every action matched here MUST be non-admin-conferring, which asserts the
+    exclusion regex in privileged_constants stays in sync with this one.
+
+    Args:
+        action: A UI-Scopes action name.
+
+    Returns:
+        True if the action is a mutating per-type entity scope, False otherwise.
+    """
+    if not _MUTATING_ENTITY_SCOPE_RE.match(action):
+        return False
+    # Invariant: a mutating entity scope must be excluded from admin derivation.
+    # If this ever fails, the two regexes have drifted apart.
+    assert not is_admin_conferring_action(action)  # nosec B101 - boundary invariant
+    return True

--- a/registry/services/custom_entity_scopes.py
+++ b/registry/services/custom_entity_scopes.py
@@ -25,7 +25,7 @@ from ..auth.privileged_constants import is_admin_conferring_action
 
 # The four actions minted per type. Ordering is stable so callers that iterate
 # (mint/cleanup) produce a deterministic scope set. ``get`` is folded into
-# ``list`` (a single list scope gates both list and get); see D5 in the LLD.
+# ``list`` (a single list scope gates both list and get).
 _ENTITY_SCOPE_ACTIONS: tuple[str, ...] = ("list", "create", "modify", "delete")
 
 # Mutating per-type entity scopes only (list_ is read-only and excluded). Mirrors
@@ -67,6 +67,60 @@ def all_entity_scopes(
         Mapping of scope name -> ``["all"]`` for every action in the set.
     """
     return {entity_scope(action, type_name): ["all"] for action in _ENTITY_SCOPE_ACTIONS}
+
+
+def list_grant_allows_type(
+    type_name: str,
+    granted: list[str],
+) -> bool:
+    """Return True if a ``list_<type>_entity`` grant opens the WHOLE type.
+
+    The grant value (a ui_permissions list) is interpreted in three tiers,
+    mirroring how ``list_agents`` treats agent paths (``"all"`` or a specific
+    path):
+
+    - ``"all"``                -> every record of the type (whole-type).
+    - the bare ``type_name``   -> every record of the type (whole-type; the
+      original per-type semantics, kept backward-compatible so existing
+      ``["all"]``/type-name grants and the mint/backfill are unchanged).
+    - a record path ``/type/uuid`` -> only that record (per-record; handled by
+      :func:`list_grant_record_paths`, NOT here).
+
+    So this returns True only for the whole-type tiers. A purely record-scoped
+    grant returns False here (the caller sees only their granted records, not
+    the whole type).
+
+    Args:
+        type_name: The custom type name.
+        granted: The caller's ``list_<type>_entity`` grant list (may be empty).
+
+    Returns:
+        True if the grant opens the entire type, False otherwise.
+    """
+    return "all" in granted or type_name in granted
+
+
+def list_grant_record_paths(
+    type_name: str,
+    granted: list[str],
+) -> list[str]:
+    """Return the specific record paths a ``list_<type>_entity`` grant allows.
+
+    Extracts the per-record tier of the grant: entries shaped like the record's
+    synthetic path ``/<type>/<uuid>`` for THIS type. Whole-type tokens
+    (``"all"``, the bare type name) are not paths and are excluded here — callers
+    check those via :func:`list_grant_allows_type`. Used to build the list-query
+    path filter and the single-record/search per-record checks.
+
+    Args:
+        type_name: The custom type name (paths must be under ``/<type>/``).
+        granted: The caller's ``list_<type>_entity`` grant list.
+
+    Returns:
+        The subset of ``granted`` that are record paths for this type.
+    """
+    prefix = f"/{type_name}/"
+    return [g for g in granted if isinstance(g, str) and g.startswith(prefix)]
 
 
 def is_per_type_entity_scope(

--- a/registry/services/custom_entity_service.py
+++ b/registry/services/custom_entity_service.py
@@ -346,12 +346,22 @@ class CustomEntityService:
         skip: int,
         limit: int,
         user_context: dict,
+        restrict_paths: list[str] | None = None,
     ) -> tuple[list[CustomEntityRecord], int]:
         """List records of a type with in-query visibility filtering.
 
         Returns (page_slice, total_count) where total_count is the number of
         records THIS user can see — both use the SAME filter so the count
         matches the slice.
+
+        The discovery grant and the per-record visibility filter compose here:
+
+        - ``restrict_paths=None`` — whole-type access (grant is ``"all"``/type
+          name, or admin). Only the per-record visibility filter applies.
+        - ``restrict_paths=[...]`` — the caller holds only specific records of
+          this type (record-scoped ``list_<type>_entity``). The result is
+          additionally constrained to those record paths, intersected with the
+          visibility filter. An empty list yields no records.
         """
         # Read path: a list page tolerates brief cross-replica staleness, so
         # use the TTL cache rather than an authoritative Mongo read per page.
@@ -359,7 +369,21 @@ class CustomEntityService:
         if descriptor is None:
             raise UnknownCustomTypeError(type_name)
         visibility_filter = _build_visibility_filter(user_context)
+
+        if restrict_paths is not None:
+            # Intersect the granted record paths with the visibility filter.
+            # `_id` is the synthetic record path. Combine with $and so neither
+            # clause clobbers the other (visibility_filter is None for admins,
+            # but admins never pass restrict_paths, so this branch is non-admin).
+            path_clause: dict = {"_id": {"$in": restrict_paths}}
+            if visibility_filter:
+                combined_filter: dict | None = {"$and": [path_clause, visibility_filter]}
+            else:
+                combined_filter = path_clause
+        else:
+            combined_filter = visibility_filter
+
         entities = self._get_entities()
-        items = await entities.list_paginated(type_name, skip, limit, visibility_filter)
-        total = await entities.count(type_name, visibility_filter)
+        items = await entities.list_paginated(type_name, skip, limit, combined_filter)
+        total = await entities.count(type_name, combined_filter)
         return items, total

--- a/registry/services/scope_service.py
+++ b/registry/services/scope_service.py
@@ -27,6 +27,11 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # Constants
+# The built-in registry-admin group that per-type custom-entity scopes are minted
+# to on type-create. Admins get the full scope set so they can manage records of a
+# new type immediately; non-admins are granted scopes explicitly via the IAM UI.
+ADMIN_GROUP_NAME: str = "mcp-registry-admin"
+
 STANDARD_METHODS: list[str] = [
     "initialize",
     "notifications/initialized",
@@ -635,3 +640,89 @@ async def add_group_mapping_to_scope(
     except Exception as e:
         logger.error(f"Error adding group mapping to scope {scope_name}: {e}")
         return False
+
+
+class ScopeMintError(Exception):
+    """Raised when minting a custom type's scopes to the admin group fails.
+
+    Type creation treats this as fatal: a type whose scopes could not be granted
+    to admins is unusable (no one can list/create its records), so the caller
+    should surface the failure rather than leave an orphaned type.
+    """
+
+
+async def mint_custom_type_scopes(
+    type_name: str,
+) -> bool:
+    """Grant the per-type custom-entity scope set to the admin group.
+
+    Adds ``list/create/modify/delete_<type>_entity: ["all"]`` to
+    ``mcp-registry-admin`` via a targeted ui_permissions merge (no whole-doc
+    round-trip, so the privileged-write guard is not involved). Fails closed:
+    raises ScopeMintError if the group is missing or the write fails, so type
+    creation can abort.
+
+    Args:
+        type_name: The custom type name whose scopes to mint.
+
+    Returns:
+        True on success. Raises ScopeMintError on failure (never returns False).
+    """
+    from .custom_entity_scopes import all_entity_scopes
+
+    scopes = all_entity_scopes(type_name)
+    scope_repo = get_scope_repository()
+    try:
+        success = await scope_repo.merge_ui_permissions(ADMIN_GROUP_NAME, scopes)
+    except Exception as e:
+        raise ScopeMintError(f"Failed to mint scopes for custom type '{type_name}': {e}") from e
+
+    if not success:
+        raise ScopeMintError(
+            f"Failed to mint scopes for custom type '{type_name}': "
+            f"group '{ADMIN_GROUP_NAME}' not found or not updated"
+        )
+
+    logger.info(
+        "Minted per-type scopes for custom type '%s' to group '%s': %s",
+        type_name,
+        ADMIN_GROUP_NAME,
+        sorted(scopes.keys()),
+    )
+    return True
+
+
+async def cleanup_custom_type_scopes(
+    type_name: str,
+) -> int:
+    """Remove a custom type's scope set from EVERY group that holds it.
+
+    Sweeps all groups (not just ``mcp-registry-admin``) so a non-admin who was
+    granted the type's scopes does not keep a dangling permission after the type
+    is deleted. Best-effort: logs and returns 0 on error rather than raising,
+    matching the delete-type teardown which prioritizes record/descriptor
+    removal.
+
+    Args:
+        type_name: The custom type name whose scopes to remove.
+
+    Returns:
+        The number of group documents modified.
+    """
+    from .custom_entity_scopes import all_entity_scopes
+
+    keys = list(all_entity_scopes(type_name).keys())
+    scope_repo = get_scope_repository()
+    try:
+        modified = await scope_repo.remove_ui_permission_keys_from_all_groups(keys)
+    except Exception as e:
+        logger.error(f"Failed to clean up scopes for custom type '{type_name}': {e}")
+        return 0
+
+    logger.info(
+        "Cleaned up per-type scopes for custom type '%s' from %d group(s): %s",
+        type_name,
+        modified,
+        sorted(keys),
+    )
+    return modified

--- a/scripts/backfill-custom-entity-scopes.py
+++ b/scripts/backfill-custom-entity-scopes.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Backfill per-type custom-entity scopes for pre-existing types.
+
+Types created before the per-type authorization feature have no minted UI-Scopes,
+so their records became admin-only after the upgrade. This one-time migration
+grants each EXISTING custom type's full scope set
+(``list/create/modify/delete_<type>_entity: ["all"]``) to the ``mcp-registry-admin``
+group and triggers an auth-server scope reload.
+
+BEHAVIOR CHANGE (announced): this backfill grants the scope set to
+``mcp-registry-admin`` ONLY. Existing types therefore become admin-only until an
+admin explicitly grants scopes to other groups via the IAM UI. Records that were
+previously visible to non-admins (public/group-restricted) are hidden from them
+until such a grant is made -- this is the intended, stricter parity with
+``list_service``.
+
+The migration is IDEMPOTENT: minting is a per-key ``$set`` merge, so re-running
+it simply re-writes the same scope values. Safe to run repeatedly.
+
+Usage:
+    # Dry run (default) - list the types that would be backfilled
+    SECRET_KEY=... DOCUMENTDB_HOST=localhost \\
+        uv run python scripts/backfill-custom-entity-scopes.py
+
+    # Actually apply changes
+    SECRET_KEY=... DOCUMENTDB_HOST=localhost \\
+        uv run python scripts/backfill-custom-entity-scopes.py --apply
+
+    # MongoDB CE (single-node) backend
+    MCP_STORAGE_BACKEND=mongodb-ce DOCUMENTDB_HOST=localhost \\
+        uv run python scripts/backfill-custom-entity-scopes.py --apply
+
+Requires the registry package importable (run from the repo root via uv). The
+storage backend and connection are read from the same environment the registry
+uses (MCP_STORAGE_BACKEND, DOCUMENTDB_HOST, etc.).
+"""
+
+import argparse
+import asyncio
+import logging
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Backfill per-type custom-entity scopes to mcp-registry-admin",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    # Dry run (default)
+    uv run python scripts/backfill-custom-entity-scopes.py
+
+    # Apply changes
+    uv run python scripts/backfill-custom-entity-scopes.py --apply
+""",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually apply changes (default is a dry run)",
+    )
+    return parser.parse_args()
+
+
+async def _run_backfill(
+    dry_run: bool,
+) -> dict[str, int]:
+    """Backfill scopes for every existing custom type.
+
+    Args:
+        dry_run: If True, only report which types would be backfilled.
+
+    Returns:
+        Summary dict with counts (types_found, types_minted).
+    """
+    from registry.repositories.factory import get_custom_entity_service
+    from registry.services.scope_service import (
+        ScopeMintError,
+        mint_custom_type_scopes,
+        trigger_auth_server_reload,
+    )
+
+    service = get_custom_entity_service()
+    descriptors = await service.list_types()
+    type_names = sorted(d.name for d in descriptors)
+
+    logger.info("Found %d existing custom type(s): %s", len(type_names), type_names)
+
+    if dry_run:
+        logger.info("DRY RUN - no changes will be made")
+        for name in type_names:
+            logger.info("  Would mint scopes for type: %s", name)
+        return {"types_found": len(type_names), "types_minted": 0}
+
+    minted = 0
+    for name in type_names:
+        try:
+            await mint_custom_type_scopes(name)
+            minted += 1
+            logger.info("  Minted scopes for type: %s", name)
+        except ScopeMintError as e:
+            logger.error("  Failed to mint scopes for type %s: %s", name, e)
+
+    if minted:
+        reloaded = await trigger_auth_server_reload()
+        logger.info("Triggered auth-server scope reload: success=%s", reloaded)
+
+    return {"types_found": len(type_names), "types_minted": minted}
+
+
+async def main() -> None:
+    """Main entry point for the backfill migration."""
+    args = _parse_args()
+    dry_run = not args.apply
+
+    logger.info("=" * 60)
+    logger.info("Custom-Entity Scope Backfill")
+    logger.info("=" * 60)
+    logger.info("Mode: %s", "DRY RUN" if dry_run else "APPLY CHANGES")
+    logger.info("=" * 60)
+
+    result = await _run_backfill(dry_run)
+
+    logger.info("=" * 60)
+    logger.info("Backfill Summary:")
+    logger.info("  Types found:  %d", result["types_found"])
+    logger.info("  Types minted: %d", result["types_minted"])
+    if dry_run:
+        logger.info("  Note: dry run. Use --apply to make changes.")
+    logger.info("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/integration/test_custom_entities_integration.py
+++ b/tests/integration/test_custom_entities_integration.py
@@ -199,3 +199,93 @@ class TestCustomEntityLifecycle:
         count = await svc.delete_type(type_name, force=True)
         assert count == 1
         assert await svc.get_type(type_name) is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestListRecordsRestrictPaths:
+    """Per-record discovery restriction against real MongoDB.
+
+    Exercises list_records(restrict_paths=...), i.e. the $and of the record-path
+    $in clause with the visibility filter, which unit tests (mocked repo) cannot
+    verify actually behaves against the database.
+    """
+
+    async def _seed_three_public(self, svc, type_name):
+        """Create three PUBLIC records; return their paths (a, b, c)."""
+        await svc.create_type(_descriptor(type_name))
+        paths = []
+        for label in ("a", "b", "c"):
+            rec = await svc.create_record(
+                type_name,
+                CustomEntityCreate(name=label, visibility="public", attributes={"title": label}),
+                owner="alice",
+            )
+            paths.append(rec.path)
+        return paths
+
+    async def test_restrict_none_returns_whole_type(self, service):
+        svc, type_name = service
+        await self._seed_three_public(svc, type_name)
+        # None = whole-type access; only the visibility filter applies (all public).
+        items, total = await svc.list_records(type_name, 0, 100, BOB, restrict_paths=None)
+        assert total == 3
+        assert {r.name for r in items} == {"a", "b", "c"}
+
+    async def test_restrict_to_one_path_returns_only_that_record(self, service):
+        svc, type_name = service
+        pa, _pb, _pc = await self._seed_three_public(svc, type_name)
+        # Granting ONE record path must surface only that record — NOT the sibling
+        # public records. This is the invariant, verified against real Mongo.
+        items, total = await svc.list_records(type_name, 0, 100, BOB, restrict_paths=[pa])
+        assert total == 1
+        assert {r.name for r in items} == {"a"}
+
+    async def test_restrict_to_subset_returns_that_subset(self, service):
+        svc, type_name = service
+        pa, pb, _pc = await self._seed_three_public(svc, type_name)
+        items, total = await svc.list_records(type_name, 0, 100, BOB, restrict_paths=[pa, pb])
+        assert total == 2
+        assert {r.name for r in items} == {"a", "b"}
+
+    async def test_empty_restrict_returns_nothing(self, service):
+        svc, type_name = service
+        await self._seed_three_public(svc, type_name)
+        # Fail-closed: an empty path grant ($in: []) matches no records.
+        items, total = await svc.list_records(type_name, 0, 100, BOB, restrict_paths=[])
+        assert total == 0
+        assert items == []
+
+    async def test_restrict_intersects_visibility_not_union(self, service):
+        """The path clause AND the visibility filter — a granted path the caller
+        cannot see by visibility is still excluded (neither layer alone suffices).
+        """
+        svc, type_name = service
+        await svc.create_type(_descriptor(type_name))
+        pub = await svc.create_record(
+            type_name,
+            CustomEntityCreate(name="pub", visibility="public", attributes={"title": "p"}),
+            owner="alice",
+        )
+        priv = await svc.create_record(
+            type_name,
+            CustomEntityCreate(name="priv", visibility="private", attributes={"title": "q"}),
+            owner="alice",  # owned by alice, NOT bob
+        )
+        # Bob is granted BOTH paths, but priv is alice's private record: the
+        # visibility filter must still exclude it (grant does not override
+        # visibility). Only pub survives the $and.
+        items, total = await svc.list_records(
+            type_name, 0, 100, BOB, restrict_paths=[pub.path, priv.path]
+        )
+        assert total == 1
+        assert {r.name for r in items} == {"pub"}
+
+        # Alice (the owner) granted the same two paths sees both — her private
+        # record passes visibility, confirming the exclusion above was visibility
+        # (owner mismatch), not the path clause.
+        items_a, total_a = await svc.list_records(
+            type_name, 0, 100, ALICE, restrict_paths=[pub.path, priv.path]
+        )
+        assert total_a == 2
+        assert {r.name for r in items_a} == {"pub", "priv"}

--- a/tests/unit/api/test_custom_entity_routes.py
+++ b/tests/unit/api/test_custom_entity_routes.py
@@ -30,9 +30,37 @@ from registry.services.custom_entity_errors import (
 
 logger = logging.getLogger(__name__)
 
-USER_CTX: dict[str, Any] = {"username": "bob", "is_admin": False, "groups": []}
-VALID_UUID: str = str(uuid4())
 TYPE: str = "workflow"
+VALID_UUID: str = str(uuid4())
+
+# A non-admin who holds the full per-type scope set for TYPE. Used for the
+# happy-path tests below (the gate passes, then service behavior is exercised).
+FULL_SCOPES: dict[str, list[str]] = {
+    f"list_{TYPE}_entity": ["all"],
+    f"create_{TYPE}_entity": ["all"],
+    f"modify_{TYPE}_entity": ["all"],
+    f"delete_{TYPE}_entity": ["all"],
+}
+USER_CTX: dict[str, Any] = {
+    "username": "bob",
+    "is_admin": False,
+    "groups": [],
+    "ui_permissions": FULL_SCOPES,
+}
+# Admin bypasses every gate via is_admin, regardless of ui_permissions.
+ADMIN_CTX: dict[str, Any] = {
+    "username": "admin",
+    "is_admin": True,
+    "groups": [],
+    "ui_permissions": {},
+}
+# A non-admin with NO per-type scopes; every gate should deny (404/403).
+NO_SCOPE_CTX: dict[str, Any] = {
+    "username": "eve",
+    "is_admin": False,
+    "groups": [],
+    "ui_permissions": {},
+}
 
 
 def _record(name: str = "r") -> CustomEntityRecord:
@@ -167,4 +195,87 @@ class TestUpdateDelete:
         )
         client = _make_client(USER_CTX)
         resp = client.delete(f"/api/custom/{TYPE}/{VALID_UUID}")
+        assert resp.status_code == 404
+
+
+@pytest.mark.unit
+class TestPerTypeScopeGates:
+    """Per-type authorization gates: read hides the type (404), mutate 403.
+
+    Each gate is checked for a non-holder (deny), a scope-holder (pass), and an
+    admin (catch-all pass). Admin bypasses via is_admin even with empty
+    ui_permissions.
+    """
+
+    # ── Read gate: no list scope hides the type entirely (404) ──
+    def test_list_no_scope_404_hides_type(self, patched_service):
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.get(f"/api/custom/{TYPE}")
+        assert resp.status_code == 404
+        patched_service.list_records.assert_not_awaited()
+
+    def test_list_holder_ok(self, patched_service):
+        client = _make_client(USER_CTX)
+        assert client.get(f"/api/custom/{TYPE}").status_code == 200
+
+    def test_list_admin_ok(self, patched_service):
+        client = _make_client(ADMIN_CTX)
+        assert client.get(f"/api/custom/{TYPE}").status_code == 200
+
+    def test_get_no_scope_404(self, patched_service):
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.get(f"/api/custom/{TYPE}/{VALID_UUID}")
+        assert resp.status_code == 404
+        patched_service.get_record.assert_not_awaited()
+
+    def test_get_admin_ok(self, patched_service):
+        client = _make_client(ADMIN_CTX)
+        assert client.get(f"/api/custom/{TYPE}/{VALID_UUID}").status_code == 200
+
+    # ── Create gate: the PRIMARY GAP being closed (403 for non-holder) ──
+    def test_create_no_scope_403(self, patched_service):
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.post(f"/api/custom/{TYPE}", json={"name": "x"})
+        assert resp.status_code == 403
+        patched_service.create_record.assert_not_awaited()
+
+    def test_create_holder_ok(self, patched_service):
+        client = _make_client(USER_CTX)
+        assert client.post(f"/api/custom/{TYPE}", json={"name": "x"}).status_code == 201
+
+    def test_create_admin_ok(self, patched_service):
+        client = _make_client(ADMIN_CTX)
+        assert client.post(f"/api/custom/{TYPE}", json={"name": "x"}).status_code == 201
+
+    def test_create_list_only_scope_still_403(self, patched_service):
+        # Holding only the read scope must NOT permit create.
+        ctx = {**NO_SCOPE_CTX, "ui_permissions": {f"list_{TYPE}_entity": ["all"]}}
+        client = _make_client(ctx)
+        resp = client.post(f"/api/custom/{TYPE}", json={"name": "x"})
+        assert resp.status_code == 403
+
+    # ── Update / delete gates ──
+    def test_update_no_scope_403(self, patched_service):
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.put(f"/api/custom/{TYPE}/{VALID_UUID}", json={"name": "x"})
+        assert resp.status_code == 403
+        patched_service.update_record.assert_not_awaited()
+
+    def test_delete_no_scope_403(self, patched_service):
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.delete(f"/api/custom/{TYPE}/{VALID_UUID}")
+        assert resp.status_code == 403
+        patched_service.delete_record.assert_not_awaited()
+
+    # ── Rating routes are view-gated (require list scope) ──
+    def test_rate_no_scope_404(self, patched_service):
+        patched_service.update_rating = AsyncMock(return_value=4.0)
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.post(f"/api/custom/{TYPE}/{VALID_UUID}/rate", json={"rating": 4})
+        assert resp.status_code == 404
+
+    def test_get_rating_no_scope_404(self, patched_service):
+        patched_service.get_rating = AsyncMock(return_value={"num_stars": 0})
+        client = _make_client(NO_SCOPE_CTX)
+        resp = client.get(f"/api/custom/{TYPE}/{VALID_UUID}/rating")
         assert resp.status_code == 404

--- a/tests/unit/api/test_custom_type_routes.py
+++ b/tests/unit/api/test_custom_type_routes.py
@@ -154,6 +154,37 @@ class TestCreate:
             resp = client.post("/api/custom-types", json=self._payload())
         assert resp.status_code == 500
 
+    def test_create_rolls_back_descriptor_when_mint_fails(
+        self, patched_service, patched_scope_hooks
+    ):
+        # A mint failure must not leave an orphaned descriptor behind (an
+        # identical retry would otherwise 409). The route deletes the just-created
+        # type so create stays atomic.
+        from registry.services.scope_service import ScopeMintError
+
+        patched_scope_hooks["mint"] = AsyncMock(side_effect=ScopeMintError("boom"))
+        with patch.object(
+            custom_type_routes, "mint_custom_type_scopes", patched_scope_hooks["mint"]
+        ):
+            client = _make_client(ADMIN_CTX, patched_service)
+            resp = client.post("/api/custom-types", json=self._payload())
+        assert resp.status_code == 500
+        patched_service.delete_type.assert_awaited_once_with("workflow", force=False)
+
+    def test_create_survives_rollback_failure(self, patched_service, patched_scope_hooks):
+        # If the rollback delete itself fails, the route still returns 500 (it does
+        # not mask the original mint failure with a rollback error).
+        from registry.services.scope_service import ScopeMintError
+
+        patched_service.delete_type = AsyncMock(side_effect=RuntimeError("db down"))
+        patched_scope_hooks["mint"] = AsyncMock(side_effect=ScopeMintError("boom"))
+        with patch.object(
+            custom_type_routes, "mint_custom_type_scopes", patched_scope_hooks["mint"]
+        ):
+            client = _make_client(ADMIN_CTX, patched_service)
+            resp = client.post("/api/custom-types", json=self._payload())
+        assert resp.status_code == 500
+
     def test_non_admin_forbidden(self, patched_service):
         client = _make_client(USER_CTX, patched_service)
         resp = client.post("/api/custom-types", json=self._payload())

--- a/tests/unit/api/test_custom_type_routes.py
+++ b/tests/unit/api/test_custom_type_routes.py
@@ -63,7 +63,30 @@ def service() -> MagicMock:
 
 
 @pytest.fixture
-def patched_service(service):
+def patched_scope_hooks():
+    """Stub out the mint/cleanup/reload calls the type routes now make.
+
+    Type create mints the per-type scope set (fatal on failure) and reloads the
+    auth server; delete cleans up scopes and reloads. These tests focus on the
+    route behavior, so the scope-store side effects are stubbed and their
+    invocation asserted where relevant.
+    """
+    with (
+        patch.object(
+            custom_type_routes, "mint_custom_type_scopes", new=AsyncMock(return_value=True)
+        ) as mint,
+        patch.object(
+            custom_type_routes, "cleanup_custom_type_scopes", new=AsyncMock(return_value=1)
+        ) as cleanup,
+        patch.object(
+            custom_type_routes, "trigger_auth_server_reload", new=AsyncMock(return_value=True)
+        ) as reload,
+    ):
+        yield {"mint": mint, "cleanup": cleanup, "reload": reload}
+
+
+@pytest.fixture
+def patched_service(service, patched_scope_hooks):
     with patch.object(custom_type_routes, "_get_service", return_value=service):
         yield service
 
@@ -111,6 +134,26 @@ class TestCreate:
         assert resp.status_code == 201
         patched_service.create_type.assert_awaited_once()
 
+    def test_create_mints_scopes(self, patched_service, patched_scope_hooks):
+        client = _make_client(ADMIN_CTX, patched_service)
+        resp = client.post("/api/custom-types", json=self._payload())
+        assert resp.status_code == 201
+        # The per-type scope set is minted for the created type name.
+        patched_scope_hooks["mint"].assert_awaited_once_with("workflow")
+        patched_scope_hooks["reload"].assert_awaited_once()
+
+    def test_create_fails_when_mint_fails(self, patched_service, patched_scope_hooks):
+        # Mint is FATAL: a type whose scopes could not be granted is unusable.
+        from registry.services.scope_service import ScopeMintError
+
+        patched_scope_hooks["mint"] = AsyncMock(side_effect=ScopeMintError("boom"))
+        with patch.object(
+            custom_type_routes, "mint_custom_type_scopes", patched_scope_hooks["mint"]
+        ):
+            client = _make_client(ADMIN_CTX, patched_service)
+            resp = client.post("/api/custom-types", json=self._payload())
+        assert resp.status_code == 500
+
     def test_non_admin_forbidden(self, patched_service):
         client = _make_client(USER_CTX, patched_service)
         resp = client.post("/api/custom-types", json=self._payload())
@@ -141,6 +184,13 @@ class TestDelete:
         resp = client.delete("/api/custom-types/workflow")
         assert resp.status_code == 204
         patched_service.delete_type.assert_awaited_once_with("workflow", force=False)
+
+    def test_delete_cleans_up_scopes(self, patched_service, patched_scope_hooks):
+        client = _make_client(ADMIN_CTX, patched_service)
+        resp = client.delete("/api/custom-types/workflow")
+        assert resp.status_code == 204
+        patched_scope_hooks["cleanup"].assert_awaited_once_with("workflow")
+        patched_scope_hooks["reload"].assert_awaited_once()
 
     def test_non_admin_forbidden(self, patched_service):
         client = _make_client(USER_CTX, patched_service)

--- a/tests/unit/api/test_search_routes.py
+++ b/tests/unit/api/test_search_routes.py
@@ -1830,6 +1830,13 @@ class TestSemanticSearchCustomEntities:
         self, mock_http_request, mock_search_repo, regular_user_context
     ):
         # regular_user_context: username="regular_user", groups=["registry-users-lob1"]
+        # the type gate runs before per-record visibility, so grant the list
+        # scope here to exercise the per-record filter (the type-gate denial is
+        # covered separately below).
+        regular_user_context = {
+            **regular_user_context,
+            "ui_permissions": {"list_prompt_template_entity": ["all"]},
+        }
         mock_search_repo.search = AsyncMock(
             return_value={
                 "servers": [],
@@ -1893,4 +1900,41 @@ class TestSemanticSearchCustomEntities:
         )
 
         assert {c.name for c in response.custom} == {"Tagged"}
+        assert response.total_custom == 1
+
+    @pytest.mark.asyncio
+    async def test_type_gate_hides_disallowed_type_even_public(
+        self, mock_http_request, mock_search_repo, regular_user_context
+    ):
+        """a non-admin without list_<type>_entity sees NO records of that type,
+        not even public ones — the type-level gate runs before per-record
+        visibility. Only the type the caller can list survives.
+        """
+
+        def _rec(entity_type: str, name: str) -> dict[str, Any]:
+            r = _custom_record(f"/{entity_type}/{name}", name, "public")
+            r["entity_type"] = entity_type
+            return r
+
+        mock_search_repo.search = AsyncMock(
+            return_value={
+                "servers": [],
+                "tools": [],
+                "agents": [],
+                "custom": [
+                    _rec("prompt_template", "AllowedPublic"),
+                    _rec("secret_type", "HiddenPublic"),
+                ],
+            }
+        )
+        ctx = {
+            **regular_user_context,
+            "ui_permissions": {"list_prompt_template_entity": ["all"]},
+        }
+        request = SemanticSearchRequest(query="x")
+
+        response = await semantic_search(mock_http_request, request, ctx, mock_search_repo)
+
+        # secret_type is dropped by the type gate despite being public.
+        assert {c.name for c in response.custom} == {"AllowedPublic"}
         assert response.total_custom == 1

--- a/tests/unit/api/test_search_routes.py
+++ b/tests/unit/api/test_search_routes.py
@@ -1938,3 +1938,38 @@ class TestSemanticSearchCustomEntities:
         # secret_type is dropped by the type gate despite being public.
         assert {c.name for c in response.custom} == {"AllowedPublic"}
         assert response.total_custom == 1
+
+    @pytest.mark.asyncio
+    async def test_record_scoped_grant_surfaces_only_granted_record(
+        self, mock_http_request, mock_search_repo, regular_user_context
+    ):
+        """A grant for ONE record path must not surface sibling PUBLIC records.
+
+        Regression guard for the whole_type_cache short-circuit: a record-scoped
+        list_<type>_entity grant is not whole-type, so each hit must be checked
+        against its own path. Granting /prompt_template/a must return only "A",
+        never the public "B"/"C" of the same type.
+        """
+        ctx = {
+            **regular_user_context,
+            "ui_permissions": {"list_prompt_template_entity": ["/prompt_template/a"]},
+        }
+        mock_search_repo.search = AsyncMock(
+            return_value={
+                "servers": [],
+                "tools": [],
+                "agents": [],
+                "custom": [
+                    _custom_record("/prompt_template/a", "A", "public"),
+                    _custom_record("/prompt_template/b", "B", "public"),
+                    _custom_record("/prompt_template/c", "C", "public"),
+                ],
+            }
+        )
+        request = SemanticSearchRequest(query="prompt")
+
+        response = await semantic_search(mock_http_request, request, ctx, mock_search_repo)
+
+        # Only the granted record surfaces; public siblings stay hidden.
+        assert {c.name for c in response.custom} == {"A"}
+        assert response.total_custom == 1

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -32,6 +32,7 @@ from registry.auth.dependencies import (
     map_cognito_groups_to_scopes,
     nginx_proxied_auth,
     user_can_access_server,
+    user_can_list_custom_entity_type,
     user_can_modify_servers,
     user_has_ui_permission_for_service,
     user_has_wildcard_access,
@@ -1638,6 +1639,29 @@ class TestAuthPathsAgreeOnIsAdmin:
 
 @pytest.mark.unit
 @pytest.mark.auth
+class TestUserCanListCustomEntityType:
+    """Type-level discovery gate for custom entities (D3, search parity)."""
+
+    def test_admin_sees_all_types(self):
+        ctx = {"is_admin": True, "ui_permissions": {}}
+        assert user_can_list_custom_entity_type("dataset", ctx) is True
+
+    def test_holder_sees_their_type(self):
+        ctx = {"is_admin": False, "ui_permissions": {"list_dataset_entity": ["all"]}}
+        assert user_can_list_custom_entity_type("dataset", ctx) is True
+
+    def test_non_holder_denied(self):
+        ctx = {"is_admin": False, "ui_permissions": {"list_other_entity": ["all"]}}
+        assert user_can_list_custom_entity_type("dataset", ctx) is False
+
+    def test_missing_ui_permissions_fails_closed(self):
+        assert user_can_list_custom_entity_type("dataset", {"is_admin": False}) is False
+
+    def test_scoped_to_specific_type_name(self):
+        ctx = {"is_admin": False, "ui_permissions": {"list_dataset_entity": ["dataset"]}}
+        assert user_can_list_custom_entity_type("dataset", ctx) is True
+
+
 class TestUserIsAdmin:
     """Tests for _user_is_admin function.
 
@@ -1778,3 +1802,37 @@ class TestUserIsAdmin:
 
         # Assert
         assert result is False
+
+    # ── Per-type custom-entity scopes are EXCLUDED from admin derivation ──
+    # These match a mutating prefix (create_/modify_/delete_) but must NOT confer
+    # admin, or granting a non-admin group create_dataset_entity: ["all"] would
+    # silently promote them. This MODIFIES the PR #717/#663 contract.
+    @pytest.mark.parametrize(
+        "action",
+        [
+            "create_dataset_entity",
+            "modify_dataset_entity",
+            "delete_dataset_entity",
+            "create_n8n_workflow_entity",
+            "delete_a-b_entity",
+        ],
+    )
+    def test_per_type_entity_scope_does_not_grant_admin(self, action: str):
+        """A non-admin holding a per-type entity mutation scope is NOT admin."""
+        assert _user_is_admin({action: ["all"]}) is False
+
+    def test_per_type_list_entity_does_not_grant_admin(self):
+        """list_<type>_entity is read-only-prefixed and never admin."""
+        assert _user_is_admin({"list_dataset_entity": ["all"]}) is False
+
+    def test_real_admin_action_alongside_entity_scope_still_admin(self):
+        """A genuine admin action still confers admin even next to entity scopes."""
+        ui_permissions = {
+            "create_dataset_entity": ["all"],  # excluded
+            "register_service": ["all"],  # real admin
+        }
+        assert _user_is_admin(ui_permissions) is True
+
+    def test_non_entity_create_still_grants_admin(self):
+        """create_virtual_server (not an *_entity scope) still confers admin."""
+        assert _user_is_admin({"create_virtual_server": ["all"]}) is True

--- a/tests/unit/auth/test_dependencies.py
+++ b/tests/unit/auth/test_dependencies.py
@@ -1640,7 +1640,7 @@ class TestAuthPathsAgreeOnIsAdmin:
 @pytest.mark.unit
 @pytest.mark.auth
 class TestUserCanListCustomEntityType:
-    """Type-level discovery gate for custom entities (D3, search parity)."""
+    """Discovery gate for custom entities (search parity)."""
 
     def test_admin_sees_all_types(self):
         ctx = {"is_admin": True, "ui_permissions": {}}
@@ -1660,6 +1660,37 @@ class TestUserCanListCustomEntityType:
     def test_scoped_to_specific_type_name(self):
         ctx = {"is_admin": False, "ui_permissions": {"list_dataset_entity": ["dataset"]}}
         assert user_can_list_custom_entity_type("dataset", ctx) is True
+
+    # --- per-record grant tier ---
+
+    def test_record_grant_reachable_as_discovery_precheck(self):
+        # record_path=None: a specific-record grant makes the TYPE reachable
+        # (so the collection/search isn't 404'd) even without whole-type access.
+        ctx = {
+            "is_admin": False,
+            "ui_permissions": {"list_dataset_entity": ["/dataset/abc"]},
+        }
+        assert user_can_list_custom_entity_type("dataset", ctx) is True
+
+    def test_record_grant_allows_only_that_record(self):
+        ctx = {
+            "is_admin": False,
+            "ui_permissions": {"list_dataset_entity": ["/dataset/abc"]},
+        }
+        assert user_can_list_custom_entity_type("dataset", ctx, "/dataset/abc") is True
+        # A DIFFERENT record of the same type is not granted — this is the
+        # "one grant must not open every record" guarantee.
+        assert user_can_list_custom_entity_type("dataset", ctx, "/dataset/xyz") is False
+
+    def test_whole_type_grant_allows_any_record(self):
+        ctx = {"is_admin": False, "ui_permissions": {"list_dataset_entity": ["all"]}}
+        assert user_can_list_custom_entity_type("dataset", ctx, "/dataset/anything") is True
+
+    def test_no_grant_denies_specific_record(self):
+        assert (
+            user_can_list_custom_entity_type("dataset", {"is_admin": False}, "/dataset/abc")
+            is False
+        )
 
 
 class TestUserIsAdmin:

--- a/tests/unit/repositories/test_scope_repo_privileged_guard.py
+++ b/tests/unit/repositories/test_scope_repo_privileged_guard.py
@@ -63,11 +63,28 @@ class TestGrantsAdmin:
             {"list_service": ["all"]},
             {"register_service": ["currenttime"]},
             {},
+            # Per-type entity scopes are excluded from BOTH consumers.
+            {"create_dataset_entity": ["all"]},
+            {"modify_dataset_entity": ["all"]},
+            {"delete_dataset_entity": ["all"]},
+            {"list_dataset_entity": ["all"]},
         ]
         for ui_permissions in cases:
             assert _grants_admin(ui_permissions) == _user_is_admin(ui_permissions), (
                 f"disagreement on {ui_permissions}"
             )
+
+    # ── Per-type entity mutation scopes are NOT admin-conferring here ──
+    def test_per_type_entity_scope_does_not_grant_admin(self):
+        assert _grants_admin({"create_dataset_entity": ["all"]}) is False
+        assert _grants_admin({"modify_dataset_entity": ["all"]}) is False
+        assert _grants_admin({"delete_dataset_entity": ["all"]}) is False
+        assert _grants_admin({"list_dataset_entity": ["all"]}) is False
+
+    def test_real_admin_action_alongside_entity_scope_still_grants(self):
+        assert (
+            _grants_admin({"create_dataset_entity": ["all"], "register_service": ["all"]}) is True
+        )
 
 
 def _make_repo() -> DocumentDBScopeRepository:

--- a/tests/unit/repositories/test_scope_repo_ui_permission_merge.py
+++ b/tests/unit/repositories/test_scope_repo_ui_permission_merge.py
@@ -1,0 +1,118 @@
+"""Unit tests for targeted ui_permissions merge/remove on the scope repository.
+
+These back the per-type custom-entity scope mint (merge_ui_permissions) and
+cleanup (remove_ui_permission_keys / *_from_all_groups). They assert the exact
+Mongo update shape ($set / $unset per key) and the matched-count -> bool
+contract, without a live DB.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from registry.repositories.documentdb.scope_repository import DocumentDBScopeRepository
+
+
+def _make_repo():
+    repo = DocumentDBScopeRepository()
+    collection = MagicMock()
+    repo._get_collection = AsyncMock(return_value=collection)
+    repo._scopes_cache = {}
+    return repo, collection
+
+
+@pytest.mark.unit
+class TestMergeUiPermissions:
+    @pytest.mark.asyncio
+    async def test_merge_sets_each_key(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+
+        scopes = {"create_dataset_entity": ["all"], "list_dataset_entity": ["all"]}
+        result = await repo.merge_ui_permissions("mcp-registry-admin", scopes)
+
+        assert result is True
+        _, update = collection.update_one.call_args[0]
+        set_fields = update["$set"]
+        assert set_fields["ui_permissions.create_dataset_entity"] == ["all"]
+        assert set_fields["ui_permissions.list_dataset_entity"] == ["all"]
+        assert "updated_at" in set_fields
+        # Cache reflects the merge.
+        assert repo._scopes_cache["UI-Scopes"]["mcp-registry-admin"]["create_dataset_entity"] == [
+            "all"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_merge_group_missing_returns_false(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock(return_value=MagicMock(matched_count=0))
+        result = await repo.merge_ui_permissions("nope", {"create_x_entity": ["all"]})
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_merge_empty_is_noop(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock()
+        assert await repo.merge_ui_permissions("g", {}) is False
+        collection.update_one.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_merge_db_error_returns_false(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock(side_effect=RuntimeError("boom"))
+        assert await repo.merge_ui_permissions("g", {"create_x_entity": ["all"]}) is False
+
+
+@pytest.mark.unit
+class TestRemoveUiPermissionKeys:
+    @pytest.mark.asyncio
+    async def test_unset_each_key(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+        repo._scopes_cache = {"UI-Scopes": {"g": {"create_x_entity": ["all"], "keep": ["all"]}}}
+
+        result = await repo.remove_ui_permission_keys("g", ["create_x_entity"])
+
+        assert result is True
+        _, update = collection.update_one.call_args[0]
+        assert "ui_permissions.create_x_entity" in update["$unset"]
+        # Cache pruned but unrelated keys preserved.
+        assert "create_x_entity" not in repo._scopes_cache["UI-Scopes"]["g"]
+        assert "keep" in repo._scopes_cache["UI-Scopes"]["g"]
+
+    @pytest.mark.asyncio
+    async def test_group_missing_returns_false(self):
+        repo, collection = _make_repo()
+        collection.update_one = AsyncMock(return_value=MagicMock(matched_count=0))
+        assert await repo.remove_ui_permission_keys("g", ["create_x_entity"]) is False
+
+
+@pytest.mark.unit
+class TestRemoveFromAllGroups:
+    @pytest.mark.asyncio
+    async def test_sweep_returns_modified_count(self):
+        repo, collection = _make_repo()
+        collection.update_many = AsyncMock(return_value=MagicMock(modified_count=3))
+
+        modified = await repo.remove_ui_permission_keys_from_all_groups(
+            ["create_x_entity", "list_x_entity"]
+        )
+
+        assert modified == 3
+        match_filter, update = collection.update_many.call_args[0]
+        # Only groups holding at least one key are touched.
+        assert "$or" in match_filter
+        assert "ui_permissions.create_x_entity" in update["$unset"]
+
+    @pytest.mark.asyncio
+    async def test_empty_keys_noop(self):
+        repo, collection = _make_repo()
+        collection.update_many = AsyncMock()
+        assert await repo.remove_ui_permission_keys_from_all_groups([]) == 0
+        collection.update_many.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_db_error_returns_zero(self):
+        repo, collection = _make_repo()
+        collection.update_many = AsyncMock(side_effect=RuntimeError("boom"))
+        assert await repo.remove_ui_permission_keys_from_all_groups(["create_x_entity"]) == 0

--- a/tests/unit/scripts/test_backfill_custom_entity_scopes.py
+++ b/tests/unit/scripts/test_backfill_custom_entity_scopes.py
@@ -1,0 +1,89 @@
+"""Unit tests for scripts/backfill-custom-entity-scopes.py.
+
+The backfill grants each existing custom type's scope set to mcp-registry-admin
+and triggers a reload. It must be idempotent (re-running mints the same scopes)
+and a dry run must not mint. The module is loaded by path because the filename
+uses hyphens (not importable as a package).
+"""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "backfill-custom-entity-scopes.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("backfill_custom_entity_scopes", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _descriptor(name: str) -> MagicMock:
+    d = MagicMock()
+    d.name = name
+    return d
+
+
+@pytest.mark.unit
+class TestBackfill:
+    @pytest.mark.asyncio
+    async def test_apply_mints_every_type(self):
+        module = _load_module()
+        service = MagicMock()
+        service.list_types = AsyncMock(
+            return_value=[_descriptor("dataset"), _descriptor("workflow")]
+        )
+        mint = AsyncMock(return_value=True)
+        reload = AsyncMock(return_value=True)
+
+        with (
+            patch("registry.repositories.factory.get_custom_entity_service", return_value=service),
+            patch("registry.services.scope_service.mint_custom_type_scopes", mint),
+            patch("registry.services.scope_service.trigger_auth_server_reload", reload),
+        ):
+            result = await module._run_backfill(dry_run=False)
+
+        assert result == {"types_found": 2, "types_minted": 2}
+        assert {c.args[0] for c in mint.await_args_list} == {"dataset", "workflow"}
+        reload.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_mint(self):
+        module = _load_module()
+        service = MagicMock()
+        service.list_types = AsyncMock(return_value=[_descriptor("dataset")])
+        mint = AsyncMock(return_value=True)
+
+        with (
+            patch("registry.repositories.factory.get_custom_entity_service", return_value=service),
+            patch("registry.services.scope_service.mint_custom_type_scopes", mint),
+        ):
+            result = await module._run_backfill(dry_run=True)
+
+        assert result == {"types_found": 1, "types_minted": 0}
+        mint.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_rerun_mints_again(self):
+        # Re-running is safe: mint is an idempotent $set merge, so a second run
+        # over the same type set mints the same scopes without error.
+        module = _load_module()
+        service = MagicMock()
+        service.list_types = AsyncMock(return_value=[_descriptor("dataset")])
+        mint = AsyncMock(return_value=True)
+        reload = AsyncMock(return_value=True)
+
+        with (
+            patch("registry.repositories.factory.get_custom_entity_service", return_value=service),
+            patch("registry.services.scope_service.mint_custom_type_scopes", mint),
+            patch("registry.services.scope_service.trigger_auth_server_reload", reload),
+        ):
+            first = await module._run_backfill(dry_run=False)
+            second = await module._run_backfill(dry_run=False)
+
+        assert first == second == {"types_found": 1, "types_minted": 1}
+        assert mint.await_count == 2

--- a/tests/unit/services/test_custom_entity_scopes.py
+++ b/tests/unit/services/test_custom_entity_scopes.py
@@ -1,0 +1,126 @@
+"""Unit tests for per-type custom-entity scope naming and provisioning.
+
+Covers the naming single-source-of-truth (custom_entity_scopes), the
+admin-derivation exclusion predicate (privileged_constants), and the mint /
+cleanup service helpers (scope_service) including the fatal-on-failure contract.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from registry.auth.privileged_constants import is_admin_conferring_action
+from registry.services import scope_service
+from registry.services.custom_entity_scopes import (
+    all_entity_scopes,
+    entity_scope,
+    is_per_type_entity_scope,
+)
+from registry.services.scope_service import (
+    ADMIN_GROUP_NAME,
+    ScopeMintError,
+    cleanup_custom_type_scopes,
+    mint_custom_type_scopes,
+)
+
+
+@pytest.mark.unit
+class TestNaming:
+    def test_entity_scope_format(self):
+        assert entity_scope("create", "dataset") == "create_dataset_entity"
+        assert entity_scope("list", "n8n_workflow") == "list_n8n_workflow_entity"
+
+    def test_all_entity_scopes_full_set(self):
+        scopes = all_entity_scopes("dataset")
+        assert scopes == {
+            "list_dataset_entity": ["all"],
+            "create_dataset_entity": ["all"],
+            "modify_dataset_entity": ["all"],
+            "delete_dataset_entity": ["all"],
+        }
+
+    def test_is_per_type_entity_scope_mutating_only(self):
+        assert is_per_type_entity_scope("create_dataset_entity") is True
+        assert is_per_type_entity_scope("modify_dataset_entity") is True
+        assert is_per_type_entity_scope("delete_dataset_entity") is True
+        # list_ is read-only; not a "mutating per-type entity scope".
+        assert is_per_type_entity_scope("list_dataset_entity") is False
+        # Non-entity actions are not per-type entity scopes.
+        assert is_per_type_entity_scope("register_service") is False
+        assert is_per_type_entity_scope("create_virtual_server") is False
+
+
+@pytest.mark.unit
+class TestAdminConferringExclusion:
+    """The boundary predicate: entity mutation scopes are non-conferring."""
+
+    def test_real_admin_actions_confer(self):
+        assert is_admin_conferring_action("register_service") is True
+        assert is_admin_conferring_action("create_virtual_server") is True
+        assert is_admin_conferring_action("delete_agent") is True
+
+    def test_read_only_never_confers(self):
+        assert is_admin_conferring_action("list_service") is False
+        assert is_admin_conferring_action("get_agent") is False
+        assert is_admin_conferring_action("list_dataset_entity") is False
+
+    def test_per_type_mutation_scopes_excluded(self):
+        assert is_admin_conferring_action("create_dataset_entity") is False
+        assert is_admin_conferring_action("modify_dataset_entity") is False
+        assert is_admin_conferring_action("delete_dataset_entity") is False
+
+    def test_every_minted_scope_is_non_conferring(self):
+        # No scope the feature mints may ever confer admin.
+        for action in all_entity_scopes("dataset"):
+            assert is_admin_conferring_action(action) is False
+
+
+@pytest.mark.unit
+class TestMintAndCleanup:
+    @pytest.mark.asyncio
+    async def test_mint_persists_full_scope_set(self):
+        repo = AsyncMock()
+        repo.merge_ui_permissions = AsyncMock(return_value=True)
+        with patch.object(scope_service, "get_scope_repository", return_value=repo):
+            result = await mint_custom_type_scopes("dataset")
+        assert result is True
+        repo.merge_ui_permissions.assert_awaited_once_with(
+            ADMIN_GROUP_NAME, all_entity_scopes("dataset")
+        )
+
+    @pytest.mark.asyncio
+    async def test_mint_raises_when_group_missing(self):
+        repo = AsyncMock()
+        repo.merge_ui_permissions = AsyncMock(return_value=False)
+        with patch.object(scope_service, "get_scope_repository", return_value=repo):
+            with pytest.raises(ScopeMintError):
+                await mint_custom_type_scopes("dataset")
+
+    @pytest.mark.asyncio
+    async def test_mint_raises_when_repo_errors(self):
+        repo = AsyncMock()
+        repo.merge_ui_permissions = AsyncMock(side_effect=RuntimeError("db down"))
+        with patch.object(scope_service, "get_scope_repository", return_value=repo):
+            with pytest.raises(ScopeMintError):
+                await mint_custom_type_scopes("dataset")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_sweeps_all_groups(self):
+        repo = AsyncMock()
+        repo.remove_ui_permission_keys_from_all_groups = AsyncMock(return_value=2)
+        with patch.object(scope_service, "get_scope_repository", return_value=repo):
+            modified = await cleanup_custom_type_scopes("dataset")
+        assert modified == 2
+        repo.remove_ui_permission_keys_from_all_groups.assert_awaited_once_with(
+            list(all_entity_scopes("dataset").keys())
+        )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_non_fatal_on_error(self):
+        repo = AsyncMock()
+        repo.remove_ui_permission_keys_from_all_groups = AsyncMock(
+            side_effect=RuntimeError("db down")
+        )
+        with patch.object(scope_service, "get_scope_repository", return_value=repo):
+            modified = await cleanup_custom_type_scopes("dataset")
+        assert modified == 0  # swallowed, not raised

--- a/tests/unit/services/test_custom_entity_scopes.py
+++ b/tests/unit/services/test_custom_entity_scopes.py
@@ -15,6 +15,8 @@ from registry.services.custom_entity_scopes import (
     all_entity_scopes,
     entity_scope,
     is_per_type_entity_scope,
+    list_grant_allows_type,
+    list_grant_record_paths,
 )
 from registry.services.scope_service import (
     ADMIN_GROUP_NAME,
@@ -48,6 +50,44 @@ class TestNaming:
         # Non-entity actions are not per-type entity scopes.
         assert is_per_type_entity_scope("register_service") is False
         assert is_per_type_entity_scope("create_virtual_server") is False
+
+
+@pytest.mark.unit
+class TestListGrantTiers:
+    """The list_<type>_entity grant is interpreted in three tiers."""
+
+    def test_all_opens_whole_type(self):
+        assert list_grant_allows_type("n8n", ["all"]) is True
+
+    def test_bare_type_name_opens_whole_type(self):
+        # Backward-compatible with the original per-type semantics.
+        assert list_grant_allows_type("n8n", ["n8n"]) is True
+
+    def test_record_path_does_not_open_whole_type(self):
+        # A record-scoped grant is NOT whole-type: it must not surface every
+        # (public) record — only the named record via list_grant_record_paths.
+        grant = ["/n8n/6aac5d9c-c002-4761-b614-58c21c4adb9a"]
+        assert list_grant_allows_type("n8n", grant) is False
+
+    def test_empty_grant_opens_nothing(self):
+        assert list_grant_allows_type("n8n", []) is False
+
+    def test_record_paths_extracted_for_type_only(self):
+        grant = [
+            "/n8n/1111aaaa-c002-4761-b614-58c21c4adb9a",
+            "/n8n/2222bbbb-c002-4761-b614-58c21c4adb9a",
+            "/policy/3333cccc-c002-4761-b614-58c21c4adb9a",  # other type
+            "all",  # whole-type token, not a path
+        ]
+        paths = list_grant_record_paths("n8n", grant)
+        assert paths == [
+            "/n8n/1111aaaa-c002-4761-b614-58c21c4adb9a",
+            "/n8n/2222bbbb-c002-4761-b614-58c21c4adb9a",
+        ]
+
+    def test_record_paths_empty_for_whole_type_grant(self):
+        assert list_grant_record_paths("n8n", ["all"]) == []
+        assert list_grant_record_paths("n8n", ["n8n"]) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/services/test_custom_entity_scopes.py
+++ b/tests/unit/services/test_custom_entity_scopes.py
@@ -14,7 +14,6 @@ from registry.services import scope_service
 from registry.services.custom_entity_scopes import (
     all_entity_scopes,
     entity_scope,
-    is_per_type_entity_scope,
     list_grant_allows_type,
     list_grant_record_paths,
 )
@@ -40,16 +39,6 @@ class TestNaming:
             "modify_dataset_entity": ["all"],
             "delete_dataset_entity": ["all"],
         }
-
-    def test_is_per_type_entity_scope_mutating_only(self):
-        assert is_per_type_entity_scope("create_dataset_entity") is True
-        assert is_per_type_entity_scope("modify_dataset_entity") is True
-        assert is_per_type_entity_scope("delete_dataset_entity") is True
-        # list_ is read-only; not a "mutating per-type entity scope".
-        assert is_per_type_entity_scope("list_dataset_entity") is False
-        # Non-entity actions are not per-type entity scopes.
-        assert is_per_type_entity_scope("register_service") is False
-        assert is_per_type_entity_scope("create_virtual_server") is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# Add per-type authorization scopes for custom entities

## Problem

Custom entity records (`/api/custom/{type}`) were the only first-class asset
without a per-type permission layer. Servers, agents, and skills each have a
`list_/register_/modify_/delete_` UI-permission set; custom entities relied
entirely on per-record owner + visibility metadata. Two concrete gaps versus
servers/agents:

1. **Create was ungated** — any authenticated user could `POST /api/custom/{type}`
   and create records of any admin-defined type. There was no analogue to
   `register_service` / `publish_agent`.
2. **Discovery was not type-gated** — listing and search returned every record the
   caller could view, with no `list_<type>` analogue, so a user could enumerate
   records of a type regardless of whether they should know it exists.

## Change

Each custom type now mints a per-type scope set —
`list_/create_/modify_/delete_<type>_entity` — that gates discovery and mutation,
layered on top of (not replacing) the existing per-record owner/visibility checks
(defense-in-depth, exactly as `modify_agent` and owner-or-admin coexist today).
This brings custom entities to authorization parity with servers and agents.

- **Route gates** (`custom_entity_routes.py`): list/get/rate require the view scope
  and 404 the type when absent (hide existence); create/modify/delete require the
  matching mutate scope and 403 when absent. Admin is the catch-all bypass. Fails
  closed on missing permissions.
- **Discovery parity** (`search_routes.py`): the discovery gate runs before
  per-record visibility, so a caller with no `list_<type>_entity` sees zero records
  of that type — including public ones — matching how `list_service` hides servers.
- **Per-record discovery grants** (parity with `list_agents`): the
  `list_<type>_entity` grant is now interpreted in three tiers — `"all"` or the
  bare `<type>` name open the WHOLE type; a record path `/<type>/<uuid>` opens just
  that record. This lets an admin grant a group specific records of a type, exactly
  as `list_agents` can hold specific agent paths. The collection list filters to
  the granted paths, single-record GET/rate check the specific path, and search
  checks each hit's own path. Granting one record never exposes other (even public)
  records of the type. Existing `"all"`/type-name grants are unchanged.
- **Provisioning** (`custom_type_routes.py`): creating a type mints its scope set to
  the `mcp-registry-admin` group (fatal if it fails — the type would be unusable);
  deleting a type sweeps the scopes from every group. Both trigger an auth-server
  scope reload (non-fatal; self-heals on the next periodic reload).

## Safe naming of dynamic permissions (the key design point)

Admin is derived from holding any mutating-prefix UI-permission
(`create_/modify_/delete_/...`) granted for `["all"]`. Naming a per-type scope
`create_<type>_entity` would naively promote anyone granted it to full admin. To
prevent that, the admin-derivation rule now runs through a single shared predicate
`is_admin_conferring_action()` in the dependency-free `registry/auth/privileged_constants.py`,
which excludes per-type entity mutation scopes (`^(create|modify|delete)_.+_entity$`).
Both consumers — the per-request admin check and the privileged-write guard — use
that one predicate, so they cannot drift. The minted mutating action set is exactly
the excluded set (a runtime assertion guards against future drift), and type names
are charset-constrained (`^[a-z0-9_-]+$`) so a scope key is always a safe MongoDB
field path.

## Frontend

The IAM group-editor (`IAMGroups.tsx`) renders the per-type scope keys grouped by
type, enumerated from the existing registry config (no new endpoint), shown only
when the custom-types feature is enabled. The `list_<type>_entity` control is a
dedicated record picker (`iam/CustomTypeListPicker.tsx`): an "All" toggle plus a
searchable multi-select of the type's records (record NAME shown, record PATH
stored — matching the backend grant format). Create/modify/delete remain free-text
grants. An admin can grant a group either the whole type or specific records.

## Upgrade note (behavior change)

Types created before this feature have no minted scopes. Run
`scripts/backfill-custom-entity-scopes.py --apply` once after upgrade (dry-run by
default) to grant existing types' scopes to `mcp-registry-admin`. Until an admin
then grants scopes to other groups, pre-existing types become admin-only —
including their public records — which is the intended parity with `list_service`.
This is a MongoDB-only migration; no IdP/Keycloak change is required
(`ui_permissions` never leaves the registry scope store).

## Tests

New/updated coverage for: the admin-derivation exclusion (a non-admin holding
`create_<type>_entity:["all"]` is not admin, via both consumers; real admins still
are), every route gate (403/404 for non-holders, pass for holders and admins), the
create gap, mint-on-create (and fatal-on-failure), cleanup-on-delete, the targeted
ui-permission merge/remove/sweep helpers, search type-gating, and the idempotent
backfill.

Per-record discovery adds: the three-tier grant predicates
(`list_grant_allows_type` / `list_grant_record_paths` — all/type-name/path and
cross-type path isolation), the `record_path` gate in
`user_can_list_custom_entity_type` (a grant for one record allows only that record,
never a sibling), and a search-route regression test asserting a record-scoped
grant surfaces only the granted record and not other public records of the type
(guards the whole-type-cache short-circuit). Touched-area run: 238 passing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
