### PR TITLE
feat(metrics): add target_kind label to auth-request metric for MCP vs agent routing

### DIFF
--- a/auth_server/metrics_middleware.py
+++ b/auth_server/metrics_middleware.py
@@ -61,6 +61,7 @@ _MCP_TRANSPORT_ENDPOINTS: frozenset[str] = frozenset({"mcp", "sse", "messages"})
 # REGISTRY_ROOT_PATH prefix is stripped.
 _CONTROL_PLANE_FIRST_SEGMENTS: frozenset[str] = frozenset({"api", "static", "oauth2"})
 
+
 # Target-kind classification for the routing metric. Each rule recognizes a
 # routed DATA-PLANE target by its URL shape, checked in order (most specific
 # first). Anything that matches no rule and is not control plane is "unknown"

--- a/auth_server/metrics_middleware.py
+++ b/auth_server/metrics_middleware.py
@@ -48,6 +48,53 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# MCP transport endpoints. A data-plane MCP request ends in one of these (e.g.
+# "{server}/mcp", "{server}/sse"); its presence is what distinguishes a genuine
+# MCP server call from a control-plane path that merely has segments.
+_MCP_TRANSPORT_ENDPOINTS: frozenset[str] = frozenset({"mcp", "sse", "messages"})
+
+# Path prefixes that are CONTROL PLANE, not a routed target. These reach
+# /validate (the /api/* and static locations set auth_request in nginx) but must
+# NEVER be counted as MCP-server or agent routing. This mirrors the auth server's
+# own rule that /api/ paths do not yield a server_name (see server.py: the
+# `path_parts[0] != "api"` guard). Matched on the FIRST path segment after the
+# REGISTRY_ROOT_PATH prefix is stripped.
+_CONTROL_PLANE_FIRST_SEGMENTS: frozenset[str] = frozenset({"api", "static", "oauth2"})
+
+# Target-kind classification for the routing metric. Each rule recognizes a
+# routed DATA-PLANE target by its URL shape, checked in order (most specific
+# first). Anything that matches no rule and is not control plane is "unknown"
+# (never silently attributed to MCP servers) -- the classifier is an ALLOWLIST,
+# fail-safe by design, so a new/unrecognized route cannot inflate mcp_server.
+#
+# To track a NEW routed target type in the future: add one entry to
+# _TARGET_KIND_RULES with a predicate over the (already root-stripped) path
+# segments, and add the matching nginx route. No change to classify/emit logic.
+#
+# Each rule is (kind_label, predicate) where predicate(path_parts) -> bool.
+def _is_a2a_agent(path_parts: list[str]) -> bool:
+    # "{root}/agent/{agent_path}/..." -> at least "agent" + one path segment.
+    return len(path_parts) >= 2 and path_parts[0] == "agent"
+
+
+def _is_virtual_server(path_parts: list[str]) -> bool:
+    # "{root}/virtual/{id}/{transport}" -> a virtual MCP server data-plane call.
+    return len(path_parts) >= 2 and path_parts[0] == "virtual"
+
+
+def _is_mcp_server(path_parts: list[str]) -> bool:
+    # A real MCP server call ends in an MCP transport endpoint
+    # ("{server}/mcp", "{server}/sse", ...). Requiring the transport suffix is
+    # what keeps control-plane paths (which never carry it) out of mcp_server.
+    return len(path_parts) >= 2 and path_parts[-1] in _MCP_TRANSPORT_ENDPOINTS
+
+
+_TARGET_KIND_RULES: tuple[tuple[str, Any], ...] = (
+    ("a2a_agent", _is_a2a_agent),
+    ("virtual_mcp_server", _is_virtual_server),
+    ("mcp_server", _is_mcp_server),
+)
+
 
 class AuthMetricsMiddleware(BaseHTTPMiddleware):
     """
@@ -149,6 +196,73 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
         except Exception:
             return "unknown"
 
+    def classify_target_kind(self, original_url: str) -> str:
+        """Classify a validated request by the kind of target it routes to.
+
+        Splits the auth metric by routed data-plane target type so routing
+        volume can be tracked per kind. Returns one of:
+
+        - ``a2a_agent``          - an A2A agent reverse-proxy call
+        - ``virtual_mcp_server`` - a virtual MCP server call
+        - ``mcp_server``         - a (real) MCP server transport call
+        - ``control_plane``      - an /api/, static, or oauth2 request (NOT a
+                                   routed target: the dashboard, login, config,
+                                   skill/agent CRUD, ARD, public endpoints)
+        - ``unknown``            - no path, or a shape we do not recognize
+
+        This is an ALLOWLIST classifier: a path is attributed to a data-plane
+        target ONLY when it matches an explicit rule. Everything else is
+        control_plane/unknown, never silently counted as an MCP server. That
+        mirrors the auth server's own rule that ``/api/`` paths yield no
+        server_name and do not engage the rate-limit target axis, so this metric
+        cannot inadvertently count control-plane API calls as MCP-server traffic.
+
+        Note on skills: skills have no data-plane proxy route -- they are managed
+        only via ``/api/skills/...`` CRUD -- so they correctly classify as
+        control_plane, not a routed target.
+
+        Path shapes honor an optional ``REGISTRY_ROOT_PATH`` prefix. Kept
+        self-contained (not imported from ``server``) to avoid a circular
+        import: ``server`` imports this middleware.
+
+        Args:
+            original_url: The X-Original-URL header value from nginx.
+
+        Returns:
+            The target-kind label.
+        """
+        if not original_url:
+            return "unknown"
+
+        try:
+            from urllib.parse import urlparse
+
+            parsed_url = urlparse(original_url)
+            path = parsed_url.path.strip("/")
+
+            registry_prefix = os.environ.get("REGISTRY_ROOT_PATH", "").strip("/")
+            if registry_prefix and path.startswith(registry_prefix):
+                path = path[len(registry_prefix) :].lstrip("/")
+
+            path_parts = path.split("/") if path else []
+            if not path_parts:
+                return "unknown"
+
+            # Control plane is checked FIRST so an /api/* path can never fall
+            # through to a data-plane target label.
+            if path_parts[0] in _CONTROL_PLANE_FIRST_SEGMENTS:
+                return "control_plane"
+
+            # Allowlist: attribute to a data-plane target only on an explicit match.
+            for kind, predicate in _TARGET_KIND_RULES:
+                if predicate(path_parts):
+                    return kind
+
+            # Recognized as neither control plane nor a known routed target.
+            return "unknown"
+        except Exception:
+            return "unknown"
+
     async def extract_tool_and_method_info(self, request: Request) -> dict[str, Any]:
         """Extract detailed tool and method information from headers (X-Body) instead of consuming body."""
         tool_info = {
@@ -210,8 +324,10 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
 
         # Extract server name from original URL header
         original_url = request.headers.get("X-Original-URL")
+        target_kind = "unknown"
         if original_url:
             server_name = self.extract_server_name_from_url(original_url)
+            target_kind = self.classify_target_kind(original_url)
 
         # Extract detailed tool/method information
         tool_info = await self.extract_tool_and_method_info(request)
@@ -275,6 +391,7 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
                     method=auth_method,
                     duration_ms=duration_ms,
                     server_name=server_name,
+                    target_kind=target_kind,
                     user_hash=user_hash,
                     error_code=error_code,
                     request_id=request_id,
@@ -316,15 +433,20 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
         method: str,
         duration_ms: float,
         server_name: str,
+        target_kind: str,
         user_hash: str,
         error_code: str = None,
         request_id: str = None,
     ):
         """Emit authentication metric via OTel and (optionally) legacy HTTP POST.
 
