### PR TITLE
Harden the AgentCore sync adapter's egress and secret handling

### DIFF
--- a/cli/agentcore/models.py
+++ b/cli/agentcore/models.py
@@ -201,6 +201,27 @@ def _get_auth_scheme(authorizer_type: str) -> str:
     return mapping.get(authorizer_type, "none")
 
 
+def _warn_if_world_readable(abs_path: str) -> None:
+    """Log a warning if a credential file is group/other-readable.
+
+    The registry JWT is a long-lived write credential. This adapter only reads
+    the token file (it is written by the credential provider), so it cannot fix
+    the mode at write time here, but it surfaces an over-permissive file so an
+    operator notices a 0o644 token on a shared host. Best-effort: never fails.
+    """
+    try:
+        mode = os.stat(abs_path).st_mode
+        if mode & 0o077:
+            logger.warning(
+                "Token file %s is group/other-accessible (mode %o); a registry JWT "
+                "should be 0o600. Restrict it (chmod 600) to avoid local disclosure.",
+                abs_path,
+                mode & 0o777,
+            )
+    except OSError:
+        pass
+
+
 def _load_token(token_file: str) -> str:
     """Load JWT token from a JSON file.
 
@@ -212,6 +233,7 @@ def _load_token(token_file: str) -> str:
     or missing token field.
     """
     abs_path = os.path.abspath(token_file)
+    _warn_if_world_readable(abs_path)
     try:
         with open(abs_path) as f:
             data = json.load(f)

--- a/cli/agentcore/registration.py
+++ b/cli/agentcore/registration.py
@@ -29,6 +29,7 @@ from .models import (
     _slugify,
     _validate_https_url,
 )
+from .security import is_safe_egress_url, write_secret_file
 
 # Add parent directory to path for api imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -45,31 +46,16 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-IDP_PATTERNS: dict[str, str] = {
-    "cognito-idp": "cognito",
-    "auth0.com": "auth0",
-    "okta.com": "okta",
-    "microsoftonline.com": "entra",
-    "/realms/": "keycloak",
-}
-
-
 # ---------------------------------------------------------------------------
 # Private helper functions
 # ---------------------------------------------------------------------------
 
-
-def _detect_idp_vendor(discovery_url: str) -> str:
-    """Detect IdP vendor from OIDC discovery URL.
-
-    Scans the URL for known identity-provider patterns and returns
-    a short vendor label (e.g. "cognito", "okta").  Returns "unknown"
-    when no pattern matches.
-    """
-    for pattern, vendor in IDP_PATTERNS.items():
-        if pattern in discovery_url:
-            return vendor
-    return "unknown"
+# Re-exported so registration builds the same idp_vendor label the token
+# refresher later keys its secret lookup on. Single hardened implementation
+# (hostname-boundary match, not substring-in-URL) lives in token_refresher —
+# do not reintroduce a local copy, or the two can drift and a look-alike host
+# could be classified into a vendor whose real client secret is then exfiltrated.
+from .token_refresher import _detect_idp_vendor  # noqa: E402
 
 
 def _retry_registry_call(func):
@@ -184,9 +170,22 @@ class RegistrationBuilder:
             allowed_clients = jwt_config.get("allowedClients", [])
 
             if discovery_url:
