### PR TITLE
fix: update Lambda dependencies for urllib3 vulnerabilities

### DIFF
--- a/terraform/aws-ecs/lambda/rotate-documentdb/requirements.txt
+++ b/terraform/aws-ecs/lambda/rotate-documentdb/requirements.txt
@@ -1,2 +1,3 @@
-boto3>=1.26.0
-botocore>=1.29.0
+boto3>=1.43.7
+botocore>=1.43.7
+urllib3>=2.7.0

--- a/terraform/aws-ecs/lambda/rotate-rds/requirements.txt
+++ b/terraform/aws-ecs/lambda/rotate-rds/requirements.txt
@@ -1,2 +1,3 @@
-boto3>=1.26.0
-botocore>=1.29.0
+boto3>=1.43.7
+botocore>=1.43.7
+urllib3>=2.7.0


### PR DESCRIPTION
The secret-rotation Lambdas under `terraform/aws-ecs/lambda/` (rotate-rds, rotate-documentdb) resolve urllib3 transitively through botocore with no floor, which pulls in versions affected by four high-severity advisories:
- CVE-2025-66471: Improper Handling of Highly Compressed Data (CWE-409), fixed in urllib3 2.6.0
- CVE-2025-66418: Allocation of Resources Without Limits or Throttling (CWE-770), fixed in urllib3 2.6.0
- CVE-2026-21441: Improper Handling of Highly Compressed Data (CWE-409), fixed in urllib3 2.6.3
- CVE-2026-44431: Insertion of Sensitive Information Into Sent Data (CWE-200), fixed in urllib3 2.7.0

This pins `urllib3>=2.7.0` explicitly and raises the `boto3`/`botocore` floors to `1.43.7`. Both Lambdas run on `python3.13`, which urllib3 2.7.0 supports.