### PR TITLE
feat(egress): surface per-user connect on server card + connect modal (#1495)

### DIFF
--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import {
   WrenchScrewdriverIcon,
@@ -6,11 +7,14 @@ import {
   PencilIcon,
   ClockIcon,
   LinkIcon,
+  PowerIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
   TrashIcon,
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
+import { isSafeUrl } from '../utils/safeUrl';
+import type { EgressCardState } from '../utils/egressAuth';
 import ServerConfigModal from './ServerConfigModal';
 import SecurityScanModal from './SecurityScanModal';
 import StarRatingWidget from './StarRatingWidget';
@@ -167,6 +171,10 @@ interface ServerCardProps {
   onServerUpdate?: (path: string, updates: Partial<Server>) => void;
   onDelete?: (path: string) => Promise<void>;
   authToken?: string | null;
+  // Per-user egress state for this server (undefined => not eligible / no icon).
+  egressConnect?: EgressCardState;
+  // Called after a connect/disconnect in the modal so the dashboard refreshes.
+  onEgressChanged?: () => void;
 }
 
 interface Tool {
@@ -175,7 +183,81 @@ interface Tool {
   schema?: any;
 }
 
-const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, canDelete, onRefreshSuccess, onShowToast, onServerUpdate, onDelete, authToken }) => {
+
+/**
+ * Compact per-server egress affordance in the card header. Reflects three
+ * states (not-connected / connected / needs-reconnect) with a mode-aware label,
+ * from the shared EgressCardState so the card and the connect-modal callout
+ * never disagree.
+ */
+function EgressConnectButton({
+  serverPath,
+  serverName,
+  state,
+  onShowToast,
+}: {
+  serverPath: string;
+  serverName: string;
+  state: EgressCardState;
+  onShowToast?: (message: string, type: 'success' | 'error') => void;
+}) {
+  const navigate = useNavigate();
+  const connected = state.connected;
+
+  let label: string;
+  let tooltip: string;
+  if (state.needsReconnect) {
+    label = 'Reconnect';
+    tooltip = 'Connection expired or failed — reconnect';
+  } else if (connected) {
+    label = 'Connected';
+    tooltip = 'Account connected — manage on Connected Accounts';
+  } else if (state.mode === 'pat') {
+    label = 'Submit token';
+    tooltip = 'Submit a personal access token for this server';
+  } else {
+    label = 'Link account';
+    tooltip = 'Link your account for this server';
+  }
+
+  const handleClick = () => {
+    // PAT cannot use an OAuth redirect, and a healthy connected 3LO just needs
+    // management: route both to Connected Accounts (server preselected).
+    if (state.mode === 'pat' || (connected && !state.needsReconnect)) {
+      navigate(`/connected-accounts?server=${encodeURIComponent(serverPath)}`);
+      return;
+    }
+    // Not-connected or needs-reconnect 3LO: open the gateway front door.
+    // MANDATORY isSafeUrl guard before window.open (defense in depth): connect_url
+    // is server-built but is technically influenceable via a crafted admin path,
+    // so never open it unguarded. Fail closed on unsafe/empty.
+    if (!isSafeUrl(state.connectUrl)) {
+      onShowToast?.('Cannot open the connect URL for this server.', 'error');
+      return;
+    }
+    window.open(state.connectUrl, '_blank', 'noopener,noreferrer');
+  };
+
+  const iconClass = state.needsReconnect
+    ? 'h-4 w-4 text-amber-500'
+    : connected
+      ? 'h-4 w-4 text-green-600 dark:text-green-400'
+      : 'h-4 w-4 text-gray-400';
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="p-2 hover:bg-gray-50 dark:hover:bg-gray-700/50 rounded-lg transition-all duration-200 flex-shrink-0"
+      title={tooltip}
+      aria-label={`${label} for ${serverName}`}
+    >
+      <PowerIcon className={iconClass} />
+    </button>
+  );
+}
+
+const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, canDelete, onRefreshSuccess, onShowToast, onServerUpdate, onDelete, authToken, egressConnect, onEgressChanged }) => {
   const { user } = useAuth();
   const isAdmin = user?.is_admin === true;
   const [tools, setTools] = useState<Tool[]>([]);
@@ -579,6 +661,17 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
               </button>
             )}
 