-                metadata["discovery_url"] = discovery_url
-                metadata["allowed_clients"] = allowed_clients
-                metadata["idp_vendor"] = _detect_idp_vendor(discovery_url)
+                # Validate the Bedrock-metadata-supplied discovery_url through the
+                # canonical SSRF/URL guard before persisting it: a tampered gateway
+                # could point it at an internal/attacker endpoint that the token
+                # refresher would later send client_credentials (incl. the client
+                # secret) to. Reject non-http(s)/private/metadata targets here so a
+                # rogue URL never becomes a stored credential-fetch destination.
+                if not is_safe_egress_url(discovery_url):
+                    logger.warning(
+                        "Skipping OIDC enrichment for %s: discoveryUrl failed SSRF/scheme "
+                        "validation (refusing to persist an unsafe credential-fetch target)",
+                        raw_name,
+                    )
+                else:
+                    metadata["discovery_url"] = discovery_url
+                    metadata["allowed_clients"] = allowed_clients
+                    metadata["idp_vendor"] = _detect_idp_vendor(discovery_url)
 
         return InternalServiceRegistration(
             path=path,
@@ -409,8 +408,9 @@ class SyncOrchestrator:
             logger.info("No CUSTOM_JWT gateways -- skipping manifest")
             return
 
-        with open(self.manifest_path, "w") as f:
-            json.dump(self._manifest_entries, f, indent=2)
+        # The manifest holds OIDC discovery URLs + per-client refresh metadata
+        # used to mint credentials; write it 0o600 atomically, not world-readable.
+        write_secret_file(self.manifest_path, json.dumps(self._manifest_entries, indent=2))
 
         logger.info(f"Wrote {len(self._manifest_entries)} entries to {self.manifest_path}")
 
@@ -485,6 +485,16 @@ class SyncOrchestrator:
         jwt_config = gateway.get("authorizerConfiguration", {}).get("customJWTAuthorizer", {})
         discovery_url = jwt_config.get("discoveryUrl", "")
         if not discovery_url:
+            return
+
+        # Same guard as build_gateway_registration: never persist a discovery_url
+        # into the refresh manifest that fails SSRF/scheme validation, or the
+        # token refresher would later send client_credentials to it.
+        if not is_safe_egress_url(discovery_url):
+            logger.warning(
+                "Skipping manifest entry for %s: discoveryUrl failed SSRF/scheme validation",
+                server_path,
+            )
             return
 
         self._manifest_entries.append(

--- a/cli/agentcore/security.py
+++ b/cli/agentcore/security.py
@@ -1,0 +1,276 @@
+"""Security helpers for the AgentCore sync adapter.
+
+The sync adapter runs as a standalone CLI / sidecar that talks to the registry
+API and to external OIDC identity providers, and it writes bearer tokens and a
+refresh manifest to disk. This module centralises the egress and secret-handling
+guards so every call site shares one hardened implementation instead of a
+copy-pasted snippet:
+
+- ``guarded_oidc_get`` fetches an OIDC discovery/token document through the
+  canonical SSRF/URL guard (``registry.utils.url_guard``), so a registrant- or
+  manifest-supplied ``discovery_url`` cannot be steered at a private/loopback/
+  link-local/metadata address or a non-http(s) scheme, and the resolved IP is
+  re-validated at connect time (rebinding-safe).
+- ``require_secure_registry_url`` refuses to send a bearer/OAuth credential to a
+  cleartext ``http://`` registry unless it is loopback (local dev), so the
+  PATCH auth-credential call never leaks tokens on the wire.
+- ``write_secret_file`` writes token/manifest files ``0o600`` atomically.
+- ``validate_account_ids`` enforces the 12-digit AWS account-id shape and an
+  explicit allowlist (fail-closed empty) before any cross-account AssumeRole.
+
+The URL guard is imported from ``registry.utils.url_guard`` on purpose: it is
+the single hardened implementation the rest of the codebase uses. It was
+decoupled from the registry's server config (lazy ``_get_settings``) so this
+standalone tool can import it without needing SECRET_KEY / DocumentDB / etc.
+The FEDERATION_PROFILE is used because it carries an empty bypass allowlist —
+an external IdP endpoint must never be able to resolve to an internal target.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import re
+import tempfile
+from typing import Any
+from urllib.parse import urlparse
+
+from registry.exceptions import UrlValidationError
+from registry.utils.url_guard import FEDERATION_PROFILE, guarded_client, validate_url
+
+logger = logging.getLogger(__name__)
+
+# AWS account IDs are exactly 12 digits.
+_ACCOUNT_ID_RE = re.compile(r"^\d{12}$")
+
+# Owner-only file permissions for on-disk secrets (tokens, refresh manifest).
+_SECRET_FILE_MODE = 0o600
+
+
+class EgressSecurityError(Exception):
+    """Raised when an egress target or credential transport fails a guard."""
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return True if the host is loopback (localhost / 127.0.0.0/8 / ::1)."""
+    if not host:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def require_secure_registry_url(registry_url: str) -> None:
+    """Refuse to carry a credential to a cleartext non-loopback registry.
+
+    The sync adapter sends a Bearer registry JWT (and PATCHes upstream OAuth2
+    access tokens) to ``REGISTRY_URL``. Over plaintext ``http://`` to a remote
+    host those credentials are exposed to any on-path attacker, so this fails
+    closed: ``https://`` is always allowed; ``http://`` is allowed ONLY when the
+    host is loopback (local development). Anything else raises.
+
+    Args:
+        registry_url: The configured registry base URL.
+
+    Raises:
+        EgressSecurityError: If a credential would be sent over cleartext to a
+            non-loopback host, or the URL is malformed / non-http(s).
+    """
+    parsed = urlparse(registry_url)
+    scheme = parsed.scheme.lower()
+    if scheme == "https":
+        return
+    if scheme == "http" and _is_loopback_host(parsed.hostname or ""):
+        return
+    if scheme not in ("http", "https"):
+        raise EgressSecurityError(
+            f"REGISTRY_URL must use http(s): got scheme '{parsed.scheme}' in {registry_url!r}"
+        )
+    raise EgressSecurityError(
+        "Refusing to send registry credentials over cleartext HTTP to a non-loopback "
+        f"host ({registry_url!r}). Use https:// (or http://localhost for local dev)."
+    )
+
+
+def guarded_oidc_get(
+    url: str,
+    timeout: int,
+) -> Any:
+    """GET an OIDC discovery/token document through the canonical URL guard.
+
+    Validates ``url`` (HTTPS-only + SSRF, default-deny private/loopback/link-
+    local/reserved/metadata) and pins the resolved public IP at connect time via
+    the shared guarded client, so a poisoned DNS record or a tampered manifest
+    that points ``discovery_url`` at an internal/attacker target is refused before
+    any request is sent. ``require_https=True`` because the OIDC exchange carries
+    the OAuth2 client secret — proving the target is public is not enough; the
+    transport must also be encrypted so an on-path attacker cannot read it.
+
+    Args:
+        url: The OIDC discovery or token endpoint URL (registrant-supplied).
+        timeout: Connect/read timeout in seconds.
+
+    Returns:
+        The ``httpx.Response`` (caller invokes ``.json()`` / ``.raise_for_status()``).
+
+    Raises:
+        EgressSecurityError: If the URL fails SSRF/HTTPS/scheme validation.
+    """
+    try:
+        validate_url(url, profile=FEDERATION_PROFILE, resolve=True, require_https=True)
+    except UrlValidationError as e:
+        raise EgressSecurityError(f"Blocked OIDC fetch to unsafe URL {url!r}: {e}") from e
+
+    # guarded_client pins the validated IP for the life of the request and
+    # re-validates on redirects, so it is rebinding-safe.
+    with guarded_client(profile=FEDERATION_PROFILE, timeout=timeout) as client:
+        return client.get(url)
+
+
+def guarded_oidc_post(
+    url: str,
+    timeout: int,
+    *,
+    headers: dict[str, str] | None = None,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    """POST to an OIDC token endpoint through the canonical URL guard.
+
+    Same SSRF/scheme validation and connect-time IP pinning as
+    ``guarded_oidc_get``. Used for the ``client_credentials`` grant, which sends
+    the OAuth2 client secret in the body — so the destination (derived from a
+    registrant/manifest ``discovery_url``) must be proven non-internal first.
+
+    Args:
+        url: The OAuth2 token endpoint URL.
+        timeout: Connect/read timeout in seconds.
+        headers: Optional request headers.
+        data: Optional form body.
+
+    Returns:
+        The ``httpx.Response``.
+
+    Raises:
+        EgressSecurityError: If the URL fails SSRF/HTTPS/scheme validation.
+    """
+    try:
+        validate_url(url, profile=FEDERATION_PROFILE, resolve=True, require_https=True)
+    except UrlValidationError as e:
+        raise EgressSecurityError(f"Blocked OIDC token POST to unsafe URL {url!r}: {e}") from e
+
+    with guarded_client(profile=FEDERATION_PROFILE, timeout=timeout) as client:
+        return client.post(url, headers=headers or {}, data=data or {})
+
+
+def is_safe_egress_url(url: str) -> bool:
+    """Return True if ``url`` passes the SSRF/scheme guard (no network I/O).
+
+    Used at REGISTRATION time (and re-checked at manifest-read time) to reject a
+    Bedrock-metadata ``discovery_url`` that is non-HTTPS or resolves to a private/
+    loopback/link-local/metadata target BEFORE it is persisted or used as a
+    credential-fetch destination (so a tampered gateway URL never becomes a stored
+    or refresh-time egress target). ``require_https=True`` — the discovery_url is
+    the endpoint the client secret is later sent to, so it must be encrypted, not
+    merely public. Validates format + resolves and checks the IP, but sends no
+    HTTP request. Fails closed on any error.
+
+    Args:
+        url: The candidate egress URL.
+
+    Returns:
+        True if the URL is a safe public HTTPS target, else False.
+    """
+    if not url:
+        return False
+    try:
+        validate_url(url, profile=FEDERATION_PROFILE, resolve=True, require_https=True)
+        return True
+    except UrlValidationError:
+        return False
+    except Exception:  # defensive: any resolver/parse error fails closed
+        return False
+
+
+def write_secret_file(
+    path: str,
+    content: str,
+) -> None:
+    """Write ``content`` to ``path`` atomically with ``0o600`` permissions.
+
+    Tokens and the refresh manifest carry live credentials, so they must not be
+    world-readable. Writes to a temp file in the same directory (created with
+    ``0o600`` via ``os.open``), then atomically replaces the target so a reader
+    never observes a partial or default-mode file.
+
+    Args:
+        path: Destination path.
+        content: Text to write.
+    """
+    abs_path = os.path.abspath(path)
+    directory = os.path.dirname(abs_path) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".tmp-", suffix=".secret")
+    try:
+        os.fchmod(fd, _SECRET_FILE_MODE)
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_path, abs_path)
+        # os.replace preserves the temp file's 0o600 mode on the new inode; if
+        # the target pre-existed with looser perms it is now gone (replaced).
+        os.chmod(abs_path, _SECRET_FILE_MODE)
+    except BaseException:
+        # Best-effort cleanup of the temp file on any failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def validate_account_ids(
+    account_ids: list[str],
+    allowlist: list[str] | None = None,
+) -> list[str]:
+    """Validate cross-account IDs against the 12-digit shape and an allowlist.
+
+    Cross-account AssumeRole widens the blast radius to every listed account, so
+    the account set is validated fail-closed:
+
+    - Every ID must match ``^\\d{12}$`` (reject anything else).
+    - When an allowlist is provided (non-empty), every requested ID must be a
+      member; a request for an off-list account raises.
+
+    This helper does NOT decide what happens when no allowlist is supplied — that
+    policy lives at the call site (``sync._parse_account_ids``), which fails
+    CLOSED for cross-account requests unless an allowlist is set or the explicit
+    ``AGENTCORE_ALLOW_ANY_ACCOUNT`` opt-in is present. Callers that pass
+    ``allowlist=None`` here have already made that authorization decision; this
+    function then enforces shape only.
+
+    Args:
+        account_ids: Requested target account IDs.
+        allowlist: Optional explicit allowlist of permitted account IDs.
+
+    Returns:
+        The validated list of account IDs.
+
+    Raises:
+        EgressSecurityError: On a malformed ID or an off-allowlist ID.
+    """
+    for acct in account_ids:
+        if not _ACCOUNT_ID_RE.match(acct):
+            raise EgressSecurityError(
+                f"Invalid AWS account ID {acct!r}: expected exactly 12 digits."
+            )
+    if allowlist:
+        allowed = set(allowlist)
+        rejected = [a for a in account_ids if a not in allowed]
+        if rejected:
+            raise EgressSecurityError(
+                f"Account ID(s) {rejected} are not in AGENTCORE_ALLOWED_ACCOUNTS; "
+                "refusing cross-account AssumeRole (fail closed)."
+            )
+    return account_ids

--- a/cli/agentcore/sync.py
+++ b/cli/agentcore/sync.py
@@ -186,15 +186,24 @@ def _parse_account_ids(accounts_str: str) -> list[str]:
     the set is validated fail-closed at this single chokepoint (feeds both the
     server sync and token-refresh account loops):
 
-    - Every ID must be exactly 12 digits (``validate_account_ids``).
+    - An empty/blank value returns ``[]`` (current-account-only sync). This is
+      the default and is unchanged: single-account deployments are unaffected.
+    - Every requested ID must be exactly 12 digits (``validate_account_ids``).
     - When ``AGENTCORE_ALLOWED_ACCOUNTS`` is set, every requested ID must be a
