### PR TITLE
Fix virtual tools/list endpoint resolution and partial caching

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -336,8 +336,27 @@ local function _collect_backend_locations(mapping)
 end
 
 
+-- Append mapping-file metadata for one backend when live discovery fails.
+local function _append_mapping_tools_for_backend(enriched_tools, mapping, backend_location)
+    if not mapping.tools then
+        return
+    end
+
+    for _, tool in ipairs(mapping.tools) do
+        if tool.backend_location == backend_location then
+            enriched_tools[#enriched_tools + 1] = {
+                name = tool.name,
+                description = tool.description or "",
+                inputSchema = _ensure_mcp_schema(tool.inputSchema),
+                required_scopes = tool.required_scopes,
+            }
+        end
+    end
+end
+
+
 -- Fetch tools/list from a single backend via ngx.location.capture.
--- Returns the tools array from the backend, or empty table on failure.
+-- Returns the tools array and true on success, or an empty table and false on failure.
 -- On stale session error (status >= 400), invalidates and retries once.
 local function _fetch_backend_tools_list(backend_location, client_session_id, server_id)
     local req_body = cjson.encode({
@@ -384,27 +403,33 @@ local function _fetch_backend_tools_list(backend_location, client_session_id, se
     if not res or res.status ~= 200 then
         ngx.log(ngx.ERR, "Failed to fetch tools/list from ", backend_location,
             " status=", res and res.status or "nil")
-        return {}
+        return {}, false
+    end
+
+    if res.truncated then
+        ngx.log(ngx.ERR, "Truncated tools/list response from ", backend_location)
+        return {}, false
     end
 
     -- Backend may respond with SSE format (text/event-stream) or raw JSON
     local json_body = _parse_sse_body(res.body)
     if not json_body then
         ngx.log(ngx.ERR, "Empty or unparseable tools/list response from ", backend_location)
-        return {}
+        return {}, false
     end
 
     local ok, data = pcall(cjson.decode, json_body)
     if not ok then
         ngx.log(ngx.ERR, "Failed to parse tools/list response from ", backend_location)
-        return {}
+        return {}, false
     end
 
-    if data.result and data.result.tools then
-        return data.result.tools
+    if data.result and type(data.result.tools) == "table" then
+        return data.result.tools, true
     end
 
-    return {}
+    ngx.log(ngx.ERR, "Missing tools array in tools/list response from ", backend_location)
+    return {}, false
 end
 
 
@@ -438,55 +463,47 @@ local function _handle_tools_list(request_id, mapping, user_scopes_str, client_s
     if not enriched_tools then
         enriched_tools = {}
         local backend_locations = _collect_backend_locations(mapping)
-        local fetch_ok = false
+        local all_fetches_ok = true
 
         for _, backend_loc in ipairs(backend_locations) do
-            local backend_tools = _fetch_backend_tools_list(backend_loc, client_session_id, server_id)
-            if #backend_tools > 0 then
-                fetch_ok = true
+            local backend_tools, backend_ok = _fetch_backend_tools_list(
+                backend_loc, client_session_id, server_id)
+            if not backend_ok then
+                all_fetches_ok = false
+                ngx.log(ngx.WARN, "Backend tools/list fetch failed for ", backend_loc,
+                    " -- falling back to mapping file metadata for this backend")
+                _append_mapping_tools_for_backend(enriched_tools, mapping, backend_loc)
             end
 
-            for _, bt in ipairs(backend_tools) do
-                local mapping_entry = allowed_tools[bt.name]
-                if mapping_entry then
-                    -- Use the mapping's display name (alias) instead of original name
-                    local display_name = mapping_entry.name
-                    -- Use mapping's description if non-empty (override), else backend's
-                    local desc = mapping_entry.description
-                    if not desc or desc == "" then
-                        desc = bt.description or ""
+            if backend_ok then
+                for _, bt in ipairs(backend_tools) do
+                    local mapping_entry = allowed_tools[bt.name]
+                    if mapping_entry then
+                        -- Use the mapping's display name (alias) instead of original name
+                        local display_name = mapping_entry.name
+                        -- Use mapping's description if non-empty (override), else backend's
+                        local desc = mapping_entry.description
+                        if not desc or desc == "" then
+                            desc = bt.description or ""
+                        end
+                        enriched_tools[#enriched_tools + 1] = {
+                            name = display_name,
+                            description = desc,
+                            inputSchema = _ensure_mcp_schema(bt.inputSchema or bt.input_schema),
+                            required_scopes = mapping_entry.required_scopes,
+                        }
                     end
-                    enriched_tools[#enriched_tools + 1] = {
-                        name = display_name,
-                        description = desc,
-                        inputSchema = _ensure_mcp_schema(bt.inputSchema or bt.input_schema),
-                        required_scopes = mapping_entry.required_scopes,
-                    }
                 end
             end
         end
 
-        -- Fallback: if all backend fetches failed, use mapping file metadata
-        if not fetch_ok then
-            ngx.log(ngx.WARN, "All backend tools/list fetches failed for server=", server_id,
-                " -- falling back to mapping file metadata")
-            enriched_tools = {}
-            if mapping.tools then
-                for _, tool in ipairs(mapping.tools) do
-                    enriched_tools[#enriched_tools + 1] = {
-                        name = tool.name,
-                        description = tool.description or "",
-                        inputSchema = _ensure_mcp_schema(tool.inputSchema),
-                        required_scopes = tool.required_scopes,
-                    }
-                end
+        -- Cache only fully discovered results. A fallback response remains complete,
+        -- but the next request should retry failed backends instead of serving it for 60s.
+        if all_fetches_ok then
+            local ok_enc, encoded = pcall(cjson.encode, enriched_tools)
+            if ok_enc then
+                session_cache:set(enriched_cache_key, encoded, ENRICHED_CACHE_TTL)
             end
-        end
-
-        -- Cache enriched tools (pre-scope-filtered, 60s TTL)
-        local ok_enc, encoded = pcall(cjson.encode, enriched_tools)
-        if ok_enc then
-            session_cache:set(enriched_cache_key, encoded, ENRICHED_CACHE_TTL)
         end
     end
 

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -16,6 +16,7 @@ import httpx
 from registry.constants import REGISTRY_CONSTANTS, DeploymentType, HealthStatus
 
 from .config import settings
+from .endpoint_utils import get_endpoint_url_from_server_info
 from .metrics import NGINX_CONFIG_WRITES, NGINX_UPDATES_SKIPPED
 
 logger = logging.getLogger(__name__)
@@ -1573,28 +1574,13 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 parsed_url = urlparse(proxy_pass_url)
                 upstream_host = parsed_url.netloc
 
-                # Build MCP endpoint URL from the server's mcp_endpoint or proxy_pass_url.
-                # mcp_endpoint is defended by two layers: (1) registration-time
-                # validation rejects an mcp_endpoint containing nginx
-                # metacharacters (including "$") via the same canonical guard as
-                # proxy_pass_url, so a "$" can never legitimately be stored; and
-                # (2) the render-time _sanitize_for_nginx_set below strips "$"
-                # and escapes quotes/backslashes as defense in depth for any
-                # legacy value persisted before validation existed.
-                mcp_endpoint = server_info.get("mcp_endpoint", "")
-                if mcp_endpoint:
-                    mcp_parsed = urlparse(mcp_endpoint)
-                    mcp_path = mcp_parsed.path.rstrip("/")
-                    # Construct full MCP URL from proxy_pass host + mcp path
-                    mcp_proxy_url = f"{parsed_url.scheme}://{parsed_url.netloc}{mcp_path}"
-                else:
-                    # Fallback: use proxy_pass_url, appending /mcp only if needed
-                    bare_url = proxy_pass_url.rstrip("/")
-                    # Check if URL already ends with common MCP endpoint paths
-                    if bare_url.endswith("/mcp") or bare_url.endswith("/sse"):
-                        mcp_proxy_url = bare_url
-                    else:
-                        mcp_proxy_url = f"{bare_url}/mcp"
+                # Resolve custom and nested transport paths centrally, but retain
+                # the proxy host because explicit endpoints may use a public host.
+                # Registration-time validation and the render-time sanitizer below
+                # continue to protect both endpoint sources from nginx metacharacters.
+                resolved_endpoint = get_endpoint_url_from_server_info(server_info)
+                endpoint_path = urlparse(resolved_endpoint).path.rstrip("/")
+                mcp_proxy_url = f"{parsed_url.scheme}://{parsed_url.netloc}{endpoint_path}"
 
                 # Use regular internal location (not named @) so proxy_pass
                 # can include a URI path for the MCP endpoint

--- a/tests/unit/test_virtual_server_nginx.py
+++ b/tests/unit/test_virtual_server_nginx.py
@@ -180,6 +180,42 @@ class TestGenerateVirtualBackendLocations:
         assert "resolver " not in result
 
     @pytest.mark.asyncio
+    async def test_preserves_nested_mcp_transport_path(self, mock_server_repository):
+        """A configured /mcp/... endpoint must not receive a second /mcp suffix."""
+        vs = _make_vs_config()
+        mock_server_repository.get.return_value = {
+            "proxy_pass_url": "https://insights.example.com/mcp/http",
+        }
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_backend_locations([vs])
+
+        assert "proxy_pass https://insights.example.com/mcp/http;" in result
+        assert "/mcp/http/mcp" not in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_mcp_endpoint_keeps_proxy_host(self, mock_server_repository):
+        """Explicit endpoint paths use the private proxy host for internal routing."""
+        vs = _make_vs_config()
+        mock_server_repository.get.return_value = {
+            "proxy_pass_url": "http://insights-service:8000",
+            "mcp_endpoint": "https://public.example.com/custom/mcp/http",
+        }
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_backend_locations([vs])
+
+        assert (
+            'set $vs_backend_github "http://insights-service:8000/custom/mcp/http"'
+            in result
+        )
+        assert "public.example.com" not in result
+
+    @pytest.mark.asyncio
     async def test_credentials_not_forwarded_to_untrusted_backend(self, mock_server_repository):
         """The caller's credential must not be relayed to a registrant-controlled backend.
 


### PR DESCRIPTION
## Summary

- Reuse the centralized endpoint resolver when generating virtual backend routes, so nested transport paths such as `/mcp/http` are not rewritten as `/mcp/http/mcp`.
- Track backend discovery success separately from the returned tool count, including valid empty tool lists.
- Fall back to mapping metadata per failed backend instead of dropping that backend whenever another backend succeeds.
- Cache enriched tools only after every backend succeeds, so fallback responses are retried on the next request rather than cached for 60 seconds.
- Treat truncated or malformed backend responses as discovery failures.

## Problem

A virtual server backed by multiple MCP servers could return only the tools from whichever backend happened to respond successfully. Because any non-empty backend response marked the whole aggregation successful, that partial list was then cached for 60 seconds. A separate endpoint-building path also appended `/mcp` to valid nested endpoints such as `/mcp/http`, causing a 404 and triggering the partial-list behavior.

## Verification

- `pytest tests/unit/test_virtual_server_nginx.py -q --no-cov`: 28 passed.
- Full upstream unit suite: 5,417 passed and 24 skipped; the sole environment failure was rerun successfully with the upstream-locked `hvac` dependency present.
- Ruff passed for the changed Python files (excluding the repository's existing F541 findings).
- The modified router compiled successfully with OpenResty LuaJIT.
- An OpenResty harness with one healthy and one failing backend verified that the first response included per-backend fallback metadata without populating the enriched cache; the next request retried the recovered backend, used its live metadata, and then cached the complete result.

## Compatibility and security

Explicit MCP endpoint paths still use the configured proxy host for internal routing. Existing registration-time URL validation and render-time nginx sanitization remain in place.