+            {/* Egress "Link account" affordance — only for servers with per-user
+                egress auth the current user can reach (egressConnect defined). */}
+            {egressConnect && !isArdDiscovery && (
+              <EgressConnectButton
+                serverPath={server.path}
+                serverName={server.name}
+                state={egressConnect}
+                onShowToast={onShowToast}
+              />
+            )}
+
             {/* Full JSON Details + Security Scan — interactive actions, hidden for
                 ARD discovery-only imports so the card is fully read-only. */}
             {!isArdDiscovery && (
@@ -909,6 +1002,8 @@ const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, on
         isOpen={showConfig}
         onClose={() => setShowConfig(false)}
         onShowToast={onShowToast}
+        egressConnect={egressConnect}
+        onEgressChanged={onEgressChanged}
       />
 
       <SecurityScanModal

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -7,12 +7,12 @@ import {
   PencilIcon,
   ClockIcon,
   LinkIcon,
-  PowerIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
   TrashIcon,
   InformationCircleIcon,
 } from '@heroicons/react/24/outline';
+import PlugIcon from './icons/PlugIcon';
 import { isSafeUrl } from '../utils/safeUrl';
 import type { EgressCardState } from '../utils/egressAuth';
 import ServerConfigModal from './ServerConfigModal';
@@ -252,7 +252,7 @@ function EgressConnectButton({
       title={tooltip}
       aria-label={`${label} for ${serverName}`}
     >
-      <PowerIcon className={iconClass} />
+      <PlugIcon className={iconClass} />
     </button>
   );
 }

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -15,6 +15,7 @@ import {
 import PlugIcon from './icons/PlugIcon';
 import { isSafeUrl } from '../utils/safeUrl';
 import type { EgressCardState } from '../utils/egressAuth';
+import { useEgressConnect } from '../contexts/EgressConnectContext';
 import ServerConfigModal from './ServerConfigModal';
 import SecurityScanModal from './SecurityScanModal';
 import StarRatingWidget from './StarRatingWidget';
@@ -257,9 +258,15 @@ function EgressConnectButton({
   );
 }
 
-const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, canDelete, onRefreshSuccess, onShowToast, onServerUpdate, onDelete, authToken, egressConnect, onEgressChanged }) => {
+const ServerCard: React.FC<ServerCardProps> = React.memo(({ server, onToggle, onEdit, canModify, canHealthCheck = true, canToggle = true, canDelete, onRefreshSuccess, onShowToast, onServerUpdate, onDelete, authToken, egressConnect: egressConnectProp, onEgressChanged: onEgressChangedProp }) => {
   const { user } = useAuth();
   const isAdmin = user?.is_admin === true;
+  // Egress connect state: prefer the explicit prop (dashboard grid passes it),
+  // else fall back to the shared context so render paths that don't thread the
+  // prop (discover/search rows via DiscoverListRow) still show the affordance.
+  const egressCtx = useEgressConnect();
+  const egressConnect = egressConnectProp ?? egressCtx.stateByPath.get(server.path);
+  const onEgressChanged = onEgressChangedProp ?? egressCtx.reload;
   const [tools, setTools] = useState<Tool[]>([]);
   const [loadingTools, setLoadingTools] = useState(false);
   const [showTools, setShowTools] = useState(false);

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react';
-import { ClipboardDocumentIcon, KeyIcon, PowerIcon } from '@heroicons/react/24/outline';
+import { ClipboardDocumentIcon, KeyIcon } from '@heroicons/react/24/outline';
+import PlugIcon from './icons/PlugIcon';
 import axios from 'axios';
 import type { Server } from './ServerCard';
 import { useRegistryConfig } from '../hooks/useRegistryConfig';
@@ -109,7 +110,7 @@ function EgressConnectCallout({
   if (state.mode === 'pat') {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-900/20 p-4">
-        <PowerIcon className="h-5 w-5 flex-shrink-0 text-purple-600 dark:text-purple-400" />
+        <PlugIcon className="h-5 w-5 flex-shrink-0 text-purple-600 dark:text-purple-400" />
         <span className="text-sm text-purple-900 dark:text-purple-100">
           This server needs a personal access token before its tools appear.
         </span>
@@ -134,7 +135,7 @@ function EgressConnectCallout({
             : 'border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-900/20'
         }`}
       >
-        <PowerIcon
+        <PlugIcon
           className={`h-5 w-5 flex-shrink-0 ${
             warn ? 'text-amber-500' : 'text-purple-600 dark:text-purple-400'
           }`}
@@ -158,7 +159,7 @@ function EgressConnectCallout({
 
   return (
     <div className="flex items-center gap-3 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
-      <PowerIcon className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
+      <PlugIcon className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
       <span className="text-sm text-green-900 dark:text-green-100">
         Connected to {providerLabel}. This server can act on your behalf.
       </span>

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -1,10 +1,16 @@
 import React, { useCallback, useState, useEffect } from 'react';
-import { ClipboardDocumentIcon, KeyIcon } from '@heroicons/react/24/outline';
+import { ClipboardDocumentIcon, KeyIcon, PowerIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import type { Server } from './ServerCard';
 import { useRegistryConfig } from '../hooks/useRegistryConfig';
 import useEscapeKey from '../hooks/useEscapeKey';
 import { getBaseURL } from '../utils/basePath';
+import { isSafeUrl } from '../utils/safeUrl';
+import {
+  initiateConsent,
+  disconnect as disconnectEgress,
+  type EgressCardState,
+} from '../utils/egressAuth';
 
 const IDE_LABELS = {
   'cursor': 'Cursor',
@@ -30,6 +36,142 @@ interface ServerConfigModalProps {
    * server. Used to build the `resource` field on /api/tokens/generate.
    */
   resourceType?: 'server' | 'virtual_server';
+  // Per-user egress state for this server (undefined => no callout). Shared with
+  // the card icon so the two surfaces never disagree.
+  egressConnect?: EgressCardState;
+  // Refresh the dashboard's egress state after a connect/disconnect here.
+  onEgressChanged?: () => void;
+}
+
+
+/**
+ * The issue #1495 "Connect your account" callout, shown at the top of the
+ * connect modal for a per-user-egress server. Roomier than the card icon, so it
+ * carries the full treatment: connect / connected+disconnect / reconnect on a
+ * dead token. Reuses the same initiate()/disconnect() client the Connected
+ * Accounts page uses.
+ */
+function EgressConnectCallout({
+  serverPath,
+  state,
+  onEgressChanged,
+  onShowToast,
+}: {
+  serverPath: string;
+  state: EgressCardState;
+  onEgressChanged?: () => void;
+  onShowToast?: (message: string, type: 'success' | 'error') => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const providerLabel = state.provider
+    ? state.provider.charAt(0).toUpperCase() + state.provider.slice(1)
+    : 'account';
+
+  const startConnect = async () => {
+    setBusy(true);
+    try {
+      // Prefer the same initiate() the Connected Accounts page uses; fall back
+      // to the server-built connect_url front door. Both are opened, never fetched.
+      let url = '';
+      try {
+        url = await initiateConsent(serverPath);
+      } catch {
+        url = state.connectUrl;
+      }
+      // MANDATORY isSafeUrl guard before window.open (fail closed on unsafe/empty).
+      if (!isSafeUrl(url)) {
+        onShowToast?.('Cannot open the connect URL for this server.', 'error');
+        return;
+      }
+      window.open(url, '_blank', 'noopener,noreferrer');
+      // The callback tab vaults the token; refresh so the card/callout flip to
+      // "Connected" when the user returns.
+      onEgressChanged?.();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setBusy(true);
+    try {
+      await disconnectEgress(state.provider, serverPath);
+      onShowToast?.(`Disconnected ${providerLabel}.`, 'success');
+      onEgressChanged?.();
+    } catch {
+      onShowToast?.(`Could not disconnect ${providerLabel}.`, 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // PAT server: no OAuth redirect — point at the token form on Connected Accounts.
+  if (state.mode === 'pat') {
+    return (
+      <div className="flex items-center gap-3 rounded-lg border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-900/20 p-4">
+        <PowerIcon className="h-5 w-5 flex-shrink-0 text-purple-600 dark:text-purple-400" />
+        <span className="text-sm text-purple-900 dark:text-purple-100">
+          This server needs a personal access token before its tools appear.
+        </span>
+        <a
+          href={`/connected-accounts?server=${encodeURIComponent(serverPath)}`}
+          className="ml-auto text-sm font-medium text-purple-700 dark:text-purple-300 hover:underline"
+        >
+          Submit token
+        </a>
+      </div>
+    );
+  }
+
+  // 3LO: not connected / needs reconnect / connected.
+  if (!state.connected || state.needsReconnect) {
+    const warn = state.needsReconnect;
+    return (
+      <div
+        className={`flex items-center gap-3 rounded-lg border p-4 ${
+          warn
+            ? 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20'
+            : 'border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-900/20'
+        }`}
+      >
+        <PowerIcon
+          className={`h-5 w-5 flex-shrink-0 ${
+            warn ? 'text-amber-500' : 'text-purple-600 dark:text-purple-400'
+          }`}
+        />
+        <span className="text-sm text-gray-900 dark:text-gray-100">
+          {warn
+            ? `Your ${providerLabel} connection expired or failed — reconnect to restore this server's tools.`
+            : `This server acts on your behalf. Connect your ${providerLabel} account before copying the config.`}
+        </span>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={startConnect}
+          className="ml-auto flex-shrink-0 rounded-md bg-purple-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-purple-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-purple-500"
+        >
+          {busy ? 'Opening…' : warn ? `Reconnect ${providerLabel}` : `Connect ${providerLabel} account`}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 p-4">
+      <PowerIcon className="h-5 w-5 flex-shrink-0 text-green-600 dark:text-green-400" />
+      <span className="text-sm text-green-900 dark:text-green-100">
+        Connected to {providerLabel}. This server can act on your behalf.
+      </span>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={handleDisconnect}
+        className="ml-auto flex-shrink-0 rounded-md px-3 py-1.5 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-red-500"
+      >
+        {busy ? 'Working…' : 'Disconnect'}
+      </button>
+    </div>
+  );
 }
 
 const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
@@ -38,6 +180,8 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
   onClose,
   onShowToast,
   resourceType = 'server',
+  egressConnect,
+  onEgressChanged,
 }) => {
   const [jwtToken, setJwtToken] = useState<string | null>(null);
   const [tokenLoading, setTokenLoading] = useState(false);
@@ -739,6 +883,18 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
         </div>
 
         <div className="space-y-4">
+          {/* Egress "Connect your account" callout (#1495): shown before the
+              config the user copies, so per-user-auth servers stop silently
+              returning "0 tools". Only rendered when eligible. */}
+          {egressConnect && (
+            <EgressConnectCallout
+              serverPath={server.path}
+              state={egressConnect}
+              onEgressChanged={onEgressChanged}
+              onShowToast={onShowToast}
+            />
+          )}
+
           <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
             <h4 className="font-medium text-blue-900 dark:text-blue-100 mb-2">
               How to use this configuration:

--- a/frontend/src/components/icons/PlugIcon.tsx
+++ b/frontend/src/components/icons/PlugIcon.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+/**
+ * An electrical-plug icon (two-prong plug), drawn inline because Heroicons —
+ * the project's icon set — has no plug/socket glyph. Matches the Heroicons
+ * 24x24 outline style (currentColor stroke, width 1.5) so it sits cleanly
+ * alongside the other card action icons. Accepts a `className` for sizing/color
+ * exactly like a Heroicons component.
+ */
+function PlugIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 22v-5M9 8V2M15 8V2M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8h12Z"
+      />
+    </svg>
+  );
+}
+
+export default PlugIcon;

--- a/frontend/src/contexts/EgressConnectContext.tsx
+++ b/frontend/src/contexts/EgressConnectContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext } from 'react';
+import type { EgressCardState } from '../utils/egressAuth';
+
+/**
+ * Shared per-user egress connect state for server cards, so every place that
+ * renders a ServerCard (dashboard grid, discover/search rows) shows the same
+ * "connect your account" affordance without threading props through each render
+ * path. ServerCard reads this context by server path; the provider (Dashboard)
+ * owns the fetch + refresh.
+ */
+interface EgressConnectContextValue {
+  // Per-server-path egress state; empty map when the feature is off or the
+  // caller is not a per-user principal.
+  stateByPath: Map<string, EgressCardState>;
+  // Re-fetch the state after a connect/disconnect (e.g. from the modal callout).
+  reload: () => void;
+}
+
+const EgressConnectContext = createContext<EgressConnectContextValue>({
+  stateByPath: new Map(),
+  reload: () => {},
+});
+
+
+export const EgressConnectProvider = EgressConnectContext.Provider;
+
+
+/** Read the shared egress connect state (state map + reload callback). */
+export function useEgressConnect(): EgressConnectContextValue {
+  return useContext(EgressConnectContext);
+}

--- a/frontend/src/pages/ConnectedAccountsPage.tsx
+++ b/frontend/src/pages/ConnectedAccountsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   LinkIcon,
   TrashIcon,
@@ -29,6 +29,7 @@ import { isSafeUrl } from '../utils/safeUrl';
  */
 const ConnectedAccountsPage: React.FC = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [connections, setConnections] = useState<EgressConnection[]>([]);
   const [available, setAvailable] = useState<AvailableEgressServer[]>([]);
   const [loading, setLoading] = useState(true);
@@ -89,6 +90,13 @@ const ConnectedAccountsPage: React.FC = () => {
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Preselect the dropdown when a server is passed via ?server= (from the card
+  // icon / connect-modal callout), so the user lands ready to connect/submit.
+  useEffect(() => {
+    const s = searchParams.get('server');
+    if (s) setServerPath(s);
+  }, [searchParams]);
 
   const handleConnect = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -72,6 +72,7 @@ import type {
 import axios from 'axios';
 import { getBaseURL } from '../utils/basePath';
 import { isEgressAuthEnabled, loadEgressCardState, type EgressCardState } from '../utils/egressAuth';
+import { EgressConnectProvider } from '../contexts/EgressConnectContext';
 import {
   buildLocalRuntimeForm,
   buildLocalRuntimeJson,
@@ -2652,7 +2653,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
   }
 
   return (
-    <>
+    <EgressConnectProvider value={{ stateByPath: egressStateByPath, reload: reloadEgressState }}>
       {/* Toast Notification */}
       {toast && (
         <Toast
@@ -3149,7 +3150,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         isLoading={customDeleteLoading}
       />
 
-    </>
+    </EgressConnectProvider>
   );
 };
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -71,7 +71,7 @@ import type {
 } from '../types/customEntity';
 import axios from 'axios';
 import { getBaseURL } from '../utils/basePath';
-import { isEgressAuthEnabled } from '../utils/egressAuth';
+import { isEgressAuthEnabled, loadEgressCardState, type EgressCardState } from '../utils/egressAuth';
 import {
   buildLocalRuntimeForm,
   buildLocalRuntimeJson,
@@ -315,6 +315,9 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     egress_target_audience: '',
   });
   const [egressEnabled, setEgressEnabled] = useState(false);
+  // Per-server egress connect state (card icon + connect-modal callout). Keyed by
+  // server path; empty when the feature is off or the caller is not per-user.
+  const [egressStateByPath, setEgressStateByPath] = useState<Map<string, EgressCardState>>(new Map());
   const [editLoading, setEditLoading] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
@@ -373,6 +376,17 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
       active = false;
     };
   }, []);
+
+  // Load the per-server egress connect state for the card icon + modal callout.
+  // Returns an empty map when the feature is off or the caller is not per-user.
+  // Extracted so the modal can re-run it after a connect/disconnect.
+  const reloadEgressState = useCallback(() => {
+    void loadEgressCardState().then(setEgressStateByPath);
+  }, []);
+
+  useEffect(() => {
+    reloadEgressState();
+  }, [reloadEgressState]);
 
   // Reset viewFilter to 'discover' when the active tab is hidden by the
   // deployment feature flag. For servers and custom-entity types we ALSO redirect
@@ -2224,6 +2238,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                       onShowToast={showToast}
                       onServerUpdate={handleServerUpdate}
                       authToken={agentApiToken}
+                      egressConnect={egressStateByPath.get(server.path)}
+                      onEgressChanged={reloadEgressState}
                     />
                   );
 
