### PR TITLE
mock agent health in test and update jose scanning

### DIFF
--- a/tests/security/test_no_python_jose.py
+++ b/tests/security/test_no_python_jose.py
@@ -68,21 +68,29 @@ def test_python_jose_absent_from_lock(repo_root: Path, lockfile: str):
 
 def test_no_jose_imports_in_source(repo_root: Path):
     """No source file should import python-jose (the `jose` package)."""
-    offenders: list[str] = []
-    for base in (
-        "auth_server",
-        "registry",
-        "cli",
-        "servers",
-        "agents",
-        "metrics-service",
-        "scripts",
-    ):
-        base_dir = repo_root / base
-        if not base_dir.is_dir():
-            continue
-        for py in base_dir.rglob("*.py"):
-            text = py.read_text(errors="ignore")
-            if "from jose" in text or "import jose" in text:
-                offenders.append(str(py.relative_to(repo_root)))
+    import subprocess  # nosec B404
+
+    result = subprocess.run(  # nosec B603
+        [
+            "grep",
+            "-rl",
+            "--include=*.py",
+            "--exclude-dir=.venv",
+            "--exclude-dir=node_modules",
+            "--exclude-dir=__pycache__",
+            "--exclude-dir=.git",
+            "--exclude-dir=.scratchpad",
+            "--exclude-dir=.agents",
+            "--exclude-dir=.claude",
+            "--exclude-dir=tests",
+            "-E",
+            r"^(from|import) jose\b",
+            str(repo_root),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    offenders = [
+        str(Path(f).relative_to(repo_root)) for f in result.stdout.strip().splitlines() if f
+    ]
     assert not offenders, f"python-jose (`jose`) imported in: {offenders} (SA-13)"

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -559,6 +559,12 @@ class TestRegisterAgent:
             patch("registry.api.agent_routes.agent_service") as mock_agent_service,
             patch("registry.utils.agent_validator.agent_validator") as mock_validator,
             patch("registry.api.agent_routes.settings.allow_caller_supplied_asset_id", False),
+            patch("registry.api.agent_routes._refresh_agent_health", new_callable=AsyncMock),
+            patch(
+                "registry.api.agent_routes._perform_agent_security_scan_on_registration",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=None)
             mock_agent_service.register_agent = AsyncMock(side_effect=capture_register)
@@ -602,6 +608,12 @@ class TestRegisterAgent:
             patch("registry.api.agent_routes.agent_service") as mock_agent_service,
             patch("registry.utils.agent_validator.agent_validator") as mock_validator,
             patch("registry.api.agent_routes.settings.allow_caller_supplied_asset_id", True),
+            patch("registry.api.agent_routes._refresh_agent_health", new_callable=AsyncMock),
+            patch(
+                "registry.api.agent_routes._perform_agent_security_scan_on_registration",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=None)
             mock_agent_service.register_agent = AsyncMock(side_effect=capture_register)

--- a/tests/unit/api/test_agent_routes.py
+++ b/tests/unit/api/test_agent_routes.py
@@ -502,6 +502,12 @@ class TestRegisterAgent:
         with (
             patch("registry.api.agent_routes.agent_service") as mock_agent_service,
             patch("registry.utils.agent_validator.agent_validator") as mock_validator,
+            patch("registry.api.agent_routes._refresh_agent_health", new_callable=AsyncMock),
+            patch(
+                "registry.api.agent_routes._perform_agent_security_scan_on_registration",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
         ):
             mock_agent_service.get_agent_info = AsyncMock(return_value=None)
             mock_agent_service.register_agent = AsyncMock(return_value=True)


### PR DESCRIPTION
Fixes slow tests due to live health timeouts and improves jose scanning speed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
