### PR TITLE
fix(egress): apply transient-failure hardening to the token vend read path (follow-up to #1490)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6931,6 +6931,20 @@ async def mcp_proxy(
         relay_authorization=relay_ingress_auth,
     )
 
+    # Re-authorize the caller's scopes against the EXACT body we are about to act
+    # on, BEFORE any outbound work (egress vend or upstream forward). /validate
+    # authorizes on a separately-captured copy (X-Body) that can diverge from this
+    # body (e.g. a large body that spilled to disk, which /validate then treats as
+    # an unprivileged "initialize"), so we authorize the forwarded bytes here and
+    # fail closed on any body we cannot parse (TM-15). Running this FIRST is a
+    # security ordering guarantee: an unscoped caller is denied 403 regardless of
+    # egress-vend / OpenBao availability -- otherwise a transient vend failure
+    # (503) could mask a genuine authorization denial, turning a "denied" into a
+    # "retry later" in responses, logs, and metrics. Authorized-but-not-connected
+    # callers still pass here and reach the egress consent/local-answer paths
+    # below (they already had these methods in scope on the connected path).
+    await _authorize_forwarded_mcp_body(server_name, request_body, user_scopes)
+
     # True once we inject a vaulted egress token below. An egress upstream is
     # itself an OAuth resource server: if it rejects our injected token it 401s
     # with its OWN WWW-Authenticate (resource_metadata pointing at the upstream's
@@ -7184,18 +7198,6 @@ async def mcp_proxy(
                     req_id=req_id,
                     vend=vend,
                 )