-      member of that explicit allowlist; an off-list account raises. When it is
-      unset the shape check still applies and the widened (shape-only) scope is
-      logged, preserving backward compatibility for existing single-tenant
-      deployments while making the trust boundary explicit.
+      member of that explicit allowlist; an off-list account raises.
+    - When cross-account IDs are requested but NO allowlist is set, this fails
+      CLOSED: it raises unless the operator has set the separate, discouraged
+      ``AGENTCORE_ALLOW_ANY_ACCOUNT`` opt-in (in which case shape-only validation
+      applies and the widened scope is logged at WARNING). NOTE: this is a
+      behavior change from prior releases, which accepted any 12-digit
+      cross-account list unconditionally -- operators who set
+      ``AGENTCORE_ACCOUNTS`` for cross-account sync must now also set
+      ``AGENTCORE_ALLOWED_ACCOUNTS`` (recommended) or the opt-in.
 
     Raises:
-        EgressSecurityError: On a malformed or off-allowlist account ID.
+        EgressSecurityError: On a malformed or off-allowlist account ID, or on a
+            cross-account request with neither an allowlist nor the explicit
+            ``AGENTCORE_ALLOW_ANY_ACCOUNT`` opt-in.
     """
     if not accounts_str or not accounts_str.strip():
         return []

--- a/cli/agentcore/sync.py
+++ b/cli/agentcore/sync.py
@@ -24,6 +24,11 @@ from .models import (
     DEFAULT_TOKEN_FILE,
     _load_token,
 )
+from .security import (
+    EgressSecurityError,
+    require_secure_registry_url,
+    validate_account_ids,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +53,11 @@ def build_parser() -> argparse.ArgumentParser:
             "  REGISTRY_TOKEN_FILE           Path to registry auth token file\n"
             "  AGENTCORE_ACCOUNTS            Comma-separated account IDs (cross-account)\n"
             "  AGENTCORE_ASSUME_ROLE_NAME    Role name to assume (default: AgentCoreSyncRole)\n"
+            "  AGENTCORE_ALLOWED_ACCOUNTS    Comma-separated allowlist bounding which\n"
+            "                                account IDs may be assumed (recommended for\n"
+            "                                cross-account; required unless the opt-in below)\n"
+            "  AGENTCORE_ALLOW_ANY_ACCOUNT   Set 1/true to accept any 12-digit account when\n"
+            "                                no allowlist is set (fail-open, discouraged)\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -170,10 +180,54 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _parse_account_ids(accounts_str: str) -> list[str]:
-    """Parse comma-separated account IDs, stripping whitespace."""
+    """Parse + validate comma-separated cross-account IDs.
+
+    Cross-account AssumeRole widens the blast radius to every listed account, so
+    the set is validated fail-closed at this single chokepoint (feeds both the
+    server sync and token-refresh account loops):
+
+    - Every ID must be exactly 12 digits (``validate_account_ids``).
+    - When ``AGENTCORE_ALLOWED_ACCOUNTS`` is set, every requested ID must be a
+      member of that explicit allowlist; an off-list account raises. When it is
+      unset the shape check still applies and the widened (shape-only) scope is
+      logged, preserving backward compatibility for existing single-tenant
+      deployments while making the trust boundary explicit.
+
+    Raises:
+        EgressSecurityError: On a malformed or off-allowlist account ID.
+    """
     if not accounts_str or not accounts_str.strip():
         return []
-    return [a.strip() for a in accounts_str.split(",") if a.strip()]
+    requested = [a.strip() for a in accounts_str.split(",") if a.strip()]
+
+    allowlist_str = os.environ.get("AGENTCORE_ALLOWED_ACCOUNTS", "")
+    allowlist = [a.strip() for a in allowlist_str.split(",") if a.strip()]
+    if not allowlist:
+        # No allowlist configured. Fail CLOSED for cross-account AssumeRole unless
+        # the operator has explicitly acknowledged the widened scope, so an
+        # AGENTCORE_ACCOUNTS value coming from a lower-trust source (a manifest, a
+        # control-plane message, a ticket) cannot silently drive AssumeRole into
+        # arbitrary accounts. The explicit opt-in is a separate env var so it
+        # can't be set by the same injection that sets AGENTCORE_ACCOUNTS by
+        # accident.
+        allow_any = os.environ.get("AGENTCORE_ALLOW_ANY_ACCOUNT", "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        if not allow_any:
+            raise EgressSecurityError(
+                f"Refusing cross-account AssumeRole for {len(requested)} account(s): "
+                "set AGENTCORE_ALLOWED_ACCOUNTS to an explicit comma-separated allowlist "
+                "(recommended), or set AGENTCORE_ALLOW_ANY_ACCOUNT=1 to accept any "
+                "12-digit account (fail-open, discouraged)."
+            )
+        logger.warning(
+            "AGENTCORE_ALLOW_ANY_ACCOUNT is set; accepting %d cross-account target(s) on "
+            "12-digit shape validation only, with no allowlist. Prefer AGENTCORE_ALLOWED_ACCOUNTS.",
+            len(requested),
+        )
+    return validate_account_ids(requested, allowlist=allowlist or None)
 
 
 def _assume_role_session(
@@ -224,6 +278,14 @@ def _assume_role_session(
 
 def cmd_sync(args: argparse.Namespace) -> int:
     """Execute the sync subcommand: discover, register, write manifest."""
+    # Fail fast: the sync sends the registry Bearer token on every call, so
+    # refuse a cleartext-HTTP registry to a non-loopback host before doing work.
+    try:
+        require_secure_registry_url(args.registry_url)
+    except EgressSecurityError as e:
+        logger.error(str(e))
+        return 1
+
     # Load registry token
     try:
         token = _load_token(args.token_file)
@@ -244,8 +306,12 @@ def cmd_sync(args: argparse.Namespace) -> int:
 
     registry = RegistryClient(registry_url=args.registry_url, token=token)
 
-    # Determine accounts to scan
-    account_ids = _parse_account_ids(getattr(args, "accounts", ""))
+    # Determine accounts to scan (fails closed on an unauthorized/malformed set)
+    try:
+        account_ids = _parse_account_ids(getattr(args, "accounts", ""))
+    except EgressSecurityError as e:
+        logger.error(str(e))
+        return 1
     role_name = getattr(args, "assume_role_name", "AgentCoreSyncRole")
 
     # Build list of (label, session_or_none) pairs
@@ -311,8 +377,12 @@ def cmd_list(args: argparse.Namespace) -> int:
     """Execute the list subcommand: discover and display resources."""
     from .discovery import AgentCoreScanner
 
-    # Determine accounts to scan
-    account_ids = _parse_account_ids(getattr(args, "accounts", ""))
+    # Determine accounts to scan (fails closed on an unauthorized/malformed set)
+    try:
+        account_ids = _parse_account_ids(getattr(args, "accounts", ""))
+    except EgressSecurityError as e:
+        logger.error(str(e))
+        return 1
     role_name = getattr(args, "assume_role_name", "AgentCoreSyncRole")
 
     account_sessions: list[tuple[str, object]] = []

--- a/cli/agentcore/token_refresher.py
+++ b/cli/agentcore/token_refresher.py
@@ -27,12 +27,24 @@ import argparse
 import json
 import logging
 import os
+import re
 import time
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlparse
 
 import boto3
 import requests
+
+from .models import _warn_if_world_readable
+from .security import (
+    EgressSecurityError,
+    guarded_oidc_get,
+    guarded_oidc_post,
+    is_safe_egress_url,
+    require_secure_registry_url,
+    write_secret_file,
+)
 
 # Configure logging with basicConfig
 logging.basicConfig(
@@ -48,13 +60,28 @@ TOKEN_REQUEST_TIMEOUT: int = 15
 REGISTRY_REQUEST_TIMEOUT: int = 15
 SECURITY_SCAN_TIMEOUT: int = 120
 
-IDP_PATTERNS: dict[str, str] = {
-    "cognito-idp": "cognito",
+# Shape guards for values spliced out of a (registrant/manifest-supplied)
+# Cognito discovery_url before they reach boto3 — the region is interpolated into
+# the client's endpoint host, so it must not carry host-steering characters.
+_AWS_REGION_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+$")
+_COGNITO_POOL_ID_RE = re.compile(r"^[a-z]{2}-[a-z]+-\d+_[A-Za-z0-9]+$")
+
+# IdP vendor detection. Matched against the parsed HOSTNAME on registered-domain
+# boundaries (host == domain or host endswith "." + domain), NEVER as a substring
+# of the whole URL: a substring match ("auth0.com" in url) classifies a look-alike
+# host like ``myorg.auth0.com.attacker.example`` as auth0, and the vendor's real
+# client secret (from AUTH0_CLIENT_SECRET etc.) would then be POSTed to the
+# attacker. Keycloak is the exception — it has no fixed vendor domain and is
+# identified by the ``/realms/`` path segment.
+IDP_HOST_SUFFIXES: dict[str, str] = {
+    "amazoncognito.com": "cognito",
     "auth0.com": "auth0",
     "okta.com": "okta",
+    "oktapreview.com": "okta",
     "microsoftonline.com": "entra",
-    "/realms/": "keycloak",
 }
+# Cognito discovery URLs use the cognito-idp.<region>.amazonaws.com service host.
+_COGNITO_HOST_RE = re.compile(r"^cognito-idp\.[a-z]{2}-[a-z]+-\d+\.amazonaws\.com$")
 
 IDP_SECRET_ENV_VARS: dict[str, str] = {
     "auth0": "AUTH0_CLIENT_SECRET",
@@ -98,16 +125,62 @@ def _read_manifest(
     if not isinstance(entries, list):
         raise ValueError(f"Manifest must be a JSON array, got {type(entries).__name__}")
 
-    logger.info(f"Read {len(entries)} entries from {manifest_path}")
-    return entries
+    # Re-validate each entry's discovery_url at READ time, not just at
+    # registration. The manifest is a credential-fetch driver read fresh on every
+    # refresh; if it was tampered on disk (or hand-authored / delivered from a
+    # lower-trust source), an entry whose discovery_url now points at a private/
+    # metadata/non-HTTPS target must be dropped BEFORE it reaches any egress —
+    # including the Cognito secret path, which parses discovery_url and calls AWS
+    # before the fetch-time guards run. Fail closed: drop the entry, keep the rest.
+    safe_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            logger.error("Dropping malformed manifest entry (not an object): %r", entry)
+            continue
+        # An entry missing either required field cannot drive a valid refresh
+        # (and would KeyError downstream); drop it fail-closed rather than carry
+        # it forward.
+        discovery_url = entry.get("discovery_url", "")
+        if not entry.get("server_path"):
+            logger.error("Dropping manifest entry: missing server_path")
+            continue
+        if not discovery_url:
+            logger.error(
+                "Dropping manifest entry for %s: missing discovery_url",
+                entry.get("server_path", "<unknown>"),
+            )
+            continue
+        if not is_safe_egress_url(discovery_url):
+            logger.error(
+                "Dropping manifest entry for %s: discovery_url failed SSRF/HTTPS "
+                "validation at read time (refusing to drive a credential fetch to it)",
+                entry.get("server_path", "<unknown>"),
+            )
+            continue
+        safe_entries.append(entry)
+
+    logger.info(f"Read {len(safe_entries)} entries from {manifest_path}")
+    return safe_entries
+
+
+def _host_matches_domain(host: str, domain: str) -> bool:
+    """Return True if ``host`` is ``domain`` or a subdomain of it (label-safe).
+
+    Boundary-anchored so ``auth0.com.attacker.example`` does NOT match
+    ``auth0.com`` (it would under a naive substring/endswith-without-dot check).
+    """
+    return host == domain or host.endswith("." + domain)
 
 
 def _detect_idp_vendor(
     discovery_url: str,
 ) -> str:
-    """Detect IdP vendor from OIDC discovery URL.
+    """Detect IdP vendor from an OIDC discovery URL, matching on the HOSTNAME.
 
-    Matches known patterns in the URL string.
+    Parses the URL and matches known vendor domains on registered-domain
+    boundaries (not substring-in-URL), so a look-alike host cannot be
+    misclassified into a vendor whose real client secret would then be sent to
+    it. Keycloak has no fixed domain and is detected by the ``/realms/`` path.
 
     Args:
         discovery_url: OIDC discovery URL.
@@ -115,9 +188,19 @@ def _detect_idp_vendor(
     Returns:
         Vendor name (cognito, auth0, okta, entra, keycloak, or unknown).
     """
