### PR TITLE
Keep Skills/Agents tabs visible with an access hint when discovery scope is missing

### DIFF
--- a/cli/examples/3p-mcp-servers-only.json
+++ b/cli/examples/3p-mcp-servers-only.json
@@ -52,7 +52,8 @@
   ],
   "ui_permissions": {
     "list_service": ["/com-github-github-mcp-server", "/slack", "/figma", "/atlassian"],
-    "health_check_service": ["all"]
+    "health_check_service": ["all"],
+    "list_skills": ["all"]
   },
   "create_in_idp": true
 }

--- a/cli/examples/public-mcp-users.json
+++ b/cli/examples/public-mcp-users.json
@@ -55,7 +55,8 @@
   "ui_permissions": {
     "list_service": ["all"],
     "list_agents": ["/flight-booking", "/flight-booking-agent"],
-    "get_agent": ["/flight-booking", "/flight-booking-agent"]
+    "get_agent": ["/flight-booking", "/flight-booking-agent"],
+    "list_skills": ["all"]
   },
   "create_in_idp": true
 }

--- a/cli/examples/read_all_register_new.json
+++ b/cli/examples/read_all_register_new.json
@@ -1,11 +1,21 @@
 {
   "scope_name": "read-all-register-new",
   "scope_type": "server_scope",
-  "description": "Non-admin read-write users: can see ALL servers and agents, search, register new servers, and run health checks. Cannot toggle server enabled/disabled state, cannot change lifecycle status, and cannot delete servers. Newly registered servers are visible immediately because access is granted via the '*' wildcard.",
+  "description": "Non-admin read-write users: can see ALL servers and agents in the UI (list_service/list_agents), search, register new servers, and run health checks. Cannot toggle server enabled/disabled state, cannot change lifecycle status, and cannot delete servers. Gateway tool access (server_access) is granted to the shipped demo servers (currenttime, mcpgw, realserverfaketools); grant additional servers explicitly with the add-to-groups admin command as they are registered. A reserved wildcard ('*'/'all') server name in server_access is refused by the import guard, so name each server.",
   "group_mappings": ["read-all-register-new"],
   "server_access": [
     {
-      "server": "*",
+      "server": "/currenttime",
+      "methods": ["initialize", "notifications/initialized", "ping", "tools/list", "tools/call", "resources/list", "resources/templates/list"],
+      "tools": ["*"]
+    },
+    {
+      "server": "/mcpgw",
+      "methods": ["initialize", "notifications/initialized", "ping", "tools/list", "tools/call", "resources/list", "resources/templates/list"],
+      "tools": ["*"]
+    },
+    {
+      "server": "/realserverfaketools",
       "methods": ["initialize", "notifications/initialized", "ping", "tools/list", "tools/call", "resources/list", "resources/templates/list"],
       "tools": ["*"]
     },
@@ -21,7 +31,8 @@
     "get_agent": ["all"],
     "list_virtual_server": ["all"],
     "register_service": ["*"],
-    "health_check_service": ["all"]
+    "health_check_service": ["all"],
+    "list_skills": ["all"]
   },
   "create_in_idp": true
 }

--- a/docs/faq/granting-skill-and-agent-discovery-permissions.md
+++ b/docs/faq/granting-skill-and-agent-discovery-permissions.md
@@ -80,17 +80,41 @@ To scope discovery to specific resources instead of the whole family, list their
 
 ## Option 3: One-time `list_skills` backfill (new-scope bootstrap)
 
-`list_skills` is a new scope, so no group holds it after upgrade, not even the admin group. Run the backfill once per deployment to grant `list_skills: ["all"]` to the built-in `mcp-registry-admin` group. It is a dry run by default; add `--apply` to make the change:
+`list_skills` is a new scope, so no group holds it after upgrade, not even the admin group. Run the backfill once per deployment to grant `list_skills: ["all"]` to the built-in `mcp-registry-admin` group. It is a dry run by default; add `--apply` to make the change.
+
+The simplest place to run it is **inside a running container**, where the registry's own environment (`.env`, `SECRET_KEY`, and the Mongo/DocumentDB service names) is already present:
 
 ```bash
-# Dry run first (prints what would change)
-uv run python scripts/backfill-skill-list-scope.py
+# Docker Compose
+docker compose exec registry uv run python scripts/backfill-skill-list-scope.py --apply
 
-# Apply the change
-uv run python scripts/backfill-skill-list-scope.py --apply
+# Kubernetes / EKS (exec into the registry pod)
+kubectl exec -it deploy/registry -- uv run python scripts/backfill-skill-list-scope.py --apply
 ```
 
+If you run it **outside** the deployment (a host shell, a one-off ECS task, an admin pod that is not the registry), the registry service names may not resolve. Pass the connection explicitly. The password and `SECRET_KEY` are read from the environment only, never as CLI args:
+
+```bash
+# MongoDB CE reached directly (skip replica-set discovery that advertises
+# internal hostnames); password + SECRET_KEY come from the environment
+DOCUMENTDB_PASSWORD=... SECRET_KEY=... \
+  uv run python scripts/backfill-skill-list-scope.py --apply \
+  --host localhost --username admin --direct-connection \
+  --auth-server-url http://localhost:8888
+
+# Amazon DocumentDB (TLS + SCRAM-SHA-1 via --storage-backend documentdb)
+DOCUMENTDB_PASSWORD=... SECRET_KEY=... \
+  uv run python scripts/backfill-skill-list-scope.py --apply \
+  --storage-backend documentdb --tls \
+  --host docdb.cluster-xxxx.us-east-1.docdb.amazonaws.com --username admin \
+  --auth-server-url https://your-auth-server
+```
+
+Run `uv run python scripts/backfill-skill-list-scope.py --help` for the full connection-argument list (`--host`, `--port`, `--database`, `--username`, `--auth-source`, `--tls`, `--direct-connection`, `--storage-backend`, `--auth-server-url`). The same arguments work for `scripts/backfill-custom-entity-scopes.py`.
+
 This only fixes the built-in admin group. Any non-admin group that should see skills still needs `list_skills` granted explicitly via Option 1 or Option 2. There is no equivalent backfill for `list_agents`, because that scope already existed before the gate.
+
+`--auth-server-url` matters when you run the script outside the deployment: after writing the grant, the script asks the auth-server to reload its scope cache. If that URL is not reachable, the grant is still persisted but the running auth-server keeps the old scopes until it is restarted or reloaded.
 
 ## Related mutation scopes (owner self-service)
 

