### PR TITLE
fix(logout): make internalized OAuth2 logout work behind CloudFront / on the S2S hop (#1503)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1155,10 +1155,43 @@ def _is_redirect_within_cookie_domain(
         if request_host and parsed.scheme == request_scheme and hostname == request_host:
             return True
 
+    # Trust the deployment's own configured external host. On the internal
+    # server-to-server logout hop (issue #1503), the registry reaches auth-server
+    # over the cluster network, so the request origin auth-server reconstructs is
+    # the internal scheme/host (e.g. http/loopback), NOT the public URL — the
+    # same-origin match above then fails for a legitimate https public
+    # redirect_uri and the redirect is wrongly dropped (Cognito then rejects the
+    # logout with "Required parameters missing"). The redirect_uri's host being
+    # the deployment's OWN declared public host is safe by definition (it is not
+    # user-controlled here; it is derived from the registry's trusted-host
+    # allowlist), so accept it regardless of the reconstructed request scheme.
+    configured_host = _configured_external_host()
+    if configured_host and hostname == configured_host:
+        return True
+
     if not cookie_domain:
         return False
     apex = cookie_domain.lstrip(".").lower()
     return hostname == apex or hostname.endswith(f".{apex}")
+
+
+def _configured_external_host() -> str:
+    """Return the deployment's own public host from configured external URLs.
+
+    Prefers ``AUTH_SERVER_EXTERNAL_URL`` (the public URL, distinct from the
+    internal ``registry_url``/service URL), falling back to ``REGISTRY_URL``.
+    Returns a lower-cased hostname (no scheme/port) or "" if none is configured.
+    This is the deployment's own declared host, used to approve a same-origin
+    redirect_uri even when the request reaches auth-server over the internal
+    network (where the reconstructed request scheme/host is not the public one).
+    """
+    for env_name in ("AUTH_SERVER_EXTERNAL_URL", "REGISTRY_URL"):
+        raw = os.environ.get(env_name, "").strip()
+        if raw:
+            host = (urlparse(raw).hostname or "").lower()
+            if host:
+                return host
+    return ""
 
 
 def _is_safe_redirect_url(

--- a/docs/idp/cognito.md
+++ b/docs/idp/cognito.md
@@ -139,7 +139,7 @@ One Secrets Manager entry is created (`cognito_client_secret`) and the registry/
 Two separate URL lists on the App Client must be configured, and Cognito rejects any value not present in the matching list:
 
 - **Allowed callback URLs** — the auth-server sends `redirect_uri = <registry-external-url>/oauth2/callback/cognito` during login.
-- **Allowed sign-out URLs** — the auth-server sends `logout_uri = <registry-external-url>/login` during logout. This is easy to miss; if only the callback is registered, login works but logout fails with a Cognito error page (`Required String parameter 'redirect_uri' is not present` or a sign-out URL mismatch).
+- **Allowed sign-out URLs** — the auth-server sends `logout_uri = <registry-external-url>/logout` during logout (`/logout` renders the "Successfully Logged Out" confirmation screen, then auto-redirects to `/login`). This is easy to miss; if only the callback is registered, login works but logout fails with a Cognito error page (`error=Required+parameters+missing` / a sign-out URL mismatch). Cognito requires an EXACT match (no wildcards), so the exact `/logout` URL must be registered.
 
 The registry does NOT configure Cognito for you (it is bring-your-own), so this is a manual step.
 
@@ -156,13 +156,13 @@ When you use a custom domain (`enable_route53_dns = true`), you know the registr
 
 2. On the App Client, set:
    - **Allowed callback URLs:** `<that URL>/oauth2/callback/cognito`
-   - **Allowed sign-out URLs:** `<that URL>/login`
+   - **Allowed sign-out URLs:** `<that URL>/logout`
 
    **From the AWS console:**
    - Open the Cognito console, select your User Pool.
    - Go to **App integration** -> **App clients** -> select your app client.
    - Under **Hosted UI** (or **Login pages**), click **Edit**.
-   - Add the callback URL to **Allowed callback URLs** and the `/login` URL to **Allowed sign-out URLs** (keep any existing entries, e.g. the localhost ones for local testing), then **Save changes**.
+   - Add the callback URL to **Allowed callback URLs** and the `/logout` URL to **Allowed sign-out URLs** (keep any existing entries, e.g. the localhost ones for local testing), then **Save changes**.
 
    **From the CLI** (note: `update-user-pool-client` replaces the full lists, so include every URL you want to keep):
 
@@ -175,8 +175,8 @@ When you use a custom domain (`enable_route53_dns = true`), you know the registr
        "https://<your-registry-domain>/oauth2/callback/cognito" \
        "http://localhost:8888/oauth2/callback/cognito" \
      --logout-urls \
-       "https://<your-registry-domain>/login" \
-       "http://localhost:8888/login" \
+       "https://<your-registry-domain>/logout" \
+       "http://localhost:8888/logout" \
      --allowed-o-auth-flows code \
      --allowed-o-auth-scopes openid email profile aws.cognito.signin.user.admin \
      --allowed-o-auth-flows-user-pool-client \
@@ -364,9 +364,9 @@ A common cause on Terraform/ECS CloudFront-only deployments: a `terraform apply`
 
 ### Logout fails with a Cognito error page
 
-**Symptom:** Login works, but clicking logout lands on a Cognito error page (e.g. `Required String parameter 'redirect_uri' is not present`), with a URL like `.../error?...&logout_uri=https%3A%2F%2F<domain>%2Flogin`.
+**Symptom:** Login works, but clicking logout lands on a Cognito error page (e.g. `error=Required+parameters+missing`), with a URL like `.../error?...&client_id=<id>` (note the missing/rejected `logout_uri`).
 
-**Fix:** The App Client's **Allowed sign-out URLs** must include `<registry-external-url>/login` — this is a separate list from the callback URLs, and is easy to miss. The auth-server sends `logout_uri = <registry-external-url>/login` on logout; Cognito rejects it if it is not registered. Add it (see [Mode 2, Step 4](#step-4-register-the-callback-and-sign-out-urls-on-the-app-client-post-deployment)). The `logout_uri` echoed in the error page URL is the value Cognito rejected, not a separate problem.
+**Fix:** The App Client's **Allowed sign-out URLs** must include `<registry-external-url>/logout` — this is a separate list from the callback URLs, and is easy to miss. The auth-server sends `logout_uri = <registry-external-url>/logout` on logout (the `/logout` page shows the "Successfully Logged Out" confirmation, then redirects to `/login`); Cognito requires an exact match and rejects it if not registered. Add it (see [Mode 2, Step 4](#step-4-register-the-callback-and-sign-out-urls-on-the-app-client-post-deployment)). Unlike Keycloak (whose `post.logout.redirect.uris="+"` accepts any registered redirect URI, so `/logout` works with no extra config), Cognito has no wildcard — register the exact `/logout` URL.
 
 ### Empty groups after login
 

--- a/registry/auth/routes.py
+++ b/registry/auth/routes.py
@@ -333,6 +333,18 @@ async def logout_handler(
         # so it is configured and reachable in every deployment mode (EKS,
         # Docker/Compose, ECS, EC2, local).
         if provider:
+            # Post-logout landing page: "/logout" renders the "Successfully Logged
+            # Out" confirmation screen (frontend/src/pages/Logout.tsx), then
+            # auto-redirects to /login after 5s. The IdP returns the browser here
+            # after terminating the session, so this URL MUST be registered as a
+            # valid post-logout / sign-out redirect in the IdP:
+            #   - Cognito: add "<host>/logout" to the app client's Sign-out URLs
+            #     (an unregistered logout_uri is rejected with "Required parameters
+            #     missing" -- issue #1503).
+            #   - Keycloak/Entra/Okta: add "<host>/logout" to the client's valid
+            #     post-logout redirect URIs.
+            # See docs/idp/*.md. If a deployment cannot register "/logout", point
+            # this at a registered page (e.g. "/login") at the cost of the screen.
             redirect_uri = _build_external_url(request, "/logout")
             logout_params: dict[str, str] = {"redirect_uri": redirect_uri}
 

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -323,6 +323,38 @@ class TestIsRedirectWithinCookieDomain:
         request = self._request(forwarded_host="localhost:7860", forwarded_proto="http")
         assert not _is_redirect_within_cookie_domain("https://localhost:7860/logout", "", request)
 
+    def test_configured_external_host_trusted_on_s2s_hop(self, monkeypatch):
+        """Issue #1503: on the internal S2S logout hop the request scheme reconstructs
+        as http and X-Forwarded-Host is absent, so the same-origin match fails for a
+        legitimate https public redirect_uri. The redirect_uri host matching the
+        deployment's own AUTH_SERVER_EXTERNAL_URL must still be accepted."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        monkeypatch.setenv("AUTH_SERVER_EXTERNAL_URL", "https://d2xl2zfuhgc4l0.cloudfront.net")
+        # Reconstructed request origin is internal (http, no forwarded host).
+        request = self._request(forwarded_host="", forwarded_proto="", url_host="127.0.0.1")
+        assert _is_redirect_within_cookie_domain(
+            "https://d2xl2zfuhgc4l0.cloudfront.net/logout", "", request
+        )
+
+    def test_configured_external_host_falls_back_to_registry_url(self, monkeypatch):
+        """REGISTRY_URL is used when AUTH_SERVER_EXTERNAL_URL is unset."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        monkeypatch.delenv("AUTH_SERVER_EXTERNAL_URL", raising=False)
+        monkeypatch.setenv("REGISTRY_URL", "https://app.example.com")
+        request = self._request(forwarded_host="", forwarded_proto="", url_host="127.0.0.1")
+        assert _is_redirect_within_cookie_domain("https://app.example.com/logout", "", request)
+
+    def test_non_configured_host_still_rejected_on_s2s_hop(self, monkeypatch):
+        """A redirect to a host that is NOT the configured external host is still
+        rejected even on the internal hop (the fix does not open a general bypass)."""
+        from auth_server.server import _is_redirect_within_cookie_domain
+
+        monkeypatch.setenv("AUTH_SERVER_EXTERNAL_URL", "https://d2xl2zfuhgc4l0.cloudfront.net")
+        request = self._request(forwarded_host="", forwarded_proto="", url_host="127.0.0.1")
+        assert not _is_redirect_within_cookie_domain("https://evil.example.net/logout", "", request)
+
 
 class TestGroupToScopeMapping:
     """Tests for mapping IdP groups to MCP scopes."""

--- a/tests/unit/auth/test_logout_handler.py
+++ b/tests/unit/auth/test_logout_handler.py
@@ -171,6 +171,20 @@ class TestLogoutHandlerS2S:
         assert kwargs["headers"]["X-Forwarded-Proto"] == "https"
 
     @pytest.mark.asyncio
+    async def test_post_logout_redirect_uri_lands_on_logout_screen(self):
+        """The post-logout redirect_uri lands on /logout, which renders the
+        'Successfully Logged Out' confirmation screen. This URL must be registered
+        as a valid sign-out redirect in the IdP (Cognito rejects an unregistered
+        logout_uri with 'Required parameters missing' -- issue #1503); the
+        same-origin fix lets the https public /logout through on the S2S hop."""
+        factory, instance = _mock_s2s_client(_s2s_response())
+        await self._run(factory)
+
+        _, kwargs = instance.get.call_args
+        redirect_uri = kwargs["params"]["redirect_uri"]
+        assert redirect_uri.endswith("/logout"), redirect_uri
+
+    @pytest.mark.asyncio
     async def test_cookie_cleared_on_success(self):
         """The session cookie must be cleared on the IdP redirect response."""
         factory, _ = _mock_s2s_client(_s2s_response())


### PR DESCRIPTION
## Summary

PR #1509 internalized the OAuth2 logout flow (the registry now calls auth-server server-to-server instead of redirecting the browser through it, so the `id_token_hint` JWT never traverses public infrastructure). That change broke logout on **Cognito behind CloudFront**: after clicking logout the browser landed on Cognito's error page:

```
.../error?error=Required+parameters+missing&client_id=...
```

This PR fixes it. Two independent root causes, both confirmed against live ECS auth-server/registry traces:

### 1. Same-origin redirect check dropped the `redirect_uri` on the internal S2S hop

On the registry→auth-server internal call, auth-server reconstructs the request origin from the internal connection (scheme `http`, loopback host), and the `X-Forwarded-*` headers the registry sets do not survive to the same-origin comparison. A legitimate **https public** `redirect_uri` (`https://<cloudfront>/logout`) therefore failed the host+scheme same-origin match and was nulled — so Cognito received no valid `logout_uri`.

**Fix:** `_is_redirect_within_cookie_domain` now also accepts a `redirect_uri` whose **host matches the deployment's own configured external host** (`AUTH_SERVER_EXTERNAL_URL`, falling back to `REGISTRY_URL`), regardless of the reconstructed request scheme. That host is the deployment's declared public origin (already allowlist-validated by the registry's `_resolve_trusted_host`), so this is **not** a general redirect bypass — a non-configured host is still rejected (test included).

### 2. Sign-out URL registration (Cognito exact-match vs Keycloak wildcard)

The post-logout redirect is `/logout` (renders the "Successfully Logged Out" confirmation screen, then auto-redirects to `/login`).

- **Keycloak** accepts this with **no extra setup** — the imported realm (`keycloak/import/realm-config.json`) sets `mcp-gateway-web` `post.logout.redirect.uris='+'` with `redirectUris` including `REGISTRY_URL/*` (wildcard covers `/logout`).
- **Cognito** has no wildcard and requires the **exact** sign-out URL, so `<host>/logout` must be registered on the app client. `docs/idp/cognito.md` is corrected here: it previously told operators to register `/login` while the code sends `/logout`, and cited the wrong error string.

## Trace evidence

```
auth-server: redirect diag: url_host='...cloudfront.net' url_scheme='https' ... req_scheme='http'
auth-server: Blocked unsafe ... redirect (reason=cookie_domain): https://...cloudfront.net
```
Host matched; scheme did not (https vs the internally-reconstructed http) → redirect_uri dropped. After the fix the block is gone and Cognito receives a valid `logout_uri`.

## Testing

- New: same-origin check accepts the configured external host on the S2S hop (+ `REGISTRY_URL` fallback, + a non-configured host is still rejected); the logout handler forwards `redirect_uri=/logout`.
- Existing same-origin/open-redirect tests (incl. scheme-mismatch reject) still pass. **275 auth/logout unit tests pass**; ruff/format clean.

## Verification

- [x] Keycloak logout verified end-to-end (confirmation screen shows, session terminated).
- [x] Cognito logout verified end-to-end (with `<host>/logout` registered in the app client's sign-out URLs — see `docs/idp/cognito.md`).

## Notes

- No new config parameters. No `docs/unified-parameter-reference.md` change needed.
- Cognito's sign-out URLs are bring-your-own (not Terraform-managed); on a CloudFront-domain change, re-register `<host>/logout` (the existing "CloudFront domain changes on recreate" note in `docs/idp/cognito.md` covers this).

Fixes the #1503 logout regression introduced by #1509.

