### PR TITLE
fix: use relative redirects to prevent internal URL leak (#1606)

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -165,6 +165,8 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
+    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
+    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -166,6 +166,8 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
+    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
+    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};


### PR DESCRIPTION
## Problem

After PR #1507 added trailing slashes to nginx location blocks, requests without trailing slash trigger nginx's automatic 301 redirect. With `absolute_redirect on` (the default), the `Location` header leaks the internal scheme and port:

```
Location: http://<gateway-host>:8080/registry/<server>/
```

MCP clients follow this redirect and hang on the unreachable internal address.

## Fix

Add `absolute_redirect off;` to both nginx templates so redirects use relative `Location` headers:

```
Location: /registry/<server>/
```

This is resolved by the client against the original `https://<gateway-host>` origin, which works correctly behind TLS-terminating proxies.

## Changes

- `docker/nginx_rev_proxy_http_and_https.conf`: Add `absolute_redirect off;`
- `docker/nginx_rev_proxy_http_only.conf`: Add `absolute_redirect off;`

Fixes #1606