--- a/docs/faq/granting-skill-and-agent-discovery-permissions.md
+++ b/docs/faq/granting-skill-and-agent-discovery-permissions.md
@@ -1,0 +1,111 @@
+# Why did the Skills or Agents tab go empty, and how do I grant a group access?
+
+After the skill and agent discovery gate landed, discovery of skills and agents is controlled by a `list_` UI permission, the same way MCP servers already worked. This is a fail-closed change: a non-admin user whose group does **not** hold the grant sees **zero** skills or agents, including public ones, and the tab shows a hint like:
+
+> You don't have access to view agents. Agent discovery is managed by your registry administrator. Ask them to grant your group the "list_agents" permission so agents appear here.
+
+Admins are unaffected: they bypass the discovery check and see everything.
+
+## Quick answer
+
+An administrator grants the group the missing discovery scope (`list_skills` or `list_agents`). There are two ways to do it: the IAM UI (per group, no file editing) or the `registry_management.py` CLI (scriptable, good for many groups). For the brand-new `list_skills` scope there is also a one-time backfill script that grants it to the built-in admin group.
+
+## The permissions involved
+
+| Capability | Permission key | Applies to |
+| --- | --- | --- |
+| See agents in the UI / search | `list_agents` | Agent paths or `"all"` |
+| See skills in the UI / search | `list_skills` | Skill paths or `"all"` |
+
+Grant `["all"]` to let the group discover every skill/agent, or a list of specific resource paths to scope discovery to just those. `list_` scopes are read-only, so `["all"]` is safe and does **not** trigger admin auto-promotion (unlike the mutating `modify_`/`delete_`/`toggle_`/`publish_`/`register_`/`create_` prefixes).
+
+## Option 1: Grant via the IAM UI (recommended for one or two groups)
+
+1. Sign in as an administrator and open **Settings > IAM > Groups**.
+2. Click the group you want to edit (for example the read-write group your users belong to).
+3. In the **UI Permissions** editor, find the discovery scope:
+   - For agents, the **`list_agents`** entry.
+   - For skills, the **`list_skills`** entry.
+4. Turn on the **All** toggle to grant discovery of every resource, or use the multi-select to pick specific records (the record **name** is shown, the record **path** is stored).
+5. **Save** the group. Members pick up the change on their next login or token refresh.
+
+See [IAM Settings UI](../iam-settings-ui.md) for the full Groups editor reference.
+
+## Option 2: Grant via the CLI (scriptable, good for many groups)
+
+The `import-group` command **upserts** a group: it creates the group if it does not exist and updates it in place if it does. So the flow is read the current definition, add the scope, re-import.
+
+```bash
+export REGISTRY_URL="https://your-registry"
+export TOKEN_FILE=".token"   # an admin JWT token file
+
+# 1. See the group's current scope definition
+uv run python api/registry_management.py \
+  --registry-url "$REGISTRY_URL" \
+  --token-file "$TOKEN_FILE" \
+  describe-group --name my-group --json > my-group.json
+```
+
+Edit `my-group.json` and add the discovery scope under `ui_permissions`:
+
+```json
+{
+  "scope_name": "my-group",
+  "ui_permissions": {
+    "list_service": ["all"],
+    "list_agents": ["all"],
+    "list_skills": ["all"]
+  }
+}
+```
+
+```bash
+# 2. Re-import to apply the change (updates the existing group in place)
+uv run python api/registry_management.py \
+  --registry-url "$REGISTRY_URL" \
+  --token-file "$TOKEN_FILE" \
+  import-group --file my-group.json
+```
+
+To scope discovery to specific resources instead of the whole family, list their paths rather than `"all"`:
+
+```json
+{
+  "ui_permissions": {
+    "list_agents": ["/flight-booking", "/hotel-search"],
+    "list_skills": ["/code-review"]
+  }
+}
+```
+
+## Option 3: One-time `list_skills` backfill (new-scope bootstrap)
+
+`list_skills` is a new scope, so no group holds it after upgrade, not even the admin group. Run the backfill once per deployment to grant `list_skills: ["all"]` to the built-in `mcp-registry-admin` group. It is a dry run by default; add `--apply` to make the change:
+
+```bash
+# Dry run first (prints what would change)
+uv run python scripts/backfill-skill-list-scope.py
+
+# Apply the change
+uv run python scripts/backfill-skill-list-scope.py --apply
+```
+
+This only fixes the built-in admin group. Any non-admin group that should see skills still needs `list_skills` granted explicitly via Option 1 or Option 2. There is no equivalent backfill for `list_agents`, because that scope already existed before the gate.
+
+## Related mutation scopes (owner self-service)
+
+Discovery (`list_`) is separate from mutation. If a non-admin can now *see* skills or agents but can no longer edit, delete, or toggle ones they own, grant the group the matching mutation scope too. Mutations are a dual gate: the caller needs the scope for the resource (or `"all"`) **and** must be an admin or the resource's owner.
+
+| Action | Skill scope | Agent scope |
+| --- | --- | --- |
+| Edit | `modify_skill` | `modify_agent` |
+| Delete | `delete_skill` | `delete_agent` |
+| Enable/disable | `toggle_skill` | `toggle_agent` |
+
+Grant these the same way as the discovery scopes (IAM UI or `import-group`). Note that a group which previously managed agents via the server scopes (`modify_service` / `toggle_service`) must be switched to the agent scopes (`modify_agent` / `toggle_agent`), which are now what the agent routes enforce.
+
+## Related documentation
+
+- [Scopes Management](../scopes-mgmt.md) - full scope file format, the complete UI-permissions reference table, and upgrade notes.
+- [IAM Settings UI](../iam-settings-ui.md) - the visual Groups editor.
+- [How do I create a non-admin group that can register servers but not delete them?](read-write-non-admin-group.md) - a worked example of a scoped read-write group.

