### PR TITLE
fix(egress): fall back to JWT exp when token response omits expires_in

### DIFF
--- a/registry/egress_auth/oauth_engine.py
+++ b/registry/egress_auth/oauth_engine.py
@@ -16,6 +16,7 @@ plus the operator ``client_id``/``client_secret``. Token material is returned as
 
 import base64
 import hashlib
+import json
 import logging
 import secrets
 from datetime import UTC, datetime, timedelta
@@ -151,10 +152,40 @@ def _parse_token_response(cfg: OAuthProviderConfig, payload: dict) -> dict:
 # --------------------------------------------------------------------------- #
 
 
-def _expires_at(expires_in: int | None) -> str | None:
-    if not expires_in:
+def _jwt_exp(access_token: str | None) -> int | None:
+    """Best-effort ``exp`` (epoch seconds) from a JWT access token, else None.
+
+    Opaque (non-JWT) tokens and any decode/parse failure return None; the payload
+    is base64url-decoded WITHOUT signature verification purely to read the
+    provider-asserted lifetime, never to trust the token.
+    """
+    if not access_token or access_token.count(".") != 2:
         return None
-    return (datetime.now(UTC) + timedelta(seconds=int(expires_in))).isoformat()
+    payload_b64 = access_token.split(".")[1]
+    payload_b64 += "=" * (-len(payload_b64) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64.encode("ascii")))
+    except (ValueError, TypeError):
+        return None
+    exp = claims.get("exp")
+    return int(exp) if isinstance(exp, (int, float)) and not isinstance(exp, bool) else None
+
+
+def _expires_at(expires_in: int | None, access_token: str | None = None) -> str | None:
+    """ISO expiry from ``expires_in`` when present, else the access token's JWT ``exp``.
+
+    Some providers (e.g. Salesforce) omit ``expires_in`` from the token response
+    but issue a JWT access token bounded by an ``exp`` claim. Without this
+    fallback ``expires_at`` stays None, the vend path treats the token as
+    long-lived and never fires the single-flight refresh, so the gateway keeps
+    injecting a token the upstream has already expired ("Invalid token").
+    """
+    if expires_in:
+        return (datetime.now(UTC) + timedelta(seconds=int(expires_in))).isoformat()
+    exp = _jwt_exp(access_token)
+    if exp is not None:
+        return datetime.fromtimestamp(exp, tz=UTC).isoformat()
+    return None
 
 
 def _build_token_request(
@@ -230,7 +261,7 @@ def _to_stored_token(
         # the prior one (some don't re-send it on refresh).
         refresh_token=parsed.get("refresh_token") or fallback_refresh,
         token_type=parsed.get("token_type", "Bearer"),
-        expires_at=_expires_at(parsed.get("expires_in")),
+        expires_at=_expires_at(parsed.get("expires_in"), access),
         scopes=[s for s in scopes if s],
         status="active",
         client_id=client_id,

--- a/registry/egress_auth/oauth_engine.py
+++ b/registry/egress_auth/oauth_engine.py
@@ -168,7 +168,7 @@ def _jwt_exp(access_token: str | None) -> int | None:
     except (ValueError, TypeError):
         return None
     exp = claims.get("exp")
-    return int(exp) if isinstance(exp, (int, float)) and not isinstance(exp, bool) else None
+    return int(exp) if isinstance(exp, int | float) and not isinstance(exp, bool) else None
 
 
 def _expires_at(expires_in: int | None, access_token: str | None = None) -> str | None:

--- a/tests/unit/egress_auth/test_oauth_engine.py
+++ b/tests/unit/egress_auth/test_oauth_engine.py
@@ -6,6 +6,8 @@ no real provider is contacted.
 
 import base64
 import hashlib
+import json
+from datetime import UTC, datetime
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -126,6 +128,73 @@ class TestExchangeAndRefresh:
             await oauth_engine.exchange_code(
                 PROVIDER_REGISTRY["github"], "cid", "secret", "c", "https://gw/cb", "v"
             )
+
+
+def _make_jwt(exp: int | None) -> str:
+    """Minimal unsigned JWT (header.payload.sig) carrying an optional ``exp`` claim."""
+
+    def seg(obj: dict) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    claims: dict = {"iss": "https://example.my.salesforce.com"}
+    if exp is not None:
+        claims["exp"] = exp
+    return f"{seg({'alg': 'RS256', 'typ': 'JWT'})}.{seg(claims)}.sig"
+
+
+@pytest.mark.unit
+class TestExpiresAtFallback:
+    """Providers that omit ``expires_in`` (e.g. Salesforce) still bound the access
+    token via the JWT ``exp`` claim. Cover both token-endpoint call sites, since
+    exchange and refresh both funnel through ``_to_stored_token``."""
+
+    def test_expires_in_takes_precedence_over_jwt_exp(self):
+        # Stale JWT exp must not override an explicit, fresher expires_in.
+        past = int(datetime.now(UTC).timestamp()) - 3600
+        at = oauth_engine._expires_at(3600, _make_jwt(past))
+        assert at is not None
+        assert datetime.fromisoformat(at) > datetime.now(UTC)
+
+    def test_jwt_exp_used_when_expires_in_missing(self):
+        exp = int(datetime.now(UTC).timestamp()) + 7200
+        at = oauth_engine._expires_at(None, _make_jwt(exp))
+        assert at is not None
+        assert datetime.fromisoformat(at) == datetime.fromtimestamp(exp, tz=UTC)
+
+    def test_none_for_opaque_token_without_expires_in(self):
+        assert oauth_engine._expires_at(None, "opaque-not-a-jwt") is None
+
+    def test_none_for_jwt_without_exp_claim(self):
+        assert oauth_engine._expires_at(None, _make_jwt(None)) is None
+
+    def test_none_for_malformed_jwt(self):
+        assert oauth_engine._expires_at(None, "a.!!!notb64!!!.c") is None
+
+    async def test_exchange_sets_expires_at_from_jwt(self, monkeypatch):
+        exp = int(datetime.now(UTC).timestamp()) + 14400  # Salesforce ~4h JWT
+
+        async def fake_post(cfg, data, headers):
+            # No expires_in, JWT access token -- the Salesforce shape.
+            return {"access_token": _make_jwt(exp), "refresh_token": "rt", "scope": "mcp_api"}
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        tok = await oauth_engine.exchange_code(
+            PROVIDER_REGISTRY["github"], "cid", "secret", "c", "https://gw/cb", "v"
+        )
+        assert tok.expires_at is not None
+        assert datetime.fromisoformat(tok.expires_at) == datetime.fromtimestamp(exp, tz=UTC)
+
+    async def test_refresh_sets_expires_at_from_jwt(self, monkeypatch):
+        exp = int(datetime.now(UTC).timestamp()) + 14400
+
+        async def fake_post(cfg, data, headers):
+            return {"access_token": _make_jwt(exp)}
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        tok = await oauth_engine.refresh_token(PROVIDER_REGISTRY["google"], "cid", "secret", "rt")
+        assert tok.expires_at is not None
+        assert datetime.fromisoformat(tok.expires_at) == datetime.fromtimestamp(exp, tz=UTC)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Some OAuth providers (e.g. **Salesforce**) omit `expires_in` from the token
response but issue a **JWT access token bounded by an `exp` claim**. In that
case `_expires_at` returned `None`, so `StoredToken.expires_at` stayed unset.

Downstream, `EgressAuthService._is_near_expiry` treats a `None` expiry as
"long-lived" and returns `False`, so the lazy single-flight refresh **never
fires**. Once the JWT's `exp` passes (Salesforce ~4h), the gateway keeps
injecting the already-expired token and the upstream rejects every call with
`{"errors":[{"message":"Invalid token"}]}` — with no self-healing until the
user manually re-consents.

## Fix

Add a best-effort `_jwt_exp()` helper that base64url-decodes the access token
payload (WITHOUT signature verification — purely to read the provider-asserted
lifetime) and, when `expires_in` is absent, uses the `exp` claim to compute
`expires_at`.

- `expires_in`, when present, still wins (explicit provider lifetime).
- Opaque (non-JWT) tokens, malformed payloads, or a missing/non-numeric `exp`
  → `None` (unchanged "no expiry info" behaviour).
- Applied at the single `_to_stored_token` chokepoint, so it covers **both**
  the `exchange_code` and `refresh_token` paths.

## Tests

7 new unit tests in `tests/unit/egress_auth/test_oauth_engine.py`:
precedence of `expires_in` over a stale JWT `exp`, JWT `exp` used when
`expires_in` is missing, opaque / no-`exp` / malformed → `None`, and
end-to-end `exchange` + `refresh` asserting `expires_at` is derived from the
JWT. `ruff check`/`format` clean.

## Note

This pairs with the `acquire_lease` `DuplicateKeyError` guard in #1520: once
this change makes JWT-only providers actually enter the refresh path, the
refresh lease must not crash on the DocumentDB upsert-contention race. Both are
needed for reliable per-user egress refresh against providers like Salesforce.