### PR TITLE
fix(token-ttl): complete #1477 — UI mint flows, compose wiring, FAQ accuracy

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -288,6 +288,11 @@ services:
       # M2M Direct Registration
       - M2M_DIRECT_REGISTRATION_ENABLED=${M2M_DIRECT_REGISTRATION_ENABLED:-true}
       - MAX_TOKENS_PER_USER_PER_HOUR=${MAX_TOKENS_PER_USER_PER_HOUR:-100}
+      # MCP access-token lifetime (hours). Default when omitted / hard cap on
+      # requests. Read by the registry (validation); mirrored to auth-server
+      # (minting). Max is bounded to a 7-day ceiling in code. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # Telemetry Configuration
       # Disable all:       set MCP_TELEMETRY_DISABLED=1  to disable all telemetry (startup ping + heartbeat)
       # Heartbeat opt-out: set MCP_TELEMETRY_OPT_OUT=1   to disable daily heartbeat only
@@ -418,6 +423,11 @@ services:
       - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       - TRUSTED_EXTERNAL_HOSTS=${TRUSTED_EXTERNAL_HOSTS:-}
       - SECRET_KEY=${SECRET_KEY}
+      # MCP access-token lifetime (hours). auth-server mints + clamps to the
+      # configured max (bounded to a 7-day ceiling in code). Must match the
+      # registry's values. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # Exact-match allowlist of OAuth login/logout redirect URIs (comma-separated
       # absolute URLs). Empty (default) falls back to the weaker cookie-domain
       # heuristic; set it to harden against open-redirect via a controlled subdomain.

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -289,6 +289,11 @@ services:
       # M2M Direct Registration
       - M2M_DIRECT_REGISTRATION_ENABLED=${M2M_DIRECT_REGISTRATION_ENABLED:-true}
       - MAX_TOKENS_PER_USER_PER_HOUR=${MAX_TOKENS_PER_USER_PER_HOUR:-100}
+      # MCP access-token lifetime (hours). Default when omitted / hard cap on
+      # requests. Read by the registry (validation); mirrored to auth-server
+      # (minting). Max is bounded to a 7-day ceiling in code. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # Telemetry Configuration
       # Disable all:       set MCP_TELEMETRY_DISABLED=1  to disable all telemetry (startup ping + heartbeat)
       # Heartbeat opt-out: set MCP_TELEMETRY_OPT_OUT=1   to disable daily heartbeat only
@@ -372,6 +377,11 @@ services:
       - TRUSTED_PROXY_HOPS=${TRUSTED_PROXY_HOPS:-1}
       - TRUSTED_EXTERNAL_HOSTS=${TRUSTED_EXTERNAL_HOSTS:-}
       - SECRET_KEY=${SECRET_KEY}
+      # MCP access-token lifetime (hours). auth-server mints + clamps to the
+      # configured max (bounded to a 7-day ceiling in code). Must match the
+      # registry's values. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # Exact-match allowlist of OAuth login/logout redirect URIs (comma-separated
       # absolute URLs). Empty (default) falls back to the weaker cookie-domain
       # heuristic; set it to harden against open-redirect via a controlled subdomain.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -443,6 +443,11 @@ services:
       # M2M Direct Registration
       - M2M_DIRECT_REGISTRATION_ENABLED=${M2M_DIRECT_REGISTRATION_ENABLED:-true}
       - MAX_TOKENS_PER_USER_PER_HOUR=${MAX_TOKENS_PER_USER_PER_HOUR:-100}
+      # MCP access-token lifetime (hours). Default when omitted / hard cap on
+      # requests. Read by the registry (validation); mirrored to auth-server
+      # (minting). Max is bounded to a 7-day ceiling in code. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # OpenTelemetry / OTLP (mirrored for config panel visibility)
       - OTEL_OTLP_ENDPOINT=${OTEL_OTLP_ENDPOINT:-}
       - OTEL_OTLP_EXPORT_INTERVAL_MS=${OTEL_OTLP_EXPORT_INTERVAL_MS:-30000}