--- a/docs/faq/granting-skill-and-agent-discovery-permissions.md
+++ b/docs/faq/granting-skill-and-agent-discovery-permissions.md
@@ -19,6 +19,17 @@ An administrator grants the group the missing discovery scope (`list_skills` or 
 
 Grant `["all"]` to let the group discover every skill/agent, or a list of specific resource paths to scope discovery to just those. `list_` scopes are read-only, so `["all"]` is safe and does **not** trigger admin auto-promotion (unlike the mutating `modify_`/`delete_`/`toggle_`/`publish_`/`register_`/`create_` prefixes).
 
+## Finding which groups need the grant
+
+To see which groups are missing `list_agents` / `list_skills` across a whole deployment, run the read-only audit. It lists every group, flags the ones missing a discovery scope, and prints the exact fix commands per group. It changes nothing:
+
+```bash
+uv run python scripts/audit-discovery-scopes.py \
+  --registry-url http://localhost --token-file .token
+```
+
+The audit drives `api/registry_management.py` under the hood, so it uses the same auth as the CLI. For a group whose `server_access` contains a reserved wildcard server (`"*"`/`"all"`), it prints the IAM-UI recipe instead of a re-import command, because the import guard refuses wildcard `server_access`. Use `--scope list_skills` to audit just one scope.
+
 ## Option 1: Grant via the IAM UI (recommended for one or two groups)
 
 1. Sign in as an administrator and open **Settings > IAM > Groups**.

--- a/docs/faq/granting-skill-and-agent-discovery-permissions.md
+++ b/docs/faq/granting-skill-and-agent-discovery-permissions.md
@@ -6,10 +6,6 @@ After the skill and agent discovery gate landed, discovery of skills and agents 
 
 Admins are unaffected: they bypass the discovery check and see everything.
 
-## Quick answer
-
-An administrator grants the group the missing discovery scope (`list_skills` or `list_agents`). There are two ways to do it: the IAM UI (per group, no file editing) or the `registry_management.py` CLI (scriptable, good for many groups). For the brand-new `list_skills` scope there is also a one-time backfill script that grants it to the built-in admin group.
-
 ## The permissions involved
 
 | Capability | Permission key | Applies to |
@@ -19,45 +15,14 @@ An administrator grants the group the missing discovery scope (`list_skills` or 
 
 Grant `["all"]` to let the group discover every skill/agent, or a list of specific resource paths to scope discovery to just those. `list_` scopes are read-only, so `["all"]` is safe and does **not** trigger admin auto-promotion (unlike the mutating `modify_`/`delete_`/`toggle_`/`publish_`/`register_`/`create_` prefixes).
 
-## Finding which groups need the grant
+There are two situations, described below: creating a **new** group (get the scope right from the start) and **backfilling** groups that already exist.
 
-To see which groups are missing `list_agents` / `list_skills` across a whole deployment, run the read-only audit. It lists every group, flags the ones missing a discovery scope, and prints the exact fix commands per group. It changes nothing:
+## New groups: include the discovery scope from the start
 
-```bash
-uv run python scripts/audit-discovery-scopes.py \
-  --registry-url http://localhost --token-file .token
-```
+When you author a new group, put `list_agents` / `list_skills` in its `ui_permissions` so members can discover skills and agents immediately. Two ways:
 
-The audit drives `api/registry_management.py` under the hood, so it uses the same auth as the CLI. For a group whose `server_access` contains a reserved wildcard server (`"*"`/`"all"`), it prints the IAM-UI recipe instead of a re-import command, because the import guard refuses wildcard `server_access`. Use `--scope list_skills` to audit just one scope.
-
-## Option 1: Grant via the IAM UI (recommended for one or two groups)
-
-1. Sign in as an administrator and open **Settings > IAM > Groups**.
-2. Click the group you want to edit (for example the read-write group your users belong to).
-3. In the **UI Permissions** editor, find the discovery scope:
-   - For agents, the **`list_agents`** entry.
-   - For skills, the **`list_skills`** entry.
-4. Turn on the **All** toggle to grant discovery of every resource, or use the multi-select to pick specific records (the record **name** is shown, the record **path** is stored).
-5. **Save** the group. Members pick up the change on their next login or token refresh.
-
-See [IAM Settings UI](../iam-settings-ui.md) for the full Groups editor reference.
-
-## Option 2: Grant via the CLI (scriptable, good for many groups)
-
-The `import-group` command **upserts** a group: it creates the group if it does not exist and updates it in place if it does. So the flow is read the current definition, add the scope, re-import.
-
-```bash
-export REGISTRY_URL="https://your-registry"
-export TOKEN_FILE=".token"   # an admin JWT token file
-
-# 1. See the group's current scope definition
-uv run python api/registry_management.py \
-  --registry-url "$REGISTRY_URL" \
-  --token-file "$TOKEN_FILE" \
-  describe-group --name my-group --json > my-group.json
-```
-
-Edit `my-group.json` and add the discovery scope under `ui_permissions`:
+- **IAM UI:** Settings > IAM > Groups > **Create Group**, and in the **UI Permissions** editor turn on the **All** toggle (or multi-select specific records) for `list_agents` and `list_skills`. See [IAM Settings UI](../iam-settings-ui.md).
+- **CLI:** author the group JSON with the scopes present, then import it:
 
 ```json
 {
@@ -71,29 +36,23 @@ Edit `my-group.json` and add the discovery scope under `ui_permissions`:
 ```
 
 ```bash
-# 2. Re-import to apply the change (updates the existing group in place)
+export REGISTRY_URL="https://your-registry"
+export TOKEN_FILE=".token"   # an admin JWT token file
+
 uv run python api/registry_management.py \
-  --registry-url "$REGISTRY_URL" \
-  --token-file "$TOKEN_FILE" \
+  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
   import-group --file my-group.json
 ```
 
-To scope discovery to specific resources instead of the whole family, list their paths rather than `"all"`:
+The shipped example group files ([cli/examples/](../../cli/examples/)) already include `list_skills`, so copying one as a starting point gets this right for free. To scope discovery to specific resources instead of the whole family, list their paths rather than `"all"` (e.g. `"list_agents": ["/flight-booking"]`).
 
-```json
-{
-  "ui_permissions": {
-    "list_agents": ["/flight-booking", "/hotel-search"],
-    "list_skills": ["/code-review"]
-  }
-}
-```
+## Backfilling existing groups
 
-## Option 3: One-time `list_skills` backfill (new-scope bootstrap)
+Existing groups created before the gate do not hold the new scope. Fix them in two steps.
 
-`list_skills` is a new scope, so no group holds it after upgrade, not even the admin group. Run the backfill once per deployment to grant `list_skills: ["all"]` to the built-in `mcp-registry-admin` group. It is a dry run by default; add `--apply` to make the change.
+### Step 1: the built-in admin group (`list_skills` bootstrap)
 
-The simplest place to run it is **inside a running container**, where the registry's own environment (`.env`, `SECRET_KEY`, and the Mongo/DocumentDB service names) is already present:
+`list_skills` is brand new, so no group holds it after upgrade, not even the admin group. Run the one-time backfill to grant `list_skills: ["all"]` to `mcp-registry-admin`. It is a dry run by default; add `--apply` to make the change. The simplest place to run it is **inside a running container**, where the registry's own environment is already present:
 
 ```bash
 # Docker Compose
@@ -103,7 +62,7 @@ docker compose exec registry uv run python scripts/backfill-skill-list-scope.py 
 kubectl exec -it deploy/registry -- uv run python scripts/backfill-skill-list-scope.py --apply
 ```
 
-If you run it **outside** the deployment (a host shell, a one-off ECS task, an admin pod that is not the registry), the registry service names may not resolve. Pass the connection explicitly. The password and `SECRET_KEY` are read from the environment only, never as CLI args:
+To run it **outside** the deployment (host shell, one-off ECS task, admin pod), the registry service names may not resolve, so pass the connection explicitly. The password and `SECRET_KEY` are read from the environment only, never as CLI args:
 
 ```bash
 # MongoDB CE reached directly (skip replica-set discovery that advertises
@@ -121,11 +80,34 @@ DOCUMENTDB_PASSWORD=... SECRET_KEY=... \
   --auth-server-url https://your-auth-server
 ```
 
-Run `uv run python scripts/backfill-skill-list-scope.py --help` for the full connection-argument list (`--host`, `--port`, `--database`, `--username`, `--auth-source`, `--tls`, `--direct-connection`, `--storage-backend`, `--auth-server-url`). The same arguments work for `scripts/backfill-custom-entity-scopes.py`.
+Run `--help` for the full connection-argument list (`--host`, `--port`, `--database`, `--username`, `--auth-source`, `--tls`, `--direct-connection`, `--storage-backend`, `--auth-server-url`). `--auth-server-url` matters when you run outside the deployment: after writing the grant, the script asks the auth-server to reload its scope cache; if that URL is not reachable, the grant is persisted but the running auth-server keeps the old scopes until restarted or reloaded. There is no equivalent backfill for `list_agents`, because that scope already existed before the gate.
 
-This only fixes the built-in admin group. Any non-admin group that should see skills still needs `list_skills` granted explicitly via Option 1 or Option 2. There is no equivalent backfill for `list_agents`, because that scope already existed before the gate.
+### Step 2: every other existing group (audit, then grant)
 
-`--auth-server-url` matters when you run the script outside the deployment: after writing the grant, the script asks the auth-server to reload its scope cache. If that URL is not reachable, the grant is still persisted but the running auth-server keeps the old scopes until it is restarted or reloaded.
+The backfill only fixes the admin group. For all other groups, first find which ones are missing a discovery scope with the **read-only** audit. It lists every group, flags the gaps, and prints the exact grant command per group. It changes nothing and works against any deployment surface (it only needs the registry URL and an admin token):
+
+```bash
+uv run python scripts/audit-discovery-scopes.py \
+  --registry-url http://localhost --token-file .token
+```
+
+The audit drives `api/registry_management.py` under the hood, so it uses the same auth as the CLI. Use `--scope list_skills` to audit just one scope.
+
+Then grant the scope to each flagged group. The audit prints one of two recipes per group:
+
+- **Most groups:** a describe -> edit -> import round-trip. `import-group` **upserts** (updates the group in place), so you read the current definition, add the discovery key under `ui_permissions`, and re-import:
+
+  ```bash
+  uv run python api/registry_management.py \
+    --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
+    describe-group --name my-group --json > my-group.json
+  # add "list_skills": ["all"] (and/or "list_agents") under "ui_permissions", then:
+  uv run python api/registry_management.py \
+    --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
+    import-group --file my-group.json
+  ```
+
+- **Groups whose `server_access` contains a reserved wildcard server (`"*"`/`"all"`):** these cannot be re-imported (the import guard refuses wildcard `server_access`), so grant the scope via the IAM UI instead: Settings > IAM > Groups > *group* > UI Permissions > turn on **All** for the missing scope. The audit flags these automatically.
 
 ## Related mutation scopes (owner self-service)
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -40,6 +40,7 @@ Common questions and answers about the MCP Gateway Registry.
 
 ## Access Control and Visibility
 
+- [Why did the Skills or Agents tab go empty, and how do I grant a group discovery access?](granting-skill-and-agent-discovery-permissions.md)
 - [How do I restrict which agents a user can see based on their group?](group-restricted-agent-visibility.md)
 - [How do I restrict which MCP servers a user can see based on their Entra ID group?](restrict-server-visibility-by-entra-group.md)
 - [How do I create a non-admin group that can register servers and run health checks but cannot toggle, edit, or delete them?](read-write-non-admin-group.md)

--- a/docs/scopes-mgmt.md
+++ b/docs/scopes-mgmt.md
@@ -6,6 +6,26 @@ This document describes the scope configuration file format used by the MCP Gate
 
 Scopes define what resources (MCP servers, agents) users can access and what actions they can perform. The registry uses JSON-based scope configuration files that can be loaded during initialization or managed via the CLI.
 
+## Upgrade: skills and agents are now discovery-gated
+
+Skill and agent discovery is gated on a `list_*` UI permission, matching MCP servers. This is a fail-closed change: a non-admin group that does not hold the grant sees **zero** resources of that family, including public ones. If skills or agents suddenly stop appearing for a non-admin user after upgrade, the user's group is missing the discovery scope. Take these actions once, per deployment:
+
+- **Skills discovery (`list_skills`).** This scope is new, so no group has it until you grant it. Run the one-time backfill to grant `list_skills: ["all"]` to the built-in admin group (dry-run by default):
+
+  ```bash
+  uv run python scripts/backfill-skill-list-scope.py --apply
+  ```
+
+  Then grant `list_skills` to any non-admin group that should see skills. Admins are unaffected (they bypass the check).
+
+- **Skill mutation (`modify_skill` / `delete_skill` / `toggle_skill`).** A non-admin who **owns** a skill now also needs the matching mutation scope; ownership alone is no longer sufficient. Grant these to whichever non-admin group manages skills. Not covered by the backfill.
+
+- **Agent delete (`delete_agent`).** A non-admin who owns an agent now needs `delete_agent` to delete it (previously ownership alone was enough). Every admin surface already carries this scope, so no data migration is required; grant it to any non-admin group that should delete agents it owns.
+
+- **Agent modify / toggle (`modify_agent` / `toggle_agent`).** These are now enforced against the agent family's own scopes. A non-admin who previously managed agents via the server scopes (`modify_service` / `toggle_service`) must instead be granted `modify_agent` / `toggle_agent`.
+
+The tabs for Servers and custom entity types are hidden when the user lacks the corresponding `list_*` scope. The Skills and Agents tabs stay visible and show an in-page hint explaining that discovery access is admin-managed, so a user whose access changed learns what to ask for rather than seeing the tab disappear.
+
 ## Scope Configuration File Format
 
 ### Example Files
@@ -208,11 +228,24 @@ UI permissions control what actions users can perform in the web interface and R
 | `publish_agent` | Register new agents via UI | Agent paths or `"all"` |
 | `modify_agent` | Edit agents via UI | Agent paths or `"all"` |
 | `delete_agent` | Delete agents via UI | Agent paths or `"all"` |
+| `toggle_agent` | Enable/disable agents via UI | Agent paths or `"all"` |
 | `list_service` | View MCP servers in UI | Server names or `"all"` |
 | `register_service` | Register new MCP servers | Server names or `"all"` |
 | `health_check_service` | Run health checks | Server names or `"all"` |
 | `toggle_service` | Enable/disable servers | Server names or `"all"` |
 | `modify_service` | Edit server configurations | Server names or `"all"` |
+| `delete_service` | Delete servers via UI | Server names or `"all"` |
+| `list_skills` | View skills in UI | Skill paths or `"all"` |
+| `publish_skill` | Register new skills via UI | Skill paths or `"all"` |
+| `modify_skill` | Edit skills via UI | Skill paths or `"all"` |
+| `delete_skill` | Delete skills via UI | Skill paths or `"all"` |
+| `toggle_skill` | Enable/disable skills via UI | Skill paths or `"all"` |
+| `list_<type>_entity` | View records of a custom entity type | Record paths or `"all"` |
+| `create_<type>_entity` | Create records of a custom entity type | Record paths or `"all"` |
+| `modify_<type>_entity` | Edit records of a custom entity type | Record paths or `"all"` |
+| `delete_<type>_entity` | Delete records of a custom entity type | Record paths or `"all"` |
+
+Every mutation (`modify_*`, `delete_*`, `toggle_*`) is a **dual gate**: the caller must hold the scope for the specific resource (or `"all"`) **and** be an admin or the resource's owner. Admins bypass both halves. Discovery (`list_*`) requires only the scope: a caller without the `list_*` grant for a family sees zero resources of that family, including public ones (fail closed).
 
 **Example - Read-only access:**
 ```json

--- a/docs/scopes-mgmt.md
+++ b/docs/scopes-mgmt.md
@@ -258,7 +258,34 @@ UI permissions control what actions users can perform in the web interface and R
 | `modify_<type>_entity` | Edit records of a custom entity type | Record paths or `"all"` |
 | `delete_<type>_entity` | Delete records of a custom entity type | Record paths or `"all"` |
 
-Every mutation (`modify_*`, `delete_*`, `toggle_*`) is a **dual gate**: the caller must hold the scope for the specific resource (or `"all"`) **and** be an admin or the resource's owner. Admins bypass both halves. Discovery (`list_*`) requires only the scope: a caller without the `list_*` grant for a family sees zero resources of that family, including public ones (fail closed).
+### How each operation is authorized
+
+Authorization is uniform across all four asset families (servers, agents, skills, custom entities). An **admin** bypasses every check below and can do anything. For a **non-admin**, each operation resolves as follows:
+
+| Operation | Gate for a non-admin caller |
+| --- | --- |
+| **Discover** (`list_*`) | scope only (holds the `list_` grant for the resource or `"all"`) |
+| **Create** (`register_`/`publish_`/`create_`) | scope only (a non-empty create grant) |
+| **Modify** (`modify_*`) | scope **AND** owner |
+| **Delete** (`delete_*`) | scope **AND** owner |
+| **Toggle** (`toggle_*`) | scope **AND** owner |
+
+**Dual gate (mutations).** Modify, delete, and toggle each require the caller to hold the scope for the specific resource (or `"all"`) **AND** be the resource's owner. Both halves are required: a scope grant alone does not let a non-admin mutate a resource someone else owns, and ownership alone does not let them mutate it without the scope. This is identical across servers, agents, skills, and custom entities.
+
+**Ownership** is the `registered_by` field for servers and agents, and the `owner` field for skills and custom entities (set to the creating user at registration).
+
+**Discovery (`list_*`) is scope-only and fail-closed.** A caller without the `list_` grant for a family sees zero resources of that family, including public ones. Discovery does not depend on ownership.
+
+The per-family scope names for each operation are:
+
+| Operation | Server | Agent | Skill | Custom entity `<type>` |
+| --- | --- | --- | --- | --- |
+| Discover | `list_service` | `list_agents` | `list_skills` | `list_<type>_entity` |
+| Create | `register_service` | `publish_agent` | `publish_skill` | `create_<type>_entity` |
+| Modify | `modify_service` | `modify_agent` | `modify_skill` | `modify_<type>_entity` |
+| Delete | `delete_service` | `delete_agent` | `delete_skill` | `delete_<type>_entity` |
+| Toggle | `toggle_service` | `toggle_agent` | `toggle_skill` | (n/a) |
+| Health check | `health_check_service` | (n/a) | (n/a) | (n/a) |
 
 **Example - Read-only access:**
 ```json

--- a/docs/scopes-mgmt.md
+++ b/docs/scopes-mgmt.md
@@ -10,13 +10,26 @@ Scopes define what resources (MCP servers, agents) users can access and what act
 
 Skill and agent discovery is gated on a `list_*` UI permission, matching MCP servers. This is a fail-closed change: a non-admin group that does not hold the grant sees **zero** resources of that family, including public ones. If skills or agents suddenly stop appearing for a non-admin user after upgrade, the user's group is missing the discovery scope. Take these actions once, per deployment:
 
-- **Skills discovery (`list_skills`).** This scope is new, so no group has it until you grant it. Run the one-time backfill to grant `list_skills: ["all"]` to the built-in admin group (dry-run by default):
+- **Skills discovery (`list_skills`).** This scope is new, so no group has it until you grant it. Run the one-time backfill to grant `list_skills: ["all"]` to the built-in admin group (dry-run by default). The simplest place to run it is inside a running container, where the registry environment is already present:
 
   ```bash
-  uv run python scripts/backfill-skill-list-scope.py --apply
+  # Docker Compose
+  docker compose exec registry uv run python scripts/backfill-skill-list-scope.py --apply
+
+  # Kubernetes / EKS
+  kubectl exec -it deploy/registry -- uv run python scripts/backfill-skill-list-scope.py --apply
   ```
 
-  Then grant `list_skills` to any non-admin group that should see skills. Admins are unaffected (they bypass the check).
+  To run it outside the deployment (host shell, one-off ECS task, admin pod), pass the connection explicitly; the password and `SECRET_KEY` are read from the environment, never as CLI args:
+
+  ```bash
+  DOCUMENTDB_PASSWORD=... SECRET_KEY=... \
+    uv run python scripts/backfill-skill-list-scope.py --apply \
+    --host <mongo-host> --username admin --direct-connection \
+    --auth-server-url <auth-server-url>
+  ```
+
+  See `--help` for the full connection-argument list (`--tls`, `--storage-backend documentdb` for Amazon DocumentDB, etc.). Then grant `list_skills` to any non-admin group that should see skills. Admins are unaffected (they bypass the check).
 
 - **Skill mutation (`modify_skill` / `delete_skill` / `toggle_skill`).** A non-admin who **owns** a skill now also needs the matching mutation scope; ownership alone is no longer sufficient. Grant these to whichever non-admin group manages skills. Not covered by the backfill.
 

--- a/frontend/src/components/entities/EmptyState.tsx
+++ b/frontend/src/components/entities/EmptyState.tsx
@@ -18,7 +18,7 @@ const TONE_CLASSES: Record<EmptyStateTone, string> = {
 
 interface EmptyStateProps {
   title: string;
-  subtitle?: string;
+  subtitle?: React.ReactNode;
   tone?: EmptyStateTone;
   /** Optional call-to-action button rendered under the message. */
   cta?: React.ReactNode;

--- a/frontend/src/components/entities/sections/SkillsSection.tsx
+++ b/frontend/src/components/entities/sections/SkillsSection.tsx
@@ -15,6 +15,12 @@ interface SkillsSectionProps {
   error: string | null;
   /** True when a search term or non-default lifecycle filter is active. */
   isFiltered: boolean;
+  /**
+   * True when the caller holds the `list_skills` discovery scope (or is admin).
+   * When false, the empty state explains that skill access is admin-managed
+   * instead of claiming no skills are registered.
+   */
+  hasListAccess: boolean;
   canModify: boolean;
   page: number;
   totalPages: number;
@@ -44,6 +50,7 @@ const SkillsSection: React.FC<SkillsSectionProps> = ({
   loading,
   error,
   isFiltered,
+  hasListAccess,
   canModify,
   page,
   totalPages,
@@ -95,14 +102,18 @@ const SkillsSection: React.FC<SkillsSectionProps> = ({
       ) : filteredCount === 0 ? (
         <EmptyState
           tone="amber"
-          title="No skills found"
+          title={
+            hasListAccess ? 'No skills found' : "You don't have access to view skills"
+          }
           subtitle={
-            isFiltered
-              ? 'Press Enter in the search bar to search semantically'
-              : 'No skills are registered yet'
+            !hasListAccess
+              ? 'Skill discovery is managed by your registry administrator. Ask them to grant your group the "list_skills" permission so skills appear here.'
+              : isFiltered
+                ? 'Press Enter in the search bar to search semantically'
+                : 'No skills are registered yet'
           }
           cta={
-            !isFiltered && canModify ? (
+            hasListAccess && !isFiltered && canModify ? (
               <button
                 onClick={onAddSkill}
                 className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg text-white bg-amber-600 hover:bg-amber-700 transition-colors"

--- a/frontend/src/components/entities/sections/SkillsSection.tsx
+++ b/frontend/src/components/entities/sections/SkillsSection.tsx
@@ -106,11 +106,24 @@ const SkillsSection: React.FC<SkillsSectionProps> = ({
             hasListAccess ? 'No skills found' : "You don't have access to view skills"
           }
           subtitle={
-            !hasListAccess
-              ? 'Skill discovery is managed by your registry administrator. Ask them to grant your group the "list_skills" permission so skills appear here.'
-              : isFiltered
-                ? 'Press Enter in the search bar to search semantically'
-                : 'No skills are registered yet'
+            !hasListAccess ? (
+              <>
+                Skill discovery is managed by your registry administrator. Ask them to grant
+                your group the "list_skills" permission so skills appear here.{' '}
+                <a
+                  href="https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/faq/granting-skill-and-agent-discovery-permissions.md"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-amber-600 dark:text-amber-400 hover:underline"
+                >
+                  Learn more
+                </a>
+              </>
+            ) : isFiltered ? (
+              'Press Enter in the search bar to search semantically'
+            ) : (
+              'No skills are registered yet'
+            )
           }
           cta={
             hasListAccess && !isFiltered && canModify ? (

--- a/frontend/src/components/entities/sections/__tests__/SkillsSection.test.tsx
+++ b/frontend/src/components/entities/sections/__tests__/SkillsSection.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+// SkillsSection pulls in SkillCard -> react-markdown (ESM). The empty-state
+// tests never render a card, so mock the markdown deps to keep jest's module
+// loader happy (same pattern as SkillResources.test.tsx).
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+import SkillsSection from '../SkillsSection';
+
+// Minimal prop factory: SkillsSection is pure presentation, so most handlers
+// can be no-ops. Individual tests override just the fields they exercise.
+const baseProps = {
+  paginatedSkills: [],
+  filteredCount: 0,
+  loading: false,
+  error: null,
+  isFiltered: false,
+  hasListAccess: true,
+  canModify: false,
+  page: 0,
+  totalPages: 1,
+  pageSize: 50,
+  onPageChange: () => {},
+  authToken: null,
+  onAddSkill: () => {},
+  onToggle: () => {},
+  onEdit: () => {},
+  onDelete: () => {},
+  onRefreshSuccess: () => {},
+  onShowToast: () => {},
+  onSkillUpdate: () => {},
+  canToggleSkill: () => false,
+};
+
+describe('SkillsSection empty state', () => {
+  it('shows the admin-access hint when the caller lacks list_skills', () => {
+    render(<SkillsSection {...baseProps} hasListAccess={false} />);
+
+    expect(
+      screen.getByText("You don't have access to view skills"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/list_skills/)).toBeInTheDocument();
+    // The "no skills registered yet" copy must NOT appear — it would be
+    // misleading when skills exist but are hidden by the discovery gate.
+    expect(
+      screen.queryByText(/No skills are registered yet/),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the ordinary empty copy when the caller has list access', () => {
+    render(<SkillsSection {...baseProps} hasListAccess={true} />);
+
+    expect(screen.getByText('No skills found')).toBeInTheDocument();
+    expect(screen.getByText(/No skills are registered yet/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("You don't have access to view skills"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2347,7 +2347,15 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                     </div>
                     <p className="text-gray-500 dark:text-gray-300 text-sm max-w-md mx-auto">
                       Agent discovery is managed by your registry administrator. Ask them to
-                      grant your group the "list_agents" permission so agents appear here.
+                      grant your group the "list_agents" permission so agents appear here.{' '}
+                      <a
+                        href="https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/faq/granting-skill-and-agent-discovery-permissions.md"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-cyan-600 dark:text-cyan-400 hover:underline"
+                      >
+                        Learn more
+                      </a>
                     </p>
                   </>
                 ) : (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -374,21 +374,23 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     };
   }, []);
 
-  // Reset viewFilter to 'discover' when the active tab is hidden — either by the
-  // deployment feature flag OR because the user lacks the entity's list_ scope
-  // (tab-gating mirror of the backend discovery gate; Discover always stays, it
-  // filters per-result). Redirecting avoids stranding the user on an empty/hidden
-  // tab reached via a bookmarked URL or a scope change mid-session.
+  // Reset viewFilter to 'discover' when the active tab is hidden by the
+  // deployment feature flag. For servers and custom-entity types we ALSO redirect
+  // when the user lacks the entity's list_ scope (those tabs stay hidden). Agents
+  // and Skills are deliberately NOT redirected on a missing scope: their tabs stay
+  // visible and render an access hint (see the agents/skills empty states) so a
+  // user whose skills/agents access changed learns why the tab is empty and what
+  // a registry admin must grant, rather than the tab silently disappearing. The
+  // backend discovery gate remains authoritative (the endpoints still return
+  // empty/404 without the scope).
   useEffect(() => {
     if (viewFilter === 'virtual' && registryConfig?.features.virtual_servers === false) {
       setViewFilter('discover');
     }
-    if (viewFilter === 'agents' &&
-        (registryConfig?.features.agents === false || !hasListAccess('list_agents'))) {
+    if (viewFilter === 'agents' && registryConfig?.features.agents === false) {
       setViewFilter('discover');
     }
-    if (viewFilter === 'skills' &&
-        (registryConfig?.features.skills === false || !hasListAccess('list_skills'))) {
+    if (viewFilter === 'skills' && registryConfig?.features.skills === false) {
       setViewFilter('discover');
     }
     if (viewFilter === 'servers' &&
@@ -2338,12 +2340,26 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
               </div>
             ) : filteredAgents.length === 0 ? (
               <div className="text-center py-12 bg-cyan-50 dark:bg-cyan-900/20 rounded-lg border border-cyan-200 dark:border-cyan-800">
-                <div className="text-gray-400 text-lg mb-2">No agents found</div>
-                <p className="text-gray-500 dark:text-gray-300 text-sm">
-                  {searchTerm || activeFilter !== 'all'
-                    ? 'Press Enter in the search bar to search semantically'
-                    : 'No agents are registered yet'}
-                </p>
+                {!hasListAccess('list_agents') ? (
+                  <>
+                    <div className="text-gray-400 text-lg mb-2">
+                      You don't have access to view agents
+                    </div>
+                    <p className="text-gray-500 dark:text-gray-300 text-sm max-w-md mx-auto">
+                      Agent discovery is managed by your registry administrator. Ask them to
+                      grant your group the "list_agents" permission so agents appear here.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <div className="text-gray-400 text-lg mb-2">No agents found</div>
+                    <p className="text-gray-500 dark:text-gray-300 text-sm">
+                      {searchTerm || activeFilter !== 'all'
+                        ? 'Press Enter in the search bar to search semantically'
+                        : 'No agents are registered yet'}
+                    </p>
+                  </>
+                )}
               </div>
             ) : (
               <div className="space-y-6">
@@ -2446,6 +2462,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
             loading={skillsLoading}
             error={skillsError}
             isFiltered={!!searchTerm || activeFilter !== 'all'}
+            hasListAccess={hasListAccess('list_skills')}
             canModify={user?.can_modify_servers || false}
             page={skillPage}
             totalPages={skillTotalPages}
@@ -2648,7 +2665,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                 Virtual MCP Servers
               </button>
             )}
-            {registryConfig?.features.agents !== false && hasListAccess('list_agents') && (
+            {registryConfig?.features.agents !== false && (
               <button
                 onClick={() => handleChangeViewFilter('agents')}
                 className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${
@@ -2660,7 +2677,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                 Agents
               </button>
             )}
-            {registryConfig?.features.skills !== false && hasListAccess('list_skills') && (
+            {registryConfig?.features.skills !== false && (
               <button
                 onClick={() => handleChangeViewFilter('skills')}
                 className={`px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors border-b-2 ${

--- a/scripts/_mongo_conn_args.py
+++ b/scripts/_mongo_conn_args.py
@@ -1,0 +1,175 @@
+"""Shared Mongo/DocumentDB connection CLI args for the backfill scripts.
+
+The backfill scripts (``backfill-skill-list-scope.py``,
+``backfill-custom-entity-scopes.py``) normally read their storage backend and
+connection from the registry environment / ``.env``. For deployments where those
+service names are not resolvable from where the script runs (a host shell against
+a Dockerized Mongo, a one-off ECS task pointed at Amazon DocumentDB, an EKS admin
+pod), this module adds a shared set of ``--host`` / ``--username`` / ``--tls`` /
+etc. args and translates them into the env the registry config singleton reads.
+
+SECURITY: the password and SECRET_KEY are read from the environment ONLY and are
+never accepted as CLI args (argv is world-readable via the process list). Supply
+them via ``DOCUMENTDB_PASSWORD`` / ``SECRET_KEY``.
+
+Usage from a script::
+
+    import argparse
+    from _mongo_conn_args import add_connection_args, apply_connection_overrides
+
+    parser = argparse.ArgumentParser(...)
+    add_connection_args(parser)
+    args = parser.parse_args()
+    apply_connection_overrides(args)   # BEFORE importing registry.*
+"""
+
+import argparse
+import logging
+import os
+from urllib.parse import quote_plus
+
+logger = logging.getLogger(__name__)
+
+# Environment variable holding the Mongo password. Never a CLI arg (argv is
+# world-readable via the process list).
+PASSWORD_ENV_VAR: str = "DOCUMENTDB_PASSWORD"
+
+# Backends that support SCRAM-SHA-256. Amazon DocumentDB v5.0 supports only
+# SCRAM-SHA-1, matching registry.utils.mongodb_connection.
+_SHA256_BACKENDS: frozenset[str] = frozenset({"mongodb-ce", "mongodb", "mongodb-atlas"})
+
+
+def add_connection_args(
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Add the shared connection-override arguments to ``parser``.
+
+    Args:
+        parser: The argument parser to extend.
+    """
+    conn = parser.add_argument_group(
+        "connection overrides",
+        "Override the Mongo/DocumentDB connection. Omit to use the registry "
+        "environment / .env. The password is read from the "
+        f"{PASSWORD_ENV_VAR} environment variable, never a CLI arg.",
+    )
+    conn.add_argument(
+        "--host",
+        default=None,
+        help="Mongo/DocumentDB host (enables CLI connection overrides when set)",
+    )
+    conn.add_argument(
+        "--port",
+        type=int,
+        default=27017,
+        help="Mongo/DocumentDB port (default: 27017)",
+    )
+    conn.add_argument(
+        "--database",
+        default="mcp_registry",
+        help="Database name (default: mcp_registry)",
+    )
+    conn.add_argument(
+        "--username",
+        default=None,
+        help=f"Username for SCRAM auth (password via ${PASSWORD_ENV_VAR})",
+    )
+    conn.add_argument(
+        "--auth-source",
+        default="admin",
+        help="authSource database for SCRAM auth (default: admin)",
+    )
+    conn.add_argument(
+        "--tls",
+        action="store_true",
+        help="Enable TLS (required for Amazon DocumentDB)",
+    )
+    conn.add_argument(
+        "--direct-connection",
+        action="store_true",
+        help="Set directConnection=true (reach a single node without replica-set "
+        "discovery; use when the advertised replica-set hostnames are not "
+        "resolvable from where the script runs)",
+    )
+    conn.add_argument(
+        "--storage-backend",
+        default="mongodb-ce",
+        choices=["mongodb-ce", "documentdb", "mongodb", "mongodb-atlas"],
+        help="Storage backend, selects the SCRAM mechanism (documentdb -> "
+        "SCRAM-SHA-1, others -> SCRAM-SHA-256). Default: mongodb-ce",
+    )
+    conn.add_argument(
+        "--auth-server-url",
+        default=None,
+        help="Auth-server base URL for the post-grant scope reload "
+        "(e.g. http://localhost:8888). Omit to use the registry environment.",
+    )
+
+
+def _build_connection_string(
+    args: argparse.Namespace,
+) -> str:
+    """Build a Mongo connection string from the CLI connection overrides.
+
+    The password comes from the environment (never argv). The SCRAM mechanism is
+    derived from ``--storage-backend`` to match the registry's own logic.
+
+    Args:
+        args: Parsed CLI args with ``host`` set.
+
+    Returns:
+        A ``mongodb://`` connection string.
+    """
+    query: list[str] = []
+    if args.username:
+        password = os.environ.get(PASSWORD_ENV_VAR, "")
+        credentials = f"{quote_plus(args.username)}:{quote_plus(password)}@"
+        mechanism = "SCRAM-SHA-256" if args.storage_backend in _SHA256_BACKENDS else "SCRAM-SHA-1"
+        query.append(f"authMechanism={mechanism}")
+        query.append(f"authSource={args.auth_source}")
+    else:
+        credentials = ""
+
+    if args.tls:
+        query.append("tls=true")
+    if args.direct_connection:
+        query.append("directConnection=true")
+
+    query_string = ("?" + "&".join(query)) if query else ""
+    return f"mongodb://{credentials}{args.host}:{args.port}/{args.database}{query_string}"
+
+
+def apply_connection_overrides(
+    args: argparse.Namespace,
+) -> None:
+    """Translate CLI connection args into the env the registry config reads.
+
+    Must run BEFORE any ``registry`` import, because ``registry.core.config``
+    instantiates its settings singleton at import time. Setting these env vars
+    first makes the singleton pick up the overrides. A no-op for the connection
+    string when ``--host`` is not supplied (the registry environment / .env is
+    used as-is), though ``--storage-backend`` / ``--auth-server-url`` are still
+    applied when provided.
+
+    Args:
+        args: Parsed CLI args produced after :func:`add_connection_args`.
+    """
+    if args.storage_backend:
+        os.environ["STORAGE_BACKEND"] = args.storage_backend
+    if args.auth_server_url:
+        os.environ["AUTH_SERVER_URL"] = args.auth_server_url
+
+    if not args.host:
+        return
+
+    os.environ["MONGODB_CONNECTION_STRING"] = _build_connection_string(args)
+    # Log the target WITHOUT credentials (host:port/db only).
+    logger.info(
+        "Using CLI connection override: %s:%s/%s (backend=%s, tls=%s, direct=%s)",
+        args.host,
+        args.port,
+        args.database,
+        args.storage_backend,
+        args.tls,
+        args.direct_connection,
+    )

--- a/scripts/audit-discovery-scopes.py
+++ b/scripts/audit-discovery-scopes.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Audit groups for the list_agents / list_skills discovery scopes.
+
+Skills and agents are gated on a per-family ``list_`` UI permission (parity with
+``list_service``). A group that lacks the grant sees ZERO skills/agents of that
+family, including public ones. This READ-ONLY audit lists every group, reports
+which ones are missing ``list_agents`` and/or ``list_skills``, and prints the
+exact commands to grant them. It never mutates anything itself, so it is safe to
+run against any environment.
+
+For each group missing a grant it prints a describe -> edit -> import recipe. A
+group whose ``server_access`` contains a reserved wildcard server (``"*"`` /
+``"all"``) cannot be re-imported (the import guard refuses it), so for those the
+script prints the alternative one-key grant path via the IAM UI instead.
+
+Auth/connection: this script does NOT talk to the registry directly. It shells
+out to ``api/registry_management.py`` (``list-groups`` / ``describe-group``) so
+all auth, token handling, and client logic stay in that one CLI. Pass the same
+``--registry-url`` and ``--token-file`` you would give registry_management.py;
+they are forwarded verbatim.
+
+Usage:
+    uv run python scripts/audit-discovery-scopes.py \\
+        --registry-url http://localhost --token-file .token
+
+    # Only check for a missing list_skills grant (ignore list_agents)
+    uv run python scripts/audit-discovery-scopes.py \\
+        --registry-url http://localhost --token-file .token --scope list_skills
+"""
+
+import argparse
+import json
+import logging
+import subprocess  # nosec B404 - used only to invoke the in-repo registry_management.py CLI
+import sys
+from pathlib import Path
+
+# Configure logging with basicConfig
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s,p%(process)s,{%(filename)s:%(lineno)d},%(levelname)s,%(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# The discovery scopes this audit checks. Servers (list_service) are excluded:
+# the server tab has always been gated, so its grants are not a new regression.
+_DISCOVERY_SCOPES: tuple[str, ...] = ("list_agents", "list_skills")
+
+# Reserved wildcard server names the import guard refuses in server_access.
+# Must match registry.repositories.documentdb.scope_repository.
+_RESERVED_SERVER_NAMES: frozenset[str] = frozenset({"all", "*"})
+
+# The management CLI this audit drives. Resolved relative to the repo root
+# (this file's parent's parent) so the audit works from any directory.
+_REPO_ROOT: Path = Path(__file__).resolve().parent.parent
+_MGMT_CLI: Path = _REPO_ROOT / "api" / "registry_management.py"
+
+# Subprocess timeout in seconds for each management CLI call.
+_CLI_TIMEOUT: int = 60
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Audit groups for missing list_agents / list_skills discovery scopes",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    uv run python scripts/audit-discovery-scopes.py \\
+        --registry-url http://localhost --token-file .token
+""",
+    )
+    parser.add_argument(
+        "--registry-url",
+        default=None,
+        help="Registry base URL (or set REGISTRY_URL)",
+    )
+    parser.add_argument(
+        "--token-file",
+        default=None,
+        help="Path to a file with an admin JWT (or set REGISTRY_TOKEN)",
+    )
+    parser.add_argument(
+        "--scope",
+        choices=list(_DISCOVERY_SCOPES),
+        default=None,
+        help="Only audit this one scope (default: both list_agents and list_skills)",
+    )
+    return parser.parse_args()
+
+
+def _run_mgmt_cli(
+    registry_url: str,
+    token_file: str | None,
+    subcommand_args: list[str],
+) -> str:
+    """Invoke api/registry_management.py and return its stdout.
+
+    Centralizes the subprocess call so auth (via --token-file) and the registry
+    URL live only in the management CLI. The command is a fixed list (no shell),
+    with a timeout, per the repo subprocess-security rules.
+
+    Args:
+        registry_url: Registry base URL, forwarded as --registry-url.
+        token_file: Token file path, forwarded as --token-file (may be None to
+            let the CLI resolve auth from its own environment).
+        subcommand_args: The subcommand and its args (e.g. ["list-groups",
+            "--no-keycloak", "--json"]).
+
+    Returns:
+        The CLI's stdout as text.
+
+    Raises:
+        RuntimeError: If the CLI exits non-zero or times out.
+    """
+    cmd = [
+        sys.executable,
+        str(_MGMT_CLI),
+        "--registry-url",
+        registry_url,
+    ]
+    if token_file:
+        cmd += ["--token-file", token_file]
+    cmd += subcommand_args
+
+    try:
+        result = subprocess.run(  # nosec B603 - fixed in-repo CLI path, list form, no shell
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_CLI_TIMEOUT,
+            check=True,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"registry_management.py timed out: {' '.join(subcommand_args)}") from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"registry_management.py failed ({' '.join(subcommand_args)}): {e.stderr.strip()}"
+        ) from e
+
+    return result.stdout
+
+
+def _extract_json(
+    text: str,
+) -> dict:
+    """Extract the JSON object from CLI stdout that may be prefixed with logs.
+
+    The management CLI logs to stdout/stderr around its JSON payload, so locate
+    the first ``{`` and parse from there.
+
+    Args:
+        text: Raw CLI stdout.
+
+    Returns:
+        The parsed JSON object, or an empty dict if none is found.
+    """
+    start = text.find("{")
+    if start == -1:
+        return {}
+    try:
+        return json.loads(text[start:])
+    except json.JSONDecodeError:
+        return {}
+
+
+def _fetch_groups(
+    registry_url: str,
+    token_file: str | None,
+) -> dict[str, dict]:
+    """List all scope groups via ``registry_management.py list-groups``.
+
+    Args:
+        registry_url: Registry base URL.
+        token_file: Admin token file path (forwarded to the CLI).
+
+    Returns:
+        The ``scopes_groups`` mapping (group name -> summary incl. ``ui_scopes``).
+    """
+    out = _run_mgmt_cli(
+        registry_url,
+        token_file,
+        ["list-groups", "--no-keycloak", "--json"],
+    )
+    return _extract_json(out).get("scopes_groups", {})
+
+
+def _fetch_group_detail(
+    registry_url: str,
+    token_file: str | None,
+    group_name: str,
+) -> dict:
+    """Get one group's full definition via ``registry_management.py describe-group``.
+
+    Used for the server_access wildcard check.
+
+    Args:
+        registry_url: Registry base URL.
+        token_file: Admin token file path (forwarded to the CLI).
+        group_name: Group to describe.
+
+    Returns:
+        The full group definition, or an empty dict on error.
+    """
+    try:
+        out = _run_mgmt_cli(
+            registry_url,
+            token_file,
+            ["describe-group", "--name", group_name, "--json"],
+        )
+    except RuntimeError as e:
+        logger.warning("Could not describe group '%s': %s", group_name, e)
+        return {}
+    return _extract_json(out)
+
+
+def _server_access_has_wildcard(
+    server_access: list[dict],
+) -> bool:
+    """Return True if any server_access rule names a reserved wildcard server.
+
+    Such a group cannot be re-imported (the import guard refuses it), so the
+    recipe for it must use the IAM UI rather than describe/edit/import.
+
+    Args:
+        server_access: The group's server_access list.
+
+    Returns:
+        True if a wildcard server rule is present.
+    """
+    for rule in server_access or []:
+        if not isinstance(rule, dict):
+            continue
+        name = rule.get("server")
+        if name and str(name).strip("/").lower() in _RESERVED_SERVER_NAMES:
+            return True
+    return False
+
+
+def _missing_scopes(
+    ui_scopes: dict,
+    scopes_to_check: tuple[str, ...],
+) -> list[str]:
+    """Return the discovery scopes a group's ui_scopes is missing.
+
+    A scope is "missing" only when the key is absent or its grant list is empty.
+    A present non-empty grant (named resources or ``["all"]``) counts as granted.
+
+    Args:
+        ui_scopes: The group's ui_permissions/ui_scopes mapping.
+        scopes_to_check: Which discovery scopes to check.
+
+    Returns:
+        The subset of scopes_to_check that are missing.
+    """
+    missing = []
+    for scope in scopes_to_check:
+        granted = (ui_scopes or {}).get(scope) or []
+        if not granted:
+            missing.append(scope)
+    return missing
+
+
+def _print_recipe(
+    group_name: str,
+    missing: list[str],
+    has_wildcard: bool,
+) -> None:
+    """Print the fix commands for one group missing discovery scopes.
+
+    Args:
+        group_name: The group to fix.
+        missing: The scopes it is missing.
+        has_wildcard: Whether its server_access has a reserved wildcard (which
+            blocks the describe/edit/import round-trip).
+    """
+    grant_json = ", ".join(f'"{s}": ["all"]' for s in missing)
+    print(f"\n# Group '{group_name}' is missing: {', '.join(missing)}")
+
+    if has_wildcard:
+        print(
+            "#   NOTE: this group's server_access contains a reserved wildcard "
+            "('*'/'all'),\n"
+            "#   so it cannot be re-imported (the import guard refuses it). Grant "
+            "the scope\n"
+            "#   via the IAM UI instead: Settings > IAM > Groups > "
+            f"{group_name} > UI Permissions,\n"
+            f"#   turn on the 'All' toggle for: {', '.join(missing)}."
+        )
+        return
+
+    print(
+        f"uv run python api/registry_management.py \\\n"
+        f"  --registry-url \"$REGISTRY_URL\" --token-file \"$TOKEN_FILE\" \\\n"
+        f"  describe-group --name {group_name} --json > {group_name}.json\n"
+        f"# then add these keys under \"ui_permissions\" in {group_name}.json:  "
+        f"{{ {grant_json} }}\n"
+        f"uv run python api/registry_management.py \\\n"
+        f"  --registry-url \"$REGISTRY_URL\" --token-file \"$TOKEN_FILE\" \\\n"
+        f"  import-group --file {group_name}.json"
+    )
+
+
+def _audit(
+    registry_url: str,
+    token_file: str | None,
+    scopes_to_check: tuple[str, ...],
+) -> int:
+    """Run the audit and print per-group fix recipes.
+
+    Args:
+        registry_url: Registry base URL.
+        token_file: Admin token file path (forwarded to the management CLI).
+        scopes_to_check: Which discovery scopes to audit.
+
+    Returns:
+        Process exit code (0 = ran successfully, regardless of findings).
+    """
+    groups = _fetch_groups(registry_url, token_file)
+    logger.info("Found %d scope group(s)", len(groups))
+
+    groups_missing = {}
+    for name, summary in groups.items():
+        ui_scopes = summary.get("ui_scopes") or summary.get("ui_permissions") or {}
+        missing = _missing_scopes(ui_scopes, scopes_to_check)
+        if missing:
+            groups_missing[name] = missing
+
+    print("=" * 60)
+    print(f"Discovery-scope audit: {len(groups_missing)} of {len(groups)} groups need a grant")
+    print("=" * 60)
+
+    if not groups_missing:
+        print("\nAll groups already hold the audited discovery scopes. Nothing to do.")
+        return 0
+
+    print(
+        "\nSet these first, then run the printed commands:\n"
+        '  export REGISTRY_URL="<your-registry-url>"\n'
+        '  export TOKEN_FILE="<path-to-admin-token-file>"'
+    )
+
+    for name in sorted(groups_missing):
+        detail = _fetch_group_detail(registry_url, token_file, name)
+        has_wildcard = _server_access_has_wildcard(detail.get("server_access", []))
+        _print_recipe(name, groups_missing[name], has_wildcard)
+
+    print("\n" + "=" * 60)
+    print("Review each command above before running it. This audit changed nothing.")
+    print("=" * 60)
+    return 0
+
+
+def main() -> None:
+    """Control flow: parse args, resolve config, run the audit."""
+    import os
+
+    args = _parse_args()
+
+    registry_url = args.registry_url or os.getenv("REGISTRY_URL")
+    if not registry_url:
+        logger.error("Provide --registry-url or set REGISTRY_URL")
+        sys.exit(1)
+
+    if not _MGMT_CLI.exists():
+        logger.error("Management CLI not found at %s", _MGMT_CLI)
+        sys.exit(1)
+
+    scopes_to_check = (args.scope,) if args.scope else _DISCOVERY_SCOPES
+
+    try:
+        exit_code = _audit(registry_url, args.token_file, scopes_to_check)
+    except RuntimeError as e:
+        logger.error("%s", e)
+        sys.exit(1)
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit-discovery-scopes.py
+++ b/scripts/audit-discovery-scopes.py
@@ -291,12 +291,12 @@ def _print_recipe(
 
     print(
         f"uv run python api/registry_management.py \\\n"
-        f"  --registry-url \"$REGISTRY_URL\" --token-file \"$TOKEN_FILE\" \\\n"
+        f'  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \\\n'
         f"  describe-group --name {group_name} --json > {group_name}.json\n"
-        f"# then add these keys under \"ui_permissions\" in {group_name}.json:  "
+        f'# then add these keys under "ui_permissions" in {group_name}.json:  '
         f"{{ {grant_json} }}\n"
         f"uv run python api/registry_management.py \\\n"
-        f"  --registry-url \"$REGISTRY_URL\" --token-file \"$TOKEN_FILE\" \\\n"
+        f'  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \\\n'
         f"  import-group --file {group_name}.json"
     )
 

--- a/scripts/backfill-custom-entity-scopes.py
+++ b/scripts/backfill-custom-entity-scopes.py
@@ -50,6 +50,12 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+# Shared Mongo/DocumentDB connection CLI args (sibling module in scripts/).
+from _mongo_conn_args import (  # noqa: E402
+    add_connection_args,
+    apply_connection_overrides,
+)
+
 # Configure logging with basicConfig
 logging.basicConfig(
     level=logging.INFO,
@@ -77,6 +83,7 @@ Examples:
         action="store_true",
         help="Actually apply changes (default is a dry run)",
     )
+    add_connection_args(parser)
     return parser.parse_args()
 
 
@@ -136,6 +143,10 @@ async def main() -> None:
     logger.info("=" * 60)
     logger.info("Mode: %s", "DRY RUN" if dry_run else "APPLY CHANGES")
     logger.info("=" * 60)
+
+    # Apply CLI connection overrides into the environment BEFORE the registry
+    # config singleton is imported inside _run_backfill.
+    apply_connection_overrides(args)
 
     result = await _run_backfill(dry_run)
 

--- a/scripts/backfill-custom-entity-scopes.py
+++ b/scripts/backfill-custom-entity-scopes.py
@@ -38,6 +38,17 @@ uses (MCP_STORAGE_BACKEND, DOCUMENTDB_HOST, etc.).
 import argparse
 import asyncio
 import logging
+import sys
+from pathlib import Path
+
+# Ensure the repo root (this file's parent's parent) is importable. Running the
+# script directly (``python scripts/backfill-custom-entity-scopes.py``) puts the
+# ``scripts/`` directory on sys.path[0], NOT the repo root, so ``import
+# registry`` would fail with ModuleNotFoundError. Prepending the repo root makes
+# the script self-contained regardless of the working directory.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 # Configure logging with basicConfig
 logging.basicConfig(

--- a/scripts/backfill-skill-list-scope.py
+++ b/scripts/backfill-skill-list-scope.py
@@ -22,22 +22,38 @@ The migration is IDEMPOTENT: minting is a per-key ``$set`` merge, so re-running
 it simply re-writes the same value. Safe to run repeatedly.
 
 Usage:
-    # Dry run (default) - report what would be granted
-    SECRET_KEY=... DOCUMENTDB_HOST=localhost \\
-        uv run python scripts/backfill-skill-list-scope.py
+    # Dry run (default) - report what would be granted, connection from env/.env
+    uv run python scripts/backfill-skill-list-scope.py
 
     # Actually apply changes
-    SECRET_KEY=... DOCUMENTDB_HOST=localhost \\
-        uv run python scripts/backfill-skill-list-scope.py --apply
+    uv run python scripts/backfill-skill-list-scope.py --apply
 
-    # MongoDB CE (single-node) backend
-    MCP_STORAGE_BACKEND=mongodb-ce DOCUMENTDB_HOST=localhost \\
-        uv run python scripts/backfill-skill-list-scope.py --apply
+The simplest place to run this is inside a running container (Docker Compose:
+``docker compose exec registry ...``; EKS: ``kubectl exec deploy/registry -- ...``),
+where the registry environment is already present. The script also adds the repo
+root to sys.path itself, so it can be run from any working directory.
 
-The script adds the repo root to sys.path itself, so it can be run from any
-working directory (e.g. ``uv run python scripts/backfill-skill-list-scope.py``).
-The storage backend and connection are read from the same environment the
-registry uses (MCP_STORAGE_BACKEND, DOCUMENTDB_HOST, etc.).
+CONNECTION: by default the storage backend and connection are read from the same
+environment the registry uses (STORAGE_BACKEND, DOCUMENTDB_HOST, etc., including
+values in a local ``.env``). For deployments where those service names are not
+resolvable from wherever you run the script (a host shell against a Dockerized
+Mongo, a one-off task pointed at Amazon DocumentDB on ECS, an EKS admin pod), the
+connection can be supplied via CLI args instead (see ``--host`` and friends).
+
+    # Amazon DocumentDB on ECS (TLS, SCRAM-SHA-1 via --storage-backend documentdb)
+    DOCUMENTDB_PASSWORD=... SECRET_KEY=... \\
+        uv run python scripts/backfill-skill-list-scope.py --apply \\
+        --storage-backend documentdb --host docdb.cluster-xxxx.us-east-1.docdb.amazonaws.com \\
+        --username admin --tls --auth-server-url http://localhost:8888
+
+    # MongoDB CE on EKS / single node reached directly (skip replica-set discovery)
+    DOCUMENTDB_PASSWORD=... SECRET_KEY=... \\
+        uv run python scripts/backfill-skill-list-scope.py --apply \\
+        --host localhost --username admin --direct-connection
+
+SECURITY: the password and SECRET_KEY are read from the environment only and are
+never accepted as CLI args (argv is visible in the process list). Supply them via
+``DOCUMENTDB_PASSWORD`` / ``SECRET_KEY`` (env vars, or a task/secret injection).
 """
 
 import argparse
@@ -54,6 +70,12 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
+
+# Shared Mongo/DocumentDB connection CLI args (sibling module in scripts/).
+from _mongo_conn_args import (  # noqa: E402
+    add_connection_args,
+    apply_connection_overrides,
+)
 
 # Configure logging with basicConfig
 logging.basicConfig(
@@ -79,11 +101,16 @@ def _parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    # Dry run (default)
+    # Dry run (default), connection from environment / .env
     uv run python scripts/backfill-skill-list-scope.py
 
-    # Apply changes
+    # Apply, connection from environment / .env
     uv run python scripts/backfill-skill-list-scope.py --apply
+
+    # Apply with an explicit connection (password + SECRET_KEY stay in env)
+    DOCUMENTDB_PASSWORD=... SECRET_KEY=... \\
+        uv run python scripts/backfill-skill-list-scope.py --apply \\
+        --host localhost --username admin --direct-connection
 """,
     )
     parser.add_argument(
@@ -91,6 +118,7 @@ Examples:
         action="store_true",
         help="Actually apply changes (default is a dry run)",
     )
+    add_connection_args(parser)
     return parser.parse_args()
 
 
@@ -147,6 +175,10 @@ async def main() -> None:
     logger.info("=" * 60)
     logger.info("Mode: %s", "DRY RUN" if dry_run else "APPLY CHANGES")
     logger.info("=" * 60)
+
+    # Apply CLI connection overrides into the environment BEFORE the registry
+    # config singleton is imported inside _run_backfill.
+    apply_connection_overrides(args)
 
     result = await _run_backfill(dry_run)
 

--- a/scripts/backfill-skill-list-scope.py
+++ b/scripts/backfill-skill-list-scope.py
@@ -34,14 +34,26 @@ Usage:
     MCP_STORAGE_BACKEND=mongodb-ce DOCUMENTDB_HOST=localhost \\
         uv run python scripts/backfill-skill-list-scope.py --apply
 
-Requires the registry package importable (run from the repo root via uv). The
-storage backend and connection are read from the same environment the registry
-uses (MCP_STORAGE_BACKEND, DOCUMENTDB_HOST, etc.).
+The script adds the repo root to sys.path itself, so it can be run from any
+working directory (e.g. ``uv run python scripts/backfill-skill-list-scope.py``).
+The storage backend and connection are read from the same environment the
+registry uses (MCP_STORAGE_BACKEND, DOCUMENTDB_HOST, etc.).
 """
 
 import argparse
 import asyncio
 import logging
+import sys
+from pathlib import Path
+
+# Ensure the repo root (this file's parent's parent) is importable. Running the
+# script directly (``python scripts/backfill-skill-list-scope.py``) puts the
+# ``scripts/`` directory on sys.path[0], NOT the repo root, so ``import
+# registry`` would fail with ModuleNotFoundError. Prepending the repo root makes
+# the script self-contained regardless of the working directory.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 # Configure logging with basicConfig
 logging.basicConfig(


### PR DESCRIPTION
## Summary

Follow-up to #1493. That PR added a discovery gate to skills and agents (a caller without the `list_` scope sees nothing) and gated the entity tabs on the matching scope. Two rough edges came out of that for non-admin users:

- The **Skills and Agents tabs silently disappeared** when the user lacked the `list_` scope, with no explanation.
- The skills empty state read **"No skills are registered yet"** even when skills exist but are hidden by the gate, which is misleading.

This PR combines the two follow-up items discussed on #1493: a UI hint, and a durable upgrade note.

## Change

- **Skills and Agents tabs stay visible** (feature-flag permitting) and no longer redirect to Discover on a missing `list_` scope. Servers and custom entity tabs keep the existing hide behavior (unchanged).
- **Access-aware empty states.** When the user lacks `list_agents` / `list_skills`, the empty state now says "You don't have access to view {agents,skills}" and points them to their registry administrator, naming the exact `list_` scope to grant, instead of the "none registered" copy.
- **Durable upgrade note** in `docs/scopes-mgmt.md`: the discovery gate, the `list_skills` backfill command, and the owner-self-service scope tightenings (skill mutation scopes, `delete_agent`, `modify_agent`/`toggle_agent`). Also refreshes the UI-permissions reference table, which was missing all skill scopes, `toggle_agent`, `delete_service`, and the custom-entity scopes.

The backend discovery gate remains authoritative: making a tab visible does not grant anything, the endpoints still return empty/403 without the scope. No backend or authorization changes in this PR.

## Tests

- New `SkillsSection` empty-state tests for both branches (with and without `list_skills`).
- Existing agent/skill/tab Dashboard tests still pass. The one failing Dashboard test (`renders the External Registries tab...`) is a pre-existing flake unrelated to this change (fails identically on `main`).
