### PR TITLE
fix(ard): surface catalog cap in config UI and correct nginx match comment

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -258,8 +258,10 @@ server {
     # Unauthenticated .well-known discovery endpoints (ARD catalog, registry-card,
     # OAuth PRM / AS metadata). Tighter rate cap than the general edge zone because
     # these endpoints hit the DB on every request and are fully anonymous.
-    # The existing `location = /.well-known/openid-configuration` (exact match)
-    # takes priority over this ^~ prefix match, so the IdP proxy is unaffected.
+    # The existing `location /.well-known/openid-configuration` is a longer
+    # (more specific) prefix, and nginx selects the longest matching prefix
+    # location, so the IdP proxy takes priority over this shorter `^~` prefix
+    # and is unaffected by this rate limit.
     location ^~ /.well-known/ {
         limit_req zone=mcp_gateway_wellknown burst=10 nodelay;
         proxy_pass http://127.0.0.1:7860/.well-known/;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -480,8 +480,10 @@ server {
     # Unauthenticated .well-known discovery endpoints (ARD catalog, registry-card,
     # OAuth PRM / AS metadata). Tighter rate cap than the general edge zone because
     # these endpoints hit the DB on every request and are fully anonymous.
-    # The existing `location = /.well-known/openid-configuration` (exact match)
-    # takes priority over this ^~ prefix match, so the IdP proxy is unaffected.
+    # The existing `location /.well-known/openid-configuration` is a longer
+    # (more specific) prefix, and nginx selects the longest matching prefix
+    # location, so the IdP proxy takes priority over this shorter `^~` prefix
+    # and is unaffected by this rate limit.
     location ^~ /.well-known/ {
         limit_req zone=mcp_gateway_wellknown burst=10 nodelay;
         proxy_pass http://127.0.0.1:7860/.well-known/;

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -273,6 +273,7 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("ard_registry_enabled", "ARD Registry Adapter", False),
             ("ard_publisher_domain", "ARD Publisher Domain", False),
             ("ard_catalog_default_namespace", "ARD URN Namespace", False),
+            ("ard_catalog_max_entries_per_type", "ARD Catalog Max Entries Per Type", False),
         ],
     },
     "otel": {


### PR DESCRIPTION
## Summary

Short follow-up to #1528 addressing two non-functional review items. No runtime or security behavior changes.

1. **Surface the new config knob in the config API/UI.** `ard_catalog_max_entries_per_type` was added to `Settings` in #1528 but not wired into `config_routes.py` `CONFIG_GROUPS`. It is now added to the "Well-Known Discovery" group next to its four ARD siblings, so it appears in `GET /api/config/full` and the System Config UI.

2. **Correct the nginx rate-limit comment.** The `.well-known` comment in both nginx templates described the IdP `openid-configuration` block as `location = /...` (exact match). It is actually a plain prefix (`location /...`). The IdP proxy still takes priority and is not rate-limited, but via the longest-matching-prefix rule, not exact-match precedence. The comment now states the actual reason.

## Testing

- `uv run python -m py_compile registry/api/config_routes.py` passes.
- `tests/unit/core/test_nginx_service.py` (rate-limit zone assertions) passes.
- `tests/unit/api/test_config_export.py`, `test_config_endpoint_auth.py` pass (config surface unaffected).