### PR TITLE
fix(a2a): accept percent-encoded ARNs so AgentCore agents are routable

### DIFF
--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -35,7 +35,20 @@ AGENT_ROUTE_PREFIX: str = "/agent"
 # nginx directive positions, so they must be validated to prevent config
 # injection (e.g. "}", ";", newlines breaking out of the location block).
 _NGINX_AGENT_PATH_SAFE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
-_NGINX_AGENT_URL_SAFE = re.compile(r"^https?://[A-Za-z0-9.\-]+(?::\d+)?(?:/[A-Za-z0-9._~\-/]*)?$")
+# The path segment also accepts percent-encoded octets (%XX), because a Bedrock
+# AgentCore runtime url embeds a percent-encoded ARN:
+#   https://bedrock-agentcore.{region}.amazonaws.com/runtimes/{encoded-ARN}/invocations
+# (built by cli/agentcore/models.py::build_invocation_url). Rejecting those made
+# every AgentCore A2A agent unroutable through the gateway.
+#
+# Only a COMPLETE triplet is allowed -- `%` must be followed by exactly two hex
+# digits -- so a bare or truncated `%` still fails. That keeps the anti-injection
+# guarantee: no unescaped `%` can reach an nginx directive position, and the
+# characters that would break out of the location block (`}`, `;`, whitespace,
+# newlines) remain excluded because they are not hex digits.
+_NGINX_AGENT_URL_SAFE = re.compile(
+    r"^https?://[A-Za-z0-9.\-]+(?::\d+)?(?:/(?:[A-Za-z0-9._~\-/]|%[0-9A-Fa-f]{2})*)?$"
+)
 
 
 # Headroom added on top of the auth-server mcp-proxy hop's own upstream timeout

--- a/tests/unit/test_agent_nginx.py
+++ b/tests/unit/test_agent_nginx.py
@@ -209,6 +209,75 @@ class TestGenerateAgentLocationBlocks:
         assert result == ""
 
     @pytest.mark.asyncio
+    async def test_generates_block_for_percent_encoded_agentcore_url(self, patched_agent_service):
+        """A Bedrock AgentCore runtime url is routable.
+
+        AgentCore invocation urls embed a percent-encoded ARN (built by
+        cli/agentcore/models.py::build_invocation_url), so the url-safety check
+        must accept %XX octets. Rejecting them made every imported AgentCore A2A
+        agent silently unroutable ("unsafe agent url" -> skipped, 0 blocks).
+        """
+        agentcore_url = (
+            "https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/"
+            "arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A123456789012%3A"
+            "runtime%2Fevcharger2-qR51Wr33ZA/invocations"
+        )
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/evcharger2"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="/evcharger2", url=agentcore_url, name="EV Charger 2")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        # Routes are emitted with the {{ROOT_PATH}} placeholder, substituted later.
+        assert "/agent/evcharger2/ {" in result
+        # The encoded ARN must survive into proxy_pass verbatim; re-encoding or
+        # stripping it would point the route at a non-existent runtime.
+        assert f"proxy_pass {agentcore_url}/;" in result
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "https://host/a%",  # truncated: no hex digits
+            "https://host/a%2",  # truncated: one hex digit
+            "https://host/a%zz",  # not hex
+            "https://host/a%2y",  # second char not hex
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_skips_agent_with_incomplete_percent_escape(self, patched_agent_service, bad_url):
+        """Only a COMPLETE %XX triplet is allowed, never a bare/partial '%'.
+
+        This is what keeps the anti-injection property while permitting
+        AgentCore urls: an unescaped '%' can never reach an nginx directive.
+        """
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/evil"])
+        patched_agent_service.get_agent_info = AsyncMock(return_value=_agent(url=bad_url))
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_percent_encoding_does_not_admit_nginx_injection(self, patched_agent_service):
+        """Allowing %XX must not let config-breaking characters through.
+
+        The characters that would break out of a location block are not hex
+        digits, so they still fail even adjacent to a valid escape.
+        """
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/evil"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(url="https://host/%2F; return 200; #")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert result == ""
+
+    @pytest.mark.asyncio
     async def test_skips_unhealthy_agent(self, patched_agent_service):
         """An unhealthy agent is skipped so no route points at a dead backend."""
         patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])


### PR DESCRIPTION
Fixes #1595

## Problem

`_NGINX_AGENT_URL_SAFE` did not allow `%` in the url path, so every Bedrock AgentCore A2A agent was silently unroutable through the gateway.

AgentCore invocation urls embed a percent-encoded ARN, and this repo's own importer builds them that way (`cli/agentcore/models.py::build_invocation_url`). An ARN cannot sit in a path segment unencoded, so `%` is unavoidable — and it is the only character in a real AgentCore url the old pattern rejected. One half of the codebase generated urls the other half refused.

Six imported agents (all enabled and healthy, three with protocol `a2a`) produced `Generated 0 A2A agent location blocks`.

## Change

Allow `%` only as a **complete `%XX` triplet**:

```python
r"^https?://[A-Za-z0-9.\-]+(?::\d+)?(?:/(?:[A-Za-z0-9._~\-/]|%[0-9A-Fa-f]{2})*)?$"
```

A bare or truncated `%` still fails, and `}`, `;`, whitespace and newlines remain excluded because they are not hex digits — so the anti-injection property the pattern exists for is unchanged.

## Security boundary

Checked rather than assumed.

**Rejected:** `%`, `%2`, `%zz`, `%2y`, `;return 1`, `}`, embedded newline, whitespace, `ftp://`
**Accepted:** real AgentCore url, plain `https`, bare docker name with port, mixed-case hex

`%0A%0D` (encoded CRLF) **is** accepted by the triplet rule. I verified against real nginx that this cannot inject config, because `proxy_pass` treats percent-escapes as opaque literal text:

```nginx
proxy_pass https://example.com/a%0A%0Dadd_header/;
# nginx: configuration file /etc/nginx/nginx.conf test is successful
```

Happy to tighten further if maintainers prefer excluding encoded control characters, though it does not appear necessary.

## Verification

On a live 1.28.0 stack:

- `Generated 0 A2A agent location blocks` → **`Generated 3`**
- Three `location /agent/*/` blocks emitted; `nginx -t` passes
- Encoded ARN survives verbatim into `proxy_pass` (re-encoding would point at a non-existent runtime)

End to end, the call now reaches AgentCore itself:

```
A2A invoke allowed for admin caller to agent /evcharger2
A2A per-agent scope validation passed for /evcharger2
GET /validate -> 200 OK
-> x-amzn-ErrorType: MissingAuthenticationTokenException
```

That 401 is from AWS, not the gateway — routing works; only the egress credential is absent, which is a separate configuration concern. Invoking the same runtime directly with a Cognito `client_credentials` token returns HTTP 200 with a real A2A response, confirming the runtime is healthy.

## Tests

Adds regression coverage: an AgentCore url produces a block with the ARN intact, four incomplete-escape forms are skipped, and an injection attempt adjacent to a valid escape is skipped. **The positive test fails against current `main`** — verified by reverting the regex and re-running.

Full suite: **6734 passed, 74 skipped**. `ruff check` and `ruff format` clean.