### PR TITLE
fix(egress): only trust the egress_user claim from self-signed tokens (follow-up to #1491)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -291,7 +291,9 @@ def _canonical_egress_user(validation_result: dict) -> str:
          this claim a Cursor/Claude bearer minted from a browser login would key
          the vault on the username while the cookie-consent path keyed on the OIDC
          sub, and the vend would miss the vaulted token ("0 tools"). Checked FIRST
-         so it wins over the self-signed token's username ``sub``.
+         so it wins over the self-signed token's username ``sub`` -- but ONLY when
+         the token is ``self_signed`` (minted by this gateway); it is ignored on
+         any other method so an external issuer cannot inject a vault key.
       2. ``data.sub`` -- the raw IdP subject. Bearer paths expose the verified
          claims here; the cookie path carries the sub persisted into the session
          at login (see create_session ``subject``).
@@ -301,8 +303,20 @@ def _canonical_egress_user(validation_result: dict) -> str:
          non-OIDC behavior unchanged; only OIDC callers change bucket).
     """
     data = validation_result.get("data") or {}
+    # ``egress_user`` is an identity-keying claim -- it selects which per-user
+    # egress-vault bucket the vend reads. Only trust it from a token THIS gateway
+    # minted itself (``self_signed``), where the claim's provenance is guaranteed.
+    # A JWT / M2M / other-issuer token could otherwise carry an attacker-chosen
+    # ``egress_user`` and key the vault on a victim's id -> a cross-user egress
+    # token vend. Gateway-built paths (session cookie, federation, network-trusted)
+    # never set ``egress_user``, so gating it here is a no-op for them and keeps
+    # the consent-write path resolving on ``sub``/``subject`` unchanged.
+    if validation_result.get("method") == AUTH_METHOD_SELF_SIGNED:
+        egress_user = data.get("egress_user")
+    else:
+        egress_user = None
     return (
-        data.get("egress_user")
+        egress_user
         or data.get("sub")
         or data.get("subject")
         or validation_result.get("sub")

--- a/tests/auth_server/unit/test_egress_mint.py
+++ b/tests/auth_server/unit/test_egress_mint.py
@@ -73,11 +73,15 @@ class TestCanonicalAuthMethod:
 
 
 @pytest.mark.unit
-class TestCanonicalEgressUser:
+class TestCanonicalEgressUserPaths:
     """The per-user egress vault id must resolve identically on the consent-write
     (cookie) and vend (bearer) paths, or the vaulted token is written under one
     id and looked up under another (permanent vend miss). It keys on the OIDC
     ``sub``, which is present in both id_tokens and access tokens across providers.
