### PR TITLE
Remove public-DNS resolver default for dynamic proxy_pass; log/meter backend 502s

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -608,6 +608,40 @@ end
 
 -- Proxy a single request to a specific backend with session management and stale retry.
 -- Returns the response body directly. Used for tools/call, resources/read, prompts/get.
+-- Record a failed backend subrequest into the same shared-dict metrics
+-- buffer that emit_metrics.lua (log_by_lua) fills for regular server
+-- locations. Virtual-server locations don't run log_by_lua_file at all, so
+-- without this, backend-proxy failures (incl. the resolver-DNS 502 class of
+-- bug -- issue #1129) were completely invisible: no access/error log entry
+-- at default level, and no metric, despite auth having already been
+-- granted. Best-effort: mirrors emit_metrics.lua's shape/key format so
+-- flush_metrics.lua picks it up with no changes; silently no-ops if the
+-- shared dict or METRICS_SERVICE_URL isn't configured (checked lazily by
+-- flush_metrics.lua).
+local function _record_backend_failure(method_name, server_id, tool_name, status)
+    local metrics = ngx.shared.metrics_buffer
+    if not metrics then
+        return
+    end
+    local entry = cjson.encode({
+        m = method_name,
+        s = server_id or "unknown",
+        t = tool_name or "",
+        c = ngx.req.get_headers()["X-Client-Name"] or "unknown",
+        ok = false,
+        d = (tonumber(ngx.var.request_time) or 0) * 1000,
+    })
+    local key = "m:" .. ngx.now() .. ":" .. ngx.worker.pid() .. ":" .. math.random(1, 999999)
+    local set_ok, set_err = metrics:set(key, entry, 300)
+    if not set_ok then
+        ngx.log(ngx.ERR, "backend-failure metric: shared dict full, dropping metric: ", set_err)
+    end
+    ngx.log(ngx.ERR, "Backend proxy failed for ", method_name,
+        " server=", server_id or "unknown",
+        " tool=", tool_name or "",
+        " status=", status or "no response")
+end
+
 local function _proxy_to_backend(request_id, method_name, proxied_params,
                                   backend_location, client_session_id, server_id,
                                   backend_version, label)
@@ -617,6 +651,7 @@ local function _proxy_to_backend(request_id, method_name, proxied_params,
         method = method_name,
         params = proxied_params,
     })
+    local tool_name = proxied_params and proxied_params.name or nil
 
     -- Get or create backend session
     local backend_session_id = nil
@@ -642,6 +677,7 @@ local function _proxy_to_backend(request_id, method_name, proxied_params,
     })
 
     if not res then
+        _record_backend_failure(method_name, server_id, tool_name, nil)
         ngx.status = 200
         ngx.say(_jsonrpc_error(request_id, -32603,
             "Backend request failed for " .. (label or method_name)))
@@ -672,11 +708,23 @@ local function _proxy_to_backend(request_id, method_name, proxied_params,
         })
 
         if not res then
+            _record_backend_failure(method_name, server_id, tool_name, nil)
             ngx.status = 200
             ngx.say(_jsonrpc_error(request_id, -32603,
                 "Backend request failed after retry for " .. (label or method_name)))
             return
         end
+    end
+
+    -- A >=500 here means the backend subrequest itself failed (e.g. nginx's
+    -- own DNS resolution for a dynamic proxy_pass upstream, or the backend
+    -- process being unreachable) -- as opposed to the backend legitimately
+    -- responding with an error, which the retry branch above already logs.
+    -- Without this, that class of failure was completely silent: no
+    -- access/error log entry, no metric, and no way to tell it apart from a
+    -- normal response short of noticing the tool call never actually ran.
+    if res.status >= 500 then
+        _record_backend_failure(method_name, server_id, tool_name, res.status)
     end
 
     -- Forward backend response

