### PR TITLE
observability: redact + count rejected OAuth redirects (#1475 follow-up)

### DIFF
--- a/auth_server/observability/meters.py
+++ b/auth_server/observability/meters.py
@@ -146,6 +146,21 @@ token_mint_total = _meter.create_counter(
 
 
 # =============================================================================
+# Redirect-validation metrics (open-redirect hardening, PR #1475 follow-up)
+# =============================================================================
+
+redirect_rejected_total = _meter.create_counter(
+    name="mcpgw_registry_redirect_rejected_total",
+    description=(
+        "Login/logout redirect URIs rejected by the allowlist, labeled by flow "
+        "(login | logout) and reason (backslash | protocol_relative | scheme | "
+        "not_in_allowlist | cookie_domain | empty)"
+    ),
+    unit="1",
+)
+
+
+# =============================================================================
 # Self-observability of the migration itself
 # =============================================================================
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -48,9 +48,12 @@ from jwt.api_jwk import PyJWK
 from metrics_middleware import add_auth_metrics_middleware
 
 try:
-    from observability.meters import token_mint_total
+    from observability.meters import redirect_rejected_total, token_mint_total
 except ImportError:
-    from auth_server.observability.meters import token_mint_total
+    from auth_server.observability.meters import (
+        redirect_rejected_total,
+        token_mint_total,
+    )
 
 try:
     from egress_obo import (
@@ -985,11 +988,23 @@ def _get_allowed_redirect_uris() -> frozenset[str]:
     return _parse_allowed_redirect_uris(os.environ.get("OAUTH2_ALLOWED_REDIRECT_URIS", ""))
 
 
-def _is_redirect_uri_allowed(
+def _evaluate_redirect(
     url: str,
     request: Request | None = None,
-) -> bool:
-    """Decide whether a login/logout redirect target is safe.
+) -> tuple[bool, str]:
+    """Decide whether a login/logout redirect target is safe, with a reason.
+
+    Single source of truth for the redirect decision. Returns
+    ``(allowed, reason)`` where ``reason`` is a short, low-cardinality label
+    suitable for a metric and for a redacted log line:
+      - ``empty``            -- no URL supplied
+      - ``backslash``        -- contains a backslash (legacy-browser bypass)
+      - ``protocol_relative``-- ``//host`` off-site redirect
+      - ``relative``         -- same-origin relative path (ALLOWED)
+      - ``scheme``           -- non-http(s) absolute scheme
+      - ``allowlist_match``  -- exact match against the allowlist (ALLOWED)
+      - ``not_in_allowlist`` -- allowlist configured, no match
+      - ``cookie_domain``    -- legacy cookie-domain heuristic decision
 
     Precedence (fail closed):
       1. Relative URLs (no scheme and no netloc) are always safe -- they are
@@ -1005,30 +1020,65 @@ def _is_redirect_uri_allowed(
          configuring the allowlist is the recommended posture.
     """
     if not url:
-        return False
+        return False, "empty"
     # A backslash is not a valid path separator, but some legacy browsers
     # rewrite it to "/" before following a redirect, turning "/\evil.com" into
     # the protocol-relative "//evil.com" (an off-site redirect). urlparse treats
     # it as a relative path, so reject it explicitly before the same-origin
     # shortcut below (fail closed).
     if "\\" in url:
-        return False
+        return False, "backslash"
+    # Reject protocol-relative ("//evil.com") before urlparse: a browser follows
+    # it off-site. urlparse classifies it as netloc (not path), so catching it
+    # here also gives an accurate reason label instead of the generic "scheme".
+    if url.startswith("//"):
+        return False, "protocol_relative"
     parsed = urlparse(url)
     if not parsed.scheme and not parsed.netloc:
-        # Reject protocol-relative ("//evil.com"): urlparse may leave it in the
-        # path, but a browser follows it off-site.
-        if url.startswith("//"):
-            return False
-        return True
+        return True, "relative"
     if parsed.scheme not in ("http", "https"):
-        return False
+        return False, "scheme"
 
     allowlist = _get_allowed_redirect_uris()
     if allowlist:
-        return _normalize_redirect_uri(url) in allowlist
+        if _normalize_redirect_uri(url) in allowlist:
+            return True, "allowlist_match"
+        return False, "not_in_allowlist"
 
     cookie_domain = os.environ.get("SESSION_COOKIE_DOMAIN", "").strip()
-    return _is_redirect_within_cookie_domain(url, cookie_domain, request)
+    allowed = _is_redirect_within_cookie_domain(url, cookie_domain, request)
+    return allowed, "cookie_domain"
+
+
+def _redact_redirect_uri(url: str) -> str:
+    """Reduce a (rejected, untrusted) redirect URL to scheme+host for logging.
+
+    A rejected redirect_uri is untrusted and its path/query/fragment may carry
+    tokens or PII, so never log it whole. Returns just ``scheme://host`` for an
+    absolute http(s) URL, or a coarse placeholder otherwise.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:  # pragma: no cover - urlparse is very tolerant
+        return "<unparseable>"
+    if parsed.scheme in ("http", "https") and parsed.hostname:
+        return f"{parsed.scheme}://{parsed.hostname}"
+    if url.startswith("//"):
+        return "//<host>"
+    return "<non-absolute>"
+
+
+def _is_redirect_uri_allowed(
+    url: str,
+    request: Request | None = None,
+) -> bool:
+    """Return whether a login/logout redirect target is safe.
+
+    Thin bool wrapper over ``_evaluate_redirect`` (the single source of truth),
+    kept for call sites and tests that only need the yes/no decision.
+    """
+    allowed, _reason = _evaluate_redirect(url, request)
+    return allowed
 
 
 def _is_redirect_within_cookie_domain(
@@ -1942,6 +1992,16 @@ async def startup_event():
         logger.error(f"Failed to load scopes configuration on startup: {e}", exc_info=True)
         # Fall back to empty config
         SCOPES_CONFIG = {"group_mappings": {}}
+
+    # Surface the redirect-validation posture once at startup so operators can
+    # tell whether the hardened exact-match allowlist is active (PR #1475).
+    if _get_allowed_redirect_uris():
+        logger.info("OAuth redirect validation: exact-match allowlist active")
+    else:
+        logger.info(
+            "OAUTH2_ALLOWED_REDIRECT_URIS not set; using legacy cookie-domain "
+            "redirect validation. Configure the allowlist for the hardened posture."
+        )
 
 
 # Add metrics collection middleware
@@ -5555,8 +5615,14 @@ async def oauth2_callback(
         # (the hardened path). When the allowlist is unset, this falls back to
         # the weaker same-origin / cookie-domain heuristic for backward
         # compatibility. Fail closed: anything else is rejected to a safe path.
-        if not _is_redirect_uri_allowed(redirect_url, request):
-            logger.warning(f"Blocked unsafe redirect URL: {redirect_url}, falling back to /")
+        allowed, reason = _evaluate_redirect(redirect_url, request)
+        if not allowed:
+            # Redact: a rejected redirect_uri is untrusted; log scheme+host only.
+            logger.warning(
+                f"Blocked unsafe login redirect (reason={reason}): "
+                f"{_redact_redirect_uri(redirect_url)}, falling back to /"
+            )
+            redirect_rejected_total.add(1, {"flow": "login", "reason": reason})
             redirect_url = "/"
         response = RedirectResponse(url=redirect_url, status_code=302)
 
@@ -5753,10 +5819,14 @@ async def oauth2_logout(
         if redirect_uri:
             parsed = urlparse(redirect_uri)
             if parsed.scheme or parsed.netloc:
-                if not _is_redirect_uri_allowed(redirect_uri, request):
+                allowed, reason = _evaluate_redirect(redirect_uri, request)
+                if not allowed:
+                    # Redact: log scheme+host only, never the raw redirect_uri.
                     logger.warning(
-                        f"Blocked unsafe logout redirect_uri for {provider}: {redirect_uri}"
+                        f"Blocked unsafe logout redirect_uri for {provider} "
+                        f"(reason={reason}): {_redact_redirect_uri(redirect_uri)}"
                     )
+                    redirect_rejected_total.add(1, {"flow": "logout", "reason": reason})
                     redirect_uri = None
 
         provider_config = OAUTH2_CONFIG["providers"][provider]

--- a/tests/auth_server/unit/test_redirect_allowlist.py
+++ b/tests/auth_server/unit/test_redirect_allowlist.py
@@ -11,9 +11,11 @@ used for backward compatibility. Relative paths are always allowed.
 import pytest
 
 from auth_server.server import (
+    _evaluate_redirect,
     _get_allowed_redirect_uris,
     _is_redirect_uri_allowed,
     _normalize_redirect_uri,
+    _redact_redirect_uri,
 )
 
 
@@ -138,3 +140,63 @@ class TestRedirectFallbackWhenAllowlistUnset:
 
     def test_empty_rejected(self):
         assert _is_redirect_uri_allowed("") is False
+
+
+@pytest.mark.unit
+class TestEvaluateRedirectReason:
+    """`_evaluate_redirect` returns a low-cardinality reason for metrics/logs."""
+
+    @pytest.fixture(autouse=True)
+    def _configure(self, monkeypatch):
+        monkeypatch.setenv("OAUTH2_ALLOWED_REDIRECT_URIS", "https://registry.example.com/")
+        monkeypatch.delenv("SESSION_COOKIE_DOMAIN", raising=False)
+
+    def test_relative_allowed_reason(self):
+        assert _evaluate_redirect("/dashboard") == (True, "relative")
+
+    def test_allowlist_match_reason(self):
+        assert _evaluate_redirect("https://registry.example.com/") == (
+            True,
+            "allowlist_match",
+        )
+
+    def test_not_in_allowlist_reason(self):
+        allowed, reason = _evaluate_redirect("https://evil.example.com/steal")
+        assert allowed is False
+        assert reason == "not_in_allowlist"
+
+    def test_backslash_reason(self):
+        assert _evaluate_redirect("/\\evil.com") == (False, "backslash")
+
+    def test_protocol_relative_reason(self):
+        assert _evaluate_redirect("//evil.com") == (False, "protocol_relative")
+
+    def test_scheme_reason(self):
+        assert _evaluate_redirect("javascript:alert(1)") == (False, "scheme")
+
+    def test_empty_reason(self):
+        assert _evaluate_redirect("") == (False, "empty")
+
+    def test_bool_wrapper_matches_evaluate(self):
+        # The thin bool wrapper must agree with the source-of-truth function.
+        for url in ("/ok", "https://registry.example.com/", "https://evil.test/x"):
+            assert _is_redirect_uri_allowed(url) is _evaluate_redirect(url)[0]
+
+
+@pytest.mark.unit
+class TestRedactRedirectUri:
+    """A rejected redirect_uri is untrusted; only scheme+host may be logged."""
+
+    def test_strips_path_query_fragment(self):
+        redacted = _redact_redirect_uri("https://evil.example.com/steal?token=secret123#frag")
+        assert redacted == "https://evil.example.com"
+        # The sensitive parts must not survive.
+        assert "steal" not in redacted
+        assert "secret123" not in redacted
+        assert "frag" not in redacted
+
+    def test_protocol_relative_has_no_host_leak(self):
+        assert _redact_redirect_uri("//evil.com/path") == "//<host>"
+
+    def test_non_absolute_is_coarse(self):
+        assert _redact_redirect_uri("/dashboard") == "<non-absolute>"


### PR DESCRIPTION
## Summary

Follow-up to the review of #1475 (merged). The redirect rejection sites already logged at WARNING, but they logged the raw, untrusted redirect URL and emitted no metric, so an open-redirect attempt and an operator misconfiguration both surfaced only as a bare log line with nothing to alert on. This closes that observability gap without changing the accept/reject behavior.

## Changes

- Extract the redirect decision into `_evaluate_redirect(url) -> (allowed, reason)` as the single source of truth. `_is_redirect_uri_allowed` becomes a thin bool wrapper, so existing call sites and tests are unchanged. `reason` is a low-cardinality label: `backslash`, `protocol_relative`, `scheme`, `not_in_allowlist`, `cookie_domain`, `relative`, `allowlist_match`, `empty`.
- Move the protocol-relative check ahead of `urlparse` so `//host` is labeled `protocol_relative` rather than the generic `scheme`. Behavior is unchanged: it is still rejected.
- Add `_redact_redirect_uri`. A rejected `redirect_uri` is untrusted and its path, query, and fragment may carry tokens or PII, so the log now records scheme and host only.
- Add a `redirect_rejected_total` counter in the auth-server meters, labeled by `flow` (login or logout) and `reason`, incremented at both rejection sites.
- Log the redirect-validation posture once at startup so operators can tell whether the hardened exact-match allowlist is active or the legacy cookie-domain fallback is in effect.

## Why

`OAUTH2_ALLOWED_REDIRECT_URIS` (added in #1475) is opt-in and defaults to the weaker cookie-domain heuristic. Operators need a way to see which mode is active and to alert when a redirect is rejected, whether that rejection is an attack or a real callback URL they forgot to allowlist.

## Tests

`tests/auth_server/unit/test_redirect_allowlist.py` gains:

- A reason-label assertion for each decision branch.
- A check that the bool wrapper agrees with `_evaluate_redirect`.
- A redaction guard asserting the path, query, and fragment never appear in the redacted string.

Full auth-server unit suite (683 tests) and the CSRF suites from #1475 pass. `ruff check`, `ruff format`, and `bandit` are clean on the changed files.

## Notes

- No new configuration parameter, so no deployment-surface or parameter-reference changes are needed.
- Release notes for the version shipping #1475 should still tell operators to set `OAUTH2_ALLOWED_REDIRECT_URIS` for the hardened posture. That is a docs task tracked separately.