-
-    # Re-authorize the caller's scopes against the EXACT body we are about to
-    # forward upstream. /validate authorizes on a separately-captured copy
-    # (X-Body) that can diverge from this body (e.g. a large body that spilled to
-    # disk, which /validate then treats as an unprivileged "initialize"), so we
-    # authorize the forwarded bytes here and fail closed on any body we cannot
-    # parse (TM-15). This runs AFTER the egress-consent block above so methods the
-    # gateway answers LOCALLY for a tokenless egress server (initialize,
-    # notifications/*, tools/list, tools/call consent) are never gated here --
-    # they are not forwarded upstream. Only the request we actually forward is
-    # re-authorized. Raises 403 before the outbound call.
-    await _authorize_forwarded_mcp_body(server_name, request_body, user_scopes)
 
     logger.info(
         f"mcp_proxy: server={server_name} method={incoming_method} filter_enabled={filter_enabled} timeout={proxy_timeout}"

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6233,6 +6233,50 @@ _EGRESS_STRIP_HEADERS: frozenset[str] = frozenset(
 )
 
 
+class EgressVendUnavailable(Exception):
+    """The registry's egress-token vend failed *transiently* -- the registry was
+    unreachable/timed out, or it answered 5xx after riding out its own bounded
+    Vault-retry budget.
+
+    Distinct from a clean miss (the registry returns HTTP 200 with
+    ``consent_required``) and from a terminal deny (401/403/404): on this
+    condition the caller must NOT forward tokenless (a misleading upstream 401)
+    nor nudge the user to reconnect (their token may be fine, the store is just
+    briefly down). It surfaces a retryable signal instead. Read-path mirror of
+    the consent-callback 503 added for the write path.
+    """
+
+
+# The vend hop's HTTP timeout is coupled to the registry's transient-retry
+# budget: the registry rides out a Vault/OpenBao leader election with a bounded
+# backoff (registry.secrets.openbao.store.transient_retry_budget_seconds, ~7.5s
+# of sleeps today) before answering. If our timeout were shorter we would abandon
+# the call -- and fail the vend -- while the registry is still legitimately
+# retrying. Derive the timeout from that budget (single source of truth) plus
+# headroom for the per-attempt request time, so the two cannot silently drift
+# apart if the retry constants ever change.
+_EGRESS_VEND_TIMEOUT_HEADROOM_SECONDS = 5.0
+_EGRESS_VEND_TIMEOUT_FALLBACK_SECONDS = 12.5
+
+
+def _egress_vend_timeout_seconds() -> float:
+    """HTTP timeout for the registry egress-token vend call, sized to outlast the
+    registry's transient Vault-retry budget (+ headroom). See the module note on
+    ``_EGRESS_VEND_TIMEOUT_HEADROOM_SECONDS``."""
+    try:
+        from registry.secrets.openbao.store import transient_retry_budget_seconds
+
+        return transient_retry_budget_seconds() + _EGRESS_VEND_TIMEOUT_HEADROOM_SECONDS
+    except Exception:  # pragma: no cover - defensive; keep a sane coupled default
+        return _EGRESS_VEND_TIMEOUT_FALLBACK_SECONDS
+
+
+# Registry vend statuses that mean "temporarily unavailable, retry" rather than a
+# terminal outcome: transport failures raise below, and the registry now answers
+# 503 when its own token store fails transiently (see vend_egress_token).
+_EGRESS_VEND_TRANSIENT_STATUSES: frozenset[int] = frozenset({502, 503, 504})
+
+
 async def _vend_egress_token(
     internal_proxy_token: str,
     server_first_segment: str,
@@ -6241,8 +6285,14 @@ async def _vend_egress_token(
 
     Forwards the verified X-Internal-Token; the registry re-verifies it,
     re-derives sub/auth_method from the signed claims, runs the allowlist
-    and upstream cross-check, and vends. Returns the JSON response dict, or
-    None on transport failure (treated as a clean miss -> consent).
+    and upstream cross-check, and vends. Returns the JSON response dict on a
+    clean answer (a hit, or a 200 ``consent_required`` miss).
+
+    Raises ``EgressVendUnavailable`` on a *transient* failure (registry
+    unreachable/timeout, or a 5xx after the registry exhausted its own Vault
+    retries) so the caller can surface a retryable signal instead of forwarding
+    tokenless. Returns None only for a terminal, non-retryable error (e.g. the
+    feature is off or the internal token was rejected).
     """
     from registry.auth.internal import generate_internal_token
 
@@ -6254,7 +6304,7 @@ async def _vend_egress_token(
         return None
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=_egress_vend_timeout_seconds()) as client:
             resp = await client.post(
                 f"{base}/_egress_internal/egress-token",
                 json={"server_path": server_first_segment},
@@ -6265,8 +6315,17 @@ async def _vend_egress_token(
                 },
             )
     except httpx.HTTPError as exc:
+        # Transport failure or timeout: the registry never gave a definitive
+        # answer, so this is transient by nature -- do not degrade to a tokenless
+        # forward.
         logger.error(f"egress vend: registry unreachable: {exc}")
-        return None
+        raise EgressVendUnavailable(str(exc)) from exc
+
+    if resp.status_code in _EGRESS_VEND_TRANSIENT_STATUSES:
+        logger.warning(
+            f"egress vend: registry returned {resp.status_code} (transient); signalling retry"
+        )
+        raise EgressVendUnavailable(f"registry returned {resp.status_code}")
 
     if resp.status_code != 200:
         logger.warning(f"egress vend: registry returned {resp.status_code}")
@@ -6349,6 +6408,34 @@ def _obo_failure_reason(exc: OboExchangeError) -> str:
     if isinstance(exc, OboUnsupportedIdpError):
         return "unsupported_idp"
     return "exchange_failed"
+
+
+def _egress_unavailable_response(req_id: object):
+    """Retryable response for a transient egress-credential-store outage.
+
+    Read-path mirror of the consent-callback 503 (write path). When the registry
+    vend fails transiently (Vault/OpenBao leader election / pod restart), we must
+    not forward tokenless -- that surfaces as a misleading upstream 401 with no
+    hint to retry -- nor answer consent_required, which would wrongly tell the
+    user to reconnect an account that is actually fine. Return HTTP 503 with a
+    ``Retry-After`` hint AND a JSON-RPC error body, so both transport-aware
+    clients and JSON-RPC parsers get a clear "temporarily unavailable, retry".
+    """
+    return JSONResponse(
+        status_code=503,
+        headers={"Retry-After": "2"},
+        content={
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {
+                "code": -32001,
+                "message": "egress_credential_service_unavailable",
+                "data": {
+                    "detail": "Egress credential service temporarily unavailable; please retry."
+                },
+            },
+        },
+    )
 
 
 def _obo_error_response(req_id: object, detail: str):
@@ -6867,7 +6954,20 @@ async def mcp_proxy(
         internal_proxy_token = request.headers.get("X-Internal-Token", "")
         if internal_proxy_token:
             server_first_segment = (server_name or "").split("/", 1)[0]
-            vend = await _vend_egress_token(internal_proxy_token, server_first_segment)
+            try:
+                vend = await _vend_egress_token(internal_proxy_token, server_first_segment)
+            except EgressVendUnavailable as exc:
+                # Transient vend failure: fail closed with a retryable signal
+                # rather than forwarding tokenless (-> silent upstream 401) or
+                # nudging a needless reconnect. Mirrors the write-path 503.
+                req_id = incoming_payload.get("id") if isinstance(incoming_payload, dict) else None
+                logger.warning(
+                    "mcp_proxy: egress vend temporarily unavailable for server=%s (%s); "
+                    "returning retryable 503",
+                    server_name,
+                    exc,
+                )
+                return _egress_unavailable_response(req_id)
             if vend and vend.get("mode") == "obo_exchange":
                 # OBO exchange: re-audience the user's ingress JWT to the internal
                 # MCP server's app via the gateway's OWN IdP credentials. The

--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -449,12 +449,29 @@ async def vend_egress_token(
         )
 
     svc = get_egress_auth_service()
-    access_token = await svc.get_valid_token(
-        auth_method=auth_method,
-        user_id=sub,
-        server_path=server_path,
-        egress_oauth=egress_oauth,
-    )
+    try:
+        access_token = await svc.get_valid_token(
+            auth_method=auth_method,
+            user_id=sub,
+            server_path=server_path,
+            egress_oauth=egress_oauth,
+        )
+    except SecretStoreError as exc:
+        # The store already rode out a bounded backoff (transient Vault/OpenBao
+        # blip during an HA leader election / pod restart) and still failed. This
+        # is NOT a miss: the user may well have a vaulted token we just can't read
+        # right now. Returning consent_required here would wrongly tell them to
+        # reconnect; a 500 would surface to the caller as an opaque tokenless
+        # upstream 401. Instead fail closed with a retryable 503, mirroring the
+        # consent-callback write path, so the vend hop can hand back a clear
+        # "temporarily unavailable, retry" signal instead of a silent failure.
+        logger.warning(
+            "egress vend: token store temporarily unavailable for %s: %s", server_path, exc
+        )
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="egress credential store temporarily unavailable",
+        ) from exc
     if access_token is not None:
         return EgressTokenResponse(access_token=access_token)
 

--- a/registry/secrets/openbao/store.py
+++ b/registry/secrets/openbao/store.py
@@ -34,6 +34,20 @@ _TRANSIENT_RETRIES = 4
 _TRANSIENT_BACKOFF_BASE = 0.5
 
 
+def transient_retry_budget_seconds() -> float:
+    """Worst-case total time ``_run`` can spend *sleeping* between transient
+    retries (0.5 + 1 + 2 + 4 = 7.5s today), excluding the per-attempt request
+    time itself.
+
+    Exposed so out-of-process callers can size their own timeout relative to
+    this budget instead of hard-coding a coupled magic number. In particular the
+    auth-server's egress-token vend HTTP call must outlast this window, or it
+    would abandon the request while the registry is still legitimately retrying
+    a Vault leader election (see ``auth_server.server._egress_vend_timeout_seconds``).
+    """
+    return sum(_TRANSIENT_BACKOFF_BASE * (2**i) for i in range(_TRANSIENT_RETRIES))
+
+
 def _is_auth_expiry_error(exc: Exception) -> bool:
     """True if an hvac error looks like an expired/invalid Vault token.
 

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -3791,6 +3791,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module.settings, "egress_consent_use_elicitation", False),
             patch.object(server_module, "_vend_egress_token", _consent_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -3831,6 +3832,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module.settings, "egress_consent_use_elicitation", True),
             patch.object(server_module, "_vend_egress_token", _consent_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -3878,6 +3880,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
         with (
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module, "_vend_egress_token", _consent_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -3919,6 +3922,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
         with (
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module, "_vend_egress_token", _consent_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -3951,6 +3955,7 @@ class TestMcpProxyEndpointHeaderPassthrough:
         with (
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module, "_vend_egress_token", _consent_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -4151,6 +4156,7 @@ class TestMcpProxyOboExchange:
         with (
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module, "_vend_egress_token", self._obo_directive_vend),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -4233,6 +4239,7 @@ class TestMcpProxyOboExchange:
             patch.object(server_module, "_vend_egress_token", self._obo_directive_vend),
             patch.object(server_module, "get_auth_provider", lambda *a, **k: _FakeEntraProvider()),
             patch.object(server_module, "obo_exchange", _failing_exchange),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -5927,6 +5934,7 @@ class TestMcpProxyEgressUnavailable:
         with (
             patch.object(server_module.settings, "egress_auth_enabled", True),
             patch.object(server_module, "_vend_egress_token", _boom),
+            _patch_scope_repo_allow_all(),
         ):
             client = TestClient(server_module.app)
             response = client.post(
@@ -5942,3 +5950,35 @@ class TestMcpProxyEgressUnavailable:
         assert "result" not in body
         assert body["error"]["code"] == -32001
         assert body["error"]["message"] == "egress_credential_service_unavailable"
+
+    def test_unscoped_caller_denied_403_before_vend_even_if_vend_would_fail(self):
+        # TM-15 ordering guarantee (reviewer request on #1529): an authorization
+        # denial must never be masked by a transient egress-availability 503. The
+        # scope re-auth runs BEFORE the vend, so a scopeless caller gets 403 and
+        # the vend is never even attempted -- regardless of OpenBao availability.
+        import auth_server.server as server_module
+
+        vend_called = {"n": 0}
+
+        async def _boom(token, server):
+            vend_called["n"] += 1
+            raise server_module.EgressVendUnavailable("registry returned 503")
+
+        with (
+            patch.object(server_module.settings, "egress_auth_enabled", True),
+            patch.object(server_module, "_vend_egress_token", _boom),
+        ):
+            client = TestClient(server_module.app)
+            response = client.post(
+                "/mcp-proxy/github",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 9,
+                    "method": "tools/call",
+                    "params": {"name": "privileged-tool"},
+                },
+                headers=_mcp_proxy_token_headers(server_name="github", scopes=[]),
+            )
+
+        assert response.status_code == 403
+        assert vend_called["n"] == 0  # denial happened before any vend/outbound work

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -5804,3 +5804,141 @@ class TestEntraLogoutQueryStringGuard:
         query = self._run_logout(oversized)
         assert "id_token_hint" not in query
         assert query["post_logout_redirect_uri"] == ["https://gw.example.com/login"]
+
+
+def _patch_vend_httpx(*, status_code=None, json_body=None, raise_exc=None):
+    """Patch auth_server.server.httpx.AsyncClient for the vend POST path
+    (``async with httpx.AsyncClient(...) as c: await c.post(...)``)."""
+    mock_client = AsyncMock()
+    if raise_exc is not None:
+        mock_client.post = AsyncMock(side_effect=raise_exc)
+    else:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.json = MagicMock(return_value=json_body)
+        mock_client.post = AsyncMock(return_value=resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return patch("auth_server.server.httpx.AsyncClient", return_value=mock_client)
+
+
+class TestVendEgressTokenTransientClassification:
+    """The vend read path must distinguish a *transient* registry/store outage
+    (retryable) from a clean answer or a terminal deny. On a transient failure it
+    raises EgressVendUnavailable so the proxy surfaces a retryable 503 instead of
+    forwarding tokenless (a misleading upstream 401) -- the read-path mirror of
+    the consent-callback 503."""
+
+    def _patches(self, server_module):
+        return (
+            patch.object(server_module.settings, "egress_registry_internal_url", "http://reg"),
+            patch(
+                "registry.auth.internal.generate_internal_token",
+                return_value="svc-token",
+            ),
+        )
+
+    async def test_transport_error_raises_unavailable(self):
+        import httpx
+
+        import auth_server.server as server_module
+
+        p_url, p_tok = self._patches(server_module)
+        with p_url, p_tok, _patch_vend_httpx(raise_exc=httpx.ConnectError("refused")):
+            with pytest.raises(server_module.EgressVendUnavailable):
+                await server_module._vend_egress_token("proxy-tok", "github")
+
+    async def test_read_timeout_raises_unavailable(self):
+        import httpx
+
+        import auth_server.server as server_module
+
+        p_url, p_tok = self._patches(server_module)
+        with p_url, p_tok, _patch_vend_httpx(raise_exc=httpx.ReadTimeout("timed out")):
+            with pytest.raises(server_module.EgressVendUnavailable):
+                await server_module._vend_egress_token("proxy-tok", "github")
+
+    async def test_503_raises_unavailable(self):
+        import auth_server.server as server_module
+
+        p_url, p_tok = self._patches(server_module)
+        with p_url, p_tok, _patch_vend_httpx(status_code=503, json_body={}):
+            with pytest.raises(server_module.EgressVendUnavailable):
+                await server_module._vend_egress_token("proxy-tok", "github")
+
+    async def test_502_and_504_raise_unavailable(self):
+        import auth_server.server as server_module
+
+        p_url, p_tok = self._patches(server_module)
+        for code in (502, 504):
+            with p_url, p_tok, _patch_vend_httpx(status_code=code, json_body={}):
+                with pytest.raises(server_module.EgressVendUnavailable):
+                    await server_module._vend_egress_token("proxy-tok", "github")
+
+    async def test_200_returns_body(self):
+        import auth_server.server as server_module
+
+        body = {"consent_required": True, "connect_url": "https://gw/connect"}
+        p_url, p_tok = self._patches(server_module)
+        with p_url, p_tok, _patch_vend_httpx(status_code=200, json_body=body):
+            got = await server_module._vend_egress_token("proxy-tok", "github")
+        assert got == body
+
+    async def test_terminal_non_2xx_returns_none_not_unavailable(self):
+        # A 401/403/404 is a terminal deny (bad internal token, feature off,
+        # unregistered upstream) -- not a transient blip. It must NOT be retried
+        # as unavailable; the proxy falls through to its existing handling.
+        import auth_server.server as server_module
+
+        p_url, p_tok = self._patches(server_module)
+        for code in (401, 403, 404):
+            with p_url, p_tok, _patch_vend_httpx(status_code=code, json_body={}):
+                got = await server_module._vend_egress_token("proxy-tok", "github")
+                assert got is None
+
+
+class TestEgressVendTimeoutCoupling:
+    """The vend HTTP timeout must outlast the registry's transient Vault-retry
+    budget, derived from the store's single source of truth so the two can't
+    drift apart."""
+
+    def test_timeout_exceeds_registry_retry_budget(self):
+        import auth_server.server as server_module
+        from registry.secrets.openbao.store import transient_retry_budget_seconds
+
+        budget = transient_retry_budget_seconds()
+        timeout = server_module._egress_vend_timeout_seconds()
+        assert timeout > budget
+        assert timeout == pytest.approx(
+            budget + server_module._EGRESS_VEND_TIMEOUT_HEADROOM_SECONDS
+        )
+
+
+class TestMcpProxyEgressUnavailable:
+    """Call-site: a transient vend failure returns a retryable 503 (JSON-RPC
+    error), never a tokenless upstream forward."""
+
+    def test_tools_call_returns_retryable_503(self):
+        import auth_server.server as server_module
+
+        async def _boom(token, server):
+            raise server_module.EgressVendUnavailable("registry returned 503")
+
+        with (
+            patch.object(server_module.settings, "egress_auth_enabled", True),
+            patch.object(server_module, "_vend_egress_token", _boom),
+        ):
+            client = TestClient(server_module.app)
+            response = client.post(
+                "/mcp-proxy/github",
+                json={"jsonrpc": "2.0", "id": 9, "method": "tools/call"},
+                headers=_mcp_proxy_token_headers(server_name="github"),
+            )
+
+        assert response.status_code == 503
+        assert response.headers.get("Retry-After") == "2"
+        body = response.json()
+        assert body["id"] == 9
+        assert "result" not in body
+        assert body["error"]["code"] == -32001
+        assert body["error"]["message"] == "egress_credential_service_unavailable"

--- a/tests/unit/egress_auth/test_internal_egress_token_route.py
+++ b/tests/unit/egress_auth/test_internal_egress_token_route.py
@@ -195,3 +195,24 @@ class TestInternalEgressTokenRoute:
         assert body.get("authorize_url") is None
         assert body.get("connect_url") is None
         assert body.get("request_state") is None
+
+    def test_store_transiently_unavailable_returns_503(self, make_client):
+        # When the token store fails transiently (get_valid_token raises
+        # SecretStoreError after the store exhausted its own retry budget), the
+        # vend must NOT masquerade as a clean miss (consent_required) -- that would
+        # wrongly tell the user to reconnect. It fails closed with a retryable 503
+        # so the auth-server vend hop can surface "temporarily unavailable, retry".
+        from registry.secrets.interfaces import SecretStoreError
+
+        client = make_client(_claims(), _server())
+
+        async def _boom(**kwargs):
+            client._svc.called = True
+            raise SecretStoreError("OpenBao get failed: connection refused")
+
+        client._svc.get_valid_token = _boom
+        r = _post(client)
+        assert r.status_code == 503
+        assert client._svc.called
+        # It is an availability signal, never a miss (no consent nudge).
+        assert "consent_required" not in r.text

--- a/tests/unit/secrets/test_stores.py
+++ b/tests/unit/secrets/test_stores.py
@@ -477,3 +477,25 @@ class TestOpenBaoTransientRetry:
         assert calls["n"] == 2
         got = await store.get_token("oauth2", "alice", "github", "/github-mcp")
         assert got is not None and got.access_token == "a1"
+
+
+@pytest.mark.unit
+class TestTransientRetryBudget:
+    """The retry budget is exported so out-of-process callers (the auth-server
+    egress vend timeout) can size themselves relative to it instead of hardcoding
+    a coupled magic number."""
+
+    def test_budget_matches_backoff_sum(self):
+        import registry.secrets.openbao.store as store_mod
+
+        expected = sum(
+            store_mod._TRANSIENT_BACKOFF_BASE * (2**i) for i in range(store_mod._TRANSIENT_RETRIES)
+        )
+        assert store_mod.transient_retry_budget_seconds() == expected
+
+    def test_budget_is_current_default(self):
+        # 0.5 + 1 + 2 + 4 = 7.5s with today's constants; a guard against silent
+        # drift that would decouple it from the auth-server vend timeout.
+        from registry.secrets.openbao.store import transient_retry_budget_seconds
+
+        assert transient_retry_budget_seconds() == pytest.approx(7.5)


### PR DESCRIPTION
## Problem

#1490 hardened the consent-callback **write** path against transient Vault/OpenBao unavailability (bounded retry in the store + a clear `503` "Connection not saved" page). As @aarora79 noted in the merge follow-up, the **token-vend read path** did not get the same graceful failure:

`auth-server -> /_egress_internal/egress-token -> registry -> OpenBao`

When OpenBao is briefly down (HA leader election / pod restart), the registry retries correctly, but after give-up:
- `svc.get_valid_token` raises `SecretStoreError`, which was unhandled → the vend endpoint `500`s;
- the auth-server's `_vend_egress_token` returns `None`, which falls through to a **tokenless upstream call → `401`**.

That is the same silent-failure class this line of work set out to remove, just on the **read** side. Two specific points from the follow-up:

1. **Implicit timeout ↔ retry-budget coupling.** The auth-server vend call used a hard-coded `timeout=10.0` while the registry's transient-retry budget is ~7.5s. It works today, but the two were coupled with no guardrail against drift.
2. **No retryable signal.** On vend failure the auth-server returned `None` and forwarded tokenless, surfacing as a raw upstream `401` rather than a "temporarily unavailable, retry" signal like the `503` added on the write path.

## Change

**Make the timeout ↔ retry-budget relationship explicit (single source of truth)**
- `registry/secrets/openbao/store.py` — expose `transient_retry_budget_seconds()` (sum of the bounded backoff, `0.5+1+2+4 = 7.5s` today).
- `auth_server/server.py` — derive the vend HTTP timeout from that budget + headroom in `_egress_vend_timeout_seconds()` (replaces the magic `10.0`), so the vend never abandons a call the registry is still legitimately retrying, and the two cannot silently drift.

**Read-path graceful failure, mirroring the write-path 503**
- `registry/api/egress_auth_routes.py` — `vend_egress_token` catches `SecretStoreError` from `get_valid_token` and returns `503` (not a `500`, and never a misleading `consent_required` that would tell the user to reconnect a token that is actually fine).
- `auth_server/server.py` — `_vend_egress_token` classifies transport failures/timeouts and `502/503/504` as **transient**, raising `EgressVendUnavailable`; the `mcp_proxy` hop returns a retryable `503` (JSON-RPC error `-32001`, `Retry-After`) instead of forwarding tokenless. Terminal denials (`401/403/404`) keep their existing behavior (fall through).

## Test plan

- `tests/unit/egress_auth/test_internal_egress_token_route.py` — vend returns `503` when the store fails transiently (never `consent_required`).
- `tests/unit/secrets/test_stores.py` — `transient_retry_budget_seconds()` matches the backoff sum and equals `7.5s` (drift guard).
- `tests/auth_server/unit/test_server.py` — `_vend_egress_token` transient classification (transport/timeout/`5xx` → raise; `401/403/404` → `None`; `200` → body); vend timeout > retry budget; `mcp_proxy` returns a retryable `503` on transient vend failure.

Ran the affected suites locally: `414 passed, 16 skipped`. `ruff check` + `ruff format` clean on changed files.

Follow-up to #1490 (non-blocking there; opened as a separate PR as suggested).
