### PR TITLE
fix: guard Entra logout URL length to avoid AADSTS90015 (#1502)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -122,6 +122,17 @@ _USER_JWT_AUDIENCE: str = "mcp-registry"
 MAX_TOKEN_LIFETIME_HOURS = 24
 DEFAULT_TOKEN_LIFETIME_HOURS = 8
 
+# Maximum length (in characters) of the full Entra logout URL before we drop the
+# optional id_token_hint. Entra ID rejects overly long logout requests with the
+# documented error AADSTS90015 ("QueryStringTooLong"), which happens for users in
+# many groups whose ID token JWT is large. Entra rejects against the entire
+# request URL, so we measure scheme+host+path+query, not the query string alone.
+# Microsoft does not publish the exact threshold, so this is a conservative
+# empirical value chosen to stay well under observed failures. Entra still
+# processes the logout without the hint (the only difference is a possible
+# account-selection prompt for multi-account users).
+MAX_LOGOUT_URL_LENGTH: int = 2000
+
 # Trailing path segments that are MCP transport endpoints, not part of the
 # registered server name. Used when deriving the scope key from a proxied path
 # so that /validate and the mcp-proxy hop authorize against the SAME server
@@ -5694,9 +5705,26 @@ async def oauth2_logout(
             logout_params = {
                 "post_logout_redirect_uri": full_redirect_uri,
             }
+            # Guard against AADSTS90015: only attach id_token_hint if the full
+            # logout URL stays under the safe length. Entra rejects against the
+            # entire request URL, so measure scheme+host+path+query, not the query
+            # string alone. Large ID tokens (users in many groups) otherwise
+            # breach Entra's limit and the logout is rejected, leaving a dangling
+            # IdP session.
             if id_token_hint:
-                logout_params["id_token_hint"] = id_token_hint
-            logger.debug(f"Entra ID logout params built: has_id_token_hint={bool(id_token_hint)}")
+                candidate_params = {**logout_params, "id_token_hint": id_token_hint}
+                candidate_url_len = len(f"{logout_url}?{urllib.parse.urlencode(candidate_params)}")
+                if candidate_url_len <= MAX_LOGOUT_URL_LENGTH:
+                    logout_params["id_token_hint"] = id_token_hint
+                else:
+                    logger.debug(
+                        f"Entra ID logout: dropping id_token_hint, logout URL would be "
+                        f"{candidate_url_len} chars (limit {MAX_LOGOUT_URL_LENGTH})"
+                    )
+            logger.debug(
+                f"Entra ID logout params built: "
+                f"has_id_token_hint={'id_token_hint' in logout_params}"
+            )
         elif "okta" in provider.lower() or (
             logout_hostname and logout_hostname.endswith(".okta.com")
         ):

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -5357,3 +5357,102 @@ class TestFederationTokenRotationStrength:
             assert response.json()["action"] == "rotated"
             assert server_module.FEDERATION_STATIC_TOKEN == self._STRONG
             assert server_module.FEDERATION_STATIC_TOKEN_AUTH_ENABLED is True
+
+
+class TestEntraLogoutQueryStringGuard:
+    """Entra logout must not breach the logout-URL length limit (AADSTS90015).
+
+    Large ID tokens (users in many groups) push the full logout URL past Entra's
+    limit. The handler drops the optional id_token_hint when the composed URL
+    would exceed MAX_LOGOUT_URL_LENGTH; Entra still processes the logout without
+    it.
+    """
+
+    _PROVIDER = "entra"
+    _LOGOUT_URL = "https://login.microsoftonline.com/tenant/oauth2/v2.0/logout"
+
+    def _run_logout(self, id_token_hint):
+        import asyncio
+        import urllib.parse
+
+        import auth_server.server as server_module
+
+        config = {
+            "providers": {
+                self._PROVIDER: {
+                    "client_id": "app-client-id",
+                    "logout_url": self._LOGOUT_URL,
+                }
+            }
+        }
+        request = Mock()
+        request.headers = {}
+
+        with (
+            patch.object(server_module, "OAUTH2_CONFIG", config),
+            patch.dict("os.environ", {"REGISTRY_URL": "https://gw.example.com"}),
+        ):
+            response = asyncio.run(
+                server_module.oauth2_logout(
+                    provider=self._PROVIDER,
+                    request=request,
+                    redirect_uri="/login",
+                    id_token_hint=id_token_hint,
+                )
+            )
+
+        parsed = urllib.parse.urlparse(response.headers["location"])
+        return urllib.parse.parse_qs(parsed.query)
+
+    def _hint_for_url_length(self, target_url_len):
+        """Build an id_token_hint that makes the composed logout URL exactly
+        target_url_len chars, so boundary behavior can be tested precisely."""
+        import urllib.parse
+
+        base_params = {"post_logout_redirect_uri": "https://gw.example.com/login"}
+        # Length of the URL with an empty hint value appended.
+        empty_hint_url_len = len(
+            f"{self._LOGOUT_URL}?" + urllib.parse.urlencode({**base_params, "id_token_hint": ""})
+        )
+        # "a" is not percent-encoded, so each char adds exactly one to the URL.
+        return "a" * (target_url_len - empty_hint_url_len)
+
+    def test_small_token_keeps_id_token_hint(self):
+        """A short id_token_hint stays in the logout query string."""
+        query = self._run_logout("short-token")
+        assert query["id_token_hint"] == ["short-token"]
+        assert query["post_logout_redirect_uri"] == ["https://gw.example.com/login"]
+
+    def test_no_hint_provided_omits_id_token_hint(self):
+        """With no id_token_hint the handler must not inject one; logout still
+        redirects with the post_logout_redirect_uri."""
+        query = self._run_logout(None)
+        assert "id_token_hint" not in query
+        assert query["post_logout_redirect_uri"] == ["https://gw.example.com/login"]
+
+    def test_hint_at_limit_is_kept(self):
+        """A hint whose composed URL is exactly at the limit is kept (boundary)."""
+        from auth_server.server import MAX_LOGOUT_URL_LENGTH
+
+        hint = self._hint_for_url_length(MAX_LOGOUT_URL_LENGTH)
+        query = self._run_logout(hint)
+        assert query["id_token_hint"] == [hint]
+
+    def test_hint_one_over_limit_is_dropped(self):
+        """A hint whose composed URL is one char over the limit is dropped."""
+        from auth_server.server import MAX_LOGOUT_URL_LENGTH
+
+        hint = self._hint_for_url_length(MAX_LOGOUT_URL_LENGTH + 1)
+        query = self._run_logout(hint)
+        assert "id_token_hint" not in query
+        assert query["post_logout_redirect_uri"] == ["https://gw.example.com/login"]
+
+    def test_oversized_token_drops_id_token_hint(self):
+        """An id_token_hint that would breach the limit is omitted; logout still
+        redirects with the post_logout_redirect_uri so Entra completes it."""
+        from auth_server.server import MAX_LOGOUT_URL_LENGTH
+
+        oversized = "a" * (MAX_LOGOUT_URL_LENGTH + 100)
+        query = self._run_logout(oversized)
+        assert "id_token_hint" not in query
+        assert query["post_logout_redirect_uri"] == ["https://gw.example.com/login"]


### PR DESCRIPTION
Entra ID rejects logout requests whose URL is too long (AADSTS90015, "QueryStringTooLong"). Users in many groups get large ID token JWTs, so appending id_token_hint to the logout URL can breach Entra's limit and the logout is rejected, leaving a dangling IdP session while the local session is already cleared.

The Entra branch now drops the optional id_token_hint when the full composed logout URL (scheme+host+path+query) would exceed MAX_LOGOUT_URL_LENGTH. Entra still terminates the session via its own SSO cookie; the only visible effect is a possible account-selection prompt for multi-account users.

Scoped to Entra: Keycloak and Okta do not inline group GUIDs into the id_token by default and have no equivalent hard rejection, and dropping the hint on Keycloak would trigger its logout-confirmation page. 

*Issue #, if available:*

Fixes #1502

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
