### PR TITLE
fix(macos-setup): ask uv for the 3.14 interpreter, not PATH's python3

### DIFF
--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -126,8 +126,13 @@ For every phase below, apply this rule:
 echo "=== Docker ==="
 docker --version 2>/dev/null && docker ps >/dev/null 2>&1 && echo "DOCKER_OK" || echo "DOCKER_FAIL"
 
-echo "=== Python ==="
-python3 --version 2>/dev/null && echo "PYTHON_OK" || echo "PYTHON_FAIL"
+echo "=== Python (>=3.14 required by pyproject.toml) ==="
+python3 --version 2>/dev/null || echo "PYTHON_FAIL"
+if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 14) else 1)' 2>/dev/null; then
+    echo "PYTHON_OK"
+elif command -v python3 >/dev/null 2>&1; then
+    echo "PYTHON_TOO_OLD"
+fi
 
 echo "=== uv ==="
 uv --version 2>/dev/null && echo "UV_OK" || echo "UV_FAIL"
@@ -151,6 +156,7 @@ For any failed check, display the install instructions:
 |-------|----------------|
 | DOCKER_FAIL | "Install Docker Desktop from https://www.docker.com/products/docker-desktop/ then start it and wait for the whale icon in the menu bar" |
 | PYTHON_FAIL | `brew install python@3.14` |
+| PYTHON_TOO_OLD | `uv python install 3.14` — the project requires Python >=3.14 (`pyproject.toml`), and Phase 5 (`uv sync`) fails with `No interpreter found for Python >=3.14` otherwise. `uv` manages this interpreter itself, so the system `python3` is left untouched. |
 | UV_FAIL | `curl -LsSf https://astral.sh/uv/install.sh \| sh` — then restart your terminal |
 | NODE_FAIL | `brew install node@20` or download from https://nodejs.org/ |
 | GIT_FAIL | `xcode-select --install` |
@@ -158,6 +164,8 @@ For any failed check, display the install instructions:
 | GETTEXT_FAIL | `brew install gettext` |
 
 **Do not proceed if Docker or git fail.** Python, uv, Node.js, jq, and gettext must also be present before continuing. Ask the user to install missing tools and retry.
+
+**Do not proceed on `PYTHON_TOO_OLD`.** A Python older than 3.14 passes a mere presence check but fails Phase 5 four phases later, where the error names `uv` rather than the unmet prerequisite. Resolve it here: run `uv python install 3.14`, then re-run the Python check and confirm `PYTHON_OK` before continuing.
 
 Log: `{ 1, "Prerequisites Check", DONE/FAILED, list of what passed/failed }`
 

--- a/.claude/skills/macos-setup/SKILL.md
+++ b/.claude/skills/macos-setup/SKILL.md
@@ -127,10 +127,16 @@ echo "=== Docker ==="
 docker --version 2>/dev/null && docker ps >/dev/null 2>&1 && echo "DOCKER_OK" || echo "DOCKER_FAIL"
 
 echo "=== Python (>=3.14 required by pyproject.toml) ==="
-python3 --version 2>/dev/null || echo "PYTHON_FAIL"
-if python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 14) else 1)' 2>/dev/null; then
+# Ask uv, not PATH. Phase 5 runs `uv sync`, which resolves its own managed
+# interpreters and ignores whatever `python3` happens to be first on PATH -- a
+# system python3 of 3.13 is fine as long as uv can see a >=3.14 somewhere.
+# Checking `python3 --version` instead reports a false failure on exactly the
+# machines where setup would have worked.
+if uv python find '>=3.14' >/dev/null 2>&1; then
+    echo "Interpreter for uv: $(uv python find '>=3.14' 2>/dev/null)"
     echo "PYTHON_OK"
-elif command -v python3 >/dev/null 2>&1; then
+else
+    echo "System python3: $(python3 --version 2>&1 || echo 'not found')"
     echo "PYTHON_TOO_OLD"
 fi
 
@@ -155,8 +161,7 @@ For any failed check, display the install instructions:
 | Check | Install command |
 |-------|----------------|
 | DOCKER_FAIL | "Install Docker Desktop from https://www.docker.com/products/docker-desktop/ then start it and wait for the whale icon in the menu bar" |