@@ -2549,6 +2565,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
               onServerUpdate={handleServerUpdate}
               onDelete={handleDeleteServer}
               authToken={agentApiToken}
+              egressConnect={egressStateByPath.get(server.path)}
+              onEgressChanged={reloadEgressState}
             />
           )}
           renderAgentCard={(agent) => (

--- a/frontend/src/utils/egressAuth.ts
+++ b/frontend/src/utils/egressAuth.ts
@@ -21,6 +21,25 @@ export interface AvailableEgressServer {
   server_name: string;
   provider: string;
   egress_auth_mode?: string;
+  // Server-built gateway front-door URL (oauth_user only; null for pat). Built
+  // from the configured registry_url so the browser never guesses the base.
+  connect_url?: string | null;
+}
+
+/**
+ * Merged per-server egress state consumed by BOTH the server-card icon and the
+ * connect-modal callout, so the two surfaces never disagree.
+ */
+export interface EgressCardState {
+  mode: 'oauth_user' | 'pat';
+  provider: string;
+  connectUrl: string; // from connect_url (oauth_user); '' for pat (never opened)
+  connected: boolean; // a connection exists for this server_path
+  status: string | null; // connection status: 'active' | 'refresh_failed' | ... (null if not connected)
+  expiresAt: string | null; // connection expiry ISO string (null if not connected)
+  // Connected but the token is dead (refresh_failed or past expiry): drives the
+  // one-click "Reconnect" affordance so it stops being a silent "0 tools".
+  needsReconnect: boolean;
 }
 
 export interface PatStatus {
@@ -51,6 +70,53 @@ export async function listConnections(): Promise<EgressConnection[]> {
 export async function listAvailableServers(): Promise<AvailableEgressServer[]> {
   const resp = await axios.get('/api/egress-auth/available-servers');
   return resp.data as AvailableEgressServer[];
+}
+
+/**
+ * Fetch the two per-user egress lists once and merge them into a per-server-path
+ * map, consumed by BOTH the server-card icon and the connect-modal callout.
+ * Returns an empty map when the feature is disabled (available-servers 404s) or
+ * the caller is not a per-user principal (returns []).
+ */
+export async function loadEgressCardState(): Promise<Map<string, EgressCardState>> {
+  const byPath = new Map<string, EgressCardState>();
+  let available: AvailableEgressServer[] = [];
+  try {
+    available = await listAvailableServers();
+  } catch {
+    // 404 = feature disabled; anything else = treat as "no egress affordance".
+    return byPath;
+  }
+  let connections: EgressConnection[] = [];
+  try {
+    connections = await listConnections();
+  } catch {
+    connections = [];
+  }
+  // Index connections by server_path for O(1) lookup of status/expiry.
+  const connByPath = new Map(connections.map(c => [c.server_path, c]));
+  const nowMs = Date.now();
+  for (const s of available) {
+    const mode = s.egress_auth_mode === 'pat' ? 'pat' : 'oauth_user';
+    const conn = connByPath.get(s.server_path);
+    const connected = !!conn;
+    const status = conn?.status ?? null;
+    const expiresAt = conn?.expires_at ?? null;
+    // A dead token (refresh_failed or expired) is still "connected" but needs a
+    // one-click reconnect so it stops being a silent "0 tools".
+    const expired = !!expiresAt && Date.parse(expiresAt) < nowMs;
+    const needsReconnect = connected && (status === 'refresh_failed' || expired);
+    byPath.set(s.server_path, {
+      mode,
+      provider: s.provider,
+      connectUrl: s.connect_url || '', // '' for pat (backend sends null); pat never opens it
+      connected,
+      status,
+      expiresAt,
+      needsReconnect,
+    });
+  }
+  return byPath;
 }
 
 /** Begin consent for a server; returns the provider authorize URL to open. */

--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -946,6 +946,12 @@ async def list_available_egress_servers(
                 "server_name": server.get("server_name") or path,
                 "provider": eo.get("provider") or "custom",
                 "egress_auth_mode": mode,
+                # Server-built gateway front door, using settings.registry_url so
+                # the browser never guesses the base URL (correct on all deploy
+                # surfaces). Only oauth_user can use /oauth2/egress/connect; a pat
+                # server 400s there, so its connect_url is None (the UI routes pat
+                # to the Connected Accounts token form instead).
+                "connect_url": _build_connect_url(path) if mode == "oauth_user" else None,
             }
         )
     results.sort(key=lambda r: r["server_name"].lower())

--- a/registry/api/egress_oauth_facade_routes.py
+++ b/registry/api/egress_oauth_facade_routes.py
@@ -165,12 +165,19 @@ async def egress_connect(
             status_code=403,
         )
 
+    # Bind the consent state to the canonical egress principal (OIDC-sub-based
+    # ``egress_user``, else ``username``) -- the SAME id the vend, the vault, and
+    # the callback account-swap guard use. Using bare ``username`` here would bind
+    # the state to a different id than the callback resolves, so the guard would
+    # reject every callback with "state user mismatch" whenever egress_user is set.
+    egress_user_id = user_context.get("egress_user") or user_context.get("username") or ""
+
     # Provider consent leg, via the existing web Connected-Accounts path: the
     # callback stores the token + shows the close-tab page. No client-side code
     # exchange -- the client just retries the original tool call.
     provider_authorize_url = get_egress_auth_service().build_consent_url(
         auth_method=auth_method,
-        user_id=user_context.get("username") or "",
+        user_id=egress_user_id,
         client_id_audit=user_context.get("client_id") or "",
         session_id=user_context.get("session_id") or "",
         server_path=server_path,
@@ -178,7 +185,7 @@ async def egress_connect(
     )
     logger.info(
         "egress connect: user=%s server=%s -> provider consent",
-        user_context.get("username"),
+        egress_user_id,
         server_path,
     )
     return RedirectResponse(provider_authorize_url, status_code=302)

--- a/tests/unit/egress_auth/test_available_servers_connect_url.py
+++ b/tests/unit/egress_auth/test_available_servers_connect_url.py
@@ -1,0 +1,112 @@
+"""Tests for GET /api/egress-auth/available-servers connect_url field.
+
+The endpoint lists per-user-egress servers the caller can reach. This suite
+covers the new ``connect_url`` field (issue #1495 / egress-connect affordance):
+- oauth_user rows carry a registry_url-based connect_url.
+- pat rows carry connect_url = None (pat cannot use the OAuth front door).
+- the URL base tracks settings.registry_url.
+- unchanged gating: [] for non-per-user callers, 404 when disabled.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import registry.api.egress_auth_routes as routes
+
+
+def _servers():
+    """Two egress servers (oauth_user + pat) plus a non-egress one."""
+    return {
+        "/slack": {
+            "server_name": "Slack MCP",
+            "egress_auth_mode": "oauth_user",
+            "egress_oauth": {"provider": "slack"},
+        },
+        "/acme-pat": {
+            "server_name": "Acme PAT",
+            "egress_auth_mode": "pat",
+            "egress_oauth": {"provider": "custom"},
+        },
+        "/plain": {
+            "server_name": "Plain",
+            "egress_auth_mode": "none",
+            "egress_oauth": None,
+        },
+    }
+
+
+class _StubServerService:
+    def __init__(self, servers):
+        self._servers = servers
+
+    async def get_all_servers(self):
+        return self._servers
+
+
+@pytest.fixture
+def make_client(monkeypatch):
+    """Factory: TestClient with controllable user context, servers, settings."""
+
+    def _build(
+        user_context,
+        servers,
+        enabled=True,
+        registry_url="https://gw.example.com",
+    ):
+        monkeypatch.setattr(routes.settings, "egress_auth_enabled", enabled)
+        monkeypatch.setattr(routes.settings, "registry_url", registry_url)
+        monkeypatch.setattr(routes, "server_service", _StubServerService(servers))
+
+        app = FastAPI()
+        app.include_router(routes.router)
+        app.dependency_overrides[routes.nginx_proxied_auth] = lambda: user_context
+        return TestClient(app)
+
+    return _build
+
+
+def _ctx(**over):
+    base = {"auth_method": "oauth2", "accessible_servers": ["*"]}
+    base.update(over)
+    return base
+
+
+@pytest.mark.unit
+class TestAvailableServersConnectUrl:
+    def test_oauth_user_row_has_connect_url(self, make_client):
+        client = make_client(_ctx(), _servers())
+        rows = client.get("/egress-auth/available-servers").json()
+        slack = next(r for r in rows if r["server_path"] == "/slack")
+        assert (
+            slack["connect_url"]
+            == "https://gw.example.com/oauth2/egress/connect?server=%2Fslack"
+        )
+
+    def test_pat_row_connect_url_is_none(self, make_client):
+        client = make_client(_ctx(), _servers())
+        rows = client.get("/egress-auth/available-servers").json()
+        pat = next(r for r in rows if r["server_path"] == "/acme-pat")
+        assert pat["egress_auth_mode"] == "pat"
+        assert pat["connect_url"] is None
+
+    def test_connect_url_uses_configured_registry_url(self, make_client):
+        client = make_client(_ctx(), _servers(), registry_url="http://localhost:9999")
+        rows = client.get("/egress-auth/available-servers").json()
+        slack = next(r for r in rows if r["server_path"] == "/slack")
+        assert slack["connect_url"].startswith(
+            "http://localhost:9999/oauth2/egress/connect"
+        )
+
+    def test_non_egress_server_absent(self, make_client):
+        client = make_client(_ctx(), _servers())
+        rows = client.get("/egress-auth/available-servers").json()
+        assert all(r["server_path"] != "/plain" for r in rows)
+
+    def test_non_per_user_caller_gets_empty(self, make_client):
+        client = make_client(_ctx(auth_method="network-trusted"), _servers())
+        assert client.get("/egress-auth/available-servers").json() == []
+
+    def test_feature_disabled_404(self, make_client):
+        client = make_client(_ctx(), _servers(), enabled=False)
+        assert client.get("/egress-auth/available-servers").status_code == 404

--- a/tests/unit/egress_auth/test_available_servers_connect_url.py
+++ b/tests/unit/egress_auth/test_available_servers_connect_url.py
@@ -79,8 +79,7 @@ class TestAvailableServersConnectUrl:
         rows = client.get("/egress-auth/available-servers").json()
         slack = next(r for r in rows if r["server_path"] == "/slack")
         assert (
-            slack["connect_url"]
-            == "https://gw.example.com/oauth2/egress/connect?server=%2Fslack"
+            slack["connect_url"] == "https://gw.example.com/oauth2/egress/connect?server=%2Fslack"
         )
 
     def test_pat_row_connect_url_is_none(self, make_client):
@@ -94,9 +93,7 @@ class TestAvailableServersConnectUrl:
         client = make_client(_ctx(), _servers(), registry_url="http://localhost:9999")
         rows = client.get("/egress-auth/available-servers").json()
         slack = next(r for r in rows if r["server_path"] == "/slack")
-        assert slack["connect_url"].startswith(
-            "http://localhost:9999/oauth2/egress/connect"
-        )
+        assert slack["connect_url"].startswith("http://localhost:9999/oauth2/egress/connect")
 
     def test_non_egress_server_absent(self, make_client):
         client = make_client(_ctx(), _servers())


### PR DESCRIPTION
## Summary

Closes #1495. Surfaces a state-aware egress "connect your account" affordance in **two** places, driven by one shared data source so they never disagree:

- **Connect/config modal callout** (the #1495 ask): connect / connected+disconnect / reconnect-on-dead-token, shown before the mcp.json config the user copies, so per-user-auth servers stop silently returning "0 tools".
- **Compact `PowerIcon` on the server card header** with a mode/state-aware tooltip (Link account / Submit token / Connected / Reconnect), for at-a-glance discovery without opening the modal.

## Changes

**Backend**
- `GET /api/egress-auth/available-servers` returns an additive `connect_url` per row, built server-side from `settings.registry_url` (reuses the existing `_build_connect_url`, so it is correct across Docker / Helm / Terraform / CDK without the browser guessing the base). `oauth_user` only; `pat` rows get `null` (they route to the Connected Accounts token form instead).

**Frontend**
- `loadEgressCardState()` merges `available-servers` + `connections` into a per-path `EgressCardState` (`connected` / `status` / `needsReconnect`), consumed by both surfaces.
- `EgressConnectButton` (card) and `EgressConnectCallout` (modal) share that state; the modal reuses the existing `initiate()` / `disconnect()` client the Connected Accounts page uses.
- Dashboard loads the map once and refreshes it after a connect/disconnect in the modal.
- Connected Accounts preselects the dropdown from `?server=`.

## Design notes

- Egress eligibility stays on the per-user endpoints (it depends on `accessible_servers` / `auth_method`), so no egress fields are added to the generic `/api/servers` list.
- No new config parameter — reuses `REGISTRY_URL`, already wired on all deploy surfaces.

## Security

- Every `window.open` is `isSafeUrl`-guarded and opened `noopener,noreferrer` (fail closed on unsafe/empty `connect_url`).
- No token/secret is handled client-side; the affordance opens the gateway front door / provider consent only.

## Testing

- New unit tests: `connect_url` present for `oauth_user`, `null` for `pat`, base tracks `registry_url`, `[]` for non-per-user callers, 404 when disabled.
- `230/230` egress unit tests pass; no regressions.
- Frontend: `tsc` clean and `eslint` 0 errors in touched files.

## Test plan

- [ ] 3LO server: card icon + modal callout show "Connect"; clicking opens consent in a new tab; state flips to Connected on return.
- [ ] Dead/`refresh_failed` token: amber icon + one-click Reconnect in the modal.
- [ ] PAT server: routes to Connected Accounts with the server preselected.
- [ ] Feature disabled (`EGRESS_AUTH_ENABLED=false`): no affordance, no error.
