### PR TITLE
fix(keycloak): derive agent token keycloak_url from env, not a hardcoded host

### DIFF
--- a/keycloak/setup/setup-agent-service-account.sh
+++ b/keycloak/setup/setup-agent-service-account.sh
@@ -438,6 +438,14 @@ generate_agent_token() {
 
     mkdir -p "$AGENT_TOKEN_DIR"
 
+    # The URL token consumers dial to mint tokens. This must be the *external*
+    # Keycloak URL, not the in-network one ($KEYCLOAK_URL, e.g. http://keycloak:8080),
+    # because the consumers run on the host rather than inside the compose network.
+    # Follow the same precedence as credentials-provider/generate_creds.sh: honour
+    # KEYCLOAK_EXTERNAL_URL, and otherwise fall back to the admin URL this script is
+    # already talking to, which is correct by construction.
+    local keycloak_external_url="${KEYCLOAK_EXTERNAL_URL:-$ADMIN_URL}"
+
     cat > "$AGENT_TOKEN_FILE" << EOF
 {
   "provider": "keycloak_m2m",
@@ -446,7 +454,7 @@ generate_agent_token() {
   "group": "$TARGET_GROUP",
   "client_id": "$AGENT_CLIENT_ID",
   "client_secret": "$AGENT_CLIENT_SECRET",
-  "keycloak_url": "https://mcpgateway.ddns.net/keycloak",
+  "keycloak_url": "$keycloak_external_url",
   "realm": "$REALM",
   "saved_at": "$(date -u '+%Y-%m-%d %H:%M:%S UTC')",
   "usage_notes": "Individual M2M client credentials for agent $AGENT_ID with complete audit trails"


### PR DESCRIPTION
fix(keycloak): derive agent token keycloak_url from env, not a hardcoded host

generate_agent_token() wrote a hardcoded "keycloak_url" into every
generated agent config:

  "keycloak_url": "https://mcpgateway.ddns.net/keycloak",

That is the upstream maintainer's demo deployment. Every field around it
is templated from the environment, so this one looks like a leftover from
manual testing. The effect is that any install -- local, on-prem, or a
different cloud deployment -- gets agent configs pointing at a host it
has no relationship with. Token generation then fails at DNS resolution:

  Failed to make token request to Keycloak:
  HTTPSConnectionPool(host='mcpgateway.ddns.net', port=443):
  Failed to resolve 'mcpgateway.ddns.net'

Read KEYCLOAK_EXTERNAL_URL instead, matching the precedence already used
by credentials-provider/generate_creds.sh, and fall back to $ADMIN_URL --
the URL this script is already successfully driving the Admin API with,
so it is correct by construction. The value must be the external URL
rather than the in-network $KEYCLOAK_URL (http://keycloak:8080), because
the token consumers run on the host, not inside the compose network.

Note this path is unreachable on current main: verify_setup() aborts the
script under `set -e` before generate_agent_token() is ever called (see
issue #1570), which is why the stale value survived. Verified with both
fixes applied against a live Keycloak -- the script completes with exit 0
and writes "keycloak_url": "http://localhost:8080".

Fallback precedence covered: KEYCLOAK_EXTERNAL_URL set (local and remote
forms), unset, and empty string all resolve correctly. shellcheck reports
no new findings.

Fixes #1572