### PR TITLE
fix(cli): forward append_mcp_path from register --config (#1603)

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -81,6 +81,14 @@ class InternalServiceRegistration(BaseModel):
     sse_endpoint: str | None = Field(
         None, description="Full URL for the SSE endpoint (overrides proxy_pass_url + /sse)"
     )
+    append_mcp_path: bool | None = Field(
+        None,
+        description=(
+            "Force/suppress the trailing '/mcp' transport suffix. Leave unset to keep "
+            "the registry default; set False for upstreams that serve JSON-RPC at their "
+            "root and 404 on '/mcp'."
+        ),
+    )
     metadata: dict[str, Any] | None = Field(
         default_factory=dict,
         description="Additional custom metadata for organization, compliance, or integration purposes",

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -873,6 +873,7 @@ def cmd_register(args: argparse.Namespace) -> int:
             overwrite=args.overwrite,
             mcp_endpoint=config.get("mcp_endpoint"),
             sse_endpoint=config.get("sse_endpoint"),
+            append_mcp_path=config.get("append_mcp_path"),
             metadata=config.get("metadata", {}),
             provider_organization=config.get("provider_organization"),
             provider_url=config.get("provider_url"),

--- a/tests/unit/api/test_registry_register_append_mcp_path.py
+++ b/tests/unit/api/test_registry_register_append_mcp_path.py
@@ -78,9 +78,7 @@ def test_register_leaves_append_mcp_path_unset_when_absent(tmp_path):
 
 @pytest.fixture
 def client() -> RegistryClient:
-    return RegistryClient(
-        registry_url="http://localhost", token="dummy-token-1234567890"
-    )
+    return RegistryClient(registry_url="http://localhost", token="dummy-token-1234567890")
 
 
 class TestAppendMcpPathOnTheWire:
@@ -91,18 +89,13 @@ class TestAppendMcpPathOnTheWire:
         response.json.return_value = {"path": "/svc", "name": "svc", "message": "ok"}
 
         with patch.object(client, "_make_request", return_value=response) as request:
-            client.register_service(
-                InternalServiceRegistration(path="/svc", name="svc", **extra)
-            )
+            client.register_service(InternalServiceRegistration(path="/svc", name="svc", **extra))
 
         return request.call_args.kwargs["data"]
 
     def test_false_is_sent(self, client: RegistryClient) -> None:
         """False is not None, so it must appear in the form payload."""
-        assert (
-            self._sent_form_data(client, append_mcp_path=False)["append_mcp_path"]
-            is False
-        )
+        assert self._sent_form_data(client, append_mcp_path=False)["append_mcp_path"] is False
 
     def test_absent_when_unset(self, client: RegistryClient) -> None:
         """Unset means absent, letting the registry apply its own default."""

--- a/tests/unit/api/test_registry_register_append_mcp_path.py
+++ b/tests/unit/api/test_registry_register_append_mcp_path.py
@@ -1,0 +1,109 @@
+"""Tests that ``register --config`` carries ``append_mcp_path`` to the registry.
+
+Issue #1603: ``POST /api/servers/register`` accepts ``append_mcp_path`` as a form
+field (``registry/api/server_routes.py``), but the CLI never sent it, so setting
+it in a config file was silently dropped. The registry then appended ``/mcp`` to
+upstreams that serve JSON-RPC at their root and 404 on ``/mcp``, and the failure
+surfaced as an upstream 404 rather than anything naming the ignored setting.
+
+The value is only meaningful when it is ``False``, which is also the value most
+easily lost: ``register_service`` serializes with ``exclude_none=True``, so the
+field has to be absent when unset but survive when explicitly false.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.registry_client import InternalServiceRegistration, RegistryClient
+
+# registry_management.py lives under api/ and imports sibling modules by name.
+_API_DIR = Path(__file__).resolve().parents[3] / "api"
+sys.path.insert(0, str(_API_DIR))
+
+import registry_management  # noqa: E402
+
+
+def _register_from_config(tmp_path, config: dict) -> InternalServiceRegistration:
+    """Run cmd_register against a config file and return the sent registration."""
+    config_file = tmp_path / "server-config.json"
+    config_file.write_text(registry_management.json.dumps(config))
+
+    mock_client = MagicMock()
+    mock_client.register_service.return_value = SimpleNamespace(
+        path=config.get("path"), message="ok"
+    )
+
+    args = SimpleNamespace(config=str(config_file), overwrite=False)
+    with patch.object(registry_management, "_create_client", return_value=mock_client):
+        assert registry_management.cmd_register(args) == 0
+
+    return mock_client.register_service.call_args[0][0]
+
+
+def _base_config(**extra) -> dict:
+    config = {
+        "path": "/salesforce-headless-360",
+        "server_name": "Salesforce Headless 360",
+        "description": "Hosted MCP endpoint that serves JSON-RPC at its root.",
+        "proxy_pass_url": "https://example.invalid/platform/headless-360",
+    }
+    config.update(extra)
+    return config
+
+
+def test_register_forwards_append_mcp_path_false(tmp_path):
+    """``"append_mcp_path": false`` in the config reaches the registration."""
+    registration = _register_from_config(tmp_path, _base_config(append_mcp_path=False))
+
+    assert registration.append_mcp_path is False
+
+
+def test_register_forwards_append_mcp_path_true(tmp_path):
+    """An explicit true is carried through as well, not just the false case."""
+    registration = _register_from_config(tmp_path, _base_config(append_mcp_path=True))
+
+    assert registration.append_mcp_path is True
+
+
+def test_register_leaves_append_mcp_path_unset_when_absent(tmp_path):
+    """Omitting it stays unset, so the registry default is not overridden."""
+    registration = _register_from_config(tmp_path, _base_config())
+
+    assert registration.append_mcp_path is None
+
+
+@pytest.fixture
+def client() -> RegistryClient:
+    return RegistryClient(
+        registry_url="http://localhost", token="dummy-token-1234567890"
+    )
+
+
+class TestAppendMcpPathOnTheWire:
+    """The field has to survive ``model_dump(exclude_none=True)``."""
+
+    def _sent_form_data(self, client: RegistryClient, **extra) -> dict:
+        response = MagicMock()
+        response.json.return_value = {"path": "/svc", "name": "svc", "message": "ok"}
+
+        with patch.object(client, "_make_request", return_value=response) as request:
+            client.register_service(
+                InternalServiceRegistration(path="/svc", name="svc", **extra)
+            )
+
+        return request.call_args.kwargs["data"]
+
+    def test_false_is_sent(self, client: RegistryClient) -> None:
+        """False is not None, so it must appear in the form payload."""
+        assert (
+            self._sent_form_data(client, append_mcp_path=False)["append_mcp_path"]
+            is False
+        )
+
+    def test_absent_when_unset(self, client: RegistryClient) -> None:
+        """Unset means absent, letting the registry apply its own default."""
+        assert "append_mcp_path" not in self._sent_form_data(client)


### PR DESCRIPTION
Fixes part 1 of #1603.

## Root cause

`POST /api/servers/register` accepts `append_mcp_path` as a form field and persists it:

```python
# registry/api/server_routes.py:1349
append_mcp_path: Annotated[bool | None, Form()] = None,
...
# :1468
if append_mcp_path is not None:
    server_entry["append_mcp_path"] = append_mcp_path
```

But `cmd_register` builds its `InternalServiceRegistration` field by field from the config dict, and `append_mcp_path` was not among them. The value was dropped with no error, and the only way to apply it was a follow-up `patch-server` call.

Confirmed on current `main` (`6d2e6ed4`): `grep append_mcp_path api/registry_client.py api/registry_management.py` returns nothing.

The consequence is the one the reporter hit — the gateway appends `/mcp` to an upstream that serves JSON-RPC at its root and 404s on `/mcp`, and the failure shows up as an upstream 404/401 with nothing naming the ignored setting.

## The fix

Two lines of wiring:

1. Declare `append_mcp_path: bool | None = None` on `InternalServiceRegistration`.
2. Read it in `cmd_register`: `append_mcp_path=config.get("append_mcp_path")`.

Nothing else is needed on the client side — `register_service` serializes with `registration.model_dump(exclude_none=True, by_alias=True)`, so a declared field goes onto the wire automatically. That default of `None` is load-bearing in both directions:

- **unset** → `exclude_none` drops it → the registry applies its own default, unchanged from today
- **explicitly `false`** → not `None`, so it survives serialization and reaches the endpoint

`overwrite` is the existing precedent for a bool travelling this path as form data.

## Scope

Deliberately limited to part 1. I left the `register --overwrite` / `is_enabled` reset alone — the reporter noted they could not isolate a trigger, and I could not reproduce it either. Guessing at a fix there would risk changing enable/disable semantics on a symptom nobody can yet pin down. Happy to look at it separately if a reproduction turns up.

The issue also floats rejecting unknown config keys with a 4xx so dropped settings are loud. That is a good idea but a much wider behavior change across every config-driven command, so it felt wrong to fold into this fix.

## Testing

New `tests/unit/api/test_registry_register_append_mcp_path.py`, 5 tests across both halves of the path:

- `test_register_forwards_append_mcp_path_false` — the reporter's exact case, `"append_mcp_path": false` in a config file reaching the registration
- `test_register_forwards_append_mcp_path_true` — explicit `true` carried too, not just the false case
- `test_register_leaves_append_mcp_path_unset_when_absent` — omitting it stays `None`
- `TestAppendMcpPathOnTheWire::test_false_is_sent` — `false` survives `exclude_none=True` into the form payload
- `TestAppendMcpPathOnTheWire::test_absent_when_unset` — unset means absent, guarding against "fixing" this by always sending the field

**Verified against unfixed `main`: 4 of the 5 fail** (the fifth is the anti-over-fix guard, which passes either way by design).

`tests/unit/api/` overall: **941 passed, 27 failed** — the same 27 failures (`test_search_routes*`, DocumentDB-backed) occur on a clean `main` checkout, unchanged by this PR.

`black --check` clean on the new test file. The two `api/` files show pre-existing `black`/`ruff` findings on clean `main` as well — `make format` targets `registry/` and `tests/`, not `api/` — so I did not reformat them and add unrelated churn.