### PR TITLE
fix(scopes): correct the inverted group_mappings in the scope seed files

### DIFF
--- a/scripts/mcp-registry-admin.json
+++ b/scripts/mcp-registry-admin.json
@@ -1,6 +1,6 @@
 {
   "_id": "mcp-registry-admin",
-  "group_mappings": ["mcp-registry-admin", "mcp-servers-unrestricted/read", "mcp-servers-unrestricted/execute"],
+  "group_mappings": ["mcp-registry-admin"],
   "server_access": [
     {
       "server": "*",

--- a/scripts/mcp-servers-unrestricted-execute.json
+++ b/scripts/mcp-servers-unrestricted-execute.json
@@ -1,6 +1,6 @@
 {
   "_id": "mcp-servers-unrestricted/execute",
-  "group_mappings": [],
+  "group_mappings": ["registry-admins", "mcp-registry-admin"],
   "server_access": [
     {
       "server": "*",

--- a/scripts/mcp-servers-unrestricted-read.json
+++ b/scripts/mcp-servers-unrestricted-read.json
@@ -1,6 +1,6 @@
 {
   "_id": "mcp-servers-unrestricted/read",
-  "group_mappings": [],
+  "group_mappings": ["registry-admins", "mcp-registry-admin"],
   "server_access": [
     {
       "server": "*",

--- a/tests/security/test_scope_seed_group_mappings.py
+++ b/tests/security/test_scope_seed_group_mappings.py
@@ -1,0 +1,136 @@
+"""
+Regression tests for the scope seed files' ``group_mappings`` arrays.
+
+``group_mappings`` is a list of IdP *group* identifiers (Keycloak group names,
+Entra ID Object IDs, PingFederate groups) that grant the scope named by ``_id``.
+``map_cognito_groups_to_scopes`` inverts every scope's array into a
+group -> scopes lookup, so an entry that names a *scope* instead of a group can
+never match a token claim, and a scope with an empty array is unreachable for
+every user.
+
+The same arrays back the login-time session-group filter
+(``auth_server/group_filter.py``), which intersects a user's IdP groups with the
+union of these arrays. A group missing here is silently dropped from the
+session, so a wrong entry degrades authorization in two places at once.
+
+These are static assertions over the seed JSON, so they hold without a live
+Keycloak or DocumentDB.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    """Get repository root directory."""
+    return Path(__file__).parent.parent.parent
+
+
+# Seed files mounted into the mongodb-init container by docker-compose.yml and
+# loaded verbatim by scripts/init-mongodb-ce.py.
+SCOPE_SEED_FILES = [
+    "scripts/registry-admins.json",
+    "scripts/mcp-registry-admin.json",
+    "scripts/mcp-servers-unrestricted-read.json",
+    "scripts/mcp-servers-unrestricted-execute.json",
+    "scripts/federation-service.json",
+]
+
+# The privileged registry scopes. Each must be reachable by at least one group,
+# otherwise no operator can administer a fresh install and the documented
+# quickstart cannot register a server.
+ADMIN_SCOPES = [
+    "registry-admins",
+    "mcp-registry-admin",
+]
+
+# Scopes that gate MCP server access for administrators. The pre-DocumentDB
+# auth_server/scopes.yml granted both to registry-admins and mcp-registry-admin.
+SERVER_ACCESS_SCOPES = [
+    "mcp-servers-unrestricted/read",
+    "mcp-servers-unrestricted/execute",
+]
+
+
+def _load(repo_root: Path, rel_path: str) -> dict:
+    return json.loads((repo_root / rel_path).read_text())
+
+
+@pytest.mark.parametrize("seed_path", SCOPE_SEED_FILES)
+def test_group_mappings_only_name_real_idp_groups(repo_root: Path, seed_path: str) -> None:
+    """Every entry must be an identifier an IdP can actually emit.
+
+    Most scopes here are deliberately named after the group that holds them
+    (``registry-admins`` is both a Keycloak group and a scope ``_id``), so a name
+    appearing in both roles is expected and correct. What is never valid is a
+    *path-qualified* scope id such as 'mcp-servers-unrestricted/read': Keycloak
+    groups cannot contain '/', so such an entry is inert -- the runtime inverts
+    these arrays into a group -> scopes map and nothing ever matches it.
+    """
+    doc = _load(repo_root, seed_path)
+
+    offenders = [g for g in doc.get("group_mappings", []) if "/" in g]
+
+    assert not offenders, (
+        f"{seed_path} lists path-qualified scope name(s) {offenders} in "
+        f"group_mappings, which expects IdP group identifiers. These can never "
+        f"match a token claim. To grant another scope to this group, add this "
+        f"group to that scope's file instead."
+    )
+
+
+@pytest.mark.parametrize("scope_id", ADMIN_SCOPES)
+def test_admin_scopes_are_reachable(repo_root: Path, scope_id: str) -> None:
+    """A privileged scope with no groups cannot be held by anyone."""
+    doc = next(
+        _load(repo_root, p) for p in SCOPE_SEED_FILES if _load(repo_root, p)["_id"] == scope_id
+    )
+
+    assert doc.get("group_mappings"), (
+        f"Scope '{scope_id}' has an empty group_mappings array, so no user can "
+        f"ever hold it. A fresh install would have no administrator."
+    )
+
+
+@pytest.mark.parametrize("scope_id", SERVER_ACCESS_SCOPES)
+def test_admin_groups_grant_server_access(repo_root: Path, scope_id: str) -> None:
+    """Admin groups must reach the unrestricted server-access scopes.
+
+    Both admin groups held these in the pre-DocumentDB scopes.yml. Without them
+    an administrator authenticates but resolves to zero server access, which
+    surfaces as a 403 on /api/servers/register.
+    """
+    doc = next(
+        _load(repo_root, p) for p in SCOPE_SEED_FILES if _load(repo_root, p)["_id"] == scope_id
+    )
+    mapped = doc.get("group_mappings", [])
+
+    missing = [g for g in ADMIN_SCOPES if g not in mapped]
+
+    assert not missing, (
+        f"Scope '{scope_id}' is not granted to admin group(s) {missing}. "
+        f"group_mappings={mapped}. Administrators will resolve to zero scopes "
+        f"and be denied server registration."
+    )
+
+
+def test_every_seed_group_mapping_is_a_plain_group_name(repo_root: Path) -> None:
+    """No entry may contain '/', the scope-name separator.
+
+    Guards the whole seed set against reintroducing the scope-vs-group confusion
+    in a file this suite does not enumerate individually.
+    """
+    violations: list[str] = []
+    for path in SCOPE_SEED_FILES:
+        doc = _load(repo_root, path)
+        for group in doc.get("group_mappings", []):
+            if "/" in group:
+                violations.append(f"{path}: {group!r}")
+
+    assert not violations, (
+        "group_mappings entries must be IdP group identifiers, but these "
+        f"contain '/', the scope-name separator: {violations}"
+    )


### PR DESCRIPTION
fix(scopes): correct the inverted group_mappings in the scope seed files

The DocumentDB seed files carry group_mappings arrays that were never
inverted when scopes moved out of auth_server/scopes.yml (removed in
1db1f082). The old YAML was keyed group -> [scopes]; the seed documents are
keyed scope -> [groups]. The migration copied each group's scope list
verbatim into that scope's group list, so the relation is transposed:

  scope                             old YAML groups              seed file
  mcp-servers-unrestricted/read     registry-admins,             []
                                    mcp-registry-admin
  mcp-servers-unrestricted/execute  (same)                       []
  mcp-registry-admin                mcp-registry-admin           mcp-registry-admin,
                                                                 ...unrestricted/read,
                                                                 ...unrestricted/execute

map_cognito_groups_to_scopes inverts these arrays into a group -> scopes
lookup, so the two consequences are:

- The unrestricted scopes have no groups and are unreachable. Every
  administrator resolves to zero server access.
- mcp-registry-admin lists two *scope* ids where group names belong. A
  Keycloak group cannot contain '/', so those entries are inert; they match
  no token claim and grant nothing.

Net effect on a fresh install: an operator in mcp-registry-admin or
registry-admins authenticates, resolves 0 scopes, and is denied server
registration. The documented quickstart cannot complete:

  User service-account-... with 1 groups mapped to 0 scopes
  ... attempted API register without register_service permission
  POST /api/servers/register HTTP/1.1 403 Forbidden

The same arrays back the login-time session-group filter
(auth_server/group_filter.py), which intersects a user's IdP groups with the
union of every group_mappings array, so a missing group is also dropped from
the session.

Restore the mapping the YAML specified: grant the two unrestricted scopes to
registry-admins and mcp-registry-admin, and drop the inert scope ids. The
Entra admin Object ID is not hardcoded -- init-mongodb-ce.py already appends
it to registry-admins from ENTRA_GROUP_ADMIN_ID.

Self-mapping (scope 'registry-admins' granted to group 'registry-admins') is
intentional throughout this project and left as is; only the transposition is
corrected.

Verified against the running stack. Reseeded, restarted registry and
auth-server, then GET /validate for a service account in mcp-registry-admin:

  before: groups=[mcp-registry-admin, ...] scopes=[]
  after : scopes=[mcp-registry-admin,
                  mcp-servers-unrestricted/read,
                  mcp-servers-unrestricted/execute]

and POST /api/servers/register then succeeds where it returned 403.
Negative control: an agent in only mcp-servers-unrestricted still resolves to
scopes=[], so this restores admin access without widening any other group's
privileges.

Adds tests/security/test_scope_seed_group_mappings.py: static assertions that
no entry is path-qualified (the scope-vs-group confusion), that the privileged
scopes are reachable, and that admin groups reach the unrestricted scopes.
4 of its 10 cases fail on the unfixed seed data. Full suite: 6697 passed,
56 skipped.

Fixes #1574