### PR TITLE
feat(egress): support public OAuth clients (token_endpoint_auth_method=none) with PKCE

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -3910,8 +3910,9 @@ class RegistryClient:
                 ``provider="custom"``.
             custom_scope_separator: Scope delimiter when the provider does not
                 use a space (custom only).
-            custom_token_auth_style: Where the client secret goes on the token
-                request -- "post_body" (default) or "basic_header" (custom only).
+            custom_token_auth_style: Token endpoint authentication style:
+                "post_body" (default), "basic_header", or "none" for a public
+                PKCE client (custom only).
             custom_resource: RFC 8707 resource indicator, sent on both the
                 authorize and token requests to bind the token to one protected
                 resource (custom only).

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -6752,8 +6752,8 @@ Examples:
     )
     egress_configure_parser.add_argument(
         "--custom-token-auth-style",
-        choices=["post_body", "basic_header"],
-        help="Where the client secret goes on the token request (custom only, default post_body)",
+        choices=["post_body", "basic_header", "none"],
+        help="Token endpoint auth style; none selects a public PKCE client (custom only)",
     )
     egress_configure_parser.add_argument(
         "--custom-resource",

--- a/docs/egress-credential-vault.md
+++ b/docs/egress-credential-vault.md
@@ -521,8 +521,29 @@ For a custom OIDC provider:
 > [FAQ: How do I use a 3LO (per-user OAuth) AgentCore Gateway with the registry?](faq/agentcore-3lo-per-user-oauth.md).
 
 - `custom_scope_separator` (default `" "`) and `custom_token_auth_style`
-  (`post_body` default, or `basic_header`) tune the wire format for providers
-  that deviate from the common case.
+  (`post_body` default, `basic_header`, or `none`) tune the wire format for
+  providers that deviate from the common case.
+- `custom_token_auth_style: "none"` is [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
+  `token_endpoint_auth_method=none`: a **public client** with no client secret at
+  all, as minted by an MCP resource server's Dynamic Client Registration endpoint
+  (for example **Datadog's MCP server**, whose DCR endpoint only issues public
+  clients). The gateway sends `client_id` plus the PKCE `S256` verifier on the
+  code exchange and refresh grants and never sends a `client_secret`; `client_id`
+  becomes required and no secret is stored (a previously stored secret is dropped
+  on the switch). PKCE remains mandatory. Example (Datadog MCP, US1, via `custom`):
+
+```jsonc
+{
+  "egress_auth_mode": "oauth_user",
+  "egress_provider": "custom",
+  "client_id": "<client_id returned by Datadog DCR>",
+  "scopes": [],
+  "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
+  "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
+  "custom_token_auth_style": "none",
+  "custom_resource": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+}
+```
 - `custom_resource` (optional) is an [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
   **resource indicator** — an absolute `https` URI (no fragment). When set, the
   gateway sends it as the `resource` parameter on the authorize request **and**

--- a/frontend/src/components/entities/forms/ServerEditModal.tsx
+++ b/frontend/src/components/entities/forms/ServerEditModal.tsx
@@ -43,6 +43,9 @@ export interface ServerEditForm {
   egress_scopes: string; // comma/space separated
   egress_custom_authorize_url: string;
   egress_custom_token_url: string;
+  // 'post_body' | 'basic_header' | 'none' — 'none' is a public client (no secret, PKCE only)
+  egress_custom_token_auth_style: string;
+  egress_custom_resource: string; // RFC 8707 resource indicator (optional)
   // obo_exchange (same-IdP OBO hop 1) field:
   egress_target_audience: string;
   // pat inject header config (admin). Blank = server defaults (Authorization / Bearer).
@@ -334,19 +337,26 @@ const ServerEditModal: React.FC<ServerEditModalProps> = ({
                         className={FIELD}
                       />
                     </div>
-                    <div>
-                      <label className={LABEL}>Client Secret</label>
-                      <input
-                        type="password"
-                        value={form.egress_client_secret}
-                        onChange={(e) =>
-                          setForm((prev) => ({ ...prev, egress_client_secret: e.target.value }))
-                        }
-                        placeholder="leave blank to keep current"
-                        autoComplete="new-password"
-                        className={FIELD}
-                      />
-                    </div>
+                    {/* A public client (custom provider, token auth 'none') has no
+                        secret by design — hide the field so nothing stale is sent. */}
+                    {!(
+                      form.egress_provider === 'custom' &&
+                      form.egress_custom_token_auth_style === 'none'
+                    ) && (
+                      <div>
+                        <label className={LABEL}>Client Secret</label>
+                        <input
+                          type="password"
+                          value={form.egress_client_secret}
+                          onChange={(e) =>
+                            setForm((prev) => ({ ...prev, egress_client_secret: e.target.value }))
+                          }
+                          placeholder="leave blank to keep current"
+                          autoComplete="new-password"
+                          className={FIELD}
+                        />
+                      </div>
+                    )}
                     <div>
                       <label className={LABEL}>Scopes</label>
                       <input
@@ -390,6 +400,50 @@ const ServerEditModal: React.FC<ServerEditModalProps> = ({
                             placeholder="https://idp.example/token"
                             className={FIELD}
                           />
+                        </div>
+                        <div>
+                          <label className={LABEL}>Token Endpoint Authentication</label>
+                          <select
+                            value={form.egress_custom_token_auth_style || 'post_body'}
+                            onChange={(e) =>
+                              setForm((prev) => ({
+                                ...prev,
+                                egress_custom_token_auth_style: e.target.value,
+                              }))
+                            }
+                            className={FIELD}
+                          >
+                            <option value="post_body">Client secret in POST body</option>
+                            <option value="basic_header">Client secret in Basic header</option>
+                            <option value="none">None — public client (PKCE only)</option>
+                          </select>
+                          {form.egress_custom_token_auth_style === 'none' && (
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                              For providers that register public OAuth clients via Dynamic
+                              Client Registration (e.g. Datadog MCP). No client secret is
+                              stored or sent; PKCE proves possession.
+                            </p>
+                          )}
+                        </div>
+                        <div>
+                          <label className={LABEL}>Resource (RFC 8707, optional)</label>
+                          <input
+                            type="text"
+                            value={form.egress_custom_resource}
+                            onChange={(e) =>
+                              setForm((prev) => ({
+                                ...prev,
+                                egress_custom_resource: e.target.value,
+                              }))
+                            }
+                            placeholder="https://mcp.example.com/mcp"
+                            className={FIELD}
+                          />
+                          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            Binds issued tokens to one protected resource. Required by some
+                            MCP servers (Atlassian Rovo, Datadog); sent on authorize, token
+                            exchange, and refresh.
+                          </p>
                         </div>
                       </>
                     )}

--- a/frontend/src/components/entities/forms/__tests__/ServerEditModal.test.tsx
+++ b/frontend/src/components/entities/forms/__tests__/ServerEditModal.test.tsx
@@ -33,6 +33,8 @@ const baseForm: ServerEditForm = {
   egress_scopes: '',
   egress_custom_authorize_url: '',
   egress_custom_token_url: '',
+  egress_custom_token_auth_style: '',
+  egress_custom_resource: '',
   egress_target_audience: '',
 };
 
@@ -157,6 +159,34 @@ describe('ServerEditModal', () => {
     expect(screen.queryByText('Target Audience')).not.toBeInTheDocument();
     // pat needs only a provider (no client id/secret fields).
     expect(screen.queryByText('Client ID')).not.toBeInTheDocument();
+  });
+
+  it('shows token auth style and resource fields for a custom provider', () => {
+    render(
+      <Harness
+        initial={{ ...baseForm, egress_auth_mode: 'oauth_user', egress_provider: 'custom' }}
+        egressEnabled
+      />,
+    );
+    expect(screen.getByText('Token Endpoint Authentication')).toBeInTheDocument();
+    expect(screen.getByText('Resource (RFC 8707, optional)')).toBeInTheDocument();
+    // Confidential styles (default post_body) still show the secret field.
+    expect(screen.getByText('Client Secret')).toBeInTheDocument();
+  });
+
+  it('hides the client secret field for a custom public client (token auth none)', () => {
+    render(
+      <Harness
+        initial={{
+          ...baseForm,
+          egress_auth_mode: 'oauth_user',
+          egress_provider: 'custom',
+          egress_custom_token_auth_style: 'none',
+        }}
+        egressEnabled
+      />,
+    );
+    expect(screen.queryByText('Client Secret')).not.toBeInTheDocument();
   });
 
   it('shows neither provider nor target audience when egress mode is none', () => {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -313,6 +313,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     egress_scopes: '',  // comma/space separated
     egress_custom_authorize_url: '',
     egress_custom_token_url: '',
+    egress_custom_token_auth_style: '',  // '' = backend default (post_body)
+    egress_custom_resource: '',  // RFC 8707 resource indicator (optional)
     egress_target_audience: '',
   });
   const [egressEnabled, setEgressEnabled] = useState(false);
@@ -1300,6 +1302,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         egress_scopes: (serverDetails.egress_oauth?.scopes || []).join(', '),
         egress_custom_authorize_url: serverDetails.egress_oauth?.custom_authorize_url || '',
         egress_custom_token_url: serverDetails.egress_oauth?.custom_token_url || '',
+        egress_custom_token_auth_style: serverDetails.egress_oauth?.custom_token_auth_style || '',
+        egress_custom_resource: serverDetails.egress_oauth?.custom_resource || '',
         egress_target_audience: serverDetails.egress_oauth?.target_audience || '',
       });
     } catch (error) {
@@ -1331,6 +1335,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         egress_scopes: '',
         egress_custom_authorize_url: '',
         egress_custom_token_url: '',
+        egress_custom_token_auth_style: '',
+        egress_custom_resource: '',
         egress_target_audience: '',
       });
     }
@@ -1539,6 +1545,8 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
                 scopes: scopesList,
                 custom_authorize_url: editForm.egress_custom_authorize_url || undefined,
                 custom_token_url: editForm.egress_custom_token_url || undefined,
+                custom_token_auth_style: editForm.egress_custom_token_auth_style || undefined,
+                custom_resource: editForm.egress_custom_resource || undefined,
               },
               { headers: csrfHeaders }
             );