@@ -602,6 +607,11 @@ services:
       # heuristic; set it to harden against open-redirect via a controlled subdomain.
       - OAUTH2_ALLOWED_REDIRECT_URIS=${OAUTH2_ALLOWED_REDIRECT_URIS:-}
       - SECRET_KEY=${SECRET_KEY}
+      # MCP access-token lifetime (hours). auth-server mints + clamps to the
+      # configured max (bounded to a 7-day ceiling in code). Must match the
+      # registry's values. Issue #1477.
+      - MCP_TOKEN_DEFAULT_TTL_HOURS=${MCP_TOKEN_DEFAULT_TTL_HOURS:-8}
+      - MCP_TOKEN_MAX_TTL_HOURS=${MCP_TOKEN_MAX_TTL_HOURS:-24}
       # Egress vault: auth-server does the marker check + the vend call to the
       # registry (it does NOT touch the secret store, so no SECRET_STORE/AWS/
       # OPENBAO vars here).

--- a/docs/faq/generate-token-longer-than-8-hours.md
+++ b/docs/faq/generate-token-longer-than-8-hours.md
@@ -2,26 +2,27 @@
 
 The token minted by the **Generate Token** page (and `POST /api/tokens/generate`) is a self-signed gateway JWT that works as an MCP access token. Its **8 hours is only the default**, not the ceiling: the shipped maximum is **24 hours**, and both the default and the maximum are operator-configurable (from [#1477](https://github.com/agentic-community/mcp-gateway-registry/issues/1477)).
 
+## Short answer
+
+**For a user going through the UI, changing the config parameters is the only way to get a longer lifetime.** The UI exposes only fixed presets (1h / 8h / 24h) and cannot request an arbitrary value, and the token API is session-authenticated (not a simple Bearer `curl`), so there is no self-service "just ask for N hours" path. An operator sets the lifetime with two `.env` parameters (restart the registry and auth-server after changing them):
+
+- `MCP_TOKEN_DEFAULT_TTL_HOURS` — the lifetime every UI entry point mints (default `8`).
+- `MCP_TOKEN_MAX_TTL_HOURS` — the ceiling on any request (default `24`, hard-capped at 168h / 7 days).
+
+To go **beyond 24h**, raising `MCP_TOKEN_MAX_TTL_HOURS` is the **only** way. The rest of this FAQ explains the details.
+
 So there are two different things you might want, and they need different actions.
 
-## I just want one token that lasts, say, 12 hours
+## I want a token with a lifetime other than the presets (e.g. 12 hours)
 
-Any value up to the configured maximum (24h by default) needs **no config change at all** — you simply request it.
+**From the UI, you can only pick the built-in presets.** The **Generate Token** page's **Expires In** dropdown offers exactly **1 hour / 8 hours / 24 hours** — there is no 12-hour option and no free-form hours field. The sidebar **Get JWT Token** button and a server's **MCP Configuration** dialog don't let you choose at all; they always mint at the **configured default** lifetime. So for anything other than 1h / 8h / 24h, the UI alone will not do it.
 
-**From the UI:** open **Generate Token** in the left sidebar, pick the lifetime from the **Expires In** dropdown, and generate.
+To get an arbitrary lifetime (say 12h) you have two options:
 
-**From the API:** pass `expires_in_hours` in the request body.
+1. **Change the default (simplest, recommended).** Set `MCP_TOKEN_DEFAULT_TTL_HOURS=12` (see the next section) and restart. Every token the sidebar button, the MCP Configuration dialog, and the "omit expires_in_hours" path mint is then 12h.
+2. **Call the API with a custom `expires_in_hours`.** The endpoint accepts any integer from `1` to the configured maximum (24 by default) in the JSON body — but see the auth note below, it is not a simple Bearer `curl`.
 
-```bash
-export REG=http://localhost   # or your deployment URL
-
-curl -sS -X POST "$REG/api/tokens/generate" \
-  -H "Authorization: Bearer $(cat .token)" \
-  -H "Content-Type: application/json" \
-  -d '{"expires_in_hours": 12}'
-```
-
-The value must be an integer between `1` and the configured maximum; a request above the maximum is rejected with `400`.
+> **`POST /api/tokens/generate` is a browser/session endpoint, not a Bearer-token API.** It is authenticated by your logged-in **session cookie** (`enhanced_auth`), so a plain `curl` with only an `Authorization: Bearer <token>` header is rejected with `401 Authentication required` — you cannot mint a new token from an existing bearer token. Drive it from the UI (which carries the session cookie and, for browsers, the CSRF token), or from a script that first performs the OAuth login and reuses the resulting session cookie. A request whose `expires_in_hours` is not an integer in `1`..max is rejected with `400`.
 
 ## I want to change the default, or allow tokens longer than 24 hours
 
@@ -52,10 +53,6 @@ It is in the left sidebar as **Generate Token**, gated by the `token-generation`
 ## Note: this is not `session_max_age_seconds`
 
 `SESSION_MAX_AGE_SECONDS` controls only the **registry browser session cookie** (and its CSRF token), not the MCP access token. Changing it does not affect how long a generated token is valid. The two defaults both being 8h is a coincidence.
-
-## Related
-
-- [Testing: MCP access-token TTL](../testing-mcp-token-ttl.md) — a manual test plan exercising the Get JWT Token button, the MCP Configuration modal, and the two TTL parameters.
 
 ## Related FAQs
 

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -185,6 +185,9 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
   onEgressChanged,
 }) => {
   const [jwtToken, setJwtToken] = useState<string | null>(null);
+  // Actual token lifetime in hours, derived from the response's expires_in
+  // (seconds) rather than hardcoded, since the default is operator-configurable.
+  const [tokenExpiresInHours, setTokenExpiresInHours] = useState<number | null>(null);
   const [tokenLoading, setTokenLoading] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -260,6 +263,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     if (isOpen && !isRegistryOnly && server.deployment !== 'local') {
       // Reset token state when modal opens
       setJwtToken(null);
+      setTokenExpiresInHours(null);
       setTokenError(null);
       fetchJwtToken();
     }
@@ -335,9 +339,11 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     setTokenLoading(true);
     setTokenError(null);
     try {
+      // Omit expires_in_hours so the server applies the configured default
+      // lifetime (MCP_TOKEN_DEFAULT_TTL_HOURS). Hardcoding a value here breaks
+      // when an operator lowers the max below it. Issue #1477.
       const body: Record<string, unknown> = {
         description: `Generated for MCP configuration (${server.name})`,
-        expires_in_hours: 8,
       };
       // ai-registry-tools (mcpgw) needs a user token because it calls registry
       // APIs internally (/api/search/semantic, /api/servers, etc.) which require
@@ -357,6 +363,10 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
         const accessToken = response.data.tokens?.access_token || response.data.access_token;
         if (accessToken) {
           setJwtToken(accessToken);
+          const expiresInSeconds = response.data.tokens?.expires_in ?? response.data.expires_in;
+          setTokenExpiresInHours(
+            typeof expiresInSeconds === 'number' ? Math.round(expiresInSeconds / 3600) : null,
+          );
         } else {
           setTokenError('Token not found in response');
         }
@@ -986,7 +996,10 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
                 </p>
               ) : jwtToken ? (
                 <p className="text-sm text-green-800 dark:text-green-200">
-                  JWT token has been automatically added to the configuration below. You can copy and paste it directly into your mcp.json file. Token expires in 8 hours.
+                  JWT token has been automatically added to the configuration below. You can copy and paste it directly into your mcp.json file.
+                  {tokenExpiresInHours
+                    ? ` Token expires in ${tokenExpiresInHours} hour${tokenExpiresInHours === 1 ? '' : 's'}.`
+                    : ''}
                 </p>
               ) : tokenError ? (
                 <p className="text-sm text-red-800 dark:text-red-200">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -106,9 +106,11 @@ const fetchAdminTokens = async () => {
   setLoading(true);
   setError('');
   try {
+    // Omit expires_in_hours so the server applies the configured default
+    // lifetime (MCP_TOKEN_DEFAULT_TTL_HOURS). Hardcoding a value here breaks
+    // when an operator lowers the max below it. Issue #1477.
     const requestData = {
       description: 'Generated via sidebar',
-      expires_in_hours: 8,
     };
 
     const response = await axios.post('/api/tokens/generate', requestData, {
@@ -684,6 +686,25 @@ const fetchAdminTokens = async () => {
                           <span>Download JSON</span>
                         </button>
                       </div>
+
+                      {/* Human-readable lifetime, derived from the response's
+                          expires_in (seconds). The lifetime is operator-
+                          configurable (MCP_TOKEN_DEFAULT_TTL_HOURS), so read it
+                          from the response rather than hardcoding a value. */}
+                      {typeof tokenData?.tokens?.expires_in === 'number' && (
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
+                          This token expires in{' '}
+                          <span className="font-medium">
+                            {(() => {
+                              const secs = tokenData.tokens.expires_in;
+                              const hrs = secs / 3600;
+                              const rounded = Math.round(hrs * 100) / 100;
+                              return `${rounded} hour${rounded === 1 ? '' : 's'}`;
+                            })()}
+                          </span>{' '}
+                          ({tokenData.tokens.expires_in} seconds).
+                        </p>
+                      )}
 
                       {/* Token Data Display */}
                       <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 max-h-96 overflow-y-auto">


### PR DESCRIPTION
Follow-up to #1587. That PR merged the core configurable MCP-token-TTL feature (config.py, .env.example, Terraform, Helm, tests), but four files were left out due to a staging mistake, so the feature is incomplete on `main` without this.

## Why this is needed

- **The UI mint buttons break when the max is lowered below 8h.** The sidebar **Get JWT Token** button and the **MCP Configuration** dialog hardcoded `expires_in_hours: 8`, so with `MCP_TOKEN_MAX_TTL_HOURS` set below 8 they fail with `expires_in_hours must be an integer between 1 and N` (the red error users see). They now omit the field so the server applies `MCP_TOKEN_DEFAULT_TTL_HOURS`.
- **docker-compose never passes the new vars.** #1587 wired `MCP_TOKEN_DEFAULT_TTL_HOURS` / `MCP_TOKEN_MAX_TTL_HOURS` into `.env.example`, Terraform, and Helm — but not `docker-compose.yml`, so compose deployments ignored them entirely. Now passed to both the registry and auth-server containers.
- **The FAQ overstated the UI.** It claimed you could pick a 12h token from the UI; the dropdown only offers 1h/8h/24h presets and the token API is session-cookie authenticated (not a Bearer curl), so changing the config params is the only way to get a longer lifetime. Corrected, with a Short answer up top.

## Changes

- `frontend/src/components/Sidebar.tsx` — omit hardcoded 8h; show actual lifetime from `expires_in`.
- `frontend/src/components/ServerConfigModal.tsx` — same omit + dynamic 'Token expires in N hours' text.
- `docker-compose.yml` — pass both vars to registry + auth-server env blocks.
- `docs/faq/generate-token-longer-than-8-hours.md` — accuracy corrections + Short answer.

## Testing

- Verified live on the running stack: with `MCP_TOKEN_DEFAULT_TTL_HOURS=2` / `MCP_TOKEN_MAX_TTL_HOURS=3`, both containers read the values, the sidebar button and modal mint a 2h token (no error), and requests above 3h are rejected with the 400 range error. Reverting the vars returns to the shipped 8h/24h defaults.
- `ServerConfigModal` jest suite passes (11/11); frontend production build is clean.

Relates to #1477 (completes what #1587 started).