### PR TITLE
fix: internalize OAuth2 logout id_token_hint (#1503)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -953,7 +953,15 @@ def _is_redirect_within_cookie_domain(
         forwarded_proto = request.headers.get("x-forwarded-proto", "").split(",")[0].strip()
         forwarded_host = request.headers.get("x-forwarded-host", "").split(",")[0].strip()
         request_scheme = forwarded_proto or request.url.scheme
-        request_host = (forwarded_host or request.url.hostname or "").lower()
+        # Compare hostnames only, never host:port. urlparse(url).hostname above
+        # already strips the port, and request.url.hostname is port-less too, but
+        # a raw X-Forwarded-Host may carry a port (e.g. "localhost:7860" from the
+        # registry's server-to-server logout hop). Normalize the forwarded value
+        # the same way so a same-origin redirect isn't falsely rejected.
+        if forwarded_host:
+            request_host = (urlparse(f"//{forwarded_host}").hostname or "").lower()
+        else:
+            request_host = (request.url.hostname or "").lower()
         if request_host and parsed.scheme == request_scheme and hostname == request_host:
             return True
 

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -375,15 +375,14 @@ server {
         proxy_pass_request_headers on;
     }
 
-    # OAuth2 Cognito logout endpoint
+    # OAuth2 logout is no longer browser-facing (issue #1503). The registry
+    # calls auth-server's /oauth2/logout/ directly over the internal network
+    # (AUTH_SERVER_URL) and redirects the browser straight to the IdP, so the
+    # id_token_hint JWT never traverses this public hop. Return 404 to close
+    # the path that would otherwise let a crafted request reintroduce the JWT
+    # into a browser-facing URL and any proxy/WAF/access logs.
     location /oauth2/logout/ {
-    proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/oauth2/logout/;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $real_scheme;
-    proxy_pass_request_headers on;
+        return 404;
     }
 
     # OAuth2 Entra ID callback endpoint
@@ -1191,15 +1190,14 @@ server {
         proxy_pass_request_headers on;
     }
 
-    # OAuth2 Cognito logout endpoint
+    # OAuth2 logout is no longer browser-facing (issue #1503). The registry
+    # calls auth-server's /oauth2/logout/ directly over the internal network
+    # (AUTH_SERVER_URL) and redirects the browser straight to the IdP, so the
+    # id_token_hint JWT never traverses this public hop. Return 404 to close
+    # the path that would otherwise let a crafted request reintroduce the JWT
+    # into a browser-facing URL and any proxy/WAF/access logs.
     location /oauth2/logout/ {
-    proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/oauth2/logout/;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $real_scheme;
-    proxy_pass_request_headers on;
+        return 404;
     }
 
     # OAuth2 Entra ID callback endpoint (HTTPS)

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -597,15 +597,14 @@ server {
         proxy_pass_request_headers on;
     }
 
-    # OAuth2 Cognito logout endpoint
+    # OAuth2 logout is no longer browser-facing (issue #1503). The registry
+    # calls auth-server's /oauth2/logout/ directly over the internal network
+    # (AUTH_SERVER_URL) and redirects the browser straight to the IdP, so the
+    # id_token_hint JWT never traverses this public hop. Return 404 to close
+    # the path that would otherwise let a crafted request reintroduce the JWT
+    # into a browser-facing URL and any proxy/WAF/access logs.
     location /oauth2/logout/ {
-    proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/oauth2/logout/;
-    proxy_http_version 1.1;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $forwarded_proto;
-    proxy_pass_request_headers on;
+        return 404;
     }
 
     # OAuth2 Entra ID callback endpoint

--- a/docs/design/session-flow-cookie-based.md
+++ b/docs/design/session-flow-cookie-based.md
@@ -296,7 +296,7 @@ See [registry/auth/csrf.py:114-158](../../registry/auth/csrf.py#L114-L158).
 
 ## 7. Logout
 
-Sequence (driven by `registry/auth/routes.py:189-288`):
+Sequence (driven by `registry/auth/routes.py:266-441`):
 
 1. **Resolve the session** before anything else, to get `provider`, `id_token`,
    and `session_id`.
@@ -307,14 +307,31 @@ Sequence (driven by `registry/auth/routes.py:189-288`):
 3. **Clear the local cookie** with a `Set-Cookie` containing the same name,
    path, and domain as the original (browsers ignore deletes that don't
    match the original attributes).
-4. **Redirect to the IdP's logout endpoint** with `id_token_hint=<token>` so
-   the SSO session at the IdP also terminates. If `id_token` is missing
-   (unusual; some flows omit it), proceed without the hint and rely on
-   browser redirect alone.
-5. **Browser ends up at `/login`**, ready to re-authenticate.
+4. **Call the auth-server directly (server-to-server)** at
+   `settings.auth_server_url` (the internal cluster URL, never the public
+   `auth_server_external_url`), forwarding `redirect_uri` and — when present
+   and well-formed — `id_token_hint=<token>`. The registry reads the `Location`
+   header from auth-server's `302` and redirects the browser straight to the
+   IdP logout URL. The `id_token_hint` JWT therefore never appears in a
+   browser-facing URL, so it can no longer be blocked by a WAF/proxy that
+   inspects query strings, or leak into browser history and access logs
+   (issue #1503). `X-Forwarded-Host`/`X-Forwarded-Proto` are forwarded so
+   auth-server's `redirect_uri` same-origin validation approves the URI.
+   If the S2S call fails, returns a non-3xx, or yields an unsafe `Location`,
+   logout still completes locally by falling back to `/login` (the session and
+   cookie were already invalidated in steps 2-3).
+5. **Browser lands at the IdP logout URL.** The `post_logout_redirect_uri`
+   sent to the IdP is the registry's own `/logout` (built by
+   `_build_external_url(request, "/logout")`). So the IdP terminates the SSO
+   session and then redirects the browser back to `/logout` — but the session
+   cookie was already cleared in step 3, so this second `/logout` resolves no
+   session, finds no `provider`, skips the S2S call entirely, and falls
+   straight through to `/login`. On the fallback path (S2S failure, non-3xx,
+   or unsafe `Location`) the browser goes to `/login` directly without the IdP
+   round trip. Either way the user ends at `/login`, ready to re-authenticate.
 
 Operational visibility: four Prometheus counters track logout outcomes
-([registry/auth/routes.py:58-77](../../registry/auth/routes.py#L58-L77)):
+([registry/auth/routes.py:12-23](../../registry/auth/routes.py#L12-L23)):
 
 - `registry_logout_id_token_hint_present_total`
 - `registry_logout_id_token_hint_missing_total`

--- a/registry/auth/routes.py
+++ b/registry/auth/routes.py
@@ -30,6 +30,12 @@ logger = logging.getLogger(__name__)
 
 _ROOT_PATH: str = os.environ.get("ROOT_PATH", "").rstrip("/")
 
+# Server-to-server logout call to auth-server. The timeout is short because the
+# hop is cluster-internal (loopback/service-discovery); if it can't answer in a
+# few seconds it is down, and the user should not stare at a blank page — the
+# local session is already invalidated by that point, so we fall back to /login.
+_S2S_LOGOUT_TIMEOUT_SECONDS: float = 5.0
+
 
 def _fallback_external_host() -> str:
     """Return the host (host[:port]) to use when the inbound Host is untrusted.
@@ -141,6 +147,29 @@ def _validate_jwt_format(token: str) -> bool:
     """
     jwt_pattern = r"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$"
     return bool(re.match(jwt_pattern, token))
+
+
+def _is_safe_logout_redirect(url: str) -> bool:
+    """Validate the IdP logout Location before redirecting the browser to it.
+
+    The Location comes from the trusted internal auth-server, but this is a
+    cheap defense-in-depth check so a malformed or unexpected value can never
+    turn into a ``javascript:``/``data:`` redirect. Absolute URLs must use
+    http/https; relative paths are allowed (auth-server falls back to a local
+    path when the provider has no logout URL). Fails closed on anything else.
+
+    Args:
+        url: The Location header value returned by the auth-server.
+
+    Returns:
+        True if the URL is safe to redirect the browser to, False otherwise.
+    """
+    if not url:
+        return False
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.scheme and not parsed.netloc:
+        return True
+    return parsed.scheme in ("http", "https")
 
 
 async def get_oauth2_providers():
@@ -285,36 +314,111 @@ async def logout_handler(
             domain=settings.session_cookie_domain,
         )
 
-        # If user was logged in via OAuth2, redirect to provider logout
+        # If user was logged in via OAuth2, terminate the IdP session too.
+        #
+        # The id_token_hint is a full OIDC JWT (typically 1-3 KB). It must
+        # never travel through a browser-facing URL (issue #1503): WAFs and
+        # reverse proxies routinely block long or JWT-looking query strings
+        # (returning 403 before the auth-server is reached, so logout fails
+        # silently after the local session has already been cleared), and the
+        # token would otherwise leak into browser history and access/proxy
+        # logs while it is being actively revoked.
+        #
+        # Instead the registry calls the auth-server directly over the
+        # internal network (settings.auth_server_url) and redirects the
+        # browser straight to the IdP logout URL returned in the Location
+        # header. The JWT only ever appears on the direct browser->IdP hop,
+        # bypassing the deployment's public infrastructure entirely. This is
+        # the same internal S2S URL already used by get_oauth2_providers(),
+        # so it is configured and reachable in every deployment mode (EKS,
+        # Docker/Compose, ECS, EC2, local).
         if provider:
-            auth_external_url = settings.auth_server_external_url
             redirect_uri = _build_external_url(request, "/logout")
-            logout_url = f"{auth_external_url}/oauth2/logout/{provider}?redirect_uri={redirect_uri}"
+            logout_params: dict[str, str] = {"redirect_uri": redirect_uri}
 
-            # Append id_token_hint for proper SSO session termination if we
-            # have an id_token from the server-side session record.
+            # Include id_token_hint for proper SSO session termination if we
+            # have a well-formed id_token from the server-side session record.
+            #
+            # We deliberately do NOT length-guard the id_token here. The logout
+            # URL-length concern (Entra's AADSTS90015 "QueryStringTooLong") is
+            # owned entirely by auth_server's oauth2_logout, which drops the hint
+            # per-provider when the composed IdP URL exceeds MAX_LOGOUT_URL_LENGTH
+            # (issue #1502 / PR #1508). That guard still runs on this S2S hop, so
+            # adding a second registry-side size check would be a redundant,
+            # divergent mechanism. The id_token also comes from our own AES-
+            # encrypted session store, not user input, so _validate_jwt_format is
+            # the only sanity check needed before forwarding.
             if id_token:
                 if not _validate_jwt_format(id_token):
                     logger.debug("id_token failed JWT format validation, not forwarding")
                     logout_jwt_validation_failed.inc()
                 else:
-                    encoded_token = urllib.parse.quote(id_token, safe="")
-                    logout_url = f"{logout_url}&id_token_hint={encoded_token}"
-
-                    if len(logout_url) > 2000:
-                        logger.debug(
-                            f"Logout URL length ({len(logout_url)}) exceeds recommended limit (2000)"
-                        )
-                        logout_url_length_warning.inc()
-
+                    logout_params["id_token_hint"] = id_token
                     logger.debug("id_token extracted and forwarded, has_id_token=True")
                     logout_id_token_hint_present.inc()
             else:
                 logger.debug("id_token not present in session, has_id_token=False")
                 logout_id_token_hint_missing.inc()
 
-            logger.debug(f"Redirecting to {provider} logout")
-            response = RedirectResponse(url=logout_url, status_code=status.HTTP_303_SEE_OTHER)
+            # Forward X-Forwarded-Host/Proto so auth-server's redirect_uri
+            # same-origin validation (_is_redirect_within_cookie_domain) sees
+            # the real public hostname and approves the post-logout URI. The
+            # host is the same trusted, allowlist-validated value baked into
+            # redirect_uri above, and the proto is derived from it so the two
+            # can never disagree.
+            s2s_url = f"{settings.auth_server_url}/oauth2/logout/{provider}"
+            trusted_host = _resolve_trusted_host(request)
+            x_forwarded_proto = "https" if redirect_uri.startswith("https") else "http"
+
+            idp_redirect_url: str | None = None
+            try:
+                # Bare client (not the SSRF-guarded client) is correct here:
+                # auth_server_url is a deployment-controlled internal service
+                # (loopback/RFC-1918/cluster-internal) that the SSRF guard is
+                # designed to block; it is not a user/registry-supplied URL.
+                async with httpx.AsyncClient(follow_redirects=False) as client:
+                    s2s_resp = await client.get(
+                        s2s_url,
+                        params=logout_params,
+                        headers={
+                            "X-Forwarded-Host": trusted_host,
+                            "X-Forwarded-Proto": x_forwarded_proto,
+                        },
+                        timeout=_S2S_LOGOUT_TIMEOUT_SECONDS,
+                    )
+                if s2s_resp.status_code in (301, 302, 303, 307, 308):
+                    idp_redirect_url = s2s_resp.headers.get("location")
+                    # Observability only — this does NOT drop or truncate the
+                    # URL (auth_server already applies the functional length
+                    # guard, PR #1508). It just surfaces when the final IdP URL
+                    # is unusually long so operators can correlate logout issues.
+                    if idp_redirect_url and len(idp_redirect_url) > 2000:
+                        logger.debug(
+                            f"IdP logout URL length ({len(idp_redirect_url)}) "
+                            "exceeds recommended limit (2000)"
+                        )
+                        logout_url_length_warning.inc()
+                else:
+                    logger.warning(
+                        f"auth-server logout returned status {s2s_resp.status_code}; "
+                        "falling back to local clear"
+                    )
+            except Exception as exc:
+                logger.warning(f"S2S auth-server logout failed: {exc}; falling back to local clear")
+
+            # Redirect the browser to the IdP logout URL when we have a safe
+            # one, else fall back to /login so logout always completes locally
+            # (the server-side session and cookie were already invalidated
+            # above). Only http(s) and relative targets are followed to guard
+            # against a javascript:/data: Location, even though the source is
+            # the trusted internal auth-server.
+            if idp_redirect_url and _is_safe_logout_redirect(idp_redirect_url):
+                redirect_target = idp_redirect_url
+            else:
+                redirect_target = "/login"
+
+            logger.debug(f"Redirecting browser after {provider} logout")
+            response = RedirectResponse(url=redirect_target, status_code=status.HTTP_303_SEE_OTHER)
             response.delete_cookie(
                 settings.session_cookie_name,
                 path="/",

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -276,6 +276,54 @@ class TestServerNameNormalization:
         assert _server_names_match("*", "another-server")
 
 
+class TestIsRedirectWithinCookieDomain:
+    """Tests for _is_redirect_within_cookie_domain same-origin validation.
+
+    The registry's server-to-server logout hop (issue #1503) forwards a raw
+    X-Forwarded-Host that may carry a port (e.g. "localhost:7860"), while the
+    redirect_uri host is port-stripped by urlparse. These tests guard against
+    the port causing a false same-origin rejection.
+    """
+
+    def _request(self, forwarded_host="", forwarded_proto="", url_host="localhost", scheme="http"):
+        request = MagicMock()
+        headers = {"x-forwarded-host": forwarded_host, "x-forwarded-proto": forwarded_proto}
+        request.headers = MagicMock()
+        request.headers.get = lambda key, default="": headers.get(key, default)
+        request.url = MagicMock()
+        request.url.hostname = url_host
+        request.url.scheme = scheme
+        return request
+
+    def test_forwarded_host_with_port_matches_portless_redirect(self):
+        """X-Forwarded-Host: localhost:7860 must match http://localhost:7860/logout."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        request = self._request(forwarded_host="localhost:7860", forwarded_proto="http")
+        assert _is_redirect_within_cookie_domain("http://localhost:7860/logout", "", request)
+
+    def test_forwarded_host_https_with_domain(self):
+        """A real public host forwarded with https matches an https redirect."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        request = self._request(forwarded_host="app.example.com", forwarded_proto="https")
+        assert _is_redirect_within_cookie_domain("https://app.example.com/logout", "", request)
+
+    def test_different_host_rejected(self):
+        """A redirect to a different host is rejected when no cookie domain covers it."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        request = self._request(forwarded_host="app.example.com", forwarded_proto="https")
+        assert not _is_redirect_within_cookie_domain("https://evil.example.net/logout", "", request)
+
+    def test_scheme_mismatch_rejected(self):
+        """A proto mismatch (http forwarded vs https redirect) is rejected."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        request = self._request(forwarded_host="localhost:7860", forwarded_proto="http")
+        assert not _is_redirect_within_cookie_domain("https://localhost:7860/logout", "", request)
+
+
 class TestGroupToScopeMapping:
     """Tests for mapping IdP groups to MCP scopes."""
 

--- a/tests/unit/auth/test_logout_handler.py
+++ b/tests/unit/auth/test_logout_handler.py
@@ -1,0 +1,229 @@
+"""Tests for the OAuth2 logout handler S2S flow (issue #1503).
+
+The logout handler must never place the id_token_hint JWT in a browser-facing
+URL. Instead it calls the auth-server directly over the internal network
+(settings.auth_server_url) and redirects the browser straight to the IdP logout
+URL returned in the Location header. These tests verify:
+
+  - the id_token_hint travels only on the internal S2S call, never in the
+    browser redirect;
+  - X-Forwarded-Host/Proto are forwarded so auth-server's redirect_uri
+    same-origin validation approves the post-logout URI;
+  - logout always completes locally (cookie cleared, /login fallback) when the
+    S2S call fails, returns a non-redirect status, or yields an unsafe Location;
+  - the internal auth_server_url is used for the S2S hop, not the public
+    auth_server_external_url (which sits behind the WAF).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+
+from registry.auth import routes
+from registry.auth.routes import _is_safe_logout_redirect, logout_handler
+from registry.core.config import Settings
+
+_SESSION_COOKIE = "mcp_gateway_session"
+_ID_TOKEN = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.c2lnbmF0dXJl"
+_IDP_LOGOUT_URL = (
+    "https://login.microsoftonline.com/common/oauth2/v2.0/logout"
+    "?post_logout_redirect_uri=https%3A%2F%2Fexample.com%2Flogout"
+)
+
+
+@pytest.fixture(autouse=True)
+def _trust_example_host():
+    """Trust example.com so redirect_uri construction does not fail closed."""
+    with patch.object(
+        Settings,
+        "trusted_external_hosts_set",
+        new_callable=PropertyMock,
+        return_value={"example.com", "localhost", "localhost:7860"},
+    ):
+        yield
+
+
+def _make_request(host: str = "example.com", scheme: str = "https") -> MagicMock:
+    """Create a mock Request with an https example.com origin."""
+    request = MagicMock()
+    header_dict = {
+        "host": host,
+        "x-cloudfront-forwarded-proto": "",
+        "x-forwarded-proto": "https" if scheme == "https" else "",
+    }
+    request.headers = MagicMock()
+    request.headers.get = lambda key, default="": header_dict.get(key, default)
+    request.url = MagicMock()
+    request.url.scheme = scheme
+    request.state = MagicMock()
+    return request
+
+
+def _mock_s2s_client(response=None, exc=None):
+    """Build a MagicMock standing in for httpx.AsyncClient(...) as a context manager."""
+    client_factory = MagicMock()
+    instance = AsyncMock()
+    if exc is not None:
+        instance.get.side_effect = exc
+    else:
+        instance.get.return_value = response
+    client_factory.return_value.__aenter__ = AsyncMock(return_value=instance)
+    client_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    return client_factory, instance
+
+
+def _s2s_response(status_code=302, location=_IDP_LOGOUT_URL):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.headers = {"location": location} if location is not None else {}
+    return resp
+
+
+def _oauth2_session():
+    return {
+        "auth_method": "oauth2",
+        "provider": "entra",
+        "id_token": _ID_TOKEN,
+        "session_id": "sess-123",
+    }
+
+
+class TestIsSafeLogoutRedirect:
+    """Unit tests for the defense-in-depth Location validator."""
+
+    def test_absolute_https_allowed(self):
+        assert _is_safe_logout_redirect("https://login.microsoftonline.com/logout") is True
+
+    def test_absolute_http_allowed(self):
+        assert _is_safe_logout_redirect("http://keycloak.example.com/logout") is True
+
+    def test_relative_path_allowed(self):
+        assert _is_safe_logout_redirect("/login") is True
+
+    def test_javascript_scheme_rejected(self):
+        assert _is_safe_logout_redirect("javascript:alert(1)") is False
+
+    def test_data_scheme_rejected(self):
+        assert _is_safe_logout_redirect("data:text/html,<script>") is False
+
+    def test_empty_rejected(self):
+        assert _is_safe_logout_redirect("") is False
+
+
+class TestLogoutHandlerS2S:
+    """Behavioral tests for the S2S logout flow."""
+
+    async def _run(self, client_factory, session_data=None):
+        """Invoke logout_handler with session resolution and delete patched."""
+        request = _make_request()
+        with (
+            patch.object(routes, "httpx") as mock_httpx,
+            patch(
+                "registry.auth.dependencies.resolve_session_from_cookie",
+                new=AsyncMock(return_value=session_data or _oauth2_session()),
+            ),
+            patch(
+                "registry.auth.session_store.delete_session",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            mock_httpx.AsyncClient = client_factory
+            response = await logout_handler(request, session="cookie-value")
+        return response
+
+    @pytest.mark.asyncio
+    async def test_id_token_hint_only_on_s2s_call_never_in_browser_url(self):
+        """The JWT must appear on the internal S2S call, not the browser redirect."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        response = await self._run(factory)
+
+        # Browser is redirected to the IdP URL from Location, which carries no
+        # id_token_hint from our side (the IdP embeds it internally).
+        assert response.status_code == 303
+        assert response.headers["location"] == _IDP_LOGOUT_URL
+        assert _ID_TOKEN not in response.headers["location"]
+
+        # The id_token_hint was passed only on the server-to-server GET.
+        _, kwargs = instance.get.call_args
+        assert kwargs["params"]["id_token_hint"] == _ID_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_s2s_uses_internal_url_not_external(self):
+        """S2S hop must target auth_server_url (internal), not the WAF-fronted external URL."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        with (
+            patch.object(routes.settings, "auth_server_url", "http://auth-server:8888"),
+            patch.object(routes.settings, "auth_server_external_url", "https://example.com"),
+        ):
+            await self._run(factory)
+
+        args, _ = instance.get.call_args
+        assert args[0] == "http://auth-server:8888/oauth2/logout/entra"
+
+    @pytest.mark.asyncio
+    async def test_forwarded_headers_sent(self):
+        """X-Forwarded-Host/Proto must be forwarded for same-origin redirect_uri validation."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        await self._run(factory)
+
+        _, kwargs = instance.get.call_args
+        assert kwargs["headers"]["X-Forwarded-Host"] == "example.com"
+        assert kwargs["headers"]["X-Forwarded-Proto"] == "https"
+
+    @pytest.mark.asyncio
+    async def test_cookie_cleared_on_success(self):
+        """The session cookie must be cleared on the IdP redirect response."""
+        factory, _ = _mock_s2s_client(_s2s_response())
+        response = await self._run(factory)
+        set_cookie = response.headers.get("set-cookie", "")
+        assert _SESSION_COOKIE in set_cookie
+
+    @pytest.mark.asyncio
+    async def test_fallback_to_login_when_s2s_raises(self):
+        """A failed S2S call must still complete logout locally via /login."""
+        factory, _ = _mock_s2s_client(exc=Exception("connection refused"))
+        response = await self._run(factory)
+        assert response.status_code == 303
+        assert response.headers["location"] == "/login"
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_non_redirect_status(self):
+        """A non-3xx auth-server response falls back to /login."""
+        factory, _ = _mock_s2s_client(_s2s_response(status_code=500, location=None))
+        response = await self._run(factory)
+        assert response.headers["location"] == "/login"
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_location_missing(self):
+        """A 3xx with no Location header falls back to /login."""
+        factory, _ = _mock_s2s_client(_s2s_response(location=None))
+        response = await self._run(factory)
+        assert response.headers["location"] == "/login"
+
+    @pytest.mark.asyncio
+    async def test_unsafe_location_rejected(self):
+        """A javascript: Location from the auth-server must not be followed."""
+        factory, _ = _mock_s2s_client(_s2s_response(location="javascript:alert(1)"))
+        response = await self._run(factory)
+        assert response.headers["location"] == "/login"
+
+    @pytest.mark.asyncio
+    async def test_malformed_id_token_not_forwarded(self):
+        """A non-JWT id_token must not be placed in the S2S params."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        session = _oauth2_session()
+        session["id_token"] = "not-a-jwt"
+        await self._run(factory, session_data=session)
+
+        _, kwargs = instance.get.call_args
+        assert "id_token_hint" not in kwargs["params"]
+
+    @pytest.mark.asyncio
+    async def test_non_oauth2_session_skips_s2s(self):
+        """A non-OAuth2 session logs out locally without any S2S call."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        session = {"auth_method": "session", "session_id": "sess-9"}
+        response = await self._run(factory, session_data=session)
+
+        instance.get.assert_not_called()
+        assert response.headers["location"] == "/login"


### PR DESCRIPTION
The logout flow redirected the browser to the public auth-server URL with the OIDC id_token_hint JWT embedded in the query string. WAFs and reverse proxies routinely block long/JWT-looking query strings, returning 403 before the auth-server was reached -- logout then failed silently after the local session had already been cleared. The JWT also leaked into browser history and access/proxy logs while it was being actively revoked.

The registry now calls auth-server's /oauth2/logout/ directly over the internal network (settings.auth_server_url, the same URL already used by get_oauth2_providers) and redirects the browser straight to the IdP logout URL returned in the Location header. The JWT only ever appears on the direct browser->IdP hop, bypassing the deployment's public infrastructure. This is deployment-agnostic: auth_server_url is configured and reachable in every mode (EKS, Docker/Compose, ECS, EC2, local).

- routes.py: server-to-server logout with X-Forwarded-Host/Proto forwarded so auth-server's redirect_uri same-origin validation approves the URI; _is_safe_logout_redirect guards the returned Location; fail-closed to /login on any S2S failure, non-3xx, or unsafe Location; 5s timeout. Logout URL length remains owned by auth-server (#1502/#1508); no duplicate guard here.
- auth_server: _is_redirect_within_cookie_domain strips the port from a forwarded Host before the same-origin comparison, so a forwarded "localhost:7860" matches the port-stripped redirect_uri hostname.
- nginx: /oauth2/logout/ is no longer browser-facing; return 404 to close the path that would otherwise let a crafted request reintroduce the JWT into a browser-facing URL and the access/WAF logs.
- docs: session-flow logout section rewritten for the S2S flow.
- tests: S2S logout flow (all failure modes) and the host-with-port same-origin validation.

*Issue #, if available:*

Fixes #1503 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
