### PR TITLE
fix(compose): pass SSRF_ALLOWED_HOSTS/CIDRS to registry in prebuilt and podman (#1513)

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -65,6 +65,10 @@ services:
       # Comma-separated host allowlist for the RUM snippet (fail-closed when set). Empty disables the check.
       - RUM_ALLOWED_HOSTS=${RUM_ALLOWED_HOSTS:-}
       - GATEWAY_ADDITIONAL_SERVER_NAMES=${GATEWAY_ADDITIONAL_SERVER_NAMES:-}
+      # SSRF guard allowlist for internal MCP-server / A2A-agent upstreams at
+      # private IPs (e.g. docker-network hostnames); mirrors docker-compose.yml.
+      - SSRF_ALLOWED_HOSTS=${SSRF_ALLOWED_HOSTS:-}
+      - SSRF_ALLOWED_CIDRS=${SSRF_ALLOWED_CIDRS:-}
       # Registry Card Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}
       # Request-source trust (audit client IP + OAuth external-URL host allowlist)

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -71,6 +71,10 @@ services:
       # Comma-separated host allowlist for the RUM snippet (fail-closed when set). Empty disables the check.
       - RUM_ALLOWED_HOSTS=${RUM_ALLOWED_HOSTS:-}
       - GATEWAY_ADDITIONAL_SERVER_NAMES=${GATEWAY_ADDITIONAL_SERVER_NAMES:-}
+      # SSRF guard allowlist for internal MCP-server / A2A-agent upstreams at
+      # private IPs (e.g. docker-network hostnames); mirrors docker-compose.yml.
+      - SSRF_ALLOWED_HOSTS=${SSRF_ALLOWED_HOSTS:-}
+      - SSRF_ALLOWED_CIDRS=${SSRF_ALLOWED_CIDRS:-}
       # Registry Card Configuration
       - REGISTRY_URL=${REGISTRY_URL:-http://localhost}
       # Request-source trust (audit client IP + OAuth external-URL host allowlist)


### PR DESCRIPTION
## Summary

Fixes #1513

`.env.example` documents `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS`, and the registry reads them (`registry/core/config.py` → `settings.ssrf_allowed_hosts` / `_cidrs`, consumed by `registry/utils/url_guard.py`). Only `docker-compose.yml` passed those two vars into the `registry` service. On a `--prebuilt` (or podman) deploy, setting them in `.env` had no effect because the value never reached the container, so an internal upstream reachable only by a docker-network hostname stayed `unhealthy: url blocked by SSRF guard` with no way to allowlist it short of hand-editing the compose file.

## Change

Add `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS` to the `registry` service `environment:` in `docker-compose.prebuilt.yml` and `docker-compose.podman.yml`, using the same `${VAR:-}` pattern as `docker-compose.yml`. `docker-compose.dhi.yml` defines only the infra services (mongodb/prometheus/grafana/keycloak-db) and no `registry` service, so it needs no change.

## Verification

Both files parse as valid YAML and the two vars are now present in `services.registry.environment`. With the passthrough in place, `SSRF_ALLOWED_HOSTS=<internal-host>` in `.env` reaches the registry container, so the health check can allowlist an internal docker-network upstream on a prebuilt deploy.
