### PR TITLE
chore(cli): drop now-unused exec import from tokenRefresh

### DIFF
--- a/cli/src/utils/tokenRefresh.ts
+++ b/cli/src/utils/tokenRefresh.ts
@@ -1,8 +1,7 @@
-import {exec, execFile} from "node:child_process";
+import {execFile} from "node:child_process";
 import {promisify} from "node:util";
 import path from "node:path";
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 export interface TokenRefreshResult {


### PR DESCRIPTION
Small follow-up to #1524.

That PR replaced the `exec()` + string-interpolation calls in `cli/src/utils/tokenRefresh.ts` with `execFile()` (arg array, no shell) to close the command-injection vector. The `exec` import and its `execAsync = promisify(exec)` wrapper are no longer referenced by anything in the module — this removes them, leaving only `execFile` / `execFileAsync`.

## Changes
- `cli/src/utils/tokenRefresh.ts`: drop the dead `exec` import and `execAsync` const.

## Testing
- `npm run typecheck` (tsc): clean.
- CLI test suite: 18/18 pass.

No behavior change — pure dead-code cleanup.