### PR TITLE
fix: normalise nginx location paths to trailing slash (#1501)

### DIFF
--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -2359,9 +2359,15 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         proxy_set_header Upgrade $http_upgrade;
         chunked_transfer_encoding off;"""
 
-        # Use the location path exactly as specified in the server configuration
-        # Users have full control over the location path format (with or without trailing slash)
-        location_path = path
+        # Always normalise the location path to end with a trailing slash (issue #1501).
+        # nginx treats `location /a` as a prefix match against ANY URL starting with
+        # `/a` (e.g. /api/, /auth, /about), so a server registered at a short path
+        # would silently hijack unrelated browser/API routes and subject them to
+        # auth_request /validate. `location /a/` only matches /a/ and paths that
+        # literally continue past the slash, so `/api/...` no longer matches. A bare
+        # `GET /a` still gets nginx's standard 301 redirect to `/a/`, and MCP clients
+        # already call `/server-name/mcp` (or /sse), which continue to match.
+        location_path = path.rstrip("/") + "/"
         logger.info(f"Creating location block for {location_path} with {transport_type} transport")
 
         return f"""

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1492,7 +1492,13 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 # The path is interpolated into a location directive; escape any
                 # nginx-special characters (defense-in-depth over Pydantic path
                 # validation) so it cannot break out of the directive.
-                safe_vs_path = self._sanitize_for_nginx_set(vs.path)
+                # Normalise to a trailing slash for the same reason as real servers
+                # (issue #1501): a bare `location /virtual/dev` prefix-matches
+                # unrelated routes like `/virtual/devtools`, hijacking them into the
+                # /validate auth subrequest. `location /virtual/dev/` only matches the
+                # subtree. The virtual_router.lua content handler receives the full
+                # URI, so the added slash does not affect routing.
+                safe_vs_path = self._sanitize_for_nginx_set(vs.path).rstrip("/") + "/"
 
                 block = f"""
     # Virtual MCP Server: {safe_name}
@@ -2045,7 +2051,24 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
 
     def _generate_transport_location_blocks(self, path: str, server_info: dict[str, Any]) -> list:
         """Generate nginx location blocks for different transport types."""
-        blocks = []
+        blocks: list[str] = []
+
+        # Render-time mirror of validate_server_path (issue #1501). A path that
+        # normalizes to empty (a slashes-only value that bypassed registration
+        # validation -- e.g. legacy data persisted before the guard existed)
+        # would render as a gateway-wide `location /` block, subjecting every URL
+        # to the /validate auth subrequest and shadowing the static catch-all.
+        # Skip it and log, rather than emit a config that hijacks the whole
+        # gateway: fail closed for this one server, keep the rest of the config.
+        if not path or not path.strip("/"):
+            logger.error(
+                "Skipping nginx location block for server with empty/slashes-only "
+                "path %r: it would render as a gateway-wide 'location /' block. "
+                "This path should have been rejected at registration.",
+                path,
+            )
+            return blocks
+
         proxy_pass_url = server_info.get("proxy_pass_url", "")
         supported_transports = server_info.get("supported_transports", ["streamable-http"])
 
@@ -2364,9 +2387,12 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         # `/a` (e.g. /api/, /auth, /about), so a server registered at a short path
         # would silently hijack unrelated browser/API routes and subject them to
         # auth_request /validate. `location /a/` only matches /a/ and paths that
-        # literally continue past the slash, so `/api/...` no longer matches. A bare
-        # `GET /a` still gets nginx's standard 301 redirect to `/a/`, and MCP clients
-        # already call `/server-name/mcp` (or /sse), which continue to match.
+        # literally continue past the slash, so `/api/...` no longer matches. MCP
+        # clients already call `/server-name/mcp` (or /sse), which continue to match.
+        # A bare `GET /a` (no trailing slash) no longer matches this block; nginx does
+        # NOT auto-redirect it to `/a/` for a proxy_pass location, so it falls through
+        # to the catch-all. This is fine because the discovery/connect URLs always
+        # include the `/mcp` (or `/sse`) suffix -- no client connects at the bare path.
         location_path = path.rstrip("/") + "/"
         logger.info(f"Creating location block for {location_path} with {transport_type} transport")
 

--- a/registry/repositories/documentdb/scope_repository.py
+++ b/registry/repositories/documentdb/scope_repository.py
@@ -140,37 +140,45 @@ def _flatten_server_access(
     return all_rules
 
 
-def _server_access_has_reserved_wildcard(
+def _server_access_has_invalid_server_rule(
     server_access: list[dict[str, Any]] | None,
 ) -> bool:
-    """Return True if any rule's ``server`` value is a reserved wildcard name.
+    """Return True if any server rule has a reserved-wildcard or empty ``server``.
 
     ``import_group`` writes ``server_access`` straight to the collection with
     ``replace_one`` and never routes through :meth:`add_server_scope`, so its
     sink guard does not apply. This scans the imported rules (in both the
     grouped ``access_rules`` shape and the direct ``server`` rule shape) so a
-    group import cannot inject a ``server: "all"`` / ``server: "*"`` rule that
-    the resolver would promote to a cross-server wildcard. The compare
-    normalizes the same way the resolver's write path does (``lstrip("/")`` +
-    trailing-slash strip + case-fold).
+    group import cannot inject a degenerate server rule that
+    :func:`registry.utils.validate_server_path` would have rejected at
+    registration. Two cases are refused, mirroring that guard:
+
+    1. ``server: "all"`` / ``server: "*"`` -- the resolver promotes these to a
+       cross-server wildcard, granting access to every server.
+    2. ``server: ""`` (or slashes-only) -- grants no access in the resolver, but
+       the same path renders as a gateway-wide ``location /`` nginx block
+       (issue #1501); reject it so this mirror stays in sync with the guard.
+
+    The compare normalizes the same way the resolver's write path does
+    (``lstrip("/")`` + trailing-slash strip + case-fold). Only rules that
+    actually carry a ``server`` key are inspected; agent rules (which have an
+    ``agent`` key and no ``server`` key) are left alone.
 
     Args:
         server_access: The ``server_access`` list from a group import.
 
     Returns:
-        True if any server rule collides with a reserved wildcard name.
+        True if any server rule is a reserved wildcard or empty/slashes-only.
     """
     for rule in _flatten_server_access(server_access or []):
-        if not isinstance(rule, dict):
-            continue
-        server_name = rule.get("server")
-        if not server_name:
+        if not isinstance(rule, dict) or "server" not in rule:
             continue
         # Coerce with str() exactly as the resolver does
         # (access_resolver.py: `str(server_name) in _WILDCARD_VALUES`) so the
         # scan cannot be blind to a non-string value the resolver would still
         # promote to a wildcard.
-        if str(server_name).strip("/").lower() in _RESERVED_SERVER_PATH_NAMES:
+        normalized = str(rule.get("server") or "").strip("/").lower()
+        if not normalized or normalized in _RESERVED_SERVER_PATH_NAMES:
             return True
     return False
 
@@ -469,11 +477,26 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
             collection = await self._get_collection()
             server_name = server_path.lstrip("/")
 
-            # Last line of defense against the reserved-wildcard escalation:
-            # refuse to write a scope row whose server name collides with the
-            # cross-server wildcard sentinel, even if a caller bypassed
-            # validate_server_path. Fail closed (return False + log, per this
-            # method's error convention).
+            # Last line of defense against writing a degenerate server path, even
+            # if a caller bypassed validate_server_path. Fail closed (return
+            # False + log, per this method's error convention).
+            #
+            # An empty/slashes-only server name is rejected too: it grants no
+            # access in the resolver (falsy), but the same path renders as a
+            # gateway-wide `location /` nginx block (issue #1501), so the
+            # registration guard now rejects it and this mirror stays in sync.
+            if not server_name.strip("/"):
+                logger.error(
+                    "Refusing to add server scope for empty/slashes-only server "
+                    "name (from path '%s'): degenerate path, rejected at "
+                    "registration",
+                    server_path,
+                )
+                return False
+
+            # Refuse to write a scope row whose server name collides with the
+            # cross-server wildcard sentinel: it would grant access to every
+            # server in the registry.
             if server_name.rstrip("/").lower() in _RESERVED_SERVER_PATH_NAMES:
                 logger.error(
                     "Refusing to add server scope for reserved wildcard name "
@@ -955,17 +978,17 @@ class DocumentDBScopeRepository(ScopeRepositoryBase):
                 )
                 return False
 
-            # Reserved-wildcard sink guard for the import path. Unlike
+            # Degenerate-server-rule sink guard for the import path. Unlike
             # add_server_scope, import_group writes server_access directly, so
-            # it needs its own check. A server rule named "all"/"*" is never
-            # legitimate (it would grant cross-server access via the resolver's
-            # wildcard promotion), so this is refused unconditionally -- an
-            # admin cannot opt into it either. Fail closed (return False + log).
-            if _server_access_has_reserved_wildcard(server_access):
+            # it needs its own check. A server rule named "all"/"*" (cross-server
+            # wildcard) or "" (renders as a gateway-wide `location /`, issue
+            # #1501) is never legitimate, so this is refused unconditionally --
+            # an admin cannot opt into it either. Fail closed (return False + log).
+            if _server_access_has_invalid_server_rule(server_access):
                 logger.error(
                     f"Refusing to import group '{group_name}': server_access "
-                    "contains a reserved wildcard server name ('all'/'*') that "
-                    "would grant cross-server access"
+                    "contains a reserved wildcard ('all'/'*') or empty server "
+                    "name that would grant cross-server access or hijack the gateway"
                 )
                 return False
 

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -465,13 +465,20 @@ def validate_server_path(
     ``*``) is rejected: such a value would silently grant access to every server
     in the registry (see :data:`_RESERVED_SERVER_PATH_NAMES`).
 
+    A path that normalizes to empty (e.g. ``/``, ``//``) is also rejected: the
+    nginx location for a server is rendered with a trailing slash (issue #1501),
+    so a slashes-only path becomes ``location /`` -- a root prefix match that
+    subjects every URL on the gateway to the ``auth_request /validate`` subrequest
+    and shadows/duplicates the static catch-all. No real server registers at the
+    root, so this is a footgun with no legitimate use; fail closed.
+
     Args:
         path: The server path (e.g. ``/github``).
 
     Raises:
         UrlValidationError: If the path is empty, contains disallowed nginx
-            metacharacters, or normalizes to a reserved cross-server wildcard
-            name.
+            metacharacters, normalizes to an empty (slashes-only) path, or
+            normalizes to a reserved cross-server wildcard name.
     """
     if not path or not isinstance(path, str):
         raise UrlValidationError(str(path), "server path is empty or not a string")
@@ -481,10 +488,18 @@ def validate_server_path(
     # Normalize the same way the scope layer does (add_server_scope does
     # server_path.lstrip("/")), then also drop trailing slashes so "/all/" and
     # "//all//" collapse to the same reserved name. Compare case-insensitively.
-    # A path that normalizes to empty (e.g. "/") is left to existing handling:
-    # an empty server name is falsy and grants no access in the resolver, so it
-    # is not part of this escalation and must stay registerable.
     normalized = path.strip("/")
+
+    # A slashes-only path normalizes to empty. It renders as `location /` after
+    # the trailing-slash normalization (issue #1501), hijacking the whole gateway
+    # into /validate. Reject it: fail closed.
+    if not normalized:
+        raise UrlValidationError(
+            path,
+            "server path must have a non-empty segment (a root/slashes-only path "
+            "would render as a gateway-wide 'location /' block)",
+        )
+
     if normalized.lower() in _RESERVED_SERVER_PATH_NAMES:
         raise UrlValidationError(
             path,

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -1003,6 +1003,33 @@ def test_create_location_block_direct_transport(nginx_service):
     assert "proxy_cache off" in block
 
 
+@pytest.mark.unit
+def test_create_location_block_appends_trailing_slash(nginx_service):
+    """Issue #1501: a server path without a trailing slash must render as a
+    trailing-slash location so nginx does a subtree prefix match (`/a/`) instead
+    of hijacking any URL that merely starts with the path (`/a` matches /api/...).
+    """
+    block = nginx_service._create_location_block(
+        "/a", "http://localhost:8000/mcp", "streamable-http"
+    )
+
+    # The location directive is normalised to end with a slash ...
+    assert "location {{ROOT_PATH}}/a/ {" in block
+    # ... and must NOT emit the bare-path form that prefix-matches /api, /auth, etc.
+    assert "location {{ROOT_PATH}}/a {" not in block
+
+
+@pytest.mark.unit
+def test_create_location_block_preserves_single_trailing_slash(nginx_service):
+    """A path already ending in a slash stays a single-slash location (no `//`)."""
+    block = nginx_service._create_location_block(
+        "/test/", "http://localhost:8000/mcp", "streamable-http"
+    )
+
+    assert "location {{ROOT_PATH}}/test/ {" in block
+    assert "location {{ROOT_PATH}}/test// {" not in block
+
+
 # =============================================================================
 # KEYCLOAK CONFIGURATION TESTS
 # =============================================================================

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -1030,8 +1030,32 @@ def test_create_location_block_preserves_single_trailing_slash(nginx_service):
     assert "location {{ROOT_PATH}}/test// {" not in block
 
 
-# =============================================================================
-# KEYCLOAK CONFIGURATION TESTS
+@pytest.mark.unit
+def test_create_location_block_normalises_multi_segment_path(nginx_service):
+    """A multi-segment path (e.g. a peer-registry namespaced server) keeps its
+    inner segments and only gains a single trailing slash."""
+    block = nginx_service._create_location_block(
+        "/peer-registry/server-name", "http://localhost:8000/mcp", "streamable-http"
+    )
+
+    assert "location {{ROOT_PATH}}/peer-registry/server-name/ {" in block
+    assert "location {{ROOT_PATH}}/peer-registry/server-name {" not in block
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("path", ["/", "//", "///", ""])
+def test_generate_transport_location_blocks_skips_empty_path(nginx_service, path):
+    """Issue #1501 render-time mirror of validate_server_path: a persisted path
+    that normalizes to empty (bypassed registration validation) must NOT render
+    a gateway-wide `location /` block. The offending server is skipped; the rest
+    of the config is unaffected."""
+    blocks = nginx_service._generate_transport_location_blocks(
+        path, {"proxy_pass_url": "http://localhost:8000/mcp"}
+    )
+
+    assert blocks == []
+
+
 # =============================================================================
 
 

--- a/tests/unit/repositories/test_scope_repo_reserved_wildcard.py
+++ b/tests/unit/repositories/test_scope_repo_reserved_wildcard.py
@@ -59,6 +59,25 @@ class TestAddServerScopeReservedWildcard:
         mock_collection.update_one.assert_not_called()
         assert repo._scopes_cache == {}
 
+    @pytest.mark.parametrize("server_path", ["/", "//", "///", ""])
+    @pytest.mark.asyncio
+    async def test_refuses_empty_server_name_and_does_not_write(
+        self, repo, mock_collection, server_path
+    ):
+        """Issue #1501: an empty/slashes-only server name renders as a
+        gateway-wide `location /` block, so the registration guard rejects it and
+        this mirror must too. Fail closed: no write."""
+        result = await repo.add_server_scope(
+            server_path=server_path,
+            scope_name="mcp-servers-unrestricted/read",
+            methods=["tools/list"],
+            tools=["*"],
+        )
+
+        assert result is False
+        mock_collection.update_one.assert_not_called()
+        assert repo._scopes_cache == {}
+
     @pytest.mark.asyncio
     async def test_allows_adjacent_name_and_writes(self, repo, mock_collection):
         # Arrange
@@ -133,6 +152,33 @@ class TestImportGroupReservedWildcard:
         assert result is False
         mock_collection.replace_one.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "server_rule",
+        [
+            {"server": "", "methods": ["tools/list"], "tools": ["*"]},
+            {"server": "/", "methods": ["tools/list"], "tools": ["*"]},
+            {"server": "//", "methods": ["tools/list"], "tools": ["*"]},
+            # A present-but-degenerate server value coerces to empty and must be
+            # refused (the resolver would grant nothing, but the guard mirrors
+            # validate_server_path which rejects the value outright). str(x or "")
+            # normalizes None / non-string falsy values to "".
+            {"server": None, "methods": ["tools/list"], "tools": ["*"]},
+            {"server": 0, "methods": ["tools/list"], "tools": ["*"]},
+            {"server": [], "methods": ["tools/list"], "tools": ["*"]},
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_empty_server_rule_refused(self, repo, mock_collection, server_rule):
+        """Issue #1501: an empty/slashes-only (or falsy, coercing-to-empty)
+        server rule renders as a gateway-wide `location /` block, so import must
+        refuse it too."""
+        server_access = [{"scope_name": "myscope", "access_rules": [server_rule]}]
+
+        result = await repo.import_group(group_name="myscope", server_access=server_access)
+
+        assert result is False
+        mock_collection.replace_one.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_benign_server_access_imports(self, repo, mock_collection):
         # Arrange: legitimate, non-wildcard server rule imports normally
@@ -150,5 +196,23 @@ class TestImportGroupReservedWildcard:
         result = await repo.import_group(group_name="myscope", server_access=server_access)
 
         # Assert
+        assert result is True
+        mock_collection.replace_one.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_only_rule_imports(self, repo, mock_collection):
+        """An agent rule has no `server` key and must not be caught by the
+        server-rule sink guard (it is inspected by validate_a2a_agent_access,
+        not this scan)."""
+        mock_collection.replace_one.return_value = MagicMock(upserted_id="myscope")
+        server_access = [
+            {
+                "scope_name": "myscope",
+                "access_rules": [{"agent": "flight-booking-agent", "actions": ["message/send"]}],
+            }
+        ]
+
+        result = await repo.import_group(group_name="myscope", server_access=server_access)
+
         assert result is True
         mock_collection.replace_one.assert_awaited_once()

--- a/tests/unit/services/test_server_service.py
+++ b/tests/unit/services/test_server_service.py
@@ -1628,7 +1628,13 @@ class TestEdgeCasesAndErrorHandling:
         mock_server_repository,
         mock_search_repository,
     ):
-        """Test handling empty or root path."""
+        """A root/slashes-only path is rejected (issue #1501).
+
+        After the trailing-slash location normalisation, a slashes-only path
+        would render as a gateway-wide ``location /`` block, so
+        ``validate_server_path`` rejects it and registration must fail closed
+        without writing anything.
+        """
         # Arrange
         root_server = {
             "path": "/",
@@ -1639,12 +1645,13 @@ class TestEdgeCasesAndErrorHandling:
         mock_server_repository.create.return_value = True
         mock_server_repository.get_state.return_value = False
 
-        # Act
-        result = await server_service.register_server(root_server)
+        from registry.exceptions import UrlValidationError
 
-        # Assert - result is now a dict
-        assert result["success"] is True
-        mock_server_repository.create.assert_called_once()
+        # Act / Assert - registration fails closed, nothing is persisted
+        with pytest.raises(UrlValidationError):
+            await server_service.register_server(root_server)
+
+        mock_server_repository.create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_long_path_handling(

--- a/tests/unit/test_virtual_server_nginx.py
+++ b/tests/unit/test_virtual_server_nginx.py
@@ -125,6 +125,26 @@ class TestGenerateVirtualServerBlocks:
         assert "error_page 403 = @forbidden_error" in result
 
     @pytest.mark.asyncio
+    async def test_location_normalised_to_trailing_slash(self, mock_virtual_server_repository):
+        """Issue #1501: the virtual-server location must render with a trailing
+        slash so nginx does a subtree prefix match (`/virtual/dev/`) instead of
+        hijacking any URL that merely starts with the path (`/virtual/dev` would
+        otherwise prefix-match `/virtual/devtools`)."""
+        vs = _make_vs_config(path="/virtual/dev", server_name="Dev")
+        mock_virtual_server_repository.list_enabled.return_value = [vs]
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_server_blocks()
+
+        # The location directive is normalised to end with a slash ...
+        assert "location {{ROOT_PATH}}/virtual/dev/ {" in result
+        # ... and must NOT emit the bare-path form that prefix-matches
+        # /virtual/devtools, /virtual/development, etc.
+        assert "location {{ROOT_PATH}}/virtual/dev {" not in result
+
+    @pytest.mark.asyncio
     async def test_multiple_virtual_servers(self, mock_virtual_server_repository):
         """Test that multiple virtual servers produce multiple location blocks."""
         vs1 = _make_vs_config(path="/virtual/dev", server_name="Dev")

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -302,12 +302,13 @@ class TestNginxMetacharacters:
         url_guard.validate_server_path(path)  # does not raise
 
     @pytest.mark.parametrize("path", ["/", "//", "///"])
-    def test_validate_server_path_allows_root_and_slashes_only(self, path):
-        """A slashes-only path normalizes to an empty server name, which is
-        falsy and grants no access in the resolver, so it is not part of the
-        reserved-wildcard escalation and must stay registerable (the escalation
-        is narrowly about the 'all'/'*' sentinels, not empty names)."""
-        url_guard.validate_server_path(path)  # does not raise
+    def test_validate_server_path_rejects_root_and_slashes_only(self, path):
+        """A slashes-only path normalizes to an empty server name and, after the
+        trailing-slash location normalization (issue #1501), renders as a
+        gateway-wide `location /` block that subjects every URL to the /validate
+        auth subrequest. No real server registers at the root, so reject it."""
+        with pytest.raises(UrlValidationError):
+            url_guard.validate_server_path(path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
MCP server location blocks were generated as `location /path` (no trailing slash), which nginx treats as a prefix match against any URL starting with that string. A server registered at a short path such as `/a` would silently intercept `/api/...`, `/auth`, and other browser/API routes and subject them to `auth_request /validate`, returning 401 for unauthenticated requests.

Normalise the path with `path.rstrip("/") + "/"` so `location /a/` only matches the `/a/` subtree. MCP clients (`/server-name/mcp`, `/server-name/sse`) are unaffected; a bare `GET /server-name` gets nginx's standard 301 to the trailing-slash form.

*Issue #, if available:*

Fixes #1501

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
