### PR TITLE
feat: add static bearer token fast-path for egress auth

### DIFF
--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -356,11 +356,28 @@ async def vend_egress_token(
     missing/invalid; a clean miss (no connection, non-per-user caller, upstream
     mismatch, etc.) returns ``consent_required=True`` with no token.
     """
-    if not settings.egress_auth_enabled:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="egress auth disabled")
-
     if not x_internal_token:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="missing X-Internal-Token")
+
+    # Static bearer fast-path: when egress_auth is disabled but the server has
+    # a stored bearer credential, vend it without requiring the full vault stack.
+    if not settings.egress_auth_enabled:
+        server_path = body.server_path if body.server_path.startswith("/") else "/" + body.server_path
+        server = await get_server_repository().get(server_path)
+        if server is not None and server.get("auth_scheme") == "bearer":
+            encrypted = server.get("auth_credential_encrypted")
+            if encrypted:
+                from ..utils.credential_encryption import decrypt_credential
+
+                credential = decrypt_credential(encrypted)
+                if credential:
+                    header_name, value_prefix = _derive_pat_inject_header(server)
+                    return EgressTokenResponse(
+                        access_token=credential,
+                        pat_header_name=header_name,
+                        pat_value_prefix=value_prefix,
+                    )
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="egress auth disabled")
 
     # Independently re-verify the mcp-proxy token; identity is the verified
     # claim, never an asserted body field.
@@ -392,6 +409,25 @@ async def vend_egress_token(
 
     # Per-server enablement: a misconfigured/half-deleted server never vends.
     egress_mode = server.get("egress_auth_mode")
+
+    # Static bearer: server has a stored encrypted credential (auth_scheme=bearer)
+    # but no per-user egress flow. Decrypt and vend directly — no vault required.
+    auth_scheme = server.get("auth_scheme", "none")
+    if egress_mode not in ("oauth_user", "obo_exchange", "pat") and auth_scheme == "bearer":
+        encrypted = server.get("auth_credential_encrypted")
+        if encrypted:
+            from ..utils.credential_encryption import decrypt_credential
+
+            credential = decrypt_credential(encrypted)
+            if credential:
+                header_name, value_prefix = _derive_pat_inject_header(server)
+                return EgressTokenResponse(
+                    access_token=credential,
+                    pat_header_name=header_name,
+                    pat_value_prefix=value_prefix,
+                )
+        return EgressTokenResponse(consent_required=True)
+
     if egress_mode not in ("oauth_user", "obo_exchange", "pat") or not server.get("egress_oauth"):
         return EgressTokenResponse(consent_required=True)
 


### PR DESCRIPTION
Author: Claude Sonnet 4.6

### Problem

MCP servers registered with `auth_scheme: bearer` — i.e. a simple static
token stored encrypted in MongoDB via the registry UI — were not reachable
through the gateway proxy. When a client request hit `/mcp-proxy/<server>/`,
the auth-server correctly validated the inbound user token and forwarded the
request, but the backend received no `Authorization` header and rejected it
with 401.

The root cause was that the egress credential vend endpoint
(`/_egress_internal/egress-token`) had two gaps:

1. When `EGRESS_AUTH_ENABLED=false` (the default), the endpoint immediately
   returned 404, so the auth-server never attempted a vend and forwarded
   tokenless.
2. When `EGRESS_AUTH_ENABLED=true`, the vend only handled `oauth_user`,
   `obo_exchange`, and `pat` modes. Servers with a plain `bearer`
   `auth_credential_encrypted` but no `egress_auth_mode` fell through to
   `consent_required=True`, again resulting in a tokenless forward.

This meant that any MCP server requiring a static bearer token — a common
pattern for in-cluster services like mcpg, custom sidecars, or internal
tooling — was effectively unreachable through the gateway even when the
credential was correctly configured in the UI.

### Fix

Two fast-paths added to `vend_egress_token` in
`registry/api/egress_auth_routes.py`:

**Path 1 — egress disabled, server has bearer credential:**
Before raising 404, check whether the requested server has
`auth_scheme=bearer` and a stored `auth_credential_encrypted`. If so,
decrypt and vend it immediately. This allows operators to use bearer-token
backends without enabling the full per-user vault stack (OpenBao / Secrets
Manager).

**Path 2 — egress enabled, server has bearer credential but no egress mode:**
After the per-user auth check and server lookup, if `egress_auth_mode` is
not set to one of the vault-backed modes but `auth_scheme=bearer` is
present, decrypt the stored credential and vend it. This handles the case
where egress is enabled for OAuth/PAT servers but a particular server only
needs a static token.

In both paths the credential is decrypted using the existing
`decrypt_credential` helper (the same one used by the health checker), and
the inject header/prefix is derived via `_derive_pat_inject_header` — so
the server's `auth_header_name` configuration is honoured consistently.

### Behaviour

- No vault required for static bearer servers — no OpenBao or Secrets
  Manager configuration needed.
- Fail-closed: if decryption fails or the credential is absent, the
  existing `consent_required` / 404 response is preserved.
- No change to PAT, `oauth_user`, or `obo_exchange` flows — those are
  unaffected.
- The `EGRESS_AUTH_ENABLED=false` 404 is preserved for servers that have
  no bearer credential, keeping the existing fail-closed default.

### Testing

Verified end-to-end against a Kubernetes-deployed mcpg (PostgreSQL MCP
server) registered with `auth_scheme: bearer`. After this change, MCP
`initialize` and `tools/call` requests through the gateway correctly
received the backend bearer token and returned valid responses.
*Description of changes:*



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
