### PR TITLE
feat(#1494): make UI scope creation authoritative (reload + validated config)

### DIFF
--- a/docs/scopes-mgmt.md
+++ b/docs/scopes-mgmt.md
@@ -403,6 +403,36 @@ Access to specific MCP servers and one agent:
 
 ## Managing Scopes
 
+### Managing scopes from the UI (recommended)
+
+Scopes can be created, edited, and deleted entirely from the registry UI — no
+direct database access or JSON file editing is required:
+
+1. Navigate to **Settings → IAM → Groups** and click **Create Group** (or
+   **Edit** on an existing group).
+2. Fill in the group name, description, and group mappings, then use the
+   pickers to grant **Server Access** (per-server methods and tools),
+   **Agent Access**, and **UI Permissions**. Alternatively, drag and drop an
+   existing scope JSON file onto the form to pre-fill it.
+3. Submit. The scope is validated, persisted, and the auth server is reloaded
+   automatically — **the scope takes effect immediately**, without restarting
+   any service.
+
+The field-by-field form produces the same scope document as the CLI
+`import-group` command, and updates and deletions also take effect
+immediately.
+
+Validation errors (for example, an unknown `ui_permissions` key or a
+`server_access` entry missing its `server` name) are rejected with a
+field-level message surfaced in the UI, rather than being silently dropped.
+
+**Limitation:** scopes whose `server_access` contains a wildcard server
+(`"*"` or `"all"`) cannot be created from the UI or the API — the scope
+service unconditionally refuses them and the API returns an actionable
+`400`. Grant broad UI visibility through `ui_permissions` (`"all"`) instead;
+invocation-level wildcard scopes must be seeded through database
+initialization (see [Bootstrap Admin Scope](#bootstrap-admin-scope)).
+
 ### Using the CLI
 
 Import a scope from JSON file:

--- a/frontend/src/components/IAMGroups.tsx
+++ b/frontend/src/components/IAMGroups.tsx
@@ -444,8 +444,9 @@ const IAMGroups: React.FC<IAMGroupsProps> = ({ onShowToast }) => {
     setIsCreating(true);
     try {
       // Build scope_config from form state.
-      // The management API currently only processes name/description.
-      // scope_config is included for future backend support.
+      // The management API validates scope_config (422 on malformed input),
+      // fully applies it via scope_service.import_group, and triggers an
+      // auth-server reload so the scope takes effect immediately.
       const scopeJson = _buildScopeJson(
         formName.trim(), formDescription.trim(),
         serverAccess, groupMappings, selectedAgents, uiPermissions, createInIdp,

--- a/registry/api/management_routes.py
+++ b/registry/api/management_routes.py
@@ -709,8 +709,8 @@ async def management_create_group(
 
     # Extract create_in_idp from scope_config (frontend sends it there)
     create_in_idp = False  # default: do not create in IdP
-    if payload.scope_config and "create_in_idp" in payload.scope_config:
-        create_in_idp = bool(payload.scope_config["create_in_idp"])
+    if payload.scope_config is not None:
+        create_in_idp = payload.scope_config.create_in_idp
     logger.debug(
         "create_in_idp=%s for group '%s' (from scope_config)",
         create_in_idp,
@@ -755,14 +755,22 @@ async def management_create_group(
                 payload.name,
             )
 
-        # Step 2: Create in MongoDB scopes collection (always)
+        # Step 2: Create in MongoDB scopes collection (always).
+        # ScopeConfig fields default to None (so PATCH can distinguish
+        # omitted from provided); for create, None means empty.
         server_access = []
         ui_permissions = {}
         agent_access = []
-        if payload.scope_config:
-            server_access = payload.scope_config.get("server_access", [])
-            ui_permissions = payload.scope_config.get("ui_permissions", {})
-            agent_access = payload.scope_config.get("agent_access", [])
+        if payload.scope_config is not None:
+            if payload.scope_config.server_access is not None:
+                server_access = [
+                    rule.model_dump(exclude_unset=True)
+                    for rule in payload.scope_config.server_access
+                ]
+            if payload.scope_config.ui_permissions is not None:
+                ui_permissions = payload.scope_config.ui_permissions
+            if payload.scope_config.agent_access is not None:
+                agent_access = payload.scope_config.agent_access
 
         # Normalize agent paths to ensure they have leading slashes
         agent_access, ui_permissions = _normalize_agent_paths_in_scope_config(
@@ -783,9 +791,33 @@ async def management_create_group(
         )
 
         if not import_success:
+            # import_group refused the write (e.g. the reserved-wildcard
+            # guard on server: "*"/"all", or the privileged-write guard).
+            # Surface an actionable 400 instead of a success response that
+            # persisted nothing.
             logger.warning(
-                "Group %s in IdP but failed to create in MongoDB: %s",
+                "Group %s in IdP but scope write was refused for: %s",
                 "created" if create_in_idp else "skipped",
+                payload.name,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Scope '{payload.name}' was not saved: the scope service "
+                    "refused the configuration. Wildcard server_access entries "
+                    '(server: "*" or "all") cannot be created here; grant '
+                    'broad UI visibility via ui_permissions ("all") instead.'
+                ),
+            )
+
+        # Propagate the change to the auth server so it takes effect without
+        # a restart, mirroring the CLI import path (server_routes.py).
+        # Non-fatal: the auth server also picks scopes up on its next reload.
+        reloaded = await scope_service.trigger_auth_server_reload()
+        if not reloaded:
+            logger.warning(
+                "Scope '%s' persisted but auth-server reload failed; "
+                "change will take effect on next auth-server restart.",
                 payload.name,
             )
 
@@ -797,6 +829,8 @@ async def management_create_group(
             is_idp_managed=create_in_idp,
         )
 
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Failed to create group: %s", exc)
         detail = str(exc).lower()
@@ -891,6 +925,17 @@ async def management_delete_group(
                 "Group deleted from IdP but failed to delete from MongoDB: %s",
                 group_name,
             )
+        else:
+            # Propagate the deletion to the auth server so the scope stops
+            # being honored without a restart, mirroring the CLI import path.
+            # Non-fatal: the auth server also reloads scopes on restart.
+            reloaded = await scope_service.trigger_auth_server_reload()
+            if not reloaded:
+                logger.warning(
+                    "Scope '%s' deleted but auth-server reload failed; "
+                    "removal will take effect on next auth-server restart.",
+                    group_name,
+                )
 
         return GroupDeleteResponse(name=group_name)
 
@@ -1044,11 +1089,18 @@ async def management_update_group(
         group_mappings = None
         agent_access = None
 
-        if payload.scope_config:
-            server_access = payload.scope_config.get("server_access")
-            ui_permissions = payload.scope_config.get("ui_permissions")
-            group_mappings = payload.scope_config.get("group_mappings")
-            agent_access = payload.scope_config.get("agent_access")
+        if payload.scope_config is not None:
+            # ScopeConfig fields default to None, so an omitted field means
+            # "preserve existing values" (critical for group_mappings, which
+            # holds Entra Object IDs) while a provided field replaces them.
+            if payload.scope_config.server_access is not None:
+                server_access = [
+                    rule.model_dump(exclude_unset=True)
+                    for rule in payload.scope_config.server_access
+                ]
+            ui_permissions = payload.scope_config.ui_permissions
+            group_mappings = payload.scope_config.group_mappings
+            agent_access = payload.scope_config.agent_access
 
         # Preserve existing group_mappings if not provided in payload
         # This is critical for Entra ID where group_mappings contains Object IDs
@@ -1082,8 +1134,31 @@ async def management_update_group(
         )
 
         if not import_success:
+            # import_group refused the write (reserved-wildcard guard or
+            # privileged-write guard). Surface an actionable 400 instead of
+            # a success response that persisted nothing.
             logger.warning(
-                "Group updated in IdP but failed to update in MongoDB: %s",
+                "Group updated in IdP but scope write was refused for: %s",
+                group_name,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Scope '{group_name}' was not updated: the scope service "
+                    "refused the configuration. Wildcard server_access entries "
+                    '(server: "*" or "all") cannot be saved here; grant '
+                    'broad UI visibility via ui_permissions ("all") instead.'
+                ),
+            )
+
+        # Propagate the change to the auth server so it takes effect without
+        # a restart, mirroring the CLI import path (server_routes.py).
+        # Non-fatal: the auth server also picks scopes up on its next reload.
+        reloaded = await scope_service.trigger_auth_server_reload()
+        if not reloaded:
+            logger.warning(
+                "Scope '%s' persisted but auth-server reload failed; "
+                "change will take effect on next auth-server restart.",
                 group_name,
             )
 

--- a/registry/schemas/management.py
+++ b/registry/schemas/management.py
@@ -52,21 +52,88 @@ class UserListResponse(BaseModel):
     total: int
 
 
+class ServerAccessRule(BaseModel):
+    """One MCP-server access rule inside a scope's server_access list."""
+
+    model_config = {"extra": "forbid"}
+
+    server: str = Field(
+        ...,
+        min_length=1,
+        description="Server name (leading/trailing slashes stripped by the caller).",
+    )
+    methods: list[str] = Field(
+        default_factory=list,
+        description="Allowed MCP methods (e.g. tools/call). Empty means none.",
+    )
+    tools: list[str] | str = Field(
+        default_factory=list,
+        description='Allowed tool names, or "*" for all tools on this server.',
+    )
+
+
+class AgentAccessRule(BaseModel):
+    """One A2A-agent access rule inside a scope's server_access list."""
+
+    model_config = {"extra": "forbid"}
+
+    agent: str = Field(..., min_length=1, description="Agent path, or */all.")
+    actions: list[str] = Field(
+        default_factory=list,
+        description="Allowed agent actions (list_agents, get_agent, invoke_agent, ...).",
+    )
+
+
+class ScopeConfig(BaseModel):
+    """Validated scope configuration carried on group create/update.
+
+    Replaces the previous free-form dict. Unknown keys are rejected so an
+    operator gets a clear 422 instead of a silently-dropped field.
+
+    All access fields default to None (omitted) rather than empty
+    collections so the PATCH handler can distinguish "not provided --
+    preserve existing values" from "explicitly provided". The create
+    handler coerces None to empty collections.
+    """
+
+    model_config = {"extra": "forbid"}
+
+    server_access: list[ServerAccessRule | AgentAccessRule] | None = Field(
+        default=None,
+        description="Per-server / per-agent invocation access rules.",
+    )
+    ui_permissions: dict[str, list[str]] | None = Field(
+        default=None,
+        description="UI permission name -> list of entity names/ids ('all' allowed).",
+    )
+    agent_access: list[str] | None = Field(
+        default=None,
+        description="Agent paths this scope may access.",
+    )
+    group_mappings: list[str] | None = Field(
+        default=None,
+        description="IdP group names/IDs. Defaults to [group_name] when omitted.",
+    )
+    create_in_idp: bool = Field(
+        default=False,
+        description="Create the group in the upstream IdP as well (default: local-only).",
+    )
+
+
 class GroupCreateRequest(BaseModel):
     """Payload for creating a group.
 
-    Note: The backend currently only processes name and description.
-    The scope_config field is accepted but not yet wired to
-    scope_service.import_group(). Future work should pass
-    server_access, group_mappings, and ui_permissions through
-    to the scope service when creating a group.
+    scope_config (server_access, ui_permissions, agent_access, group_mappings,
+    create_in_idp) is fully applied server-side via scope_service.import_group,
+    and the change takes effect immediately (the handler triggers an
+    auth-server scope reload).
     """
 
     name: str = Field(..., min_length=1)
     description: str | None = None
-    scope_config: dict | None = Field(
+    scope_config: ScopeConfig | None = Field(
         None,
-        description="Scope configuration (accepted but not yet applied server-side)",
+        description="Validated scope configuration, fully applied server-side.",
     )
 
 
@@ -120,9 +187,12 @@ class GroupUpdateRequest(BaseModel):
     """Request to update a group."""
 
     description: str | None = None
-    scope_config: dict | None = Field(
+    scope_config: ScopeConfig | None = Field(
         None,
-        description="Scope configuration (server_access, ui_permissions, etc.)",
+        description=(
+            "Validated scope configuration (server_access, ui_permissions, "
+            "agent_access, group_mappings). Omitted fields preserve existing values."
+        ),
     )
 
 

--- a/tests/unit/api/test_management_routes.py
+++ b/tests/unit/api/test_management_routes.py
@@ -969,8 +969,12 @@ class TestManagementCreateGroup:
         assert detail == "IAM provider error"
         assert "IAM service unavailable" not in detail
 
-    def test_create_group_scope_import_failure_logs_warning(self, test_client_admin):
-        """Test that scope import failure is logged but doesn't fail the request."""
+    def test_create_group_scope_import_refusal_returns_400(self, test_client_admin):
+        """A refused scope write (guard rejection) surfaces as an actionable 400.
+
+        Previously this returned 200 with only a server-side warning, so the
+        UI showed a success toast while nothing was persisted (issue #1494).
+        """
         # Arrange
         client, mock_iam = test_client_admin
         mock_iam.create_group.return_value = {
@@ -997,10 +1001,9 @@ class TestManagementCreateGroup:
                 },
             )
 
-            # Assert - should still succeed (IdP creation succeeded)
-            assert response.status_code == 200
-            data = response.json()
-            assert data["name"] == "partial-group"
+            # Assert - refusal is surfaced, not swallowed into a success toast
+            assert response.status_code == 400
+            assert "was not saved" in response.json()["detail"]
 
     def test_create_group_without_description(self, test_client_admin):
         """Test group creation without description uses empty string."""
@@ -1536,3 +1539,372 @@ class TestAgentWildcardNormalization:
 
         agent_access, _ = _normalize_agent_paths_in_scope_config([], None)
         assert agent_access == []
+
+
+# =============================================================================
+# TEST issue #1494 - Scope creation from the UI (reload + validated config)
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestScopeMutationsTriggerAuthReload:
+    """Create/update/delete via /iam/groups reload the auth server (#1494)."""
+
+    def test_create_group_triggers_reload(self, test_client_admin):
+        """A successful create triggers exactly one auth-server reload."""
+        client, mock_iam = test_client_admin
+        mock_iam.create_group.return_value = {
+            "id": "gid",
+            "name": "reload-group",
+            "path": "/reload-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reload,
+            patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
+        ):
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "reload-group",
+                    "description": "d",
+                    "scope_config": {"create_in_idp": True},
+                },
+            )
+
+        assert response.status_code == 200
+        mock_reload.assert_awaited_once()
+
+    def test_create_reload_failure_is_non_fatal(self, test_client_admin):
+        """Reload returning False still yields 200 (persisted change wins)."""
+        client, mock_iam = test_client_admin
+        mock_iam.create_group.return_value = {
+            "id": "gid",
+            "name": "reload-fail-group",
+            "path": "/reload-fail-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_reload,
+            patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
+        ):
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "reload-fail-group",
+                    "scope_config": {"create_in_idp": True},
+                },
+            )
+
+        assert response.status_code == 200
+        mock_reload.assert_awaited_once()
+
+    def test_create_refusal_returns_400_and_skips_reload(self, test_client_admin):
+        """A refused import (guard) surfaces a 400 and does not reload."""
+        client, mock_iam = test_client_admin
+        mock_iam.create_group.return_value = {
+            "id": "gid",
+            "name": "wild-group",
+            "path": "/wild-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reload,
+            patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
+        ):
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "wild-group",
+                    "scope_config": {
+                        "server_access": [{"server": "*", "methods": [], "tools": "*"}]
+                    },
+                },
+            )
+
+        assert response.status_code == 400
+        assert "was not saved" in response.json()["detail"]
+        mock_reload.assert_not_awaited()
+
+    def test_update_group_triggers_reload(self, test_client_admin):
+        """A successful PATCH triggers exactly one auth-server reload."""
+        client, _ = test_client_admin
+        existing = {
+            "id": "gid",
+            "name": "upd-group",
+            "scope_name": "upd-group",
+            "description": "old",
+            "is_idp_managed": False,
+            "group_mappings": ["upd-group"],
+            "agent_access": [],
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value=existing,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reload,
+        ):
+            response = client.patch(
+                "/api/management/iam/groups/upd-group",
+                json={
+                    "scope_config": {
+                        "server_access": [
+                            {"server": "api", "methods": ["tools/call"], "tools": ["t1"]}
+                        ]
+                    }
+                },
+            )
+
+        assert response.status_code == 200
+        mock_reload.assert_awaited_once()
+
+    def test_update_refusal_returns_400_and_skips_reload(self, test_client_admin):
+        """A refused import on PATCH surfaces a 400 and does not reload."""
+        client, _ = test_client_admin
+        existing = {
+            "id": "gid",
+            "name": "upd-wild",
+            "scope_name": "upd-wild",
+            "is_idp_managed": False,
+            "group_mappings": ["upd-wild"],
+            "agent_access": [],
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value=existing,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reload,
+        ):
+            response = client.patch(
+                "/api/management/iam/groups/upd-wild",
+                json={
+                    "scope_config": {
+                        "server_access": [{"server": "*", "methods": [], "tools": "*"}]
+                    }
+                },
+            )
+
+        assert response.status_code == 400
+        assert "was not updated" in response.json()["detail"]
+        mock_reload.assert_not_awaited()
+
+    def test_delete_group_triggers_reload(self, test_client_admin):
+        """A successful delete triggers exactly one auth-server reload."""
+        client, mock_iam = test_client_admin
+        mock_iam.delete_group.return_value = True
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value={"scope_name": "del-group", "is_idp_managed": True},
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.delete_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_reload,
+        ):
+            response = client.delete("/api/management/iam/groups/del-group")
+
+        assert response.status_code == 200
+        mock_reload.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.api
+class TestScopeConfigValidation:
+    """Typed ScopeConfig on the IAM group endpoints (#1494)."""
+
+    def test_invalid_scope_config_returns_422(self, test_client_admin):
+        """Unknown scope_config keys are rejected with a 422, not silently dropped."""
+        client, _ = test_client_admin
+
+        response = client.post(
+            "/api/management/iam/groups",
+            json={
+                "name": "bad-group",
+                "scope_config": {"sever_access": []},  # typo'd key
+            },
+        )
+
+        assert response.status_code == 422
+        assert "sever_access" in str(response.json()["detail"])
+
+    def test_malformed_server_access_rule_returns_422(self, test_client_admin):
+        """A server_access entry missing both server and agent is a 422."""
+        client, _ = test_client_admin
+
+        response = client.post(
+            "/api/management/iam/groups",
+            json={
+                "name": "bad-rule-group",
+                "scope_config": {"server_access": [{"methods": ["tools/call"]}]},
+            },
+        )
+
+        assert response.status_code == 422
+
+    def test_scope_config_applied(self, test_client_admin):
+        """server_access / ui_permissions / agent_access reach import_group."""
+        client, mock_iam = test_client_admin
+        mock_iam.create_group.return_value = {
+            "id": "gid",
+            "name": "applied-group",
+            "path": "/applied-group",
+            "attributes": None,
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_import,
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch("registry.api.management_routes.AUTH_PROVIDER", "keycloak"),
+        ):
+            response = client.post(
+                "/api/management/iam/groups",
+                json={
+                    "name": "applied-group",
+                    "description": "d",
+                    "scope_config": {
+                        "create_in_idp": True,
+                        "server_access": [
+                            {
+                                "server": "currenttime",
+                                "methods": ["initialize", "tools/call"],
+                                "tools": ["current_time_by_timezone"],
+                            },
+                            {"agent": "/my-planner", "actions": ["invoke_agent"]},
+                        ],
+                        "ui_permissions": {"list_service": ["currenttime"]},
+                        "agent_access": ["/my-planner"],
+                    },
+                },
+            )
+
+        assert response.status_code == 200
+        kwargs = mock_import.await_args.kwargs
+        assert kwargs["server_access"] == [
+            {
+                "server": "currenttime",
+                "methods": ["initialize", "tools/call"],
+                "tools": ["current_time_by_timezone"],
+            },
+            {"agent": "/my-planner", "actions": ["invoke_agent"]},
+        ]
+        assert kwargs["ui_permissions"] == {"list_service": ["currenttime"]}
+        assert kwargs["agent_access"] == ["/my-planner"]
+
+    def test_update_omitted_fields_preserve_existing(self, test_client_admin):
+        """PATCH with a partial scope_config preserves omitted fields.
+
+        Critical for group_mappings, which holds Entra Object IDs.
+        """
+        client, _ = test_client_admin
+        existing = {
+            "id": "gid",
+            "name": "partial-upd",
+            "scope_name": "partial-upd",
+            "description": "old",
+            "is_idp_managed": False,
+            "group_mappings": ["12345678-entra-object-id"],
+            "agent_access": ["/kept-agent"],
+        }
+
+        with (
+            patch(
+                "registry.api.management_routes.scope_service.get_group",
+                new_callable=AsyncMock,
+                return_value=existing,
+            ),
+            patch(
+                "registry.api.management_routes.scope_service.import_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_import,
+            patch(
+                "registry.api.management_routes.scope_service.trigger_auth_server_reload",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            response = client.patch(
+                "/api/management/iam/groups/partial-upd",
+                json={
+                    "scope_config": {"ui_permissions": {"list_service": ["api"]}}
+                },
+            )
+
+        assert response.status_code == 200
+        kwargs = mock_import.await_args.kwargs
+        assert kwargs["group_mappings"] == ["12345678-entra-object-id"]
+        assert kwargs["agent_access"] == ["/kept-agent"]
+        assert kwargs["server_access"] is None  # omitted -> preserved downstream
+        assert kwargs["ui_permissions"] == {"list_service": ["api"]}

--- a/tests/unit/schemas/test_management_models.py
+++ b/tests/unit/schemas/test_management_models.py
@@ -1,0 +1,131 @@
+"""Unit tests for the ScopeConfig models in registry/schemas/management.py.
+
+Added for issue #1494 (scope creation from the UI): scope_config on the IAM
+group create/update endpoints is now a validated Pydantic model instead of a
+free-form dict.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from registry.schemas.management import (
+    AgentAccessRule,
+    GroupCreateRequest,
+    GroupUpdateRequest,
+    ScopeConfig,
+    ServerAccessRule,
+)
+
+
+@pytest.mark.unit
+class TestServerAccessRule:
+    def test_minimal_rule(self):
+        rule = ServerAccessRule(server="currenttime")
+        assert rule.server == "currenttime"
+        assert rule.methods == []
+        assert rule.tools == []
+
+    def test_tools_accepts_star_string(self):
+        rule = ServerAccessRule(server="api", tools="*")
+        assert rule.tools == "*"
+
+    def test_empty_server_rejected(self):
+        with pytest.raises(ValidationError):
+            ServerAccessRule(server="")
+
+    def test_unknown_key_rejected(self):
+        with pytest.raises(ValidationError):
+            ServerAccessRule(server="api", methodz=["tools/call"])
+
+
+@pytest.mark.unit
+class TestAgentAccessRule:
+    def test_minimal_rule(self):
+        rule = AgentAccessRule(agent="/my-planner")
+        assert rule.agent == "/my-planner"
+        assert rule.actions == []
+
+    def test_unknown_key_rejected(self):
+        with pytest.raises(ValidationError):
+            AgentAccessRule(agent="/a", grant="invoke")
+
+
+@pytest.mark.unit
+class TestScopeConfig:
+    def test_defaults_are_none_except_create_in_idp(self):
+        """Omitted access fields stay None so PATCH can preserve existing values."""
+        cfg = ScopeConfig()
+        assert cfg.server_access is None
+        assert cfg.ui_permissions is None
+        assert cfg.agent_access is None
+        assert cfg.group_mappings is None
+        assert cfg.create_in_idp is False
+
+    def test_unknown_key_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            ScopeConfig(sever_access=[])  # typo'd key
+        assert "sever_access" in str(exc_info.value)
+
+    def test_server_access_union_discrimination(self):
+        """Dicts with a server key become ServerAccessRule; agent key -> AgentAccessRule."""
+        cfg = ScopeConfig(
+            server_access=[
+                {"server": "api", "methods": ["tools/call"], "tools": ["t1"]},
+                {"agent": "/my-planner", "actions": ["invoke_agent"]},
+            ]
+        )
+        assert isinstance(cfg.server_access[0], ServerAccessRule)
+        assert isinstance(cfg.server_access[1], AgentAccessRule)
+
+    def test_rule_missing_server_and_agent_rejected(self):
+        with pytest.raises(ValidationError):
+            ScopeConfig(server_access=[{"methods": ["tools/call"]}])
+
+    def test_ui_permissions_shape_enforced(self):
+        with pytest.raises(ValidationError):
+            ScopeConfig(ui_permissions={"list_service": "not-a-list"})
+
+    def test_frontend_shaped_payload_validates(self):
+        """The exact JSON _buildScopeJson produces (minus name/description) validates."""
+        cfg = ScopeConfig(
+            server_access=[
+                {
+                    "server": "currenttime",
+                    "methods": ["initialize", "tools/list", "tools/call"],
+                    "tools": ["current_time_by_timezone"],
+                }
+            ],
+            ui_permissions={
+                "list_service": ["currenttime"],
+                "health_check_service": ["currenttime"],
+            },
+            agent_access=[],
+            group_mappings=["currenttime-users"],
+            create_in_idp=False,
+        )
+        assert cfg.group_mappings == ["currenttime-users"]
+
+    def test_model_dump_exclude_unset_preserves_wire_shape(self):
+        """Rules dumped with exclude_unset match what the caller sent (no added keys)."""
+        cfg = ScopeConfig(server_access=[{"server": "api"}])
+        dumped = cfg.server_access[0].model_dump(exclude_unset=True)
+        assert dumped == {"server": "api"}
+
+
+@pytest.mark.unit
+class TestRequestModels:
+    def test_create_request_accepts_typed_scope_config(self):
+        req = GroupCreateRequest(
+            name="g",
+            scope_config={"create_in_idp": True, "server_access": [{"server": "api"}]},
+        )
+        assert isinstance(req.scope_config, ScopeConfig)
+        assert req.scope_config.create_in_idp is True
+
+    def test_update_request_accepts_typed_scope_config(self):
+        req = GroupUpdateRequest(scope_config={"ui_permissions": {"list_service": ["api"]}})
+        assert isinstance(req.scope_config, ScopeConfig)
+
+    def test_create_request_rejects_malformed_scope_config(self):
+        with pytest.raises(ValidationError):
+            GroupCreateRequest(name="g", scope_config={"unknown_key": 1})


### PR DESCRIPTION
Closes #1494

## Summary

Makes UI-driven scope creation authoritative: changes made through the IAM Groups UI now take effect immediately (auth-server reload) and are validated with Pydantic models instead of a free-form dict.

## Changes

- **Reload after mutation:** trigger an auth-server scope reload after IAM group create/update/delete, mirroring the CLI import path, so UI-created scopes apply immediately without an auth-server restart. Reload failure is non-fatal (logged as WARNING; the persisted change is authoritative).
- **Validated config models:** replace the free-form `scope_config` dict with validated `ScopeConfig` / `ServerAccessRule` / `AgentAccessRule` Pydantic models (`extra=forbid`). Malformed input now returns an actionable 422 instead of a silent drop or opaque 500. Access fields default to `None` so PATCH preserves omitted fields (critical for Entra Object IDs in `group_mappings`); the create handler coerces `None` to empty collections, keeping the persisted doc shape byte-identical (`model_dump(exclude_unset=True)`).
- **Guard refusals surfaced:** `import_group` guard refusals (reserved wildcard, privileged write) now return a 400 on create and update instead of a success response that persisted nothing. Added `except HTTPException: raise` to the create handler so the 400 is not swallowed by the IAM error translator.
- **Docs/comments:** fixed the stale "not yet applied server-side" docstring and frontend comment; documented "Managing scopes from the UI (recommended)" in `docs/scopes-mgmt.md`, including the wildcard-server limitation.

## Tests

- Reload fires on all three mutations; reload-failure is non-fatal; refusal-400 skips reload.
- 422 on unknown keys / malformed rules; `scope_config` reaches `import_group`; PATCH preserves omitted fields.
- New `tests/unit/schemas/test_management_models.py` for the models.

## Note

Branch is behind `main` and will need a rebase before merge.