-| PYTHON_FAIL | `brew install python@3.14` |
-| PYTHON_TOO_OLD | `uv python install 3.14` — the project requires Python >=3.14 (`pyproject.toml`), and Phase 5 (`uv sync`) fails with `No interpreter found for Python >=3.14` otherwise. `uv` manages this interpreter itself, so the system `python3` is left untouched. |
+| PYTHON_TOO_OLD | `uv python install 3.14` — the project requires Python >=3.14 (`pyproject.toml`), and Phase 5 (`uv sync`) fails with `No interpreter found for Python >=3.14` otherwise. `uv` manages this interpreter itself, so the system `python3` is left untouched (it may stay on 3.13 or older). |
 | UV_FAIL | `curl -LsSf https://astral.sh/uv/install.sh \| sh` — then restart your terminal |
 | NODE_FAIL | `brew install node@20` or download from https://nodejs.org/ |
 | GIT_FAIL | `xcode-select --install` |
@@ -165,7 +170,9 @@ For any failed check, display the install instructions:
 
 **Do not proceed if Docker or git fail.** Python, uv, Node.js, jq, and gettext must also be present before continuing. Ask the user to install missing tools and retry.
 
-**Do not proceed on `PYTHON_TOO_OLD`.** A Python older than 3.14 passes a mere presence check but fails Phase 5 four phases later, where the error names `uv` rather than the unmet prerequisite. Resolve it here: run `uv python install 3.14`, then re-run the Python check and confirm `PYTHON_OK` before continuing.
+**Do not proceed on `PYTHON_TOO_OLD`.** With no >=3.14 interpreter available to `uv`, Phase 5 fails four phases later with `No interpreter found for Python >=3.14`, an error that names `uv` rather than the unmet prerequisite. Resolve it here: run `uv python install 3.14`, then re-run the Python check and confirm `PYTHON_OK` before continuing.
+
+Note the check deliberately asks `uv`, not `python3 --version`. `uv sync` uses its own managed interpreters, so a system `python3` older than 3.14 is not a problem as long as `uv python find '>=3.14'` succeeds. Gating on `python3` instead blocks setup on machines where it would have worked.
 
 Log: `{ 1, "Prerequisites Check", DONE/FAILED, list of what passed/failed }`
 


### PR DESCRIPTION
fix(macos-setup): gate Phase 1 Python check on >=3.14

Phase 1 treated any python3 on PATH as acceptable, but the project
requires >=3.14 (pyproject.toml). On a machine with an older
interpreter, Phase 1 reported PYTHON_OK and the run proceeded through
four more phases before Phase 5 failed with "No interpreter found for
Python >=3.14" — an error naming uv rather than the unmet prerequisite.

Check the version rather than mere presence, and add a PYTHON_TOO_OLD
remediation of `uv python install 3.14`. uv is already a Phase 1
prerequisite, so this needs no new tooling and leaves the system
python3 untouched.

Verified: 3.14.0rc2 -> PYTHON_OK; 3.13.5 and 3.9.6 -> PYTHON_TOO_OLD;
no python3 on PATH -> PYTHON_FAIL only.

Fixes #1568

fix(macos-setup): ask uv for the 3.14 interpreter, not PATH's python3

The Phase 1 check I added gated on `python3 --version` from PATH, but
Phase 5 runs `uv sync`, which resolves uv's own managed interpreters and
never consults PATH. On a machine with system python3 3.13.5 and a
uv-managed 3.14.6, the check reported PYTHON_TOO_OLD and told the operator
to stop -- yet `uv sync` completed successfully and built a 3.14.6 venv.

That is a false failure on exactly the machines where setup works, which is
worse than the original bug: it blocks a working install rather than
deferring an error.

Gate on `uv python find '>=3.14'` instead, which reports what `uv sync`
will actually use. Verified both directions on this machine: PYTHON_OK with
the uv-managed 3.14.6 present, and PYTHON_TOO_OLD under
`--no-managed-python` (system-only, 3.13.5) and for an impossible '>=99.0'.

Also drop the now-unreachable PYTHON_FAIL table row, since the check no
longer emits that token.

Refs #1568