### PR TITLE
Reject Keycloak's default `account` audience during access-token validation

### DIFF
--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -126,17 +126,23 @@ class KeycloakProvider(AuthProvider):
                 f"http://localhost:8080/realms/{self.realm}",  # Localhost URL for development
             ]
 
-            # Accepted audiences:
-            #   - "account"          (Keycloak's default for user tokens)
+            # Accepted audiences: only audiences that identify THIS gateway.
             #   - self.client_id     (the gateway's own pre-defined web client)
             #   - self.m2m_client_id (the gateway's M2M client)
             #   - "mcp-gateway"      (custom audience added by the realm's
             #                         audience mapper on the `basic` scope, which
-            #                         is reliably attached to every DCR'd client.
+            #                         is reliably attached to every DCR'd client
+            #                         as well as the web and M2M clients.
             #                         See keycloak/setup/init-keycloak.sh::
             #                         setup_dcr_audience_mapper.)
+            #
+            # "account" is deliberately NOT accepted. It is Keycloak's default
+            # audience present on EVERY realm user token regardless of which
+            # client requested it, so accepting it would let a token minted for
+            # a different client in the same realm be replayed against the
+            # gateway (a same-realm cross-client confused-deputy). Fail closed:
+            # a token must carry an audience that names this gateway.
             accepted_audiences = [
-                "account",
                 self.client_id,
                 self.m2m_client_id,
                 "mcp-gateway",

--- a/docs/keycloak-mcp-clients.md
+++ b/docs/keycloak-mcp-clients.md
@@ -586,14 +586,25 @@ The `resource_metadata` URL must equal the PRM `resource` field byte-for-byte
 3. Verify signature using the matching public key
 4. Verify `iss` matches one of the valid issuer URLs (external + internal +
    localhost variants)
-5. Verify `aud` is in `[account, mcp-gateway-web, mcp-gateway-m2m, mcp-gateway]`.
-   The first three cover the gateway's pre-defined web/M2M clients and
-   Keycloak's default user-token audience. The fourth (`mcp-gateway`) is the
-   custom audience emitted by the audience protocol mapper attached to the
-   `basic` client-scope (see "Client-scopes" above and
+5. Verify `aud` is in `[mcp-gateway-web, mcp-gateway-m2m, mcp-gateway]`. The
+   first two are the gateway's pre-defined web/M2M clients; the third
+   (`mcp-gateway`) is the custom audience emitted by the audience protocol
+   mapper attached to the `basic` client-scope (see "Client-scopes" above and
    `setup_dcr_audience_mapper` in `init-keycloak.sh`). DCR'd clients receive
    `basic` automatically, so every DCR'd-client token carries
    `aud="mcp-gateway"` and is validated strictly per RFC 8707 — no fallback.
+
+   Keycloak's default `aud="account"` is deliberately **not** accepted.
+   `account` is present on every realm user token regardless of which client
+   requested it, so accepting it would let a token minted for a different client
+   in the same realm be replayed against the gateway (a same-realm cross-client
+   confused-deputy). Because the audience mapper puts `aud="mcp-gateway"` on
+   every token via the `basic` scope, dropping `account` does not lock out any
+   legitimately-issued token. **Upgrade note:** a realm provisioned before the
+   audience mapper existed (or without running the current `init-keycloak.sh` /
+   `upgrade-realm-for-dcr.sh`) mints `account`-only tokens and will now be
+   rejected with `Invalid audience` — re-run the setup to attach the mapper and
+   have users re-authenticate.
 
 #### Group → scope mapping
 

--- a/tests/auth_server/unit/providers/test_keycloak_audience_allowlist.py
+++ b/tests/auth_server/unit/providers/test_keycloak_audience_allowlist.py
@@ -1,0 +1,191 @@
+"""Unit tests for Keycloak access-token audience validation.
+
+These tests exercise the real ``KeycloakProvider.validate_token`` decode path
+with a genuine RSA keypair and PyJWT's ``verify_aud=True``, so the audience
+allowlist is enforced by the cryptography/decoder rather than by a mock.
+
+Regression coverage for the same-realm cross-client confused-deputy finding:
+Keycloak's default ``account`` audience is present on EVERY realm user token
+regardless of which client requested it. A token whose only audience is
+``account`` (i.e. minted for some other client in the realm) must be REJECTED,
+while tokens that carry an audience naming THIS gateway (``client_id``,
+``m2m_client_id``, or ``mcp-gateway``) must still validate.
+"""
+
+import json
+import logging
+import time
+from unittest.mock import patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.algorithms import RSAAlgorithm
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [pytest.mark.unit, pytest.mark.auth]
+
+
+# =============================================================================
+# Test helpers: real RSA keypair + JWKS + signed access token
+# =============================================================================
+
+
+def _build_keypair(kid: str = "test-kid") -> tuple[rsa.RSAPrivateKey, dict]:
+    """Generate an RSA keypair and the matching single-key JWKS document."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(RSAAlgorithm.to_jwk(private_key.public_key()))
+    public_jwk["kid"] = kid
+    public_jwk["alg"] = "RS256"
+    public_jwk["use"] = "sig"
+    return private_key, {"keys": [public_jwk]}
+
+
+def _sign_token(
+    private_key: rsa.RSAPrivateKey,
+    claims: dict,
+    kid: str = "test-kid",
+) -> str:
+    """Sign an access token with the given RSA private key (RS256)."""
+    return jwt.encode(claims, private_key, algorithm="RS256", headers={"kid": kid})
+
+
+def _base_claims(issuer: str, audience: str | list[str]) -> dict:
+    now = int(time.time())
+    return {
+        "iss": issuer,
+        "aud": audience,
+        "sub": "user-123",
+        "preferred_username": "alice",
+        "email": "alice@example.com",
+        "groups": ["mcp-registry-admin"],
+        "scope": "openid profile email",
+        "azp": "some-other-client",
+        "iat": now,
+        "exp": now + 3600,
+    }
+
+
+def _make_provider():
+    from providers.keycloak import KeycloakProvider
+
+    return KeycloakProvider(
+        keycloak_url="http://keycloak:8080",
+        realm="test-realm",
+        client_id="gateway-web",
+        client_secret="secret",  # noqa: S106 - test fixture, not a real secret
+        m2m_client_id="gateway-m2m",
+        m2m_client_secret="m2m-secret",  # noqa: S106 - test fixture, not a real secret
+        keycloak_external_url="https://keycloak.example.com",
+    )
+
+
+# =============================================================================
+# Rejection: a token audienced ONLY to "account" must be rejected
+# =============================================================================
+
+
+class TestAccountAudienceRejected:
+    """The default ``account`` audience alone is not a gateway audience."""
+
+    def test_account_only_audience_rejected(self):
+        """A user token minted for another client (aud=account) is rejected."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.realm_url, "account"))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            with pytest.raises(ValueError, match="[Ii]nvalid|[Aa]udience"):
+                provider.validate_token(token)
+
+    def test_unrelated_client_audience_rejected(self):
+        """An audience naming a different client entirely is rejected."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.realm_url, "some-unrelated-client"))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            with pytest.raises(ValueError):
+                provider.validate_token(token)
+
+    def test_account_in_list_without_gateway_audience_rejected(self):
+        """aud as a list containing only account (+ noise) is still rejected."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(
+            private_key,
+            _base_claims(provider.realm_url, ["account", "realm-management"]),
+        )
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            with pytest.raises(ValueError):
+                provider.validate_token(token)
+
+
+# =============================================================================
+# Acceptance: tokens carrying a legitimate gateway audience still validate
+# =============================================================================
+
+
+class TestGatewayAudienceAccepted:
+    """Audiences that name this gateway are accepted."""
+
+    def test_mcp_gateway_audience_accepted(self):
+        """The realm audience-mapper attaches aud=mcp-gateway to every token."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.realm_url, "mcp-gateway"))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            result = provider.validate_token(token)
+
+        assert result["valid"] is True
+        assert result["username"] == "alice"
+
+    def test_client_id_audience_accepted(self):
+        """A token audienced to the gateway's own web client is accepted."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.realm_url, provider.client_id))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            result = provider.validate_token(token)
+
+        assert result["valid"] is True
+
+    def test_m2m_client_id_audience_accepted(self):
+        """A token audienced to the gateway's M2M client is accepted."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.realm_url, provider.m2m_client_id))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            result = provider.validate_token(token)
+
+        assert result["valid"] is True
+
+    def test_account_plus_gateway_audience_accepted(self):
+        """A real DCR token carries both account and mcp-gateway; accepted."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(
+            private_key,
+            _base_claims(provider.realm_url, ["account", "mcp-gateway"]),
+        )
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            result = provider.validate_token(token)
+
+        assert result["valid"] is True
+
+    def test_external_issuer_with_gateway_audience_accepted(self):
+        """The external realm issuer plus a gateway audience validates."""
+        provider = _make_provider()
+        private_key, jwks = _build_keypair()
+        token = _sign_token(private_key, _base_claims(provider.external_realm_url, "mcp-gateway"))
+
+        with patch.object(provider, "get_jwks", return_value=jwks):
+            result = provider.validate_token(token)
+
+        assert result["valid"] is True