+
+    NOTE: previously this class was also named ``TestCanonicalEgressUser`` -- the
+    same name as the class further down -- so it was shadowed at import time and
+    silently NOT collected. Renamed so both suites run.
     """
 
     def test_bearer_uses_data_sub(self):
@@ -117,6 +121,36 @@ class TestCanonicalEgressUser:
 
     def test_empty_when_nothing_present(self):
         assert server._canonical_egress_user({}) == ""
+
+    def test_egress_user_honored_only_for_self_signed(self):
+        # The gateway stamps egress_user (the OIDC sub) onto its OWN self_signed
+        # USER token; there it wins over the token's username sub.
+        vr = {
+            "method": server.AUTH_METHOD_SELF_SIGNED,
+            "username": "alice@example.com",
+            "data": {"egress_user": "00000000-sub-alice", "sub": "alice@example.com"},
+        }
+        assert server._canonical_egress_user(vr) == "00000000-sub-alice"
+
+    def test_egress_user_ignored_for_non_self_signed_token(self):
+        # Trust boundary: egress_user is an identity-keying claim. From any token
+        # this gateway did NOT mint (e.g. a raw IdP jwt), it must be ignored so an
+        # external issuer cannot inject the vault key and vend a victim's token.
+        # Resolution falls through to the token's real subject instead.
+        vr = {
+            "method": "jwt",
+            "username": "attacker@example.com",
+            "data": {"egress_user": "00000000-sub-victim", "sub": "00000000-sub-attacker"},
+        }
+        assert server._canonical_egress_user(vr) == "00000000-sub-attacker"
+
+    def test_egress_user_ignored_when_method_absent(self):
+        # No method marker -> not provably gateway-minted -> egress_user ignored.
+        vr = {
+            "username": "attacker@example.com",
+            "data": {"egress_user": "00000000-sub-victim", "sub": "00000000-sub-attacker"},
+        }
+        assert server._canonical_egress_user(vr) == "00000000-sub-attacker"
 
 
 @pytest.mark.unit
@@ -286,8 +320,13 @@ class TestCanonicalEgressUser:
         # A gateway-issued self-signed USER token carries sub=username but stamps
         # the OIDC sub as egress_user. Without egress_user winning, a Cursor/Claude
         # bearer would key the vault on the username and miss the browser-consented
-        # token (the "0 tools" bug). egress_user MUST take precedence over sub.
-        vr = {"data": {"egress_user": "oidc-sub-xyz", "sub": "alice@example.com"}}
+        # token (the "0 tools" bug). egress_user MUST take precedence over sub --
+        # but only on a self_signed token (a claim minted by this gateway); see
+        # test_egress_user_ignored_for_non_self_signed_token for the trust boundary.
+        vr = {
+            "method": server.AUTH_METHOD_SELF_SIGNED,
+            "data": {"egress_user": "oidc-sub-xyz", "sub": "alice@example.com"},
+        }
         assert server._canonical_egress_user(vr) == "oidc-sub-xyz"
 
     def test_cookie_session_subject_used_when_no_egress_user(self):


### PR DESCRIPTION
## Context

Follow-up to #1491 (merged). That PR aligned the egress-vault key to the OIDC `sub` by making `_canonical_egress_user` prefer the `egress_user` claim. @omrishiv left a **requested-changes** review with a specific suggestion that was still open when the PR was merged, and no later commit addressed it — this PR applies it.

## Problem

`_canonical_egress_user` resolves the id that keys the **per-user egress vault**. After #1491 it prefers the token's `egress_user` claim over the username `sub` — but it trusted `egress_user` from **any** validated token:

```python
return (
    data.get("egress_user")   # trusted regardless of token type
    or data.get("sub")
    or ...
)
```

`egress_user` is an identity-keying claim. A `jwt` / `m2m` / other-issuer token that carries an attacker-chosen `egress_user` could key the vault on a **victim's** id and vend that victim's egress token — a cross-user credential-access vector. The `egress_user` claim is only meaningful (and provenance-guaranteed) on a token **this gateway minted itself** (`generate_user_token` → `method == "self_signed"`).

## Fix

Gate the claim to self-signed tokens, exactly as @omrishiv suggested:

```python
if validation_result.get("method") == AUTH_METHOD_SELF_SIGNED:
    egress_user = data.get("egress_user")
else:
    egress_user = None
return (egress_user or data.get("sub") or data.get("subject") or ...)
```

- No behavior change for the paths that matter: the Cursor/Claude vend presents the gateway self-signed bearer (`self_signed`) → still honored. Gateway-built paths (session cookie, federation, network-trusted) never set `egress_user`, so gating is a no-op and the consent-write path keeps resolving on `sub`/`subject`. Older self-signed tokens without the claim still fall back to `sub`.

## Also: a shadowed test suite

`tests/auth_server/unit/test_egress_mint.py` had **two** classes both named `TestCanonicalEgressUser`; the second shadows the first at import time, so the first's tests were silently never collected. Renamed the first to `TestCanonicalEgressUserPaths` so both run.

## Tests

- `egress_user` honored only for `self_signed`; ignored for a non-self_signed `jwt` and when the method marker is absent (falls through to the token's real subject).
- `tests/auth_server/unit` + `tests/unit/egress_auth`: **809 passed**. `ruff check` + `format` clean on changed files.