--- a/registry/core/metrics.py
+++ b/registry/core/metrics.py
@@ -56,6 +56,9 @@ from registry.observability.meters import (
     nginx_config_writes_total as NGINX_CONFIG_WRITES,
 )
 from registry.observability.meters import (
+    nginx_resolver_failures_total as NGINX_RESOLVER_FAILURES,
+)
+from registry.observability.meters import (
     nginx_updates_skipped_total as NGINX_UPDATES_SKIPPED,
 )
 from registry.observability.meters import (
@@ -105,6 +108,7 @@ __all__ = [
     "M2M_ORPHAN_CLEANUPS_TOTAL",
     "MODE_BLOCKED_REQUESTS",
     "NGINX_CONFIG_WRITES",
+    "NGINX_RESOLVER_FAILURES",
     "NGINX_UPDATES_SKIPPED",
     "PEER_SYNC_DURATION_SECONDS",
     "PEER_SYNC_FAILURES",

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import hashlib
 import ipaddress
 import json
@@ -16,7 +17,7 @@ import httpx
 from registry.constants import REGISTRY_CONSTANTS, DeploymentType, HealthStatus
 
 from .config import settings
-from .metrics import NGINX_CONFIG_WRITES, NGINX_UPDATES_SKIPPED
+from .metrics import NGINX_CONFIG_WRITES, NGINX_RESOLVER_FAILURES, NGINX_UPDATES_SKIPPED
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,82 @@ logger = logging.getLogger(__name__)
 # exists yet. Subsequent writes preserve whatever mode the destination
 # currently has so an operator's chmod isn't silently reverted.
 DEFAULT_NGINX_CONFIG_MODE: int = 0o644
+
+
+@functools.lru_cache(maxsize=1)
+def _discover_dns_resolver() -> str | None:
+    """Determine the nginx `resolver` directive value for dynamic proxy_pass upstreams.
+
+    Precedence:
+    1. ``NGINX_DNS_RESOLVER`` env var, if set -- explicit operator override,
+       used verbatim.
+    2. Nameservers parsed from ``/etc/resolv.conf`` -- whatever DNS is
+       already correct for this environment (Docker's embedded resolver
+       locally, kubelet's injected CoreDNS entry in any Kubernetes cluster),
+       with nothing environment-specific to hardcode or keep in sync.
+
+    IPv6 nameservers are bracketed (nginx's `resolver` directive requires
+    `[addr]` for IPv6, e.g. `resolver [fd00::a];`). Each candidate is
+    validated as a real IP address before being trusted -- resolv.conf
+    content here isn't attacker-controlled, but a malformed entry should
+    never be silently interpolated into the generated nginx config.
+
+    Returns None (and increments the NGINX_RESOLVER_FAILURES metric) if no
+    resolver can be determined at all. Callers must treat that as
+    fail-closed for the affected backend, not silently default to public
+    DNS -- a public resolver cannot resolve in-cluster Service names and
+    produces a bare, unlogged 502 on every dynamic proxy_pass (issue #1129).
+
+    Cached for the life of the process: resolv.conf does not change inside
+    a running container, and this is consulted on every nginx config
+    regen (every few seconds under the health-check poll loop).
+    """
+    override = os.environ.get("NGINX_DNS_RESOLVER")
+    if override:
+        return override
+
+    try:
+        resolv_conf_text = Path("/etc/resolv.conf").read_text()
+    except OSError as exc:
+        logger.error(
+            "Cannot determine nginx DNS resolver: /etc/resolv.conf unreadable "
+            "(%s) and NGINX_DNS_RESOLVER is not set. Dynamic proxy_pass "
+            "backends (virtual servers, and any registered server whose "
+            "hostname isn't resolvable at nginx config-load time) will have "
+            "their location blocks skipped rather than risk an unresolvable "
+            "or wrong resolver.",
+            exc,
+        )
+        NGINX_RESOLVER_FAILURES.labels(reason="resolv_conf_unreadable").inc()
+        return None
+
+    nameservers: list[str] = []
+    for line in resolv_conf_text.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[0] == "nameserver":
+            candidate = parts[1]
+            try:
+                addr = ipaddress.ip_address(candidate)
+            except ValueError:
+                logger.warning(
+                    "Ignoring malformed nameserver entry in /etc/resolv.conf: %r",
+                    candidate,
+                )
+                continue
+            nameservers.append(f"[{addr}]" if addr.version == 6 else str(addr))
+
+    if not nameservers:
+        logger.error(
+            "Cannot determine nginx DNS resolver: no valid `nameserver` "
+            "entries found in /etc/resolv.conf and NGINX_DNS_RESOLVER is not "
+            "set. Dynamic proxy_pass backends will have their location "
+            "blocks skipped rather than risk an unresolvable or wrong "
+            "resolver."
+        )
+        NGINX_RESOLVER_FAILURES.labels(reason="no_nameservers").inc()
+        return None
+
+    return " ".join(nameservers)
 
 # Route prefix under which enabled A2A agents are reverse-proxied through the
 # gateway. An agent registered at path "/flight-booking-agent" is
@@ -1633,9 +1710,24 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 if host_is_resolvable_at_startup:
                     proxy_directive = f"proxy_pass {safe_mcp_proxy_url};"
                 else:
+                    dns_resolver = _discover_dns_resolver()
+                    if dns_resolver is None:
+                        # _discover_dns_resolver() already logged the specifics
+                        # and incremented NGINX_RESOLVER_FAILURES. Skip this
+                        # backend's location block entirely rather than emit a
+                        # `resolver` directive we can't trust -- same
+                        # fail-closed philosophy as the other `continue`s in
+                        # this loop, just one level deeper (a resolver we
+                        # can't determine, not a backend we can't find).
+                        logger.error(
+                            f"Skipping virtual-server backend location for "
+                            f"{backend_path}: no DNS resolver available for its "
+                            f"dynamic proxy_pass."
+                        )
+                        NGINX_RESOLVER_FAILURES.labels(reason="backend_location_skipped").inc()
+                        continue
                     # sanitized is already underscore-safe (valid nginx var name).
                     backend_var = f"$vs_backend{sanitized}"
-                    dns_resolver = os.environ.get("NGINX_DNS_RESOLVER", "8.8.8.8 8.8.4.4")
                     dns_resolver_timeout = os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")
                     proxy_directive = (
                         f"resolver {dns_resolver} valid=10s;\n"
@@ -1936,7 +2028,13 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         else:
             host_header = "$host"
 
-        dns_resolver = os.environ.get("NGINX_DNS_RESOLVER", "8.8.8.8 8.8.4.4")
+        # This location's proxy_pass target (backend_url) is always literal,
+        # so the resolver below isn't actually consulted for this location's
+        # own upstream resolution -- kept for parity/forward-compat, but must
+        # not silently default to public DNS (see issue #1129). Fall back to
+        # a directive nginx accepts as syntactically valid but that will
+        # never resolve anything real if no trustworthy resolver is known.
+        dns_resolver = _discover_dns_resolver() or "127.0.0.1"
         dns_resolver_timeout = os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")
         safe_name = self._sanitize_for_nginx_comment(agent_name)
         route = f"{AGENT_ROUTE_PREFIX}/{agent_path}"
@@ -2229,6 +2327,18 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         mcp_proxy_read_timeout = _resolve_mcp_proxy_read_timeout_seconds()
 
         # Common proxy settings
+        # This location's proxy_pass targets above are always literal (either
+        # the fixed auth_server mcp-proxy hop, or -- for multi-version
+        # servers -- a $backend_url set from a value known at config-load
+        # time), so the resolver below is not actually consulted for this
+        # location's own upstream resolution today. It's kept for parity/
+        # forward-compat with any future dynamic proxy_pass here, but must
+        # not silently default to public DNS (see issue #1129) -- fall back
+        # to a directive nginx accepts as syntactically valid but that will
+        # never resolve anything real if no trustworthy resolver is known,
+        # rather than one that looks plausible and quietly can't see
+        # in-cluster Service names.
+        dns_resolver = _discover_dns_resolver() or "127.0.0.1"
         common_settings = f"""
         # Inbound rate limiting: every MCP request fans out to the shared
         # /validate auth subrequest, so bound it at the edge (zones + rationale
@@ -2238,12 +2348,11 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         limit_req zone=mcp_gateway_edge burst=100 nodelay;
         limit_conn mcp_gateway_conn 100;
 
-        # DNS resolver for dynamic proxy_pass upstreams.
-        # Default: 8.8.8.8 8.8.4.4 (public DNS).
-        # Override with NGINX_DNS_RESOLVER env var for environments where
-        # backend servers use internal hostnames (e.g., Kubernetes
-        # cluster-local names like *.svc.cluster.local need kube-dns).
-        resolver {os.environ.get("NGINX_DNS_RESOLVER", "8.8.8.8 8.8.4.4")} valid=10s;
+        # DNS resolver for dynamic proxy_pass upstreams (see comment above --
+        # not on this location's own proxy_pass path today).
+        # Default: derived from /etc/resolv.conf. Override with
+        # NGINX_DNS_RESOLVER for unusual setups.
+        resolver {dns_resolver} valid=10s;
         resolver_timeout {os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")}s;
 
         # Upstream timeouts for the browser -> nginx -> auth-server mcp_proxy

--- a/registry/observability/meters.py
+++ b/registry/observability/meters.py
@@ -309,6 +309,18 @@ _nginx_config_writes_counter = _meter.create_counter(
 )
 nginx_config_writes_total = _CounterAdapter(_nginx_config_writes_counter)
 
+_nginx_resolver_failures_counter = _meter.create_counter(
+    name="mcpgw_registry_nginx_resolver_failures_total",
+    description=(
+        "Times the nginx DNS resolver for dynamic proxy_pass upstreams could "
+        "not be determined (no NGINX_DNS_RESOLVER override and /etc/resolv.conf "
+        "unreadable or empty) or a virtual/dynamic backend location had to be "
+        "skipped as a result"
+    ),
+    unit="1",
+)
+nginx_resolver_failures_total = _CounterAdapter(_nginx_resolver_failures_counter)
+
 
 # Mode-blocked requests (registry/core/metrics.py:43)
 _mode_blocked_requests_counter = _meter.create_counter(


### PR DESCRIPTION
## Summary

The nginx-generated dynamic `proxy_pass` locations (virtual-server backend hops, the A2A agent-card location, and any registered MCP server whose hostname isn't resolvable at nginx config-load time) resolve their upstream host via nginx's `resolver` directive, which defaults to public DNS (`8.8.8.8 8.8.4.4`) when `NGINX_DNS_RESOLVER` isn't set. Public DNS can't resolve in-cluster/docker-compose Service names, so every such request fails DNS lookup and nginx returns a bare, effectively-unlogged 502 — the backend process never even sees it, despite auth already having been granted at `/validate`. In a Kubernetes deployment where a virtual server's backend uses a plain in-cluster Service name (no dot), every `tools/call` through that virtual server silently fails this way.

## Changes

- `registry/core/nginx_service.py`: add `_discover_dns_resolver()`, which reads `NGINX_DNS_RESOLVER` if set, else parses `/etc/resolv.conf` for nameservers (whatever DNS is already correct for the environment — Docker's embedded resolver locally, kubelet's injected CoreDNS entry in any Kubernetes cluster — with nothing environment-specific to hardcode or keep in sync), bracketing IPv6 addresses and validating each candidate as a real IP before trusting it. For the one location where the resolver is actually load-bearing (the virtual-server backend's variable-based `proxy_pass`), a resolver that can't be determined fails loud (ERROR log + a new `NGINX_RESOLVER_FAILURES` metric) and skips that backend's dynamic location block entirely, rather than silently defaulting to a resolver that can't see in-cluster names. The other two call sites (the A2A agent-card location and the regular MCP server proxy) always use a literal `proxy_pass`, so the resolver directive there is inert today; they fall back to a syntactically-valid loopback placeholder instead of failing config generation over a directive that was never actually consulted.
- `registry/observability/meters.py`, `registry/core/metrics.py`: add the `NGINX_RESOLVER_FAILURES` counter (same pattern as the existing `NGINX_CONFIG_WRITES`/`NGINX_UPDATES_SKIPPED` counters).
- `docker/lua/virtual_router.lua`: `_proxy_to_backend()` forwarded whatever status came back from the backend subrequest with zero `ngx.log` calls on the failure path. Add `_record_backend_failure()`, called whenever the subrequest returns no response or a `>=500` status — logs (method/server/tool/status) and emits a metrics-buffer event in the same shape/key format `emit_metrics.lua` already uses for regular server locations (which virtual-server locations don't run at all today), so `flush_metrics.lua` picks it up unchanged.

Deliberately out of scope: requiring registered backends to use full Service FQDNs (rejecting bare hostnames outright). Bare-hostname registrations that resolve fine via the (now-fixed) dynamic-resolution path are legitimate, not just things this fix should paper over — I'd rather leave that as a per-registration operator choice.

## Testing

Found and verified via a real incident: a virtual server whose mapped backend was registered under a bare hostname failed `tools/call` with a silent 502 (auth granted, backend never received the request). Reproduced locally against a Docker Compose stack running this same config generator. With this fix, the backend resolves via the environment's real DNS automatically (no manual resolver override needed) and `tools/call` reaches the real backend (confirmed via the backend's own `CallToolRequest` log). Forcing an unresolvable resolver value back in reproduces the 502 and confirms the new log line fires.

`python3 -c "import ast; ast.parse(...)"` clean on all three touched Python files.