### PR TITLE
fix(mcpgw): allow reverse-proxy Host so airegistry-tools stays healthy (FastMCP 3.x 421)

### DIFF
--- a/servers/mcpgw/server.py
+++ b/servers/mcpgw/server.py
@@ -39,6 +39,27 @@ logger.info(
 REGISTRY_URL = os.getenv("REGISTRY_BASE_URL", "http://localhost")
 REGISTRY_EXTERNAL_URL = os.getenv("REGISTRY_EXTERNAL_URL", "")
 
+# Host allowlist for FastMCP's DNS-rebinding protection (streamable-http).
+# FastMCP 3.x enables host/origin protection by default, allowing only
+# 127.0.0.1 / localhost. But mcpgw is always reached through the registry's
+# nginx/auth front door (proxy_pass http://<service-name>:8003/), so the request
+# Host is the container/service name, which the default rejects with 421 -> the
+# registry health check fails -> nginx drops the /airegistry-tools/ location ->
+# clients get 405.
+#
+# The fix keeps protection ON and allowlists the exact service name the gateway
+# uses to reach mcpgw. That name is "mcpgw-server" across every surface (Docker
+# Compose service name, ECS Service Connect alias, Kubernetes Service name) --
+# the same canonical value the registry's SSRF guard trusts as the built-in
+# proxy target (registry/utils/url_guard.py::_BUILTIN_PROXY_ALLOWED_HOSTS). The
+# port is stripped by FastMCP before matching, and 127.0.0.1/localhost are
+# always allowed by FastMCP's built-in defaults, so those are not listed here.
+# Operators who front mcpgw under a different name override the comma-separated
+# MCPGW_HTTP_ALLOWED_HOSTS (e.g. "my-mcpgw.svc"); "*" disables protection
+# entirely for the (discouraged) case where the Host is unpredictable.
+_DEFAULT_MCPGW_ALLOWED_HOSTS = "mcpgw-server"
+MCPGW_HTTP_ALLOWED_HOSTS = os.getenv("MCPGW_HTTP_ALLOWED_HOSTS", _DEFAULT_MCPGW_ALLOWED_HOSTS)
+
 MAX_QUERY_LENGTH: int = 500
 MIN_TOP_N: int = 1
 MAX_TOP_N: int = 50
@@ -192,6 +213,34 @@ if _auth_provider:
             status_code=302,
             headers={"Cache-Control": "no-store"},
         )
+
+
+def _resolve_allowed_hosts(
+    raw_value: str,
+) -> tuple[bool, list[str] | None]:
+    """Resolve the FastMCP host-protection settings from the env value.
+
+    Args:
+        raw_value: The MCPGW_HTTP_ALLOWED_HOSTS env value (comma-separated
+            hostnames, or "*" to allow any Host).
+
+    Returns:
+        A (host_origin_protection, allowed_hosts) tuple to pass to mcp.run:
+        - a specific list (the default, "mcpgw-server") -> (True, [hosts]):
+          protection stays ON, allowing exactly those hosts plus FastMCP's
+          built-in loopback defaults (127.0.0.1 / localhost).
+        - "*" (opt-in escape hatch) -> (False, None): host/origin protection
+          OFF, for the discouraged case where the front-door Host is
+          unpredictable. mcpgw is never directly internet-exposed, but keeping
+          protection ON with a named allowlist is still preferred.
+        - empty -> (False, None): nothing to enforce.
+    """
+    hosts = [h.strip() for h in raw_value.split(",") if h.strip()]
+
+    if not hosts or "*" in hosts:
+        return False, None
+
+    return True, hosts
 
 
 def _validate_top_n(top_n: int) -> int:
@@ -984,12 +1033,25 @@ if __name__ == "__main__":
         # Use configurable host with secure default (127.0.0.1)
         # Set HOST=0.0.0.0 in environment for Docker deployments
         host = os.environ.get("HOST", "127.0.0.1")
-        logger.info(f"Running in HTTP mode on {host}:{port} (stateless=True)")
+        # Configure FastMCP's DNS-rebinding protection so a reverse-proxied Host
+        # (the service/container name) is not rejected with 421. See
+        # MCPGW_HTTP_ALLOWED_HOSTS above for why the default is permissive.
+        host_origin_protection, allowed_hosts = _resolve_allowed_hosts(MCPGW_HTTP_ALLOWED_HOSTS)
+        logger.info(
+            "Running in HTTP mode on %s:%s (stateless=True, "
+            "host_origin_protection=%s, allowed_hosts=%s)",
+            host,
+            port,
+            host_origin_protection,
+            allowed_hosts if allowed_hosts is not None else "*",
+        )
         mcp.run(
             transport="streamable-http",
             host=host,
             port=int(port),
             stateless_http=True,
+            host_origin_protection=host_origin_protection,
+            allowed_hosts=allowed_hosts,
         )
     else:
         logger.info("Running in stdio mode")

--- a/tests/unit/servers/mcpgw/test_resolve_allowed_hosts.py
+++ b/tests/unit/servers/mcpgw/test_resolve_allowed_hosts.py
@@ -1,0 +1,94 @@
+"""Unit tests for _resolve_allowed_hosts in servers/mcpgw/server.py.
+
+Covers the FastMCP DNS-rebinding host-protection resolution that fixes the
+airegistry-tools 421 -> unhealthy -> 405 chain: the mcpgw server is reached
+through the registry front door as Host "mcpgw-server", which FastMCP 3.x's
+default host protection rejected. The default keeps protection ON and allowlists
+that service name; "*" is an opt-in escape hatch that disables protection.
+
+Isolation note: servers/mcpgw/server.py imports `fastmcp` (absent from the main
+venv), so it must be stubbed before import. A sibling test file stubs it too and
+force-re-imports the module; to avoid cross-file interference we import the
+function inside a fixture that snapshots and restores sys.modules, leaving no
+cached server module or fastmcp stub behind for other files.
+"""
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def resolve_allowed_hosts():
+    """Import _resolve_allowed_hosts under an isolated, restored module state."""
+    saved = {
+        name: sys.modules.get(name)
+        for name in ("fastmcp", "servers.mcpgw.server", "server")
+    }
+
+    fastmcp_stub = types.ModuleType("fastmcp")
+    fastmcp_stub.Context = type("Context", (), {})
+    mock_mcp = MagicMock()
+    mock_mcp.tool.return_value = lambda fn: fn  # decorator no-op
+    fastmcp_stub.FastMCP = MagicMock(return_value=mock_mcp)
+    sys.modules["fastmcp"] = fastmcp_stub
+    sys.modules.pop("servers.mcpgw.server", None)
+
+    mcpgw_path = str(Path(__file__).resolve().parents[4] / "servers" / "mcpgw")
+    if mcpgw_path not in sys.path:
+        sys.path.insert(0, mcpgw_path)
+
+    from servers.mcpgw.server import _resolve_allowed_hosts
+
+    try:
+        yield _resolve_allowed_hosts
+    finally:
+        # Restore prior module state so sibling test files re-import cleanly.
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+
+class TestResolveAllowedHosts:
+    def test_default_service_name_keeps_protection_on(self, resolve_allowed_hosts) -> None:
+        # The shipped default: protection ON, allowlisting the front-door host.
+        protection, hosts = resolve_allowed_hosts("mcpgw-server")
+        assert protection is True
+        assert hosts == ["mcpgw-server"]
+
+    def test_star_disables_protection(self, resolve_allowed_hosts) -> None:
+        # Opt-in escape hatch: "*" turns protection OFF (allowed_hosts=None).
+        protection, hosts = resolve_allowed_hosts("*")
+        assert protection is False
+        assert hosts is None
+
+    def test_empty_disables_protection(self, resolve_allowed_hosts) -> None:
+        protection, hosts = resolve_allowed_hosts("")
+        assert protection is False
+        assert hosts is None
+
+    def test_whitespace_only_disables_protection(self, resolve_allowed_hosts) -> None:
+        protection, hosts = resolve_allowed_hosts("   ")
+        assert protection is False
+        assert hosts is None
+
+    def test_comma_separated_list_is_parsed_and_trimmed(self, resolve_allowed_hosts) -> None:
+        protection, hosts = resolve_allowed_hosts("mcpgw-server, my-mcpgw.svc ,other")
+        assert protection is True
+        assert hosts == ["mcpgw-server", "my-mcpgw.svc", "other"]
+
+    def test_star_among_other_hosts_still_disables(self, resolve_allowed_hosts) -> None:
+        # If any entry is "*", protection is off regardless of the others.
+        protection, hosts = resolve_allowed_hosts("mcpgw-server,*")
+        assert protection is False
+        assert hosts is None
+
+    def test_single_custom_host(self, resolve_allowed_hosts) -> None:
+        protection, hosts = resolve_allowed_hosts("my-mcpgw.internal")
+        assert protection is True
+        assert hosts == ["my-mcpgw.internal"]

--- a/tests/unit/servers/mcpgw/test_resolve_allowed_hosts.py
+++ b/tests/unit/servers/mcpgw/test_resolve_allowed_hosts.py
@@ -24,10 +24,7 @@ import pytest
 @pytest.fixture
 def resolve_allowed_hosts():
     """Import _resolve_allowed_hosts under an isolated, restored module state."""
-    saved = {
-        name: sys.modules.get(name)
-        for name in ("fastmcp", "servers.mcpgw.server", "server")
-    }
+    saved = {name: sys.modules.get(name) for name in ("fastmcp", "servers.mcpgw.server", "server")}
 
     fastmcp_stub = types.ModuleType("fastmcp")
     fastmcp_stub.Context = type("Context", (), {})


### PR DESCRIPTION
## Symptom

Connecting to the built-in **airegistry-tools** MCP server (e.g. from Claude Code) fails with **HTTP 405** at `/airegistry-tools/mcp`, and the server shows **Unhealthy** in the UI.

## Root cause

**PR #1021** ("multi-replica airegistry-tools support") moved mcpgw to **FastMCP 3.x** (`fastmcp>=3.2.0,<4.0.0`) and switched to `stateless_http=True`. FastMCP 3.x enables **host/origin DNS-rebinding protection by default**, allowing only `127.0.0.1` / `localhost` as the request `Host`.

But mcpgw is always reached through the registry's nginx/auth front door via `proxy_pass http://mcpgw-server:8003/`, so the `Host` is `mcpgw-server`. FastMCP rejects that with **421 Misdirected Request**, which cascades:

```
Host: mcpgw-server:8003 → 421
  → registry health check fails ("session initialization failed")
    → server marked Unhealthy
      → nginx drops the /airegistry-tools/ location block (only healthy servers get one)
        → request falls through → 405 Method Not Allowed
```

Latent since the **1.26.0** cycle (the change is in both 1.26.0 and 1.27.0). It only surfaces when a client actually connects, since it's health-check-gated.

Reproduced directly: `POST /mcp` with `Host: localhost` → 200, with `Host: mcpgw-server:8003` → 421.

## Fix

Configure FastMCP's transport security explicitly at startup in `servers/mcpgw/server.py`. **Protection stays ON**; the default allowlists `mcpgw-server` — the service name used **identically across all three surfaces**:

| Surface | How registry reaches mcpgw |
|---|---|
| Docker Compose | service `mcpgw-server` |
| Kubernetes/Helm | Service `mcpgw-server` (`charts/mcpgw` `app.name`) |
| ECS | Service Connect `dns_name = "mcpgw-server"` |

This matches the value the registry's SSRF guard already trusts as the built-in proxy target (`registry/utils/url_guard.py::_BUILTIN_PROXY_ALLOWED_HOSTS = {"mcpgw-server"}`), so **one code default fixes every deployment surface with zero per-surface config**.

- **Default** (`MCPGW_HTTP_ALLOWED_HOSTS=mcpgw-server`): `host_origin_protection=True`, `allowed_hosts=["mcpgw-server"]` (FastMCP always also allows loopback; the port is stripped before matching).
- **Override**: operators fronting mcpgw under a different name set the comma-separated `MCPGW_HTTP_ALLOWED_HOSTS` (e.g. `my-mcpgw.svc`). It's an optional extra-env var, deliberately NOT added to the reserved-env lists so it stays overridable.
- **Escape hatch**: `MCPGW_HTTP_ALLOWED_HOSTS=*` disables protection for the discouraged unpredictable-Host case.

## Verification (end-to-end, local stack)

```
POST /mcp  Host: mcpgw-server:8003   → 200   (was 421)
POST /mcp  Host: evil.example.com    → 421   (protection still enforced)
airegistry-tools health              → HEALTHY   (was unhealthy)
nginx /airegistry-tools/ location    → present   (was commented out)
front-door /airegistry-tools/mcp     → route live (was 405)
```

## Tests

7 unit tests for `_resolve_allowed_hosts` (default / `*` / empty / whitespace / comma-list / `*`-wins / custom host). Isolated via a fixture that snapshots + restores `sys.modules` so the shared `fastmcp` stub cannot leak across sibling mcpgw test files (verified in both collection orders). Full `tests/unit/servers/mcpgw/` suite: **47 passed**.

## Surface footprint

Server-side only — one change fixes Compose, Helm, and ECS because they all use the `mcpgw-server` name. No chart/Terraform edits required; the override env rides the existing `extraEnv` / `extra_env` / `mcpgw_extra_env` mechanisms.