-        Cardinality-controlled OTel attributes: ``success``, ``method``, ``server``.
-        The legacy ``user_hash`` and ``request_id`` dimensions are intentionally
-        not OTel attributes; per-user identification stays available in
+        Cardinality-controlled OTel attributes: ``success``, ``method``,
+        ``server``, ``target_kind``. ``target_kind`` (``a2a_agent`` /
+        ``mcp_server`` / ``unknown``) is a bounded label that lets the same
+        counter answer "how much traffic routed to agents vs MCP servers?"
+        without the unbounded per-target ``server`` name. The legacy
+        ``user_hash`` and ``request_id`` dimensions are intentionally not OTel
+        attributes; per-user identification stays available in
         auto-instrumentation span attributes for per-request debugging.
         """
         # 1) OTel emission (always-on, in-process, non-blocking)
@@ -332,6 +454,7 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
             "success": str(success),
             "method": method,
             "server": server_name,
+            "target_kind": target_kind,
         }
         auth_request_total.add(1, otel_attrs)
         auth_request_duration_ms.record(duration_ms, otel_attrs)
@@ -357,6 +480,7 @@ class AuthMetricsMiddleware(BaseHTTPMiddleware):
                             "success": success,
                             "method": method,
                             "server": server_name,
+                            "target_kind": target_kind,
                             "user_hash": user_hash,
                         },
                         "metadata": {

--- a/auth_server/observability/meters.py
+++ b/auth_server/observability/meters.py
@@ -88,7 +88,11 @@ _meter = metrics.get_meter("mcp-auth-server")
 
 auth_request_total = _meter.create_counter(
     name="mcpgw_registry_auth_request_total",
-    description="Authentication request count, labeled by outcome and method",
+    description=(
+        "Authentication request count, labeled by outcome, method, and "
+        "target_kind (a2a_agent | virtual_mcp_server | mcp_server | "
+        "control_plane | unknown) for routing breakdown"
+    ),
     unit="1",
 )
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -278,7 +278,7 @@ exposition form** (after the OTel exporter appends the unit suffix).
 
 | Metric | Source | Labels | What it counts |
 |---|---|---|---|
-| `mcpgw_registry_auth_request_total` | auth-server | `success`, `method`, `server` | Authenticated /validate calls |
+| `mcpgw_registry_auth_request_total` | auth-server | `success`, `method`, `server`, `target_kind` | Authenticated /validate calls (`target_kind` = `a2a_agent` \| `mcp_server` \| `unknown` for routing breakdown) |
 | `mcpgw_registry_tool_execution_total` | auth-server | `tool_name`, `server_name`, `success`, `method`, `client_name`, `client_version` | MCP tool calls detected at the auth layer |
 | `mcpgw_registry_operation_total` | registry middleware | `operation`, `resource_type`, `success` | Registry API operations (list/create/update/delete/search) |
 | `tool_discovery_total` | registry middleware | `results_count_bucket` | Semantic search calls |
@@ -310,7 +310,7 @@ exposition form** (after the OTel exporter appends the unit suffix).
 
 | Metric | Source | Labels | What it measures |
 |---|---|---|---|
-| `mcpgw_registry_auth_request_duration_milliseconds` (`_count`, `_sum`, `_bucket`) | auth-server | `success`, `method`, `server` | Auth /validate latency |
+| `mcpgw_registry_auth_request_duration_milliseconds` (`_count`, `_sum`, `_bucket`) | auth-server | `success`, `method`, `server`, `target_kind` | Auth /validate latency |
 | `tool_execution_duration_milliseconds` | auth-server | same as `mcpgw_registry_tool_execution_total` | Tool call latency at auth layer |
 | `mcpgw_registry_protocol_latency_milliseconds` | auth-server | `flow_step`, `server_name` | Time between MCP protocol stages (init → tools/list, etc.) |
 | `mcpgw_registry_operation_duration_milliseconds` | registry middleware | same as `mcpgw_registry_operation_total` | Registry API operation latency |
@@ -382,6 +382,7 @@ Replace `<TARGET>` with the path you care about (e.g. `/api/servers`,
 | Goal | Query |
 |---|---|
 | Auth requests per second by outcome | `sum by (success)(rate(mcpgw_registry_auth_request_total[5m]))` |
+| Routing split: agent vs MCP-server traffic | `sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))` |
 | Auth p95 latency | `histogram_quantile(0.95, sum by (le)(rate(mcpgw_registry_auth_request_duration_milliseconds_bucket[5m])))` |
 | Session-store hit rate | `sum(rate(mcpgw_registry_session_store_resolve_total{result="hit"}[5m])) / sum(rate(mcpgw_registry_session_store_resolve_total[5m]))` |
 | Federation peer sync failures by type | `sum by (peer_id, failure_type)(rate(peer_sync_failures_total[5m]))` |

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -278,7 +278,7 @@ exposition form** (after the OTel exporter appends the unit suffix).
 
 | Metric | Source | Labels | What it counts |
 |---|---|---|---|
-| `mcpgw_registry_auth_request_total` | auth-server | `success`, `method`, `server`, `target_kind` | Authenticated /validate calls (`target_kind` = `a2a_agent` \| `mcp_server` \| `unknown` for routing breakdown) |
+| `mcpgw_registry_auth_request_total` | auth-server | `success`, `method`, `server`, `target_kind` | Authenticated /validate calls. `target_kind` = `a2a_agent` \| `virtual_mcp_server` \| `mcp_server` \| `control_plane` \| `unknown` (routing breakdown; `control_plane` = `/api/*`, static, oauth2 — never counted as a data-plane target) |
 | `mcpgw_registry_tool_execution_total` | auth-server | `tool_name`, `server_name`, `success`, `method`, `client_name`, `client_version` | MCP tool calls detected at the auth layer |
 | `mcpgw_registry_operation_total` | registry middleware | `operation`, `resource_type`, `success` | Registry API operations (list/create/update/delete/search) |
 | `tool_discovery_total` | registry middleware | `results_count_bucket` | Semantic search calls |
@@ -382,8 +382,21 @@ Replace `<TARGET>` with the path you care about (e.g. `/api/servers`,
 | Goal | Query |
 |---|---|
 | Auth requests per second by outcome | `sum by (success)(rate(mcpgw_registry_auth_request_total[5m]))` |
-| Routing split: agent vs MCP-server traffic | `sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))` |
 | Auth p95 latency | `histogram_quantile(0.95, sum by (le)(rate(mcpgw_registry_auth_request_duration_milliseconds_bucket[5m])))` |
+
+#### Target-type routing (`target_kind`)
+
+`mcpgw_registry_auth_request_total` carries a `target_kind` label so you can see how `/validate` traffic splits across routed targets: `a2a_agent`, `virtual_mcp_server`, `mcp_server`, `control_plane` (the `/api/*` / static / oauth2 control plane, never a data-plane target), and `unknown`. Chart these as a Grafana **Time series** panel with legend `{{target_kind}}`.
+
+| Goal | Query |
+|---|---|
+| Routing split — one line per target kind (main timeseries) | `sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))` |
+| Data-plane only (drop control-plane / dashboard noise) | `sum by (target_kind)(rate(mcpgw_registry_auth_request_total{target_kind!="control_plane"}[5m]))` |
+| A2A agent routing only | `sum(rate(mcpgw_registry_auth_request_total{target_kind="a2a_agent"}[5m]))` |
+| Routing split by success/failure | `sum by (target_kind, success)(rate(mcpgw_registry_auth_request_total[5m]))` |
+| Share of total per target kind (stacked %) | `sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m])) / ignoring(target_kind) group_left sum(rate(mcpgw_registry_auth_request_total[5m]))` |
+| p95 auth latency per target kind | `histogram_quantile(0.95, sum by (le, target_kind)(rate(mcpgw_registry_auth_request_duration_milliseconds_bucket[5m])))` |
+| Cumulative counts (raw growth, not rate) | `sum by (target_kind)(mcpgw_registry_auth_request_total)` |
 | Session-store hit rate | `sum(rate(mcpgw_registry_session_store_resolve_total{result="hit"}[5m])) / sum(rate(mcpgw_registry_session_store_resolve_total[5m]))` |
 | Federation peer sync failures by type | `sum by (peer_id, failure_type)(rate(peer_sync_failures_total[5m]))` |
 | Logout JWT validation failure rate | `rate(mcpgw_registry_logout_jwt_validation_failed_total[5m])` |

--- a/docs/metrics-architecture.md
+++ b/docs/metrics-architecture.md
@@ -91,8 +91,8 @@ These are the primary operational metrics emitted by the middleware layer.
 
 | Instrument | Type | Service | Attributes |
 |-----------|------|---------|------------|
-| `auth_request_total` | Counter | auth-server, registry | `success`, `method`, `server` |
-| `auth_request_duration_seconds` | Histogram | auth-server, registry | `success`, `method`, `server` |
+| `auth_request_total` | Counter | auth-server, registry | `success`, `method`, `server`, `target_kind` |
+| `auth_request_duration_seconds` | Histogram | auth-server, registry | `success`, `method`, `server`, `target_kind` |
 | `tool_execution_total` | Counter | auth-server, registry | `method`, `tool_name`, `success` |
 | `tool_execution_duration_seconds` | Histogram | auth-server, registry | `method`, `tool_name`, `success` |
 | `tool_discovery_total` | Counter | auth-server, registry | `success`, `resource_type` |

--- a/scripts/generate-routing-traffic.sh
+++ b/scripts/generate-routing-traffic.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+# Generate authenticated traffic across the gateway's routing axes so the
+# `target_kind` label on mcpgw_registry_auth_request_total populates in
+# Prometheus/Grafana. Drives three kinds of requests through /validate:
+#
+#   mcp_server    -> MCP tool calls   (POST /<server>/mcp)
+#   a2a_agent     -> A2A invocations  (POST /agent/<path>/, gateway reverse-proxy)
+#   control_plane -> registry API reads (GET /api/*)
+#
+# This is a load/observability helper, not a correctness test: it counts HTTP
+# 200s per axis and does not assert on response bodies. Use it to demo or
+# smoke-check the routing metric (see docs/OBSERVABILITY.md "Target-type
+# routing"). Non-200s are reported but do not abort the run.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ---- Defaults -------------------------------------------------------------
+REGISTRY_URL="${REGISTRY_URL:-http://localhost}"
+TOKEN_FILE="${TOKEN_FILE:-.token}"
+ITERATIONS=10
+# Total run time. 0 (default) = a single pass. A positive value repeats the
+# full pass in rounds until this many minutes elapse, so the charts show a
+# sustained line over the rate() window instead of one brief spike.
+DURATION_MINUTES=0
+# Seconds to pause between rounds when DURATION_MINUTES > 0 (paces the load).
+INTERVAL_SECONDS=5
+# Space-separated MCP server paths (each must be enabled + healthy so nginx
+# renders a /<server>/mcp location; an unhealthy/unrouted server returns 405).
+# Default is the always-present built-in registry-tools server. Add your own
+# healthy servers with --mcp-servers "airegistry-tools currenttime ...".
+MCP_SERVERS="airegistry-tools"
+# Space-separated A2A agent paths (registered + enabled in reverse-proxy mode).
+A2A_AGENTS="flight-booking"
+# Control-plane API paths (GET, read-only).
+CONTROL_PLANE_PATHS="/api/agents /api/servers"
+
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Generate traffic across the three gateway routing axes (mcp_server, a2a_agent,
+control_plane) so the target_kind routing metric populates.
+
+Options:
+  --registry-url URL     Gateway base URL (default: \$REGISTRY_URL or http://localhost)
+  --token-file PATH      JWT token file; accepts nested {"tokens":{"access_token"}}
+                         or flat {"access_token"} (default: \$TOKEN_FILE or .token)
+  --iterations N         Requests per target per axis, per round (default: $ITERATIONS)
+  --duration-minutes M   Keep looping rounds for M minutes so the charts show a
+                         sustained line (default: $DURATION_MINUTES = single pass)
+  --interval-seconds S   Pause between rounds when --duration-minutes > 0
+                         (default: $INTERVAL_SECONDS)
+  --mcp-servers "a b"    MCP server paths to call (default: "$MCP_SERVERS")
+  --a2a-agents "a b"     A2A agent paths to invoke (default: "$A2A_AGENTS")
+  -h, --help             Show this help
+
+Examples:
+  # Single pass (10 requests per target per axis)
+  $0 --registry-url http://localhost --token-file .token
+
+  # Sustained traffic for 10 minutes to watch the timeseries charts fill in
+  $0 --registry-url http://localhost --token-file .token --duration-minutes 10
+EOF
+}
+
+
+# ---- Parse args -----------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --registry-url) REGISTRY_URL="$2"; shift 2 ;;
+        --token-file) TOKEN_FILE="$2"; shift 2 ;;
+        --iterations) ITERATIONS="$2"; shift 2 ;;
+        --duration-minutes) DURATION_MINUTES="$2"; shift 2 ;;
+        --interval-seconds) INTERVAL_SECONDS="$2"; shift 2 ;;
+        --mcp-servers) MCP_SERVERS="$2"; shift 2 ;;
+        --a2a-agents) A2A_AGENTS="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo -e "${RED}Unknown option: $1${NC}"; usage; exit 1 ;;
+    esac
+done
+
+# Strip any trailing slash from the base URL.
+REGISTRY_URL="${REGISTRY_URL%/}"
+
+
+# ---- Load token (nested UI format or flat) --------------------------------
+if [[ ! -f "$TOKEN_FILE" ]]; then
+    echo -e "${RED}Token file not found: $TOKEN_FILE${NC}"
+    exit 1
+fi
+
+# .tokens.access_token (registry UI "Get JWT Token") or top-level .access_token.
+TOKEN="$(jq -r '.tokens.access_token // .access_token // empty' "$TOKEN_FILE")"
+if [[ -z "$TOKEN" ]]; then
+    echo -e "${RED}No access_token found in $TOKEN_FILE${NC}"
+    echo "Expected {\"tokens\":{\"access_token\":...}} or {\"access_token\":...}"
+    exit 1
+fi
+
+echo -e "${BLUE}Registry:${NC}   $REGISTRY_URL"
+echo -e "${BLUE}Token:${NC}      $TOKEN_FILE (loaded, ${#TOKEN} chars)"
+echo -e "${BLUE}Iterations:${NC} $ITERATIONS per target per axis, per round"
+if [[ "$DURATION_MINUTES" -gt 0 ]]; then
+    echo -e "${BLUE}Duration:${NC}   $DURATION_MINUTES min (rounds paced ${INTERVAL_SECONDS}s apart)"
+else
+    echo -e "${BLUE}Duration:${NC}   single pass"
+fi
+echo ""
+
+
+# ---- Helpers --------------------------------------------------------------
+# Count HTTP 200s over N requests; print a per-axis summary line.
+_report() {
+    local label="$1" ok="$2" total="$3"
+    if [[ "$ok" -eq "$total" ]]; then
+        echo -e "  ${GREEN}[OK]${NC} $label: $ok/$total returned 200"
+    else
+        echo -e "  ${YELLOW}[WARN]${NC} $label: $ok/$total returned 200 (rest non-200)"
+    fi
+}
+
+
+_drive_mcp_servers() {
+    echo -e "${BLUE}Axis 1 - MCP tool calls (target_kind=mcp_server)${NC}"
+    for srv in $MCP_SERVERS; do
+        local ok=0 code
+        for ((i = 1; i <= ITERATIONS; i++)); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$REGISTRY_URL/$srv/mcp" \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/json, text/event-stream" \
+                -d "{\"jsonrpc\":\"2.0\",\"id\":\"$i\",\"method\":\"tools/list\",\"params\":{}}" || echo "000")
+            [[ "$code" == "200" ]] && ok=$((ok + 1))
+        done
+        _report "/$srv/mcp" "$ok" "$ITERATIONS"
+    done
+}
+
+
+_drive_a2a_agents() {
+    echo -e "${BLUE}Axis 2 - A2A invocations through gateway (target_kind=a2a_agent)${NC}"
+    for agent in $A2A_AGENTS; do
+        local ok=0 code
+        for ((i = 1; i <= ITERATIONS; i++)); do
+            # X-Authorization = gateway token (gated + stripped at /validate);
+            # Authorization = target-agent credential (presence-only accepts any).
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$REGISTRY_URL/agent/$agent/" \
+                -H "X-Authorization: Bearer $TOKEN" \
+                -H "Authorization: Bearer traffic-gen-placeholder" \
+                -H "Content-Type: application/json" \
+                -d "{\"jsonrpc\":\"2.0\",\"id\":\"$i\",\"method\":\"message/send\",\"params\":{\"message\":{\"role\":\"user\",\"messageId\":\"gen-$i\",\"parts\":[{\"kind\":\"text\",\"text\":\"traffic $i\"}]}}}" || echo "000")
+            [[ "$code" == "200" ]] && ok=$((ok + 1))
+        done
+        _report "/agent/$agent/" "$ok" "$ITERATIONS"
+    done
+}
+
+
+_drive_control_plane() {
+    echo -e "${BLUE}Axis 3 - control-plane reads (target_kind=control_plane)${NC}"
+    for path in $CONTROL_PLANE_PATHS; do
+        local ok=0 code
+        for ((i = 1; i <= ITERATIONS; i++)); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" \
+                "$REGISTRY_URL$path" || echo "000")
+            [[ "$code" == "200" ]] && ok=$((ok + 1))
+        done
+        _report "$path" "$ok" "$ITERATIONS"
+    done
+}
+
+
+# One full pass across all three axes.
+_run_round() {
+    _drive_mcp_servers
+    _drive_a2a_agents
+    _drive_control_plane
+}
+
+
+main() {
+    if [[ "$DURATION_MINUTES" -le 0 ]]; then
+        # Single pass.
+        _run_round
+    else
+        # Loop rounds until the wall-clock deadline. SECONDS is a bash builtin
+        # that counts seconds since the shell started.
+        local deadline=$((DURATION_MINUTES * 60))
+        local round=0
+        while [[ "$SECONDS" -lt "$deadline" ]]; do
+            round=$((round + 1))
+            local elapsed_min
+            elapsed_min=$(awk "BEGIN{printf \"%.1f\", $SECONDS/60}")
+            echo -e "${BLUE}=== Round $round (t+${elapsed_min}m / ${DURATION_MINUTES}m) ===${NC}"
+            _run_round
+            # Stop if the next pause would overrun the deadline.
+            [[ "$SECONDS" -ge "$deadline" ]] && break
+            sleep "$INTERVAL_SECONDS"
+        done
+        echo -e "${BLUE}Completed $round rounds over ~${DURATION_MINUTES} min.${NC}"
+    fi
+    echo ""
+    echo -e "${GREEN}Done.${NC} Chart the split with (Prometheus/Grafana):"
+    echo "  sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))"
+}
+
+main

--- a/tests/unit/metrics/test_middleware_target_kind.py
+++ b/tests/unit/metrics/test_middleware_target_kind.py
@@ -1,0 +1,136 @@
+"""Unit tests for AuthMetricsMiddleware.classify_target_kind.
+
+The auth-request metric carries a bounded ``target_kind`` label so routing
+volume can be split by target type (A2A agent, virtual MCP server, MCP server)
+without an unbounded per-target name. Classification is an ALLOWLIST derived
+from the X-Original-URL path shape the nginx gateway forwards: a path is counted
+as a data-plane target ONLY on an explicit match, so control-plane /api/* calls
+are never miscounted as MCP-server traffic.
+"""
+
+import os
+from unittest.mock import patch
+
+from auth_server.metrics_middleware import AuthMetricsMiddleware
+
+
+def _middleware() -> AuthMetricsMiddleware:
+    # BaseHTTPMiddleware needs an app arg; a no-op placeholder is fine here.
+    return AuthMetricsMiddleware(app=lambda *a, **k: None)
+
+
+class TestClassifyA2AAgent:
+    def test_agent_reverse_proxy_path(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/agent/flight-booking/") == "a2a_agent"
+
+    def test_agent_card_path(self) -> None:
+        mw = _middleware()
+        url = "http://localhost/agent/flight-booking/.well-known/agent-card.json"
+        assert mw.classify_target_kind(url) == "a2a_agent"
+
+    def test_multi_segment_agent_path(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/agent/lob1/travel/") == "a2a_agent"
+
+    def test_bare_agent_segment_is_not_agent(self) -> None:
+        # "/agent" with no agent path fails the min-parts guard; it is not a
+        # known target and (not being control plane) classifies as unknown.
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/agent") == "unknown"
+
+
+class TestClassifyMcpServer:
+    def test_mcp_transport_suffix(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/mcpgw/mcp") == "mcp_server"
+
+    def test_sse_transport_suffix(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/currenttime/sse") == "mcp_server"
+
+    def test_peer_registry_mcp_path(self) -> None:
+        mw = _middleware()
+        url = "http://localhost/peer-registry-lob-1/cloudflare-docs/mcp"
+        assert mw.classify_target_kind(url) == "mcp_server"
+
+    def test_server_without_transport_suffix_is_not_mcp_server(self) -> None:
+        # No mcp/sse suffix -> not attributed to mcp_server (avoids counting a
+        # bare/unknown path as server traffic).
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/some-server") == "unknown"
+
+
+class TestClassifyVirtualServer:
+    def test_virtual_server_path(self) -> None:
+        mw = _middleware()
+        url = "http://localhost/virtual/dev-essentials/mcp"
+        assert mw.classify_target_kind(url) == "virtual_mcp_server"
+
+    def test_virtual_server_without_transport(self) -> None:
+        # The /virtual/{id} prefix identifies it regardless of transport suffix.
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/virtual/combined-tools/") == (
+            "virtual_mcp_server"
+        )
+
+
+class TestControlPlaneNotMiscounted:
+    """The core anti-miscounting guarantee: /api/* is never a data-plane target."""
+
+    def test_api_prefix_is_control_plane(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/api/agents") == "control_plane"
+
+    def test_api_auth_me_is_control_plane(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/api/auth/me") == "control_plane"
+
+    def test_api_skills_crud_is_control_plane(self) -> None:
+        # Skills have no data-plane proxy route; only /api/skills/... CRUD exists.
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/api/skills/docx") == "control_plane"
+
+    def test_api_ard_is_control_plane(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/api/ard/search") == "control_plane"
+
+    def test_static_is_control_plane(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/static/app.js") == "control_plane"
+
+    def test_api_that_looks_like_server_is_still_control_plane(self) -> None:
+        # A crafted /api/... path must not be attributed to mcp_server even if it
+        # superficially resembles a server/transport shape.
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/api/mcp") == "control_plane"
+
+
+class TestEdgeCases:
+    def test_empty_path_is_unknown(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("http://localhost/") == "unknown"
+
+    def test_empty_url_is_unknown(self) -> None:
+        mw = _middleware()
+        assert mw.classify_target_kind("") == "unknown"
+
+
+class TestRegistryRootPathPrefix:
+    def test_prefix_stripped_for_agent(self) -> None:
+        mw = _middleware()
+        with patch.dict(os.environ, {"REGISTRY_ROOT_PATH": "/ai-registry"}):
+            url = "http://localhost/ai-registry/agent/flight-booking/"
+            assert mw.classify_target_kind(url) == "a2a_agent"
+
+    def test_prefix_stripped_for_mcp(self) -> None:
+        mw = _middleware()
+        with patch.dict(os.environ, {"REGISTRY_ROOT_PATH": "/ai-registry"}):
+            url = "http://localhost/ai-registry/mcpgw/mcp"
+            assert mw.classify_target_kind(url) == "mcp_server"
+
+    def test_prefix_stripped_for_control_plane(self) -> None:
+        mw = _middleware()
+        with patch.dict(os.environ, {"REGISTRY_ROOT_PATH": "/ai-registry"}):
+            url = "http://localhost/ai-registry/api/agents"
+            assert mw.classify_target_kind(url) == "control_plane"


### PR DESCRIPTION
## Summary

Adds a bounded `target_kind` attribute to the auth-server OTel metrics `mcpgw_registry_auth_request_total` and `mcpgw_registry_auth_request_duration`, so operators can see how `/validate` traffic splits across routed target types:

```
a2a_agent | virtual_mcp_server | mcp_server | control_plane | unknown
```

Previously the only OTel signal separating MCP-server from agent routing was the rate-limit metrics' `entity_type`, and only when rate limiting was enabled with a limit defined. This surfaces the split unconditionally on the counter every authenticated call already increments.

## Why an allowlist (not a default)

The classifier attributes a request to a data-plane target **only on an explicit rule match**. Everything else is `control_plane` or `unknown` — a request is **never silently counted as `mcp_server`**.

This deliberately mirrors the auth server's own logic: `/api/*` paths yield no `server_name` (see the `path_parts[0] != "api"` guard in `server.py`) and do not engage the rate-limit target axis. So this metric **cannot inadvertently count control-plane API calls (dashboard, login, config, ARD, public endpoints) as MCP-server traffic**.

Path shapes were verified against `docker/nginx_rev_proxy_*.conf`:

| `X-Original-URL` shape | `target_kind` |
|---|---|
| `/agent/{path}/...` | `a2a_agent` |
| `/virtual/{id}/...` | `virtual_mcp_server` |
| `{server}/mcp` \| `/sse` \| `/messages` | `mcp_server` |
| `/api/...`, `/static/...`, `/oauth2/...` | `control_plane` |
| anything else / empty | `unknown` |

Notes:
- **Virtual servers** get their own `virtual_mcp_server` label (the rate limiter lumps them under `mcp_server`; this is a deliberate refinement). The virtual location block runs `auth_request /validate` **before** the `virtual_router.lua` rewrite, so `/validate` sees the original `/virtual/{id}` path.
- **Skills** have no data-plane proxy route (only `/api/skills/...` CRUD), so they correctly classify as `control_plane`, never a routed target.
- An MCP server match **requires an MCP transport suffix** (`/mcp`, `/sse`, `/messages`), which is what keeps control-plane-shaped paths out of `mcp_server`.

## Extensibility

To track a new routed target type later: add one `(label, predicate)` entry to `_TARGET_KIND_RULES` and its nginx route. No change to the classify/emit logic. Kept self-contained in the middleware to avoid a circular import (`server` imports `metrics_middleware`).

## Cardinality

`target_kind` is a small fixed set (5 values), safe as an OTel attribute. The unbounded per-target `server` name label is unchanged.

## Tests

21 new unit tests in `tests/unit/metrics/test_middleware_target_kind.py` covering agent / virtual / mcp / control-plane / unknown, the transport-suffix requirement, the anti-miscounting cases (`/api/*` incl. a crafted `/api/mcp`), and `REGISTRY_ROOT_PATH` prefix stripping.

```
tests/unit/metrics/ tests/unit/observability/ -> 51 passed
tests/auth_server/unit/ -> 649 passed
ruff: clean
```

## Docs

Updated `docs/OBSERVABILITY.md` (metric tables + a "routing split" example query: `sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))`) and `docs/metrics-architecture.md`.

## Example query

```promql
sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))
```

---

### Added in follow-up commits

- **docs/OBSERVABILITY.md** — a "Target-type routing" PromQL cookbook (routing split, data-plane-only, per-kind success/latency, share-of-total, cumulative) and corrected the `target_kind` label set in the metric tables (adds `virtual_mcp_server`, `control_plane`).
- **scripts/generate-routing-traffic.sh** — a load generator that drives all three routing axes (`mcp_server` / `a2a_agent` / `control_plane`) so the `target_kind` metric populates for demos/smoke-checks. Takes `--registry-url`, `--token-file` (nested or flat token), `--iterations`, and `--duration-minutes` for sustained traffic.

Verified live: drove all three axes and confirmed the split in Prometheus (`sum by (target_kind)(rate(mcpgw_registry_auth_request_total[5m]))`) — agent, MCP-server, and control-plane lines move independently; `/api/*` correctly stays `control_plane`.