--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -549,6 +549,8 @@ def _egress_config_view(server: dict) -> dict:
         "callback_url": _callback_url(),
         "custom_authorize_url": eo.get("custom_authorize_url"),
         "custom_token_url": eo.get("custom_token_url"),
+        "custom_scope_separator": eo.get("custom_scope_separator"),
+        "custom_token_auth_style": eo.get("custom_token_auth_style"),
         "custom_resource": eo.get("custom_resource"),
     }
 
@@ -645,14 +647,31 @@ async def configure_egress_auth(
             resolve_provider(eo)
         except ValueError as exc:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-        # Encrypt the secret; keep the prior one if the field is omitted on edit.
-        if body.client_secret:
-            eo["client_secret_encrypted"] = encrypt_credential(body.client_secret)
+        # Public client (RFC 7591 token_endpoint_auth_method=none, e.g. a
+        # DCR-minted MCP client like Datadog's): no secret exists by design.
+        # Require a client_id instead, and DROP any previously stored secret so
+        # a later switch back to a confidential style cannot silently reuse a
+        # stale credential. Only the 'custom' provider can select this style
+        # (every built-in is confidential); PKCE stays mandatory for custom.
+        is_public_client = (
+            body.egress_provider == "custom" and body.custom_token_auth_style == "none"  # nosec B105 - auth style enum value, not a credential
+        )
+        if is_public_client:
+            if not (body.client_id or "").strip():
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    detail="client_id required when custom_token_auth_style is 'none'",
+                )
+            eo["client_secret_encrypted"] = None
         else:
