### PR TITLE
fix(keycloak): don't assign to reserved $GROUPS in agent setup verify

### DIFF
--- a/keycloak/setup/setup-agent-service-account.sh
+++ b/keycloak/setup/setup-agent-service-account.sh
@@ -400,14 +400,19 @@ verify_setup() {
     echo ""
     echo "Verifying setup..."
 
-    # Check service account exists and is in the right group
-    GROUPS=$(curl -s -H "Authorization: Bearer $TOKEN" \
+    # Check service account exists and is in the right group.
+    # NOTE: do not name this variable GROUPS -- that is a special bash variable
+    # (an array of the caller's numeric supplementary group IDs). Assigning a
+    # scalar to it fails, and under `set -e` that aborts the script here, before
+    # the summary, even though the account was configured correctly.
+    local account_groups
+    account_groups=$(curl -s -H "Authorization: Bearer $TOKEN" \
         "$ADMIN_URL/admin/realms/$REALM/users/$USER_ID/groups" | \
         jq -r '.[].name')
 
-    echo "Service account groups: $GROUPS"
+    echo "Service account groups: $account_groups"
 
-    if echo "$GROUPS" | grep -q "$TARGET_GROUP"; then
+    if echo "$account_groups" | grep -q "$TARGET_GROUP"; then
         echo -e "${GREEN}✓ Service account is in '$TARGET_GROUP' group${NC}"
     else
         echo -e "${RED}✗ Service account is NOT in '$TARGET_GROUP' group${NC}"


### PR DESCRIPTION
fix(keycloak): don't assign to reserved $GROUPS in agent setup verify

verify_setup() stored the service account's group list in a variable
named GROUPS. GROUPS is a special bash variable -- an array of the
caller's numeric supplementary group IDs -- so the scalar assignment
fails. The script runs under `set -e`, so it aborts right there, before
printing the group name and before the final summary.

The failure is silent and misleading: the service account, its group
membership, and the groups protocol mapper have all already been created
correctly by the time verify_setup runs, so the setup actually succeeded
-- but the script exits 1 with no error message, and any caller (e.g.
the macOS setup skill's Phase 12) reports the agent creation as failed.

The bug would be latent even without `set -e`: shellcheck also flags two
SC2128 warnings, because expanding the array without an index yields
only its first element, so the group check would compare against a
numeric GID rather than the group names.

Rename the variable to account_groups and declare it local. Verified
against a live Keycloak: the script now completes with exit 0, prints
"Service account is in 'mcp-servers-unrestricted' group", and reaches
the SUCCESS summary. shellcheck drops from 7 findings to 2 (the
remainder is a pre-existing, unrelated SC2034). No other GROUPS=
assignments exist in the setup scripts.
Fixes #1570