### PR TITLE
fix(telemetry): prevent silent heartbeat drop in usage-report export

### DIFF
--- a/.claude/skills/usage-report/run_report.sh
+++ b/.claude/skills/usage-report/run_report.sh
@@ -104,6 +104,31 @@ _export_telemetry() {
         "$CSV"
 
     echo ">>> Exported $(wc -l < "$CSV") rows to $CSV"
+
+    # Safety net: a combined export must contain BOTH event types. A CSV with
+    # startups but zero heartbeats is the classic silent-drop failure (mongosh
+    # fetch timeout on the t2.micro) and would zero out the entire Liveness /
+    # Engagement / LTV half of the report. Fail loud here so the workaround is
+    # never needed manually. (The bastion telemetry_db.py also guards this now;
+    # this covers the case where an older script is present on the bastion.)
+    _verify_both_event_types "$CSV"
+}
+
+
+# Verify a combined export CSV has both startup and heartbeat rows.
+_verify_both_event_types() {
+    local csv="$1"
+    local has_startup has_heartbeat
+    has_startup="$(awk -F, 'NR>1 && $1=="startup" {print "yes"; exit}' "$csv")"
+    has_heartbeat="$(awk -F, 'NR>1 && $1=="heartbeat" {print "yes"; exit}' "$csv")"
+    if [ "$has_startup" != "yes" ] || [ "$has_heartbeat" != "yes" ]; then
+        echo "ERROR: export CSV is missing an event type (startup=${has_startup:-no}, heartbeat=${has_heartbeat:-no})." >&2
+        echo "       This is the silent heartbeat-drop failure. Not proceeding with a partial export." >&2
+        echo "       Re-run with FORCE_EXPORT=1; if it recurs, export each collection separately on the bastion." >&2
+        rm -f "$csv"
+        exit 1
+    fi
+    echo ">>> Verified export contains both startup and heartbeat events."
 }
 
 

--- a/terraform/telemetry-collector/README.md
+++ b/terraform/telemetry-collector/README.md
@@ -84,9 +84,12 @@ Privacy-first serverless telemetry collector that receives anonymous usage data 
 
   Optional Bastion Host:
   ---------------------------------------------------------------
-  When bastion_enabled = true, a t2.micro EC2 instance is
-  created in a public subnet with SSH access for direct
-  DocumentDB queries via mongosh.
+  When bastion_enabled = true, an EC2 instance (default
+  t3.medium, override via bastion_instance_type) is created
+  in a public subnet with SSH access for direct DocumentDB
+  queries via mongosh. t3.medium is the default because the
+  telemetry export streams whole collections and a t2.micro
+  starves on CPU credits during the heartbeat fetch.
 ```
 
 ## Prerequisites

--- a/terraform/telemetry-collector/bastion-scripts/telemetry_db.py
+++ b/terraform/telemetry-collector/bastion-scripts/telemetry_db.py
@@ -41,6 +41,15 @@ DEFAULT_OUTPUT = "registry_metrics.csv"
 CA_BUNDLE_PATH = os.path.expanduser("~/global-bundle.pem")
 BASTION_ENV_PATH = os.path.expanduser("~/bastion.env")
 
+# Timeout (seconds) for a full-collection mongosh fetch. The bastion is a
+# 1 GB / 1-vCPU t2.micro, so streaming a large collection is CPU-bound and can
+# take well over the old 120s default -- especially the SECOND fetch in a
+# combined export, which runs after the first fetch has already burned the
+# instance's CPU credits. A too-low timeout made the heartbeat fetch return 0
+# rows SILENTLY, zeroing out the entire Liveness/Engagement/LTV half of the
+# report. Keep this generous; the query itself is fast when not CPU-starved.
+FETCH_TIMEOUT_SECONDS = 900
+
 COLLECTIONS = ["startup_events", "heartbeat_events"]
 
 # Column order for startup events
@@ -351,11 +360,24 @@ def _fetch_documents(
         f"db.{collection}.find({{}}, {{_id:0}})"
         f".sort({{ts:1}}).forEach(d => print(JSON.stringify(d)));"
     )
-    output = _run_mongosh(endpoint, username, password, database, eval_script)
+    output = _run_mongosh(
+        endpoint,
+        username,
+        password,
+        database,
+        eval_script,
+        timeout=FETCH_TIMEOUT_SECONDS,
+    )
 
     if output is None:
-        logger.error(f"Failed to fetch documents from {collection}")
-        return []
+        # Fail loud. A silent empty return here previously let a timed-out
+        # heartbeat fetch look like a successful 0-row export, corrupting the
+        # whole liveness half of the report. Raise so the caller aborts.
+        raise RuntimeError(
+            f"Failed to fetch documents from {collection} "
+            f"(mongosh returned no output within {FETCH_TIMEOUT_SECONDS}s). "
+            f"Aborting rather than writing a partial CSV."
+        )
 
     documents = []
     for line in output.split("\n"):
@@ -707,6 +729,7 @@ def cmd_export(args: argparse.Namespace) -> None:
 
     start_time = time.time()
     all_documents = []
+    per_collection_counts: dict[str, int] = {}
 
     for collection in target_collections:
         logger.info(f"Fetching {collection}...")
@@ -718,7 +741,22 @@ def cmd_export(args: argparse.Namespace) -> None:
             collection=collection,
         )
         logger.info(f"  Found {len(docs)} documents")
+        per_collection_counts[collection] = len(docs)
         all_documents.extend(docs)
+
+    # Guard against the silent-drop failure mode: when more than one collection
+    # is requested (the combined 'all' export), a collection returning 0 rows
+    # almost always means its fetch failed rather than that it is genuinely
+    # empty (both collections have data in practice). Abort instead of writing
+    # a partial CSV that reads as a valid, complete export.
+    empty = [name for name, count in per_collection_counts.items() if count == 0]
+    if len(target_collections) > 1 and empty:
+        raise RuntimeError(
+            f"Collection(s) {empty} returned 0 documents in a combined export. "
+            f"This is almost certainly a failed fetch, not an empty collection. "
+            f"Aborting rather than writing a partial CSV. "
+            f"Re-run, or export each collection separately to isolate the failure."
+        )
 
     if not all_documents:
         logger.warning("No documents found. CSV not created.")

--- a/terraform/telemetry-collector/bastion.tf
+++ b/terraform/telemetry-collector/bastion.tf
@@ -104,12 +104,14 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
-# Bastion EC2 instance (t2.micro — free tier eligible)
+# Bastion EC2 instance. Default instance type is t3.medium (see
+# var.bastion_instance_type) so the telemetry export can stream whole
+# collections without CPU-credit starvation on the heartbeat fetch.
 resource "aws_instance" "bastion" {
   count = var.bastion_enabled ? 1 : 0
 
   ami                         = data.aws_ami.amazon_linux_2023[0].id
-  instance_type               = "t2.micro"
+  instance_type               = var.bastion_instance_type
   subnet_id                   = aws_subnet.public[0].id
   vpc_security_group_ids      = [aws_security_group.bastion[0].id]
   key_name                    = aws_key_pair.bastion[0].key_name

--- a/terraform/telemetry-collector/terraform.tfvars.example
+++ b/terraform/telemetry-collector/terraform.tfvars.example
@@ -40,7 +40,12 @@ rate_limit_window_seconds = 60  # Time window in seconds
 # Leave empty to disable alarms
 # alarm_email = "alerts@example.com"
 
-# Bastion host for DocumentDB access (free tier t2.micro)
+# Bastion host for DocumentDB access.
+# Default instance type is t3.medium so the telemetry export can stream whole
+# collections without CPU-credit starvation (t2.micro caused silent heartbeat
+# drops). Override bastion_instance_type = "t2.micro" only for a throwaway
+# free-tier bastion where slow exports are acceptable.
 bastion_enabled      = true
+# bastion_instance_type = "t3.medium"        # default; use t2.micro for free tier
 # bastion_public_key   = "ssh-rsa AAAA..."   # your ~/.ssh/id_rsa.pub
 # bastion_allowed_cidrs = ["YOUR_IP/32"]      # restrict to your IP for security

--- a/terraform/telemetry-collector/variables.tf
+++ b/terraform/telemetry-collector/variables.tf
@@ -100,6 +100,20 @@ variable "bastion_public_key" {
   default     = ""
 }
 
+variable "bastion_instance_type" {
+  description = <<-EOT
+    EC2 instance type for the bastion host. The default t3.medium (2 vCPU,
+    4 GB) is deliberately larger than free-tier t2.micro: the telemetry
+    export streams whole DocumentDB collections through mongosh, and on a
+    1-vCPU / 1 GB t2.micro the second (heartbeat) fetch exhausts CPU credits
+    and crawls, which previously caused a silent heartbeat drop. Use
+    t2.micro only for a throwaway free-tier bastion where slow exports are
+    acceptable.
+  EOT
+  type        = string
+  default     = "t3.medium"
+}
+
 variable "bastion_allowed_cidrs" {
   description = "CIDR blocks allowed to SSH to the bastion host"
   type        = list(string)


### PR DESCRIPTION
## Summary

The `/usage-report` bastion export streams whole DocumentDB collections through `mongosh`. On the free-tier **t2.micro** bastion (1 vCPU / 1 GB), the first (startup) fetch exhausts CPU credits, so the second (heartbeat) fetch ran credit-throttled and exceeded the 120s `mongosh` timeout. The fetch returned **0 documents silently**, yet the export still wrote a CSV and exited 0, zeroing out the entire **Liveness / Engagement / LTV** half of the report with no error. `Confirmed Alive = 0` was the only tell.

Heartbeats are emitted once per 24h and are the "is this deployment still alive" signal, so losing them silently corrupts the report without any hard failure.

## Fix (three layers)

1. **`telemetry_db.py`**
   - Raise the `mongosh` fetch timeout from 120s to **900s** (`FETCH_TIMEOUT_SECONDS`).
   - `_fetch_documents` now **raises** on a timeout / no-output result instead of returning an empty list silently.
   - `cmd_export` **aborts** if any collection in a combined export returns 0 rows (a near-certain failed fetch, not an empty collection), rather than writing a partial CSV that reads as complete.

2. **`run_report.sh`**
   - After downloading the CSV, verify it contains **both** `startup` and `heartbeat` events and abort (removing the partial CSV) if either is missing, so a silent drop can never reach the report.

3. **Terraform (root-cause fix)**
   - Add `bastion_instance_type` variable, default **t3.medium** (was a hardcoded `t2.micro`). On t3.medium the combined export completes in ~27s with both event types intact (the heartbeat fetch drops from 20+ min / timeout to ~2s).

## Validation

Deployed the t3.medium bastion (targeted `terraform apply`) and ran the combined export that previously failed:

| | t2.micro (before) | t3.medium (after) |
|---|---|---|
| Combined export total | 149s -> **0 heartbeats** (timed out) | **27s** |
| Heartbeat fetch | 20+ min / timeout | ~2s |
| Result | 157,627 startup + **0** heartbeat | 157,627 startup + **8,546** heartbeat |

## Deployment notes

- The instance-type change requires `terraform apply` to **replace** the bastion (new public IP; the `bastion_public_ip` output updates automatically).
- A replaced bastion comes up bare; re-run `bastion-scripts/setup-bastion.sh` to reinstall mongosh, the CA bundle, and helper scripts.