-    for pattern, vendor in IDP_PATTERNS.items():
-        if pattern in discovery_url:
+    parsed = urlparse(discovery_url)
+    host = (parsed.hostname or "").lower()
+
+    if host and _COGNITO_HOST_RE.match(host):
+        return "cognito"
+    for domain, vendor in IDP_HOST_SUFFIXES.items():
+        if host and _host_matches_domain(host, domain):
             return vendor
+    # Keycloak: no fixed vendor host — identified by the realm path segment, but
+    # only when the URL is a well-formed http(s) URL with a host (so a bare
+    # attacker string can't trivially claim keycloak).
+    if host and parsed.scheme in ("http", "https") and "/realms/" in (parsed.path or ""):
+        return "keycloak"
     return "unknown"
 
 
@@ -141,6 +224,18 @@ def _get_cognito_client_secret(
         # Parse: https://cognito-idp.{region}.amazonaws.com/{pool_id}/...
         region = discovery_url.split("cognito-idp.")[1].split(".amazonaws")[0]
         pool_id = discovery_url.split("amazonaws.com/")[1].split("/")[0]
+
+        # The region is spliced into the boto3 client's endpoint host
+        # (cognito-idp.{region}.amazonaws.com), so a crafted discovery_url could
+        # otherwise steer the signed request (with the caller's AWS creds) at an
+        # attacker-influenced host. Validate the parsed values fail-closed against
+        # the AWS region / Cognito pool-id shapes before touching boto3.
+        if not _AWS_REGION_RE.match(region):
+            logger.error(f"Refusing Cognito lookup: malformed region {region!r} in discovery_url")
+            return None
+        if not _COGNITO_POOL_ID_RE.match(pool_id):
+            logger.error(f"Refusing Cognito lookup: malformed pool_id {pool_id!r}")
+            return None
 
         client = boto3.client("cognito-idp", region_name=region)
         response = client.describe_user_pool_client(
@@ -217,15 +312,19 @@ def _get_token_endpoint(
         Token endpoint URL, or None on failure.
     """
     try:
-        response = requests.get(
-            discovery_url,
-            timeout=OIDC_DISCOVERY_TIMEOUT,
-        )
+        # SSRF-guard the registrant/manifest-supplied discovery_url: scheme +
+        # default-deny private/loopback/link-local/metadata, IP pinned at connect
+        # time. A poisoned or tampered discovery_url cannot reach an internal
+        # target or downgrade to a non-http(s) scheme.
+        response = guarded_oidc_get(discovery_url, timeout=OIDC_DISCOVERY_TIMEOUT)
         response.raise_for_status()
         token_endpoint = response.json().get("token_endpoint")
         if not token_endpoint:
             logger.error(f"No token_endpoint in OIDC discovery: {discovery_url}")
         return token_endpoint
+    except EgressSecurityError as e:
+        logger.error(f"OIDC discovery blocked by URL guard: {e}")
+        return None
     except Exception as e:
         logger.error(f"OIDC discovery failed for {discovery_url}: {e}")
         return None
@@ -299,17 +398,24 @@ def _request_token(
         data["scope"] = scope
 
     try:
-        response = requests.post(
+        # SSRF-guard the token endpoint too: this request carries the OAuth2
+        # client_secret in the body, and token_endpoint is derived from a
+        # registrant/manifest-supplied discovery document, so it must be proven
+        # non-internal (and http(s)) before the secret leaves the process.
+        response = guarded_oidc_post(
             token_endpoint,
+            timeout=TOKEN_REQUEST_TIMEOUT,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data=data,
-            timeout=TOKEN_REQUEST_TIMEOUT,
         )
         response.raise_for_status()
         token = response.json().get("access_token")
         if not token:
             logger.error("Token response missing access_token field")
         return token
+    except EgressSecurityError as e:
+        logger.error(f"OAuth2 token request blocked by URL guard: {e}")
+        return None
     except Exception as e:
         logger.error(f"Token request failed: {e}")
         return None
@@ -334,6 +440,13 @@ def _update_registry_credential(
     Returns:
         True if update succeeded, False otherwise.
     """
+    # This PATCH carries the registry Bearer JWT and a plaintext upstream OAuth2
+    # access token; refuse to send them over cleartext HTTP to a remote host.
+    try:
+        require_secure_registry_url(registry_url)
+    except EgressSecurityError as e:
+        logger.error(f"Refusing credential PATCH: {e}")
+        return False
     url = f"{registry_url.rstrip('/')}/api/servers{server_path}/auth-credential"
     try:
         response = requests.patch(
@@ -387,6 +500,12 @@ def _trigger_security_scan(
     Returns:
         True if scan was triggered successfully, False otherwise.
     """
+    # Carries the registry Bearer JWT; refuse cleartext HTTP to a remote host.
+    try:
+        require_secure_registry_url(registry_url)
+    except EgressSecurityError as e:
+        logger.error(f"Refusing rescan trigger: {e}")
+        return False
     url = f"{registry_url.rstrip('/')}/api/servers{server_path}/rescan"
     try:
         response = requests.post(
@@ -445,6 +564,7 @@ def _load_registry_token(
         ValueError: If token file is invalid or missing token field.
     """
     abs_path = os.path.abspath(token_file)
+    _warn_if_world_readable(abs_path)
     try:
         with open(abs_path) as f:
             data = json.load(f)
@@ -549,9 +669,10 @@ def refresh_all(
         else:
             failure_count += 1
 
-    # Update manifest with timestamps
-    with open(manifest_path, "w") as f:
-        json.dump(entries, f, indent=2)
+    # Update manifest with timestamps. The manifest holds OIDC discovery URLs
+    # and per-client refresh metadata used to mint credentials, so write it
+    # 0o600 (owner-only) atomically rather than a world-readable default-mode file.
+    write_secret_file(manifest_path, json.dumps(entries, indent=2))
 
     elapsed = time.time() - start_time
     summary: dict[str, Any] = {

--- a/docs/agentcore.md
+++ b/docs/agentcore.md
@@ -253,6 +253,8 @@ uv run python -m cli.agentcore.token_refresher \
 | `KEYCLOAK_CLIENT_SECRET` | -- | Client secret for Keycloak gateways |
 | `AGENTCORE_ACCOUNTS` | -- | Comma-separated AWS account IDs for cross-account scanning |
 | `AGENTCORE_ASSUME_ROLE_NAME` | `AgentCoreSyncRole` | IAM role name to assume in each target account |
+| `AGENTCORE_ALLOWED_ACCOUNTS` | -- | Comma-separated allowlist bounding which account IDs may be assumed. **Recommended** whenever `AGENTCORE_ACCOUNTS` is set: an account not on this list is rejected before any `AssumeRole`. When set it is authoritative and the opt-in below is ignored. |
+| `AGENTCORE_ALLOW_ANY_ACCOUNT` | -- | Set `1`/`true`/`yes` to accept any well-formed (12-digit) account ID when no allowlist is configured. This is a **fail-open opt-in and is discouraged** — prefer `AGENTCORE_ALLOWED_ACCOUNTS`. Without either, cross-account scanning fails closed. |
 
 ### Cross-Account Scanning
 
@@ -276,11 +278,20 @@ uv run python -m cli.agentcore sync
 
 How it works:
 
-1. The CLI parses the `--accounts` flag (or `AGENTCORE_ACCOUNTS` env var) into a list of account IDs.
-2. For each account, it calls `sts:AssumeRole` on `arn:aws:iam::{account_id}:role/{role_name}` to obtain temporary credentials.
-3. A boto3 session is created with those temporary credentials and passed to the scanner and registration builder.
-4. Discovery and registration proceed as normal, scoped to each account's resources.
-5. If `--accounts` is not provided, the CLI scans only the current account (default behavior).
+1. The CLI parses the `--accounts` flag (or `AGENTCORE_ACCOUNTS` env var) into a list of account IDs. Each ID is validated to be exactly 12 digits; a malformed ID is rejected before any AWS call.
+2. Cross-account scanning is **gated fail-closed**: if `AGENTCORE_ACCOUNTS` is non-empty, the run proceeds only when `AGENTCORE_ALLOWED_ACCOUNTS` lists every requested account, or when `AGENTCORE_ALLOW_ANY_ACCOUNT` is explicitly set. Otherwise the CLI refuses and explains how to authorize the accounts. This prevents an `AGENTCORE_ACCOUNTS` value from a lower-trust source (a manifest, a control-plane message) from silently driving `AssumeRole` into arbitrary accounts.
+3. For each authorized account, it calls `sts:AssumeRole` on `arn:aws:iam::{account_id}:role/{role_name}` to obtain temporary credentials.
+4. A boto3 session is created with those temporary credentials and passed to the scanner and registration builder.
+5. Discovery and registration proceed as normal, scoped to each account's resources.
+6. If `--accounts` is not provided, the CLI scans only the current account (default behavior) — the allowlist gate does not apply.
+
+Example with an allowlist (recommended):
+
+```bash
+export AGENTCORE_ACCOUNTS=111111111111,222222222222
+export AGENTCORE_ALLOWED_ACCOUNTS=111111111111,222222222222
+uv run python -m cli.agentcore sync
+```
 
 If `AssumeRole` fails for any account, the CLI stops and reports the error.
 

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -43,14 +43,44 @@ import logging
 import socket
 from dataclasses import dataclass, field
 from functools import lru_cache
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 import httpx
 
-from ..core.config import settings
 from ..exceptions import UrlValidationError
 
+if TYPE_CHECKING:
+    from ..core.config import Settings
+
 logger = logging.getLogger(__name__)
+
+
+# Registry settings are bound lazily on first use rather than imported at module
+# load: importing ``registry.core.config`` eagerly builds the full ``Settings()``
+# (SECRET_KEY, DocumentDB, etc.), which a standalone tool that only needs the
+# SSRF/URL guard (e.g. the AgentCore sync sidecar in ``cli/agentcore``) must not
+# require. This stays ``None`` until an allowlist factory actually needs operator
+# config, so ``import registry.utils.url_guard`` — and ``validate_url`` /
+# ``guarded_*`` with the default (empty) allowlist, e.g. FEDERATION_PROFILE —
+# work with zero registry server configuration. Tests patch this attribute
+# directly (``patch("registry.utils.url_guard.settings", ...)``).
+settings: Settings | None = None
+
+
+def _get_settings() -> Settings:
+    """Return the registry settings object, binding it lazily on first use.
+
+    Honors a caller/test-supplied module-level ``settings`` (patched in tests);
+    otherwise imports ``registry.core.config.settings`` on first access so the
+    heavy config is never built merely by importing this module.
+    """
+    if settings is not None:
+        return settings
+    from ..core.config import settings as _resolved
+
+    return _resolved
+
 
 # Default connect/read timeout applied to guarded fetches when a caller does not
 # supply its own. Keeps a hung internal target from tying up a worker.
@@ -174,7 +204,7 @@ def _skill_allowlist() -> _Allowlist:
     validation. Only operator-configured GHES hosts skip the private-IP block.
     Cached because settings are immutable per-process.
     """
-    return _Allowlist(hosts=_parse_hosts(settings.github_extra_hosts))
+    return _Allowlist(hosts=_parse_hosts(_get_settings().github_extra_hosts))
 
 
 @lru_cache(maxsize=1)
@@ -187,9 +217,10 @@ def _proxy_allowlist() -> _Allowlist:
     upgrade to an SSRF-guarded build keeps them healthy with zero configuration.
     Cached because settings are immutable per-process.
     """
+    _settings = _get_settings()
     return _Allowlist(
-        hosts=_BUILTIN_PROXY_ALLOWED_HOSTS | _parse_hosts(settings.ssrf_allowed_hosts),
-        cidrs=_parse_cidrs(settings.ssrf_allowed_cidrs),
+        hosts=_BUILTIN_PROXY_ALLOWED_HOSTS | _parse_hosts(_settings.ssrf_allowed_hosts),
+        cidrs=_parse_cidrs(_settings.ssrf_allowed_cidrs),
     )
 
 

--- a/tests/unit/cli/test_agentcore_cross_account.py
+++ b/tests/unit/cli/test_agentcore_cross_account.py
@@ -18,9 +18,17 @@ import pytest
 class TestParseAccountIds:
     """Tests for _parse_account_ids helper."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_account_env(self, monkeypatch):
+        # Isolate from any ambient allowlist / opt-in the host env may carry.
+        monkeypatch.delenv("AGENTCORE_ALLOWED_ACCOUNTS", raising=False)
+        monkeypatch.delenv("AGENTCORE_ALLOW_ANY_ACCOUNT", raising=False)
+
     def test_empty_string_returns_empty_list(self):
         from cli.agentcore.sync import _parse_account_ids
 
+        # Empty (single-account / current-account mode) never triggers the
+        # cross-account allowlist gate.
         assert _parse_account_ids("") == []
 
     def test_whitespace_only_returns_empty_list(self):
@@ -28,28 +36,64 @@ class TestParseAccountIds:
 
         assert _parse_account_ids("   ") == []
 
-    def test_single_account(self):
+    def test_single_account_with_opt_in(self, monkeypatch):
         from cli.agentcore.sync import _parse_account_ids
 
+        monkeypatch.setenv("AGENTCORE_ALLOW_ANY_ACCOUNT", "1")
         assert _parse_account_ids("111122223333") == ["111122223333"]
 
-    def test_multiple_accounts(self):
+    def test_multiple_accounts_with_opt_in(self, monkeypatch):
         from cli.agentcore.sync import _parse_account_ids
 
+        monkeypatch.setenv("AGENTCORE_ALLOW_ANY_ACCOUNT", "true")
         result = _parse_account_ids("111122223333,444455556666,777788889999")
         assert result == ["111122223333", "444455556666", "777788889999"]
 
-    def test_strips_whitespace(self):
+    def test_strips_whitespace(self, monkeypatch):
         from cli.agentcore.sync import _parse_account_ids
 
+        monkeypatch.setenv("AGENTCORE_ALLOW_ANY_ACCOUNT", "1")
         result = _parse_account_ids(" 111122223333 , 444455556666 ")
         assert result == ["111122223333", "444455556666"]
 
-    def test_ignores_empty_entries(self):
+    def test_ignores_empty_entries(self, monkeypatch):
         from cli.agentcore.sync import _parse_account_ids
 
+        monkeypatch.setenv("AGENTCORE_ALLOW_ANY_ACCOUNT", "1")
         result = _parse_account_ids("111122223333,,444455556666,")
         assert result == ["111122223333", "444455556666"]
+
+    def test_fails_closed_without_allowlist_or_opt_in(self):
+        # The core fail-closed guard: cross-account with neither an allowlist nor
+        # the explicit opt-in must raise before any AssumeRole.
+        from cli.agentcore.security import EgressSecurityError
+        from cli.agentcore.sync import _parse_account_ids
+
+        with pytest.raises(EgressSecurityError):
+            _parse_account_ids("111122223333")
+
+    def test_rejects_malformed_account_id(self, monkeypatch):
+        # Non-12-digit IDs are rejected fail-closed even with the opt-in set.
+        from cli.agentcore.security import EgressSecurityError
+        from cli.agentcore.sync import _parse_account_ids
+
+        monkeypatch.setenv("AGENTCORE_ALLOW_ANY_ACCOUNT", "1")
+        with pytest.raises(EgressSecurityError):
+            _parse_account_ids("12345,444455556666")
+
+    def test_allowlist_permits_listed_accounts(self, monkeypatch):
+        from cli.agentcore.sync import _parse_account_ids
+
+        monkeypatch.setenv("AGENTCORE_ALLOWED_ACCOUNTS", "111122223333,444455556666")
+        assert _parse_account_ids("111122223333") == ["111122223333"]
+
+    def test_allowlist_rejects_unlisted_account(self, monkeypatch):
+        from cli.agentcore.security import EgressSecurityError
+        from cli.agentcore.sync import _parse_account_ids
+
+        monkeypatch.setenv("AGENTCORE_ALLOWED_ACCOUNTS", "111122223333")
+        with pytest.raises(EgressSecurityError):
+            _parse_account_ids("999988887777")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_agentcore_registration.py
+++ b/tests/unit/cli/test_agentcore_registration.py
@@ -411,7 +411,10 @@ class TestRegistrationErrorHandling:
 class TestOIDCMetadata:
     """Tests for OIDC metadata enrichment in gateway registration."""
 
-    def test_custom_jwt_gateway_has_oidc_metadata(self):
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=True)
+    def test_custom_jwt_gateway_has_oidc_metadata(self, _mock_safe):
+        # is_safe_egress_url is patched safe (avoids real DNS in unit tests);
+        # a separate test covers the unsafe-URL drop path.
         builder = _make_builder()
         reg = builder.build_gateway_registration(SAMPLE_GATEWAY)
 
@@ -421,6 +424,18 @@ class TestOIDCMetadata:
         )
         assert reg.metadata["allowed_clients"] == ["7kqi2l0n47mnfmhfapsf29ch4h"]
         assert reg.metadata["idp_vendor"] == "cognito"
+
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=False)
+    def test_custom_jwt_unsafe_discovery_url_is_dropped(self, _mock_unsafe):
+        # A discovery_url that fails SSRF/scheme validation must NOT be persisted
+        # into the registration metadata (fail closed — no stored credential-fetch
+        # target that resolves to an internal/attacker endpoint).
+        builder = _make_builder()
+        reg = builder.build_gateway_registration(SAMPLE_GATEWAY)
+
+        assert "discovery_url" not in reg.metadata
+        assert "allowed_clients" not in reg.metadata
+        assert "idp_vendor" not in reg.metadata
 
     def test_none_auth_gateway_has_no_oidc_metadata(self):
         builder = _make_builder()
@@ -500,6 +515,23 @@ class TestDetectIdpVendor:
             == "unknown"
         )
 
+    def test_lookalike_vendor_host_is_not_classified(self):
+        # A host that merely CONTAINS a vendor domain as a non-suffix label must
+        # NOT be classified into that vendor — otherwise the vendor's real client
+        # secret would be POSTed to the attacker's look-alike host.
+        from cli.agentcore.registration import _detect_idp_vendor
+
+        assert (
+            _detect_idp_vendor(
+                "https://myorg.auth0.com.attacker.example/.well-known/openid-configuration"
+            )
+            == "unknown"
+        )
+        assert (
+            _detect_idp_vendor("https://cognito-idp.us-east-1.amazonaws.com.evil.example/x")
+            == "unknown"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Manifest collection and writing
@@ -507,9 +539,17 @@ class TestDetectIdpVendor:
 
 
 class TestManifest:
-    """Tests for manifest collection and writing."""
+    """Tests for manifest collection and writing.
 
-    def test_custom_jwt_gateway_collects_manifest_entry(self):
+    ``is_safe_egress_url`` is patched safe in the collection tests: it performs
+    real DNS resolution (``resolve=True``), which would make these unit tests
+    depend on the network and fail in an offline/isolated sandbox. The unsafe
+    path is covered separately by
+    ``TestManifestDiscoveryGuard::test_unsafe_discovery_url_not_collected``.
+    """
+
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=True)
+    def test_custom_jwt_gateway_collects_manifest_entry(self, _mock_safe):
         orch, registry, scanner = _make_orchestrator()
         scanner.scan_gateways.return_value = [SAMPLE_GATEWAY]
 
@@ -540,7 +580,8 @@ class TestManifest:
 
         assert len(orch._manifest_entries) == 0
 
-    def test_dry_run_collects_manifest_entries(self):
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=True)
+    def test_dry_run_collects_manifest_entries(self, _mock_safe):
         orch, registry, scanner = _make_orchestrator(dry_run=True)
         scanner.scan_gateways.return_value = [SAMPLE_GATEWAY]
 
@@ -548,7 +589,8 @@ class TestManifest:
 
         assert len(orch._manifest_entries) == 1
 
-    def test_write_manifest_creates_file(self, tmp_path):
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=True)
+    def test_write_manifest_creates_file(self, _mock_safe, tmp_path):
         manifest_file = tmp_path / "manifest.json"
         orch, registry, scanner = _make_orchestrator()
         orch.manifest_path = str(manifest_file)
@@ -558,10 +600,14 @@ class TestManifest:
         orch.write_manifest()
 
         import json
+        import os
+        import stat
 
         data = json.loads(manifest_file.read_text())
         assert len(data) == 1
         assert data[0]["idp_vendor"] == "cognito"
+        # The manifest carries OIDC discovery URLs; it must be written 0o600.
+        assert stat.S_IMODE(os.stat(manifest_file).st_mode) == 0o600
 
     def test_write_manifest_dry_run_skips(self, tmp_path):
         manifest_file = tmp_path / "manifest.json"
@@ -579,5 +625,19 @@ class TestManifest:
         scanner.scan_runtimes.return_value = [SAMPLE_MCP_RUNTIME]
 
         orch.sync_runtimes()
+
+        assert len(orch._manifest_entries) == 0
+
+
+class TestManifestDiscoveryGuard:
+    """A CUSTOM_JWT gateway whose discoveryUrl fails SSRF/HTTPS validation must
+    not be collected into the refresh manifest (fail closed)."""
+
+    @patch("cli.agentcore.registration.is_safe_egress_url", return_value=False)
+    def test_unsafe_discovery_url_not_collected(self, _mock_unsafe):
+        orch, registry, scanner = _make_orchestrator()
+        scanner.scan_gateways.return_value = [SAMPLE_GATEWAY]
+
+        orch.sync_gateways()
 
         assert len(orch._manifest_entries) == 0

--- a/tests/unit/cli/test_agentcore_security.py
+++ b/tests/unit/cli/test_agentcore_security.py
@@ -1,0 +1,168 @@
+"""Unit tests for cli.agentcore.security egress + secret-handling guards.
+
+Covers the four hardening surfaces added for the AgentCore sync adapter:
+- require_secure_registry_url: refuse credentials over cleartext to non-loopback
+- guarded_oidc_get / guarded_oidc_post: SSRF-guard registrant-supplied OIDC URLs
+- is_safe_egress_url: registration-time validation (no network I/O by contract)
+- write_secret_file: 0o600 atomic writes for on-disk credentials
+- validate_account_ids: 12-digit shape + explicit allowlist (fail closed)
+
+Each guard is proven to FAIL CLOSED: the vulnerable input is rejected, and the
+safe input is accepted.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import stat
+from unittest.mock import patch
+
+import pytest
+
+from cli.agentcore.security import (
+    EgressSecurityError,
+    is_safe_egress_url,
+    require_secure_registry_url,
+    validate_account_ids,
+    write_secret_file,
+)
+
+
+def _resolve_to(*ips):
+    """getaddrinfo stub resolving any host to the given public IP(s)."""
+
+    def _fake(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0)) for ip in ips]
+
+    return _fake
+
+
+class TestRequireSecureRegistryUrl:
+    """Credentials must never go over cleartext HTTP to a non-loopback host."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://registry.example.com",
+            "https://registry.example.com:8443/base",
+            "http://localhost:7860",
+            "http://127.0.0.1",
+            "http://127.0.0.1:9090/x",
+            "http://[::1]:7860",
+        ],
+    )
+    def test_accepts_https_or_loopback(self, url):
+        # Does not raise.
+        require_secure_registry_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://registry.example.com",
+            "http://10.0.0.5:7860",
+            "http://registry.internal",
+            "http://192.168.1.10",
+        ],
+    )
+    def test_rejects_cleartext_to_remote_host(self, url):
+        with pytest.raises(EgressSecurityError):
+            require_secure_registry_url(url)
+
+    @pytest.mark.parametrize("url", ["ftp://x.com", "gopher://x", "file:///etc/passwd"])
+    def test_rejects_non_http_scheme(self, url):
+        with pytest.raises(EgressSecurityError):
+            require_secure_registry_url(url)
+
+
+class TestIsSafeEgressUrl:
+    """Registration-time SSRF/scheme validation for a discovery_url."""
+
+    def test_public_https_is_safe(self):
+        # Stub DNS so the test is hermetic (is_safe_egress_url resolves the host).
+        from registry.utils import url_guard
+
+        with patch.object(url_guard.socket, "getaddrinfo", _resolve_to("93.184.216.34")):
+            assert is_safe_egress_url(
+                "https://cognito-idp.us-east-1.amazonaws.com/pool/.well-known/openid-configuration"
+            )
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+            "http://127.0.0.1/.well-known/openid-configuration",  # loopback
+            "http://10.0.0.1/x",  # private
+            "ftp://example.com/x",  # non-http scheme
+            "not-a-url",
+        ],
+    )
+    def test_unsafe_urls_rejected(self, url):
+        assert is_safe_egress_url(url) is False
+
+    def test_cleartext_http_public_url_rejected(self):
+        # A discovery_url is where the client secret is later sent, so plain
+        # http:// to even a public host must be rejected (require_https). This
+        # is the fix for the fail-open the reviewer caught.
+        assert (
+            is_safe_egress_url("http://auth.example.com/.well-known/openid-configuration") is False
+        )
+
+
+class TestWriteSecretFile:
+    """On-disk credentials must be written 0o600, atomically."""
+
+    def test_writes_owner_only_mode(self, tmp_path):
+        target = tmp_path / "token_refresh_manifest.json"
+        write_secret_file(str(target), '{"a": 1}')
+        assert target.read_text() == '{"a": 1}'
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+
+    def test_overwrites_existing_loosening_mode(self, tmp_path):
+        # A pre-existing world-readable file must end up 0o600 after rewrite.
+        target = tmp_path / "creds.json"
+        target.write_text("old")
+        os.chmod(target, 0o644)
+        write_secret_file(str(target), "new")
+        assert target.read_text() == "new"
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o600
+
+    def test_no_partial_file_on_success(self, tmp_path):
+        # Only the final file exists; no leftover temp files in the directory.
+        target = tmp_path / "t.json"
+        write_secret_file(str(target), "data")
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".tmp-")]
+        assert leftovers == []
+
+
+class TestValidateAccountIds:
+    """Cross-account IDs: 12-digit shape + explicit allowlist, fail closed."""
+
+    def test_valid_ids_pass_without_allowlist(self):
+        ids = ["123456789012", "210987654321"]
+        assert validate_account_ids(ids) == ids
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "12345",  # too short
+            "1234567890123",  # too long
+            "12345678901a",  # non-digit
+            "arn:aws:iam::123456789012:root",  # not an id
+            "",
+        ],
+    )
+    def test_malformed_id_rejected(self, bad):
+        with pytest.raises(EgressSecurityError):
+            validate_account_ids([bad])
+
+    def test_allowlist_permits_member(self):
+        assert validate_account_ids(
+            ["123456789012"], allowlist=["123456789012", "999999999999"]
+        ) == ["123456789012"]
+
+    def test_allowlist_rejects_off_list_account(self):
+        with pytest.raises(EgressSecurityError):
+            validate_account_ids(["123456789012"], allowlist=["999999999999"])

--- a/tests/unit/cli/test_agentcore_token_refresher.py
+++ b/tests/unit/cli/test_agentcore_token_refresher.py
@@ -65,9 +65,14 @@ class TestDetectIdpVendor:
 
 
 class TestReadManifest:
-    """Tests for manifest reading."""
+    """Tests for manifest reading.
 
-    def test_reads_valid_manifest(self, tmp_path):
+    ``is_safe_egress_url`` is patched to avoid real DNS in unit tests; the
+    read-time SSRF re-validation drop path has its own dedicated test below.
+    """
+
+    @patch("cli.agentcore.token_refresher.is_safe_egress_url", return_value=True)
+    def test_reads_valid_manifest(self, _mock_safe, tmp_path):
         manifest = tmp_path / "manifest.json"
         entries = [{"server_path": "/test", "discovery_url": "https://example.com"}]
         manifest.write_text(json.dumps(entries))
@@ -93,6 +98,55 @@ class TestReadManifest:
 
         with pytest.raises(ValueError, match="JSON array"):
             _read_manifest(str(manifest))
+
+    @patch("cli.agentcore.token_refresher.is_safe_egress_url", return_value=False)
+    def test_drops_entry_with_unsafe_discovery_url(self, _mock_unsafe, tmp_path):
+        # A manifest entry whose discovery_url fails SSRF/HTTPS validation at read
+        # time is dropped fail-closed (covers a tampered-on-disk manifest driving
+        # the Cognito secret path before the fetch-time guards run).
+        manifest = tmp_path / "manifest.json"
+        entries = [
+            {"server_path": "/evil", "discovery_url": "http://169.254.169.254/x"},
+        ]
+        manifest.write_text(json.dumps(entries))
+
+        result = _read_manifest(str(manifest))
+        assert result == []
+
+    @patch("cli.agentcore.token_refresher.is_safe_egress_url", return_value=True)
+    def test_drops_entry_missing_server_path(self, _mock_safe, tmp_path):
+        # An entry missing server_path would KeyError in refresh_all; drop it.
+        manifest = tmp_path / "manifest.json"
+        entries = [{"discovery_url": "https://good.example.com/x"}]
+        manifest.write_text(json.dumps(entries))
+
+        result = _read_manifest(str(manifest))
+        assert result == []
+
+    @patch("cli.agentcore.token_refresher.is_safe_egress_url", return_value=True)
+    def test_drops_non_dict_entry(self, _mock_safe, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                ["not-an-object", {"server_path": "/ok", "discovery_url": "https://ok.example/x"}]
+            )
+        )
+
+        result = _read_manifest(str(manifest))
+        assert [e["server_path"] for e in result] == ["/ok"]
+
+    @patch("cli.agentcore.token_refresher.is_safe_egress_url")
+    def test_keeps_safe_drops_unsafe_mixed(self, mock_safe, tmp_path):
+        mock_safe.side_effect = lambda u: u.startswith("https://good")
+        manifest = tmp_path / "manifest.json"
+        entries = [
+            {"server_path": "/good", "discovery_url": "https://good.example.com/x"},
+            {"server_path": "/bad", "discovery_url": "https://evil.example.com/x"},
+        ]
+        manifest.write_text(json.dumps(entries))
+
+        result = _read_manifest(str(manifest))
+        assert [e["server_path"] for e in result] == ["/good"]
 
 
 # ---------------------------------------------------------------------------
@@ -129,10 +183,33 @@ class TestGetCognitoClientSecret:
         mock_boto3.client.side_effect = Exception("Access denied")
 
         result = _get_cognito_client_secret(
-            "https://cognito-idp.us-east-1.amazonaws.com/pool/.well-known/openid-configuration",
+            "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc/.well-known/openid-configuration",
             "client-id",
         )
         assert result is None
+
+    @patch("cli.agentcore.token_refresher.boto3")
+    def test_rejects_host_steering_region(self, mock_boto3):
+        # A crafted region spliced from a tampered discovery_url is interpolated
+        # into the boto3 endpoint host — reject it (shape guard) BEFORE any AWS
+        # client is built, so boto3 is never called with an attacker host.
+        malicious = (
+            "https://cognito-idp.us-east-1.attacker.example#.amazonaws.com/"
+            "us-east-1_abc/.well-known/openid-configuration"
+        )
+        result = _get_cognito_client_secret(malicious, "client-id")
+        assert result is None
+        mock_boto3.client.assert_not_called()
+
+    @patch("cli.agentcore.token_refresher.boto3")
+    def test_rejects_malformed_pool_id(self, mock_boto3):
+        malicious = (
+            "https://cognito-idp.us-east-1.amazonaws.com/"
+            "../../evil/.well-known/openid-configuration"
+        )
+        result = _get_cognito_client_secret(malicious, "client-id")
+        assert result is None
+        mock_boto3.client.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +270,7 @@ class TestGetClientSecret:
 class TestGetTokenEndpoint:
     """Tests for OIDC discovery token endpoint extraction."""
 
-    @patch("cli.agentcore.token_refresher.requests.get")
+    @patch("cli.agentcore.token_refresher.guarded_oidc_get")
     def test_extracts_token_endpoint(self, mock_get):
         mock_response = MagicMock()
         mock_response.json.return_value = {
@@ -205,11 +282,22 @@ class TestGetTokenEndpoint:
         result = _get_token_endpoint("https://auth.example.com/.well-known/openid-configuration")
         assert result == "https://auth.example.com/oauth2/token"
 
-    @patch("cli.agentcore.token_refresher.requests.get")
+    @patch("cli.agentcore.token_refresher.guarded_oidc_get")
     def test_returns_none_on_error(self, mock_get):
         mock_get.side_effect = Exception("Connection refused")
 
         result = _get_token_endpoint("https://unreachable.example.com")
+        assert result is None
+
+    @patch("cli.agentcore.token_refresher.guarded_oidc_get")
+    def test_returns_none_when_url_guard_blocks(self, mock_get):
+        # discovery_url that fails SSRF/scheme validation is refused before any
+        # HTTP request; _get_token_endpoint fails closed (None).
+        from cli.agentcore.security import EgressSecurityError
+
+        mock_get.side_effect = EgressSecurityError("blocked: private target")
+
+        result = _get_token_endpoint("http://169.254.169.254/.well-known/openid-configuration")
         assert result is None
 
 
@@ -221,7 +309,7 @@ class TestGetTokenEndpoint:
 class TestRequestToken:
     """Tests for OAuth2 client_credentials token request."""
 
-    @patch("cli.agentcore.token_refresher.requests.post")
+    @patch("cli.agentcore.token_refresher.guarded_oidc_post")
     def test_successful_token_request(self, mock_post):
         mock_response = MagicMock()
         mock_response.json.return_value = {"access_token": "eyJtoken123"}
@@ -240,7 +328,18 @@ class TestRequestToken:
         assert call_data["client_id"] == "client-id"
         assert call_data["client_secret"] == "client-secret"
 
-    @patch("cli.agentcore.token_refresher.requests.post")
+    @patch("cli.agentcore.token_refresher.guarded_oidc_post")
+    def test_returns_none_when_url_guard_blocks(self, mock_post):
+        # token_endpoint that fails SSRF/scheme validation is refused before the
+        # client_secret leaves the process; _request_token fails closed (None).
+        from cli.agentcore.security import EgressSecurityError
+
+        mock_post.side_effect = EgressSecurityError("blocked: private target")
+
+        result = _request_token("http://127.0.0.1/token", "id", "secret")
+        assert result is None
+
+    @patch("cli.agentcore.token_refresher.guarded_oidc_post")
     def test_returns_none_on_error(self, mock_post):
         mock_post.side_effect = Exception("401 Unauthorized")
 
@@ -404,7 +503,18 @@ class TestTriggerSecurityScan:
 
 
 class TestRefreshAll:
-    """Tests for the end-to-end refresh_all flow."""
+    """Tests for the end-to-end refresh_all flow.
+
+    These exercise the refresh orchestration, not the SSRF guard, so the
+    read-time discovery_url validation is stubbed safe (real validation +
+    drop behavior is covered by TestReadManifest). Avoids real DNS on the
+    sample https discovery URLs.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _allow_manifest_urls(self):
+        with patch("cli.agentcore.token_refresher.is_safe_egress_url", return_value=True):
+            yield
 
     def _write_manifest(self, tmp_path, entries):
         manifest = tmp_path / "manifest.json"


### PR DESCRIPTION
# Harden the AgentCore sync adapter's egress and secret handling

## Summary

The AgentCore sync adapter (`cli/agentcore/`) is a standalone CLI/sidecar that
discovers Bedrock AgentCore gateways, registers them with the registry, and
refreshes upstream OAuth2 credentials. This PR adds:

1. **Credentials never travel over cleartext.** The registry hop (which carries
   the registry Bearer JWT and a minted upstream access token) refuses plain
   `http://` to any non-loopback host. The OIDC hops (which carry the OAuth2
   client secret) require HTTPS.

2. **Registrant/manifest-supplied OIDC URLs are SSRF-guarded.** The
   `discovery_url` (from Bedrock gateway metadata) and the `token_endpoint`
   derived from it are validated through the registry's canonical URL guard —
   default-deny for private/loopback/link-local/reserved/cloud-metadata targets,
   with the resolved IP pinned at connect time (rebinding-safe). Validation runs
   at three points: when a registration is built, when the refresh manifest is
   written, and again when the manifest is read at refresh time (a tampered
   manifest cannot drive a credential fetch to an internal or non-HTTPS target).

3. **IdP vendor detection is host-anchored, not substring-based.** Vendor
   classification now matches the parsed hostname on registered-domain
   boundaries, so a look-alike host such as `myorg.auth0.com.attacker.example`
   is no longer classified as the real vendor

4. **The Cognito client-secret lookup validates before calling AWS.** The
   `region`/`pool_id` spliced out of a discovery URL are shape-checked before a
   boto3 client is built.

5. **On-disk secrets are written `0o600` atomically.** The refresh manifest is
   written owner-only via a temp-file + atomic-rename helper (no world-readable
   or partial-file window). Token files that the adapter reads are checked and a
   warning is logged if they are group/other-readable.

6. **Cross-account AssumeRole fails closed.** Account IDs are validated to the
   12-digit shape, and cross-account scanning is refused unless an explicit
   `AGENTCORE_ALLOWED_ACCOUNTS` allowlist authorizes the requested accounts (or
   the operator sets the separate, discouraged `AGENTCORE_ALLOW_ANY_ACCOUNT`
   opt-in). This prevents an `AGENTCORE_ACCOUNTS` value from a lower-trust source
   from silently driving AssumeRole into arbitrary accounts.

## Why it's safer / how it fails closed

- Every guard denies on error, missing config, or ambiguity.
- The OIDC egress uses the canonical guard's federation profile, which carries an
  empty bypass allowlist — no operator config can re-permit an internal target on
  this path, and the cloud-metadata endpoint is never reachable.
- The canonical URL guard is reused rather than reimplemented. To let this
  standalone tool import it without the registry's server configuration
  (SECRET_KEY, DocumentDB, etc.), the guard's settings access was made lazy — a
  pure import-decoupling that does not change validation behavior for existing
  registry consumers (verified: full existing url_guard/consumer suites pass).

## Tests

- New `tests/unit/cli/test_agentcore_security.py` covers each guard's
  fail-closed behavior (cleartext-to-remote rejected, HTTPS/loopback accepted,
  SSRF/metadata/private/non-HTTPS URLs rejected, `0o600` atomic write incl.
  overwrite of a loose-mode file, account-id shape + allowlist).
- `test_agentcore_token_refresher.py`: OIDC fetches go through the guarded
  helpers and fail closed when blocked; Cognito host-steering region and
  malformed pool-id are rejected before boto3; manifest read drops unsafe /
  missing-field / non-dict entries; look-alike hosts classify `unknown`.
- `test_agentcore_cross_account.py`: cross-account fails closed without an
  allowlist or the explicit opt-in; allowlist permits/rejects correctly.
- `test_agentcore_registration.py`: an unsafe `discovery_url` is not persisted;
  the manifest is written `0o600`; look-alike vendor hosts are not classified.
- Full existing agentcore + url_guard + downstream consumer suites remain green.

## Documentation

`docs/agentcore.md` documents the two new environment variables
(`AGENTCORE_ALLOWED_ACCOUNTS`, `AGENTCORE_ALLOW_ANY_ACCOUNT`) and the
fail-closed cross-account behavior; the CLI `--help` epilog lists them too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