### PR DESCRIPTION
# Reject Keycloak's default `account` audience during access-token validation

## Summary

`KeycloakProvider.validate_token` accepted `"account"` as a valid token audience. `account` is Keycloak's default audience, attached to every user access token in the realm regardless of which client requested it. Accepting it meant a token minted for any other client in the same realm could be replayed against the gateway and treated as validly audienced — a same-realm cross-client confused-deputy.

This change removes `"account"` from the accepted-audiences allowlist. The gateway now only accepts tokens whose `aud` claim names the gateway itself.

## Change

`auth_server/providers/keycloak.py` — the `accepted_audiences` list in `validate_token` now contains only:

- `self.client_id` — the gateway's pre-defined web client
- `self.m2m_client_id` — the gateway's M2M client
- `"mcp-gateway"` — the custom audience the realm's audience mapper attaches to the `basic` client scope

## Why this does not lock users out

Every token issued by the realm carries `aud="mcp-gateway"` in addition to `account`. The realm setup attaches an OIDC audience mapper (`included.custom.audience: "mcp-gateway"`) to the `basic` client scope, which is a default scope inherited by the web client, the M2M client, and every dynamically-registered (DCR) client. Because PyJWT's `verify_aud=True` passes when any element of the accepted list matches any audience in the token, legitimate tokens continue to validate on their `mcp-gateway` (or `client_id`/`m2m_client_id`) audience. See `keycloak/setup/init-keycloak.sh` (`setup_dcr_audience_mapper`) for the mapper configuration.

## azp binding

Not added. The gateway legitimately serves tokens from many authorized parties — the web client, the M2M client, and every DCR'd MCP client, each with its own `azp`. Pinning `azp` to a fixed set of clients would break the DCR'd-client flow that the `mcp-gateway` audience is designed to support. The audience allowlist is the correct and complete control for this issue.

## Tests

New suite `tests/auth_server/unit/providers/test_keycloak_audience_allowlist.py` exercises the real RS256 decode path (genuine RSA keypair, real `jwt.decode` with `verify_aud=True`):

- A token audienced only to `account` is rejected; likewise an unrelated client audience, and an `aud` list of `[account, realm-management]`.
- Tokens audienced to `mcp-gateway`, `client_id`, `m2m_client_id`, the realistic `[account, mcp-gateway]` combination, and the external issuer all still validate.

Full Keycloak-related suite: 84 passed, 3 skipped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
