### PR TITLE
Fix dead @app.on_event(startup) legacy-scope-audit handler

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1762,6 +1762,16 @@ async def lifespan(app: FastAPI):
     # Runs after scopes are loaded so map_groups_to_scopes can resolve groups.
     await _build_static_token_map()
 
+    # Run the legacy-scope audit. This used to be registered via the
+    # deprecated @app.on_event("startup") API, but FastAPI/Starlette never
+    # invokes on_event handlers once a custom `lifespan` is passed to
+    # FastAPI() (as above) -- it was silently dead code, so this audit never
+    # actually ran on boot.
+    try:
+        await _audit_legacy_scopes_on_startup()
+    except Exception as exc:
+        logger.error(f"Legacy scope audit errored during startup: {exc}", exc_info=True)
+
     # Prime the MCP/token-mint audit logger at startup so the durable-sink
     # guard runs at boot. Without this the guard would only fire lazily on the
     # first audited request; priming here makes the auth-server refuse to start
@@ -1823,19 +1833,6 @@ internal_router = APIRouter(
     prefix="/internal",
     dependencies=[Depends(validate_internal_auth)],
 )
-
-
-@app.on_event("startup")
-async def startup_event():
-    """Load scopes configuration on startup."""
-    global SCOPES_CONFIG
-    try:
-        SCOPES_CONFIG = await reload_scopes_config()
-        _log_scopes_loaded(SCOPES_CONFIG)
-    except Exception as e:
-        logger.error(f"Failed to load scopes configuration on startup: {e}", exc_info=True)
-        # Fall back to empty config
-        SCOPES_CONFIG = {"group_mappings": {}}
 
 
 # Add metrics collection middleware
@@ -6932,13 +6929,3 @@ async def _audit_legacy_scopes_on_startup() -> int:
     return warnings_emitted
 
 
-@app.on_event("startup")
-async def _run_legacy_scope_audit_on_startup() -> None:
-    """Run the legacy-scope audit once during auth_server boot."""
-    try:
-        await _audit_legacy_scopes_on_startup()
-    except Exception as exc:
-        logger.error(
-            f"Legacy scope audit errored during startup: {exc}",
-            exc_info=True,
-        )

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6927,5 +6927,3 @@ async def _audit_legacy_scopes_on_startup() -> int:
     else:
         logger.info("Legacy scope audit: no issues found.")
     return warnings_emitted
-
-


### PR DESCRIPTION
## Summary

`FastAPI(..., lifespan=lifespan, ...)` in `auth_server/server.py` means Starlette never invokes `@app.on_event("startup")` handlers registered on the same app — silently, with no warning. This file has two such handlers left over from before the `lifespan` migration:

- A scope-reload handler (`startup_event`) — harmless, since `lifespan()` already reloads scopes earlier in the same startup sequence. Dead but not a functional bug.
- `_run_legacy_scope_audit_on_startup` — a real bug. The legacy-scope audit (which warns about scope/server pairs needing attention before an upgrade) never actually runs on boot, silently.

## Changes

Move `_audit_legacy_scopes_on_startup()`'s call into `lifespan()` (right after the static-token-map build, matching where the removed handler sat relative to it in registration order) and remove both dead `@app.on_event` decorators.

## Testing

`python3 -c "import ast; ast.parse(...)"` clean. Found and fixed the identical pattern in a downstream fork, where it also silently broke a static-token-map builder (that particular handler already lives correctly inside `lifespan()` on this `main`, so only the legacy-scope-audit half of the bug applies here).