### PR TITLE
test(e2e): make agent-skills list/search checks deterministic

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -5056,13 +5056,24 @@ class RegistryClient:
         logger.info(f"Retrieved skill content: {content_len} characters")
         return SkillContentResponse(**result)
 
-    def search_skills(self, query: str, tags: str | None = None) -> SkillSearchResponse:
+    def search_skills(
+        self,
+        query: str,
+        tags: str | None = None,
+        include_draft: bool = False,
+        include_deprecated: bool = False,
+    ) -> SkillSearchResponse:
         """
         Search for skills by query.
 
         Args:
             query: Search query
             tags: Optional comma-separated tags filter
+            include_draft: Include skills whose lifecycle status is ``draft``
+                (newly registered skills default to ``draft`` and are excluded
+                from search unless this is set)
+            include_deprecated: Include skills whose lifecycle status is
+                ``deprecated``
 
         Returns:
             SkillSearchResponse with matching skills
@@ -5070,11 +5081,18 @@ class RegistryClient:
         Raises:
             requests.HTTPError: If request fails
         """
-        logger.info(f"Searching skills: query='{query}', tags={tags}")
+        logger.info(
+            f"Searching skills: query='{query}', tags={tags}, "
+            f"include_draft={include_draft}, include_deprecated={include_deprecated}"
+        )
 
-        params = {"q": query}
+        params: dict[str, str] = {"q": query}
         if tags:
             params["tags"] = tags
+        if include_draft:
+            params["include_draft"] = "true"
+        if include_deprecated:
+            params["include_deprecated"] = "true"
 
         response = self._make_request(method="GET", endpoint="/api/skills/search", params=params)
 

--- a/tests/e2e_agent_skills_test.py
+++ b/tests/e2e_agent_skills_test.py
@@ -54,6 +54,12 @@ TEST_SKILL_NAME = "e2e-test-mcp-builder"
 TEST_SKILL_DESCRIPTION = "E2E Test: Build and configure MCP servers"
 TEST_SKILL_TAGS = ["e2e-test", "mcp", "builder", "automation"]
 
+# The unique tag applied to the test skill. Used to find it via the server-side
+# tag filter (list) and as a substring search term, so the list/search checks
+# pass regardless of how many other skills the registry already holds and match
+# only the test skill rather than unrelated entries.
+TEST_SKILL_UNIQUE_TAG = "e2e-test"
+
 
 class TestStatus(Enum):
     """Test result status."""
@@ -156,7 +162,10 @@ class AgentSkillsE2ETest:
         start_time = time.time()
 
         try:
-            response = self.client.list_skills()
+            # Filter by the test skill's unique tag so the check does not depend
+            # on the test skill landing in the first unsorted page of a large,
+            # already-populated registry.
+            response = self.client.list_skills(tag=TEST_SKILL_UNIQUE_TAG)
             duration_ms = (time.time() - start_time) * 1000
 
             # Check if our test skill is in the list
@@ -534,15 +543,30 @@ class AgentSkillsE2ETest:
         start_time = time.time()
 
         try:
-            response = self.client.search_skills(query="mcp builder")
+            # Skills search is lexical (substring) over name/description/tags,
+            # not semantic. Two things must be true for a deterministic pass:
+            #  1. The query must be a substring of the test skill's name/tags.
+            #     Use the unique tag ("e2e-test"), which is a literal substring
+            #     of neither the display query "mcp builder" nor any other skill.
+            #  2. Newly registered skills default to lifecycle status "draft",
+            #     which search excludes by default. Pass include_draft=True so
+            #     the just-registered test skill is in scope.
+            # Assert the test skill is actually present, not merely that some
+            # skill matched (a populated registry has unrelated matches).
+            response = self.client.search_skills(
+                query=TEST_SKILL_UNIQUE_TAG,
+                include_draft=True,
+            )
             duration_ms = (time.time() - start_time) * 1000
 
-            if response.total_count > 0:
+            # SkillSearchResponse.skills is a list of raw dicts (name key).
+            skill_names = [s.get("name") for s in response.skills]
+            if TEST_SKILL_NAME in skill_names:
                 self._record_result(
                     test_name,
                     TestStatus.PASSED,
                     duration_ms,
-                    f"Found {response.total_count} matching skills",
+                    f"Found {response.total_count} matching skills, test skill present",
                 )
                 return True
             else:
@@ -550,7 +574,7 @@ class AgentSkillsE2ETest:
                     test_name,
                     TestStatus.FAILED,
                     duration_ms,
-                    "No matching skills found",
+                    f"Test skill not found in {response.total_count} search results",
                 )
                 return False
 


### PR DESCRIPTION
## Summary

The `tests/e2e_agent_skills_test.py` suite failed its **List Skills** and **Search Skills** checks when run against a populated registry (e.g. the standard local dev stack with 100+ skills). Both were test-harness defects, not product bugs: the underlying list/search endpoints work correctly.

## Root causes

1. **List Skills** called `list_skills()` with no filter, which returns a single unsorted page (client default `limit=20`), then checked whether the just-registered test skill was in that page. On any registry holding more than a page of skills, the test skill was not in the first 20 and the check failed.

2. **Search Skills** queried `"mcp builder"` and only asserted `total_count > 0`. Two separate problems:
   - Skills search is **lexical (substring)**, not semantic (see `registry/api/skill_routes.py`). `"mcp builder"` is not a substring of the test skill's name (`e2e-test-mcp-builder`), description, or any tag, so it deterministically matched nothing.
   - A newly registered skill defaults to lifecycle status **`draft`**, which the search endpoint excludes unless `include_draft=true` is passed.
   - Asserting only `total_count > 0` was also too weak on a populated registry (unrelated skills match common terms).

## Fix

- **List Skills**: filter by the test skill's unique tag (`e2e-test`) via the server-side `tag` filter, so the check is independent of registry size.
- **Search Skills**: query the unique tag with `include_draft=True` and assert the **test skill itself** is present, not merely that some skill matched.
- **`RegistryClient.search_skills`**: add `include_draft` / `include_deprecated` pass-through params (additive, default `False` — existing callers unaffected).

## Testing

Against the local stack (`http://localhost`, admin token):

- `tests/e2e_agent_skills_test.py`: **12/12 passed** (was 10/12), confirmed deterministic across repeated runs.
- `tests/e2e_release_test.py`: **8/8 passed** (regression check for the `registry_client` change).
- `tests/unit/test_skill_routes_security.py`, `tests/unit/api/test_skill_inline_content.py`: pass (29).

No unit tests reference `search_skills`; the client signature change is additive and backwards-compatible.