### PR TITLE
fix(keycloak): add the 'basic' scope to agent M2M clients so tokens carry aud=mcp-gateway

### DIFF
--- a/keycloak/setup/setup-agent-service-account.sh
+++ b/keycloak/setup/setup-agent-service-account.sh
@@ -179,6 +179,7 @@ create_agent_m2m_client() {
         "defaultClientScopes": [
             "web-origins",
             "acr",
+            "basic",
             "profile",
             "roles",
             "email"


### PR DESCRIPTION
fix(keycloak): add the 'basic' scope to agent M2M clients so tokens carry aud=mcp-gateway

create_agent_client() is the only client-creation payload in the repo that
sets "defaultClientScopes" explicitly. Every other client -- mcp-gateway-web,
mcp-gateway-m2m in init-keycloak.sh, and the Python _ensure_client() -- omits
the field and so inherits the realm defaults, which include Keycloak's
built-in 'basic' scope. The agent payload enumerates five scopes and leaves
'basic' out.

That scope is not cosmetic here. init-keycloak.sh attaches two protocol
mappers to it, precisely because it is the one scope reliably present on
every client:

  - setup_dcr_groups_mapper    -> 'groups' claim
  - setup_dcr_audience_mapper  -> aud="mcp-gateway"

Without 'basic', the agent's tokens get neither. The audience mapper is the
one that breaks authentication. auth_server/providers/keycloak.py validates
with verify_aud=True against accepted_audiences of [client_id, m2m_client_id,
"mcp-gateway"], and deliberately excludes "account" -- that is Keycloak's
default audience on every realm token, so accepting it would permit a
same-realm cross-client confused-deputy replay. An agent token therefore
carries aud="account" and is rejected by the gateway it was just created to
call. The comment on setup_dcr_audience_mapper spells out the intent the
agent client is silently opting out of.

The 'groups' claim survives only by accident: create_agent_client attaches
its own oidc-group-membership-mapper directly to the client, duplicating
what 'basic' already provides. That masks the missing scope, since the
token looks correct on inspection until you check 'aud'.

Verified against the tokens generated by a real run of this script:

  aud       : account
  azp       : agent-test-agent-m2m
  auth_time : absent (confirming 'basic' was not attached)

and decoding those same tokens with the gateway's accepted_audiences list
raises InvalidAudienceError. Add 'basic' to the list rather than removing
the explicit block, keeping the change to one line and leaving the
already-working redundant groups mapper alone. bash -n passes.

Note this path is reachable only with #1570 and #1572 fixed; verify_setup()
aborts under `set -e` before token generation, which is why the stale
audience went unnoticed.

Fixes #1573