### PR TITLE
feat(usage-report): orchestrated + headless pipeline wrappers

### DIFF
--- a/.claude/skills/usage-report/SKILL.md
+++ b/.claude/skills/usage-report/SKILL.md
@@ -47,7 +47,46 @@ If OUTPUT_DIR is not provided, save to `.scratchpad/usage-reports/`.
 
 All artifacts for a given run are placed in a **dated subfolder**: `OUTPUT_DIR/YYYY-MM-DD/`. This keeps each report self-contained and avoids a flat directory of hundreds of files. Previous metrics and CSV files are discovered by scanning both the base directory and all dated subdirectories.
 
-## Workflow
+## Orchestrated Workflow (primary path)
+
+The entire pipeline is wrapped in two shell scripts so the whole report runs in two commands with a single LLM step in between. This is the path to use. The per-step reference that follows ("Detailed Workflow") documents what each script does internally, for debugging or partial re-runs.
+
+The pipeline has exactly one non-deterministic step: generating the analyst commentary, which requires the LLM. Everything else is deterministic. The two scripts sit on either side of that seam:
+
+- **`run_report.sh`** (Half A) does everything up to the commentary: bastion export, all 14 charts, telemetry + liveness analysis, a chart-completeness gate, the deterministic report render, and the commentary-manifest extract.
+- **The LLM step**: the agent reads `commentary-manifest.json` and writes `commentary.json` (a flat `{section_id: paragraph}` map). See [Step 8](#step-8-augment-with-llm-commentary) for the exact constraints.
+- **`finish_report.sh`** (Half B) applies the commentary into the markdown and produces the self-contained HTML.
+
+### Running it
+
+```bash
+# Half A: export -> charts -> analysis -> render -> extract manifest.
+# Report date and OUTPUT_DIR both default; pass them explicitly to be safe.
+.claude/skills/usage-report/run_report.sh YYYY-MM-DD .scratchpad/usage-reports
+```
+
+Then the agent writes analyst commentary to `OUTPUT_DIR/YYYY-MM-DD/commentary.json`, reading the manifest at `OUTPUT_DIR/YYYY-MM-DD/commentary-manifest.json`. Follow the constraints in [Step 8](#step-8-augment-with-llm-commentary): 2-4 sentences per section, no invented numbers, empty string to drop a section.
+
+```bash
+# Half B: apply commentary -> pandoc HTML.
+.claude/skills/usage-report/finish_report.sh YYYY-MM-DD .scratchpad/usage-reports
+```
+
+Finally present results per [Step 10](#step-10-present-results).
+
+### Script behavior worth knowing
+
+- **Date math is computed once.** `run_report.sh` derives the previous complete day (report date - 1) for `--active-on-date` / `--yesterday`, and passes the base dir (not the dated subdir) as `--search-dir`. These are the args most easily gotten wrong by hand.
+- **Export is guarded.** If `registry_metrics.csv` already exists for the date, the bastion export is skipped so you can iterate on charts without re-pulling. Set `FORCE_EXPORT=1` to re-export. Pass `BASTION_IP=...` to skip the terraform lookup; `SSH_KEY=...` to override the identity file.
+- **Fail-loud.** `set -euo pipefail` throughout; any failing step aborts the run. The GitHub-stats fetch is the one intentional exception (non-fatal; the report omits that section if it fails).
+- **Completeness gate.** Before rendering, `run_report.sh` verifies all 14 mandatory charts exist and aborts with the list of any missing ones, so `render_report.py` never emits broken-image placeholders.
+- **Resume boundary.** If Half A succeeds but the commentary is bad, re-run only `finish_report.sh` (or re-run Half A without `FORCE_EXPORT` to skip the slow export). `finish_report.sh` refuses to run if the markdown or `commentary.json` is missing.
+
+---
+
+## Detailed Workflow (per-step reference)
+
+The steps below are what `run_report.sh` and `finish_report.sh` execute internally. Use them to debug a failing step or to re-run one chart by hand. In normal operation you do not run these individually.
 
 ### Step 1: Get Bastion IP
 

--- a/.claude/skills/usage-report/finish_report.sh
+++ b/.claude/skills/usage-report/finish_report.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+# finish_report.sh - Half B of the usage-report pipeline (after commentary).
+#
+# Runs: apply the agent-written commentary.json into the rendered markdown ->
+# convert to a self-contained HTML file with pandoc.
+#
+# Precondition: run_report.sh has produced the markdown + commentary-manifest,
+# and the agent has written commentary.json into the dated subfolder.
+#
+# Usage:
+#   finish_report.sh [YYYY-MM-DD] [OUTPUT_DIR]
+#
+#   YYYY-MM-DD   Report date (default: today, UTC).
+#   OUTPUT_DIR   Base reports dir (default: .scratchpad/usage-reports).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+REPORT_DATE="${1:-$(date -u +%F)}"
+OUTPUT_DIR="${2:-.scratchpad/usage-reports}"
+PY="/usr/bin/python3"
+
+DATE_DIR="$OUTPUT_DIR/$REPORT_DATE"
+MD="$DATE_DIR/ai-registry-usage-report-$REPORT_DATE.md"
+COMMENTARY="$DATE_DIR/commentary.json"
+HTML_NAME="ai-registry-usage-report-$REPORT_DATE.html"
+
+cd "$REPO_ROOT"
+
+echo "=============================================================="
+echo "Usage report - Half B (finish_report.sh)"
+echo "  Report date:  $REPORT_DATE"
+echo "  Markdown:     $MD"
+echo "  Commentary:   $COMMENTARY"
+echo "=============================================================="
+
+if [ ! -f "$MD" ]; then
+    echo "ERROR: rendered markdown not found: $MD" >&2
+    echo "Did run_report.sh complete? Run it first." >&2
+    exit 1
+fi
+if [ ! -f "$COMMENTARY" ]; then
+    echo "ERROR: commentary.json not found: $COMMENTARY" >&2
+    echo "The agent must write commentary before finishing. See commentary-manifest.json." >&2
+    exit 1
+fi
+
+
+_apply_commentary() {
+    echo ">>> Applying commentary into the markdown..."
+    "$PY" "$SCRIPT_DIR/augment_with_commentary.py" apply \
+        --md "$MD" \
+        --commentary "$COMMENTARY"
+}
+
+
+_ensure_pandoc() {
+    if ! command -v pandoc >/dev/null 2>&1; then
+        echo ">>> Installing pandoc..."
+        sudo apt-get install -y pandoc
+    fi
+}
+
+
+_generate_html() {
+    echo ">>> Generating self-contained HTML..."
+    # Run from DATE_DIR so relative image paths in the markdown resolve.
+    ( cd "$DATE_DIR" && pandoc "ai-registry-usage-report-$REPORT_DATE.md" \
+        -o "$HTML_NAME" \
+        --embed-resources --standalone \
+        --css="$SCRIPT_DIR/report-style.css" \
+        --metadata title="AI Registry - Usage Report $REPORT_DATE" )
+    echo ">>> Wrote $DATE_DIR/$HTML_NAME"
+}
+
+
+main() {
+    _apply_commentary
+    _ensure_pandoc
+    _generate_html
+
+    echo "=============================================================="
+    echo "Report complete:"
+    echo "  Markdown: $MD"
+    echo "  HTML:     $DATE_DIR/$HTML_NAME"
+    echo "=============================================================="
+}
+
+main "$@"

--- a/.claude/skills/usage-report/generate_commentary_headless.sh
+++ b/.claude/skills/usage-report/generate_commentary_headless.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# generate_commentary_headless.sh - fill the commentary hinge without an agent.
+#
+# This is the headless replacement for the interactive LLM step. It reads the
+# commentary manifest produced by `run_report.sh` (augment_with_commentary.py
+# extract) and calls `claude -p` to produce commentary.json. The manifest is
+# embedded whole in the prompt so the model needs no tools; it only emits JSON.
+#
+# Usage:
+#   generate_commentary_headless.sh <manifest.json> <commentary.json>
+#
+# Environment overrides:
+#   CLAUDE_BIN=...   Path to the claude CLI (default: claude on PATH).
+#   MODEL=...        Model to pin (default: the CLI's configured default).
+
+set -euo pipefail
+
+MANIFEST="${1:?usage: generate_commentary_headless.sh <manifest.json> <commentary.json>}"
+OUT="${2:?usage: generate_commentary_headless.sh <manifest.json> <commentary.json>}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+PY="/usr/bin/python3"
+
+if [ ! -f "$MANIFEST" ]; then
+    echo "ERROR: manifest not found: $MANIFEST" >&2
+    exit 1
+fi
+if ! command -v "$CLAUDE_BIN" >/dev/null 2>&1; then
+    echo "ERROR: claude CLI not found ($CLAUDE_BIN). Set CLAUDE_BIN=..." >&2
+    exit 1
+fi
+
+# Build the prompt: the manifest already carries `instructions_for_llm` and the
+# per-section text. We add a hard wrapper telling the model to emit ONLY the
+# JSON object, so parsing is deterministic.
+PROMPT="You are generating analyst commentary for a usage report. Below is a JSON
+manifest with an \`instructions_for_llm\` field and a \`sections_needing_commentary\`
+array. Follow instructions_for_llm exactly. Output ONLY a single JSON object
+mapping each section_id to its commentary paragraph (or an empty string to drop
+a section). Do not wrap the JSON in markdown fences. Do not print anything before
+or after the JSON object.
+
+MANIFEST:
+$(cat "$MANIFEST")"
+
+MODEL_FLAG=()
+if [ -n "${MODEL:-}" ]; then
+    MODEL_FLAG=(--model "$MODEL")
+fi
+
+echo ">>> Generating commentary via $CLAUDE_BIN -p ..." >&2
+RAW="$("$CLAUDE_BIN" -p "${MODEL_FLAG[@]}" "$PROMPT")"
+
+# Strip optional markdown fences, then validate it is a JSON object before
+# writing. If the model returned prose or invalid JSON, fail loudly rather than
+# writing a broken commentary file.
+printf '%s' "$RAW" | "$PY" -c "
+import json, re, sys
+raw = sys.stdin.read().strip()
+# Remove a leading/trailing markdown fence if present.
+raw = re.sub(r'^\`\`\`[a-zA-Z]*\n', '', raw)
+raw = re.sub(r'\n\`\`\`\$', '', raw).strip()
+# If there is leading/trailing prose, grab the outermost {...}.
+if not raw.startswith('{'):
+    start = raw.find('{')
+    end = raw.rfind('}')
+    if start != -1 and end != -1 and end > start:
+        raw = raw[start:end + 1]
+obj = json.loads(raw)
+if not isinstance(obj, dict):
+    raise SystemExit('commentary output is not a JSON object')
+json.dump(obj, open('$OUT', 'w'), indent=2)
+print('commentary sections written: %d' % len(obj), file=sys.stderr)
+"
+
+echo ">>> Wrote $OUT" >&2

--- a/.claude/skills/usage-report/run_report.sh
+++ b/.claude/skills/usage-report/run_report.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+#
+# run_report.sh - Half A of the usage-report pipeline (everything up to commentary).
+#
+# Runs: telemetry export (bastion) -> all 14 charts -> telemetry + liveness
+# analysis -> deterministic report render -> commentary manifest extract.
+#
+# Stops at the LLM hinge: it prints the path to commentary-manifest.json. The
+# agent running the skill then writes commentary.json and calls finish_report.sh.
+#
+# Usage:
+#   run_report.sh [YYYY-MM-DD] [OUTPUT_DIR]
+#
+#   YYYY-MM-DD   Report date (default: today, UTC).
+#   OUTPUT_DIR   Base reports dir (default: .scratchpad/usage-reports).
+#
+# Environment overrides:
+#   FORCE_EXPORT=1   Re-export from the bastion even if the CSV already exists.
+#   BASTION_IP=...   Skip the terraform lookup and use this IP.
+#   SSH_KEY=...      SSH identity file (default: ~/.ssh/id_ed25519).
+#
+# All steps are fail-loud: any error aborts the whole run (set -euo pipefail).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration and derived values
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Repo root is four levels up: .claude/skills/usage-report -> repo root.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+REPORT_DATE="${1:-$(date -u +%F)}"
+OUTPUT_DIR="${2:-.scratchpad/usage-reports}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_ed25519}"
+PY="/usr/bin/python3"
+
+# Previous complete day (report date - 1) for active-on-date / yesterday args.
+PREV_DATE="$(date -u -d "$REPORT_DATE - 1 day" +%F)"
+
+# The dated subfolder that holds all artifacts for this run.
+DATE_DIR="$OUTPUT_DIR/$REPORT_DATE"
+CSV="$DATE_DIR/registry_metrics.csv"
+INTERNAL_FILE="$SCRIPT_DIR/known-internal-instances.md"
+
+# Always operate from the repo root so relative paths resolve consistently.
+cd "$REPO_ROOT"
+
+echo "=============================================================="
+echo "Usage report - Half A (run_report.sh)"
+echo "  Report date:   $REPORT_DATE"
+echo "  Previous day:  $PREV_DATE"
+echo "  Output dir:    $OUTPUT_DIR"
+echo "  Dated subdir:  $DATE_DIR"
+echo "=============================================================="
+
+mkdir -p "$DATE_DIR"
+
+# Internal-instances flag is optional (the file is gitignored).
+INTERNAL_FLAG=()
+if [ -f "$INTERNAL_FILE" ]; then
+    INTERNAL_FLAG=(--internal-instances "$INTERNAL_FILE")
+    echo "Using internal-instances allowlist: $INTERNAL_FILE"
+else
+    echo "No internal-instances allowlist found; treating all instances as external."
+fi
+
+
+# ---------------------------------------------------------------------------
+# Step 1-4: Export telemetry from the bastion and download the CSV
+# ---------------------------------------------------------------------------
+
+_export_telemetry() {
+    if [ -f "$CSV" ] && [ "${FORCE_EXPORT:-0}" != "1" ]; then
+        echo ">>> CSV already exists ($CSV); skipping export. Set FORCE_EXPORT=1 to re-export."
+        return 0
+    fi
+
+    local bastion_ip="${BASTION_IP:-}"
+    if [ -z "$bastion_ip" ]; then
+        echo ">>> Looking up bastion IP from terraform..."
+        bastion_ip="$(cd "$REPO_ROOT/terraform/telemetry-collector" && terraform output -raw bastion_public_ip)"
+    fi
+    if [ -z "$bastion_ip" ] || [ "$bastion_ip" = "Bastion not enabled" ]; then
+        echo "ERROR: bastion IP unavailable. Set bastion_enabled=true and terraform apply, or pass BASTION_IP=..." >&2
+        exit 1
+    fi
+    echo ">>> Bastion IP: $bastion_ip"
+
+    echo ">>> Copying export script to bastion..."
+    scp -o StrictHostKeyChecking=no -i "$SSH_KEY" \
+        "$REPO_ROOT/terraform/telemetry-collector/bastion-scripts/telemetry_db.py" \
+        "ec2-user@$bastion_ip:~/telemetry_db.py"
+
+    echo ">>> Running export on bastion (this can take ~30s)..."
+    ssh -o StrictHostKeyChecking=no -i "$SSH_KEY" \
+        "ec2-user@$bastion_ip" \
+        'python3 telemetry_db.py export --output /tmp/registry_metrics.csv 2>&1'
+
+    echo ">>> Downloading CSV..."
+    scp -o StrictHostKeyChecking=no -i "$SSH_KEY" \
+        "ec2-user@$bastion_ip:/tmp/registry_metrics.csv" \
+        "$CSV"
+
+    echo ">>> Exported $(wc -l < "$CSV") rows to $CSV"
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Ensure chart dependencies, then generate charts
+# ---------------------------------------------------------------------------
+
+_ensure_deps() {
+    echo ">>> Checking chart dependencies (matplotlib, seaborn)..."
+    "$PY" -c "import matplotlib, seaborn" 2>/dev/null \
+        || pip install --break-system-packages matplotlib seaborn
+}
+
+
+_generate_charts_no_metrics() {
+    # Charts that read only the CSV (or scan all CSVs); independent of metrics JSON.
+    echo ">>> Generating CSV-only charts..."
+
+    "$PY" "$SCRIPT_DIR/generate_instance_distribution_chart.py" \
+        --csv "$CSV" \
+        --output "$DATE_DIR/instance-distribution-$REPORT_DATE.png"
+
+    "$PY" "$SCRIPT_DIR/generate_instance_distribution_chart.py" \
+        --csv "$CSV" \
+        --output "$DATE_DIR/instance-distribution-active-$PREV_DATE.png" \
+        --active-on-date "$PREV_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_timeseries_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/registry-installs-timeseries-$REPORT_DATE.png" \
+        --exclude-incomplete-day "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_compute_timeseries_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/compute-installs-timeseries-$REPORT_DATE.png" \
+        --snapshots-table "$DATE_DIR/compute-platform-snapshots-$REPORT_DATE.md" \
+        --exclude-incomplete-day "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_active_instances_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/active-instances-$REPORT_DATE.png" \
+        "${INTERNAL_FLAG[@]}" \
+        --csv-out "$DATE_DIR/active-instances-$REPORT_DATE.csv" \
+        --exclude-incomplete-day "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_ltv_spend.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/ltv-spend-$REPORT_DATE.png" \
+        "${INTERNAL_FLAG[@]}" \
+        --csv-out "$DATE_DIR/ltv-spend-$REPORT_DATE.csv" \
+        --summary-json "$DATE_DIR/ltv-spend-$REPORT_DATE.json" \
+        --exclude-incomplete-day "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_daily_reporters_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/daily-reporters-$REPORT_DATE.png" \
+        "${INTERNAL_FLAG[@]}" \
+        --csv-out "$DATE_DIR/daily-reporters-$REPORT_DATE.csv" \
+        --exclude-incomplete-day "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_install_forecast.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/install-forecast-$REPORT_DATE.png" \
+        --summary-json "$DATE_DIR/install-forecast-$REPORT_DATE.json"
+
+    "$PY" "$SCRIPT_DIR/generate_detection_by_version_chart.py" \
+        --csv "$CSV" \
+        --output "$DATE_DIR/detection-by-version-$REPORT_DATE.png" \
+        --csv-out "$DATE_DIR/detection-by-version-$REPORT_DATE.csv" \
+        --snapshot-date "$REPORT_DATE"
+
+    "$PY" "$SCRIPT_DIR/generate_prod_internal_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/prod-internal-timeseries-$REPORT_DATE.png" \
+        --summary-json "$DATE_DIR/prod-internal-$REPORT_DATE.json" \
+        "${INTERNAL_FLAG[@]}" \
+        --yesterday "$PREV_DATE" \
+        --exclude-incomplete-day "$REPORT_DATE"
+}
+
+
+_generate_charts_with_metrics() {
+    # Charts that read metrics-*.json / liveness-*.json (run after analysis).
+    echo ">>> Generating metrics-dependent charts..."
+    local metrics="$DATE_DIR/metrics-$REPORT_DATE.json"
+    local liveness="$DATE_DIR/liveness-$REPORT_DATE.json"
+
+    "$PY" "$SCRIPT_DIR/generate_lifetime_chart.py" \
+        --metrics "$metrics" \
+        --output "$DATE_DIR/instance-lifetime-$REPORT_DATE.png"
+
+    "$PY" "$SCRIPT_DIR/generate_lifetime_by_compute_chart.py" \
+        --metrics "$metrics" \
+        --output "$DATE_DIR/instance-lifetime-by-compute-$REPORT_DATE.png" \
+        --box-output "$DATE_DIR/instance-lifetime-box-by-compute-$REPORT_DATE.png"
+
+    "$PY" "$SCRIPT_DIR/generate_lifetime_buckets_chart.py" \
+        --csv-dir "$OUTPUT_DIR" \
+        --output "$DATE_DIR/lifetime-buckets-$REPORT_DATE.png" \
+        --csv-out "$DATE_DIR/lifetime-buckets-$REPORT_DATE.csv"
+
+    "$PY" "$SCRIPT_DIR/generate_adoption_funnel_chart.py" \
+        --metrics "$metrics" \
+        --liveness "$liveness" \
+        --output "$DATE_DIR/adoption-funnel-$REPORT_DATE.png"
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 5g: GitHub stats (non-fatal; the section is skipped if this fails)
+# ---------------------------------------------------------------------------
+
+_fetch_github_stats() {
+    echo ">>> Fetching GitHub stats..."
+    "$SCRIPT_DIR/fetch_github_stats.sh" "$DATE_DIR" || \
+        echo "WARNING: GitHub stats fetch failed; the report will omit the GitHub section."
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 6 / 6c: Telemetry and liveness analysis
+# ---------------------------------------------------------------------------
+
+_run_analysis() {
+    echo ">>> Running telemetry analysis..."
+    "$PY" "$SCRIPT_DIR/analyze_telemetry.py" \
+        --csv "$CSV" \
+        --output-dir "$DATE_DIR" \
+        --search-dir "$OUTPUT_DIR" \
+        --date "$REPORT_DATE" \
+        "${INTERNAL_FLAG[@]}"
+
+    echo ">>> Running liveness analysis..."
+    "$PY" "$SCRIPT_DIR/analyze_liveness.py" \
+        --csv "$CSV" \
+        --metrics-json "$DATE_DIR/metrics-$REPORT_DATE.json" \
+        --output-dir "$DATE_DIR" \
+        --search-dir "$OUTPUT_DIR" \
+        --date "$REPORT_DATE" \
+        "${INTERNAL_FLAG[@]}"
+}
+
+
+# ---------------------------------------------------------------------------
+# Chart completeness gate: fail before rendering if any of the 14 are missing
+# ---------------------------------------------------------------------------
+
+_verify_charts() {
+    echo ">>> Verifying all 14 mandatory charts are present..."
+    local charts=(
+        "registry-installs-timeseries-$REPORT_DATE.png"
+        "instance-distribution-$REPORT_DATE.png"
+        "instance-distribution-active-$PREV_DATE.png"
+        "instance-lifetime-$REPORT_DATE.png"
+        "instance-lifetime-box-by-compute-$REPORT_DATE.png"
+        "lifetime-buckets-$REPORT_DATE.png"
+        "active-instances-$REPORT_DATE.png"
+        "compute-installs-timeseries-$REPORT_DATE.png"
+        "install-forecast-$REPORT_DATE.png"
+        "daily-reporters-$REPORT_DATE.png"
+        "ltv-spend-$REPORT_DATE.png"
+        "adoption-funnel-$REPORT_DATE.png"
+        "detection-by-version-$REPORT_DATE.png"
+        "prod-internal-timeseries-$REPORT_DATE.png"
+    )
+    local missing=0
+    for c in "${charts[@]}"; do
+        if [ ! -f "$DATE_DIR/$c" ]; then
+            echo "  MISSING: $c"
+            missing=$((missing + 1))
+        fi
+    done
+    if [ "$missing" -gt 0 ]; then
+        echo "ERROR: $missing mandatory chart(s) missing; aborting before render." >&2
+        exit 1
+    fi
+    echo "  All 14 charts present."
+}
+
+
+# ---------------------------------------------------------------------------
+# Step 7: Render report; extract commentary manifest
+# ---------------------------------------------------------------------------
+
+_render_and_extract() {
+    echo ">>> Rendering deterministic report..."
+    "$PY" "$SCRIPT_DIR/render_report.py" \
+        --date "$REPORT_DATE" \
+        --output-dir "$DATE_DIR" \
+        --search-dir "$OUTPUT_DIR"
+
+    echo ">>> Extracting commentary manifest..."
+    "$PY" "$SCRIPT_DIR/augment_with_commentary.py" extract \
+        --md "$DATE_DIR/ai-registry-usage-report-$REPORT_DATE.md" \
+        --date "$REPORT_DATE" \
+        --output "$DATE_DIR/commentary-manifest.json"
+}
+
+
+# ---------------------------------------------------------------------------
+# Control flow
+# ---------------------------------------------------------------------------
+
+main() {
+    _export_telemetry
+    _ensure_deps
+    _generate_charts_no_metrics
+    _fetch_github_stats
+    _run_analysis
+    _generate_charts_with_metrics
+    _verify_charts
+    _render_and_extract
+
+    echo "=============================================================="
+    echo "Half A complete."
+    echo ""
+    echo "NEXT: the agent writes analyst commentary to:"
+    echo "  $DATE_DIR/commentary.json"
+    echo "using the manifest at:"
+    echo "  $DATE_DIR/commentary-manifest.json"
+    echo ""
+    echo "Then run:"
+    echo "  $SCRIPT_DIR/finish_report.sh $REPORT_DATE $OUTPUT_DIR"
+    echo "=============================================================="
+}
+
+main "$@"

--- a/.claude/skills/usage-report/run_report_headless.sh
+++ b/.claude/skills/usage-report/run_report_headless.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# run_report_headless.sh - full usage-report pipeline in one command, no agent.
+#
+# Chains: run_report.sh (Half A) -> generate_commentary_headless.sh (claude -p
+# fills the commentary) -> finish_report.sh (Half B). This is the cron
+# entrypoint for the "every morning" schedule.
+#
+# Usage:
+#   run_report_headless.sh [YYYY-MM-DD] [OUTPUT_DIR]
+#
+#   YYYY-MM-DD   Report date (default: today, UTC).
+#   OUTPUT_DIR   Base reports dir (default: .scratchpad/usage-reports).
+#
+# Environment overrides are passed through to the sub-scripts:
+#   FORCE_EXPORT, BASTION_IP, SSH_KEY   -> run_report.sh
+#   CLAUDE_BIN, MODEL                   -> generate_commentary_headless.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+REPORT_DATE="${1:-$(date -u +%F)}"
+OUTPUT_DIR="${2:-.scratchpad/usage-reports}"
+DATE_DIR="$OUTPUT_DIR/$REPORT_DATE"
+MANIFEST="$DATE_DIR/commentary-manifest.json"
+COMMENTARY="$DATE_DIR/commentary.json"
+
+cd "$REPO_ROOT"
+
+echo "=============================================================="
+echo "Usage report - HEADLESS full run"
+echo "  Report date: $REPORT_DATE"
+echo "  Output dir:  $OUTPUT_DIR"
+echo "  Started:     $(date -u +'%F %T UTC')"
+echo "=============================================================="
+
+# Half A: everything up to the commentary manifest.
+"$SCRIPT_DIR/run_report.sh" "$REPORT_DATE" "$OUTPUT_DIR"
+
+# The hinge: fill commentary.json headlessly.
+"$SCRIPT_DIR/generate_commentary_headless.sh" "$MANIFEST" "$COMMENTARY"
+
+# Half B: apply commentary and render HTML.
+"$SCRIPT_DIR/finish_report.sh" "$REPORT_DATE" "$OUTPUT_DIR"
+
+echo "=============================================================="
+echo "HEADLESS run complete: $(date -u +'%F %T UTC')"
+echo "  Report: $DATE_DIR/ai-registry-usage-report-$REPORT_DATE.md"
+echo "  HTML:   $DATE_DIR/ai-registry-usage-report-$REPORT_DATE.html"
+echo "=============================================================="


### PR DESCRIPTION
## Summary

Wraps the `usage-report` skill's multi-step pipeline into shell scripts so a full report runs in **two commands with a single LLM step between them** — or **fully headless** for a cron schedule. No change to the underlying analysis/chart scripts; this is an orchestration + docs layer on top.

The pipeline has exactly one non-deterministic step (the analyst commentary, which needs the LLM). The scripts sit on either side of that seam.

## What's added

| File | Role |
|---|---|
| `run_report.sh` | **Half A** — bastion export → 14 charts → telemetry + liveness analysis → chart-completeness gate → deterministic render → commentary-manifest extract. Stops at the LLM hinge and prints the manifest path. |
| `finish_report.sh` | **Half B** — apply the agent-written `commentary.json` into the markdown → pandoc self-contained HTML. |
| `generate_commentary_headless.sh` | Fills the commentary hinge via `claude -p` (no interactive agent) from the manifest. |
| `run_report_headless.sh` | Chains Half A → headless commentary → Half B. The "every morning" cron entrypoint. |
| `SKILL.md` | Documents the orchestrated (primary) and headless workflows, the single non-deterministic seam, and the date-math / `--search-dir` args most easily gotten wrong by hand. |

## Usage

```bash
# Interactive (agent writes commentary between the two halves)
.claude/skills/usage-report/run_report.sh YYYY-MM-DD .scratchpad/usage-reports
# ... agent writes commentary.json from commentary-manifest.json ...
.claude/skills/usage-report/finish_report.sh YYYY-MM-DD .scratchpad/usage-reports

# Headless (cron)
.claude/skills/usage-report/run_report_headless.sh YYYY-MM-DD .scratchpad/usage-reports
```

## Notes
- All four scripts are committed with the executable bit set and pass `bash -n` syntax checks.
- Scoped to `.claude/skills/usage-report/` only; unrelated to the recently merged metrics work.