-            prior = (server.get("egress_oauth") or {}).get("client_secret_encrypted")
-            eo["client_secret_encrypted"] = prior
-        if not eo["client_secret_encrypted"]:
-            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="client_secret required")
+            # Encrypt the secret; keep the prior one if the field is omitted on edit.
+            if body.client_secret:
+                eo["client_secret_encrypted"] = encrypt_credential(body.client_secret)
+            else:
+                prior = (server.get("egress_oauth") or {}).get("client_secret_encrypted")
+                eo["client_secret_encrypted"] = prior
+            if not eo["client_secret_encrypted"]:
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="client_secret required")
         server["egress_auth_mode"] = "oauth_user"
         server["egress_oauth"] = eo
     elif body.egress_auth_mode == "obo_exchange":

--- a/registry/core/schemas.py
+++ b/registry/core/schemas.py
@@ -383,6 +383,7 @@ class EgressOAuthConfig(BaseModel):
     custom_token_url: str | None = None
     custom_scope_separator: str | None = None
     custom_token_auth_style: str | None = None
+    custom_resource: str | None = None
     updated_at: str | None = None
 
 

--- a/registry/egress_auth/oauth_engine.py
+++ b/registry/egress_auth/oauth_engine.py
@@ -191,12 +191,26 @@ def _expires_at(expires_in: int | None, access_token: str | None = None) -> str 
 def _build_token_request(
     cfg: OAuthProviderConfig,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     form: dict,
 ) -> tuple[dict, dict]:
-    """Return (form_data, headers), placing the client secret per the provider's style."""
+    """Return (form_data, headers), placing the client secret per the provider's style.
+
+    ``NONE`` (RFC 7591 ``token_endpoint_auth_method=none``) is a public client:
+    only ``client_id`` goes in the body and no secret exists anywhere in the
+    request. The confidential styles fail closed on a missing secret rather
+    than sending an empty one (which providers accept-then-misattribute).
+    """
     headers = {"Accept": "application/json"}
     data = dict(form)
+    if cfg.token_endpoint_auth_style == TokenEndpointAuthStyle.NONE:
+        data["client_id"] = client_id
+        return data, headers
+    if not client_secret:
+        raise OAuthEngineError(
+            f"provider {cfg.name!r} uses token_endpoint_auth_style="
+            f"{cfg.token_endpoint_auth_style.value!r} but no client_secret is configured"
+        )
     if cfg.token_endpoint_auth_style == TokenEndpointAuthStyle.BASIC_HEADER:
         basic = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
         headers["Authorization"] = f"Basic {basic}"
@@ -273,7 +287,7 @@ def _to_stored_token(
 async def exchange_code(
     cfg: OAuthProviderConfig,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     code: str,
     redirect_uri: str,
     pkce_verifier: str | None = None,
@@ -298,7 +312,7 @@ async def exchange_code(
 async def refresh_token(
     cfg: OAuthProviderConfig,
     client_id: str,
-    client_secret: str,
+    client_secret: str | None,
     refresh_token_value: str,
 ) -> StoredToken:
     """Exchange a refresh token for a new access token (and possibly new refresh token).

--- a/registry/egress_auth/schemas.py
+++ b/registry/egress_auth/schemas.py
@@ -35,10 +35,18 @@ class EgressAuthMode(str, Enum):
 
 
 class TokenEndpointAuthStyle(str, Enum):
-    """Where the client_secret goes when calling the provider token endpoint."""
+    """Where the client_secret goes when calling the provider token endpoint.
+
+    ``NONE`` is RFC 7591 ``token_endpoint_auth_method=none``: a PUBLIC client
+    with no client_secret at all (e.g. a client minted by an MCP resource
+    server's Dynamic Client Registration endpoint, such as Datadog's MCP).
+    Only ``client_id`` is sent; the PKCE verifier is the proof of possession,
+    so ``use_pkce`` stays mandatory for these providers.
+    """
 
     POST_BODY = "post_body"  # client_id/client_secret in the form body
     BASIC_HEADER = "basic_header"  # HTTP Basic auth header
+    NONE = "none"  # public client: client_id only, no secret (PKCE required)
 
 
 class OAuthProviderConfig(BaseModel):

--- a/registry/egress_auth/service.py
+++ b/registry/egress_auth/service.py
@@ -24,8 +24,10 @@ from registry.egress_auth import oauth_engine
 from registry.egress_auth.providers import resolve_provider
 from registry.egress_auth.schemas import (
     EgressConnection,
+    OAuthProviderConfig,
     OAuthState,
     StoredToken,
+    TokenEndpointAuthStyle,
 )
 from registry.egress_auth.state_codec import InvalidState, decode_state, encode_state
 from registry.secrets.interfaces import SecretStoreBase
@@ -203,7 +205,20 @@ class EgressAuthService:
     # -- helpers -------------------------------------------------------------- #
 
     @staticmethod
-    def _client_secret(egress_oauth: dict) -> str:
+    def _client_secret(
+        cfg: OAuthProviderConfig,
+        egress_oauth: dict,
+    ) -> str | None:
+        """Decrypt the operator client_secret, or None for a public client.
+
+        A provider with ``token_endpoint_auth_style == NONE`` (RFC 7591
+        ``token_endpoint_auth_method=none``, e.g. a DCR-minted public client)
+        has no secret by design; the engine sends only ``client_id`` + PKCE.
+        Confidential styles still fail closed on a missing/undecryptable secret.
+        """
+        if cfg.token_endpoint_auth_style == TokenEndpointAuthStyle.NONE:
+            return None
+
         from registry.utils.credential_encryption import decrypt_credential
 
         enc = egress_oauth.get("client_secret_encrypted")
@@ -319,7 +334,7 @@ class EgressAuthService:
         token = await oauth_engine.exchange_code(
             cfg=cfg,
             client_id=egress_oauth["client_id"],
-            client_secret=self._client_secret(egress_oauth),
+            client_secret=self._client_secret(cfg, egress_oauth),
             code=code,
             redirect_uri=self._callback_url,
             pkce_verifier=state.pkce_verifier,
@@ -412,7 +427,7 @@ class EgressAuthService:
                 new = await oauth_engine.refresh_token(
                     cfg=cfg,
                     client_id=egress_oauth["client_id"],
-                    client_secret=self._client_secret(egress_oauth),
+                    client_secret=self._client_secret(cfg, egress_oauth),
                     refresh_token_value=current.refresh_token,
                 )
             except oauth_engine.DeadRefreshTokenError:

--- a/tests/unit/egress_auth/test_configure_egress_url_validation.py
+++ b/tests/unit/egress_auth/test_configure_egress_url_validation.py
@@ -188,3 +188,110 @@ class TestConfigureEgressUrlValidation:
             json=_body(egress_provider="github", custom_resource="http://bad#frag"),
         )
         assert resp.status_code == 200, resp.text
+
+    def test_blank_secret_on_edit_keeps_stored_one(self, make_client):
+        # Editing a confidential registration with a blank secret must preserve
+        # the previously stored encrypted secret, not wipe it.
+        client = make_client(
+            server={
+                "path": "/gh",
+                "egress_oauth": {"client_secret_encrypted": "enc:oldsecret"},
+            }
+        )
+        resp = client.post("/servers/gh/egress-auth", json=_body(client_secret=None))
+        assert resp.status_code == 200, resp.text
+        eo = client._svc.updated_with["egress_oauth"]
+        assert eo["client_secret_encrypted"] == "enc:oldsecret"
+
+    def test_view_echoes_token_auth_style_and_separator(self, make_client):
+        # The non-secret config view must round-trip custom_token_auth_style
+        # (and the scope separator), or a UI read-modify-write silently resets
+        # the style to post_body -- which bricks a public-client config.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(custom_token_auth_style="basic_header", custom_scope_separator=","),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["custom_token_auth_style"] == "basic_header"
+        assert resp.json()["custom_scope_separator"] == ","
+
+
+@pytest.mark.unit
+class TestConfigurePublicClient:
+    """token_endpoint_auth_method=none (custom provider): a public client has
+    no secret by design -- the configure route must accept a secretless config,
+    require a client_id, and DROP any previously stored secret."""
+
+    def _public_body(self, **over):
+        base = _body(
+            client_secret=None,
+            custom_token_auth_style="none",
+            custom_authorize_url="https://app.datadoghq.com/oauth2/v1/authorize",
+            custom_token_url="https://app.datadoghq.com/api/v2/oauth2/token",
+            custom_resource="https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+        )
+        base.update(over)
+        return base
+
+    def test_public_client_config_without_secret_succeeds(self, make_client):
+        client = make_client()
+        resp = client.post("/servers/gh/egress-auth", json=self._public_body())
+        assert resp.status_code == 200, resp.text
+        eo = client._svc.updated_with["egress_oauth"]
+        assert eo["custom_token_auth_style"] == "none"
+        assert eo["client_secret_encrypted"] is None
+        assert resp.json()["custom_token_auth_style"] == "none"
+
+    def test_public_client_requires_client_id(self, make_client):
+        client = make_client()
+        resp = client.post("/servers/gh/egress-auth", json=self._public_body(client_id="  "))
+        assert resp.status_code == 400
+        assert "client_id required" in resp.json()["detail"]
+        assert client._svc.updated_with is None
+
+    def test_switch_to_public_client_drops_stored_secret(self, make_client):
+        # A registration previously configured confidential must not carry the
+        # stale encrypted secret into the public-client config.
+        client = make_client(
+            server={
+                "path": "/gh",
+                "egress_oauth": {"client_secret_encrypted": "enc:oldsecret"},
+            }
+        )
+        resp = client.post("/servers/gh/egress-auth", json=self._public_body())
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_oauth"]["client_secret_encrypted"] is None
+
+    def test_supplied_secret_ignored_for_public_client(self, make_client):
+        # An operator pasting a secret alongside style 'none' must not have it
+        # stored -- there is no request the engine could ever place it in.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth", json=self._public_body(client_secret="pasted-anyway")
+        )
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_oauth"]["client_secret_encrypted"] is None
+
+    def test_confidential_style_still_requires_secret(self, make_client):
+        # post_body/basic_header without a secret (and no stored prior) -> 400.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(client_secret=None, custom_token_auth_style="post_body"),
+        )
+        assert resp.status_code == 400
+        assert "client_secret required" in resp.json()["detail"]
+
+    def test_builtin_provider_cannot_go_secretless_via_style(self, make_client):
+        # custom_token_auth_style is a custom-provider knob; a built-in provider
+        # posting style 'none' stays confidential and still requires a secret.
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json=_body(
+                egress_provider="github", client_secret=None, custom_token_auth_style="none"
+            ),
+        )
+        assert resp.status_code == 400
+        assert "client_secret required" in resp.json()["detail"]

--- a/tests/unit/egress_auth/test_oauth_engine.py
+++ b/tests/unit/egress_auth/test_oauth_engine.py
@@ -271,6 +271,90 @@ class TestResourceIndicator:
 
 
 @pytest.mark.unit
+class TestPublicClientNoneStyle:
+    """RFC 7591 ``token_endpoint_auth_method=none``: a PUBLIC client (e.g. one
+    minted by an MCP resource server's DCR endpoint, such as Datadog's MCP) has
+    no client_secret at all. The engine must send ``client_id`` + PKCE verifier
+    only -- never a ``client_secret`` key, never a Basic header -- on both the
+    code exchange and the refresh grant. Confidential styles fail closed on a
+    missing secret instead of sending an empty one.
+    """
+
+    _RES = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+
+    def _public_cfg(self):
+        return resolve_provider(
+            {
+                "provider": "custom",
+                "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
+                "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
+                "custom_token_auth_style": "none",
+                "custom_resource": self._RES,
+            }
+        )
+
+    def test_build_token_request_sends_client_id_only(self):
+        cfg = self._public_cfg()
+        data, headers = oauth_engine._build_token_request(cfg, "cid", None, {"grant_type": "x"})
+        assert data["client_id"] == "cid"
+        assert "client_secret" not in data
+        assert "Authorization" not in headers
+
+    @pytest.mark.parametrize("style", ["post_body", "basic_header"])
+    def test_confidential_style_fails_closed_without_secret(self, style):
+        cfg = OAuthProviderConfig(
+            name="c",
+            display_name="C",
+            authorize_url="https://i/a",
+            token_url="https://i/t",
+            token_endpoint_auth_style=style,
+        )
+        with pytest.raises(oauth_engine.OAuthEngineError, match="no client_secret"):
+            oauth_engine._build_token_request(cfg, "cid", None, {"grant_type": "x"})
+
+    async def test_exchange_sends_verifier_and_resource_without_secret(self, monkeypatch):
+        captured: dict = {}
+        captured_headers: dict = {}
+
+        async def fake_post(cfg, data, headers):
+            captured.update(data)
+            captured_headers.update(headers)
+            return {"access_token": "at", "refresh_token": "rt", "expires_in": 3600}
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        tok = await oauth_engine.exchange_code(
+            self._public_cfg(), "cid", None, "code", "https://gw/cb", "verif"
+        )
+        assert captured["client_id"] == "cid"
+        assert captured["code_verifier"] == "verif"
+        assert captured["resource"] == self._RES
+        assert "client_secret" not in captured
+        assert "Authorization" not in captured_headers
+        assert tok.access_token == "at"
+
+    async def test_refresh_sends_client_id_and_resource_without_secret(self, monkeypatch):
+        captured: dict = {}
+
+        async def fake_post(cfg, data, headers):
+            captured.update(data)
+            return {"access_token": "at2", "expires_in": 3600}
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        tok = await oauth_engine.refresh_token(self._public_cfg(), "cid", None, "rt_old")
+        assert captured["grant_type"] == "refresh_token"
+        assert captured["client_id"] == "cid"
+        assert captured["resource"] == self._RES
+        assert "client_secret" not in captured
+        # provider did not rotate the refresh token -> keep the old one
+        assert tok.refresh_token == "rt_old"
+
+    def test_public_client_keeps_pkce_mandatory(self):
+        # use_pkce stays True for custom providers regardless of auth style;
+        # PKCE is the public client's only proof of possession.
+        assert self._public_cfg().use_pkce is True
+
+
+@pytest.mark.unit
 class TestQuirkParsers:
     def test_slack_nested_lifts_user_token(self):
         cfg = PROVIDER_REGISTRY["slack"]

--- a/tests/unit/egress_auth/test_providers.py
+++ b/tests/unit/egress_auth/test_providers.py
@@ -80,6 +80,36 @@ class TestResolveProvider:
         assert cfg.token_endpoint_auth_style == TokenEndpointAuthStyle.BASIC_HEADER
         assert cfg.use_pkce is True
 
+    def test_custom_public_client_none_style(self):
+        # token_endpoint_auth_method=none (RFC 7591 public client, e.g. a
+        # DCR-minted Datadog MCP client): the style resolves and PKCE stays on.
+        cfg = resolve_provider(
+            {
+                "provider": "custom",
+                "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
+                "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
+                "custom_token_auth_style": "none",
+            }
+        )
+        assert cfg.token_endpoint_auth_style == TokenEndpointAuthStyle.NONE
+        assert cfg.use_pkce is True
+
+    def test_custom_invalid_auth_style_raises(self):
+        with pytest.raises(ValueError):
+            resolve_provider(
+                {
+                    "provider": "custom",
+                    "custom_authorize_url": "https://idp/auth",
+                    "custom_token_url": "https://idp/token",
+                    "custom_token_auth_style": "bogus_style",
+                }
+            )
+
+    def test_builtin_providers_are_confidential(self):
+        # No built-in may ever resolve to the public-client style.
+        for name, cfg in PROVIDER_REGISTRY.items():
+            assert cfg.token_endpoint_auth_style != TokenEndpointAuthStyle.NONE, name
+
     def test_custom_resource_threaded(self):
         # RFC 8707 resource indicator is carried onto the resolved config.
         cfg = resolve_provider(

--- a/tests/unit/egress_auth/test_service.py
+++ b/tests/unit/egress_auth/test_service.py
@@ -65,6 +65,21 @@ def egress_oauth():
 
 
 @pytest.fixture
+def egress_oauth_public():
+    """A custom public-client config (token_endpoint_auth_method=none): no secret."""
+    return {
+        "provider": "custom",
+        "client_id": "dcr-public-client-id",
+        "client_secret_encrypted": None,
+        "scopes": [],
+        "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
+        "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
+        "custom_token_auth_style": "none",
+        "custom_resource": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
+    }
+
+
+@pytest.fixture
 def svc():
     store = _InMemoryStore()
     return EgressAuthService(
@@ -198,6 +213,86 @@ class TestConsentAndCallback:
     async def test_tampered_state_rejected(self, svc, egress_oauth):
         with pytest.raises(service.EgressAuthError, match="invalid state"):
             await svc.handle_callback("c", "garbage-state", egress_oauth, "alice", "oauth2")
+
+    async def test_confidential_provider_still_requires_secret(self, svc, monkeypatch):
+        # A confidential (github) config whose stored secret is missing must
+        # fail closed at the callback -- NOT silently proceed secretless.
+        _stub_exchange(monkeypatch)
+        secretless = dict(EGRESS_OAUTH)
+        secretless["client_secret_encrypted"] = None
+        url = svc.build_consent_url(
+            "oauth2", "alice", "Iv1.testclient", "sess-1", "/github-mcp", secretless
+        )
+        with pytest.raises(service.EgressAuthError, match="client_secret_encrypted missing"):
+            await svc.handle_callback("c", _extract_state(url), secretless, "alice", "oauth2")
+
+
+@pytest.mark.unit
+class TestPublicClientFlow:
+    """Public client (custom provider, token_endpoint_auth_method=none): the
+    whole consent->exchange->vend->refresh cycle works with NO stored secret,
+    and no ``client_secret`` ever reaches the token endpoint."""
+
+    async def test_consent_exchange_vend_without_secret(
+        self, svc, egress_oauth_public, monkeypatch
+    ):
+        captured: dict = {}
+
+        async def fake_post(cfg, data, headers):
+            captured.update(data)
+            return {
+                "access_token": "at_public",
+                "refresh_token": "rt_public",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            }
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        url = svc.build_consent_url(
+            "oauth2",
+            "alice",
+            "dcr-public-client-id",
+            "sess-1",
+            "/datadog-user",
+            egress_oauth_public,
+        )
+        conn = await svc.handle_callback(
+            "the-code", _extract_state(url), egress_oauth_public, "alice", "oauth2"
+        )
+        assert conn.provider == "custom" and conn.server_path == "/datadog-user"
+        assert "client_secret" not in captured
+        assert captured["client_id"] == "dcr-public-client-id"
+        assert captured["code_verifier"]  # PKCE verifier always sent
+        assert captured["resource"] == egress_oauth_public["custom_resource"]
+
+        token = await svc.get_valid_token("oauth2", "alice", "/datadog-user", egress_oauth_public)
+        assert token == "at_public"
+
+    async def test_refresh_without_secret(self, svc, egress_oauth_public, monkeypatch):
+        captured: dict = {}
+
+        async def fake_post(cfg, data, headers):
+            captured.update(data)
+            return {"access_token": "at_refreshed", "expires_in": 3600}
+
+        monkeypatch.setattr(oauth_engine, "_post_token", fake_post)
+        await svc._store.put_token(
+            "oauth2",
+            "alice",
+            "custom",
+            "/datadog-user",
+            StoredToken(
+                access_token="old",
+                refresh_token="rt_old",
+                expires_at="2000-01-01T00:00:00+00:00",
+                client_id="dcr-public-client-id",
+            ),
+        )
+        token = await svc.get_valid_token("oauth2", "alice", "/datadog-user", egress_oauth_public)
+        assert token == "at_refreshed"
+        assert captured["grant_type"] == "refresh_token"
+        assert "client_secret" not in captured
+        assert captured["resource"] == egress_oauth_public["custom_resource"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Adds `token_endpoint_auth_style: "none"` (RFC 7591 `token_endpoint_auth_method=none`) for the `custom` egress provider, so `oauth_user` egress can be configured against **public PKCE clients** — clients that have no client_secret by design, such as those minted by an MCP resource server's Dynamic Client Registration endpoint, e.g. Datadog MCP.

Previously the configure route required a `client_secret` unconditionally, making these providers impossible to configure.


## Design notes

- Only the `custom` provider can select the public style — every built-in provider is confidential, so nothing changes for existing configs.
- PKCE stays mandatory for custom providers; the S256 verifier is the proof of possession that replaces the secret (RFC 7636).
- No schema migration: `token_endpoint_auth_style` already existed on the provider config; this adds one enum value and the validation around it.


## Testing

- `uv run pytest tests/ -n 8`: 6754 passed, 74 skipped, 0 failures (coverage 65.85%).
- New unit tests: token-request shape for `none` (client_id only, no secret in body or headers), fail-closed confidential styles, secret resolution in the service layer, provider validation, configure route (client_id required for `none`, stored secret dropped on style switch, confidential path unchanged).
- Frontend: new ServerEditModal tests for the public-client fields (18/18 passing); tsc and eslint clean in touched files.
