### PR TITLE
fix(nginx): send relative redirects from the front-door server blocks (#1606)

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -169,6 +169,14 @@ server {
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};
 
+    # nginx answers a directory-style request that is missing its trailing slash
+    # with an automatic 301. With absolute_redirect on (the nginx default) that
+    # Location is rebuilt from this listener -- http:// and the internal 8080/8443
+    # container port -- which is not reachable from outside, and TLS terminates
+    # upstream anyway. MCP clients follow the redirect and hang until they time
+    # out. Emitting a relative Location keeps the client on the origin it dialed.
+    absolute_redirect off;
+
     # NOTE: do NOT add a server-scope `set $backend_url "";` default here.
     # nginx auth_request creates the /validate subrequest via
     # ngx_http_subrequest(), which sets sr->variables = r->variables -- the
@@ -1086,6 +1094,14 @@ server {
     listen 8443 ssl;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};
+
+    # nginx answers a directory-style request that is missing its trailing slash
+    # with an automatic 301. With absolute_redirect on (the nginx default) that
+    # Location is rebuilt from this listener -- http:// and the internal 8080/8443
+    # container port -- which is not reachable from outside, and TLS terminates
+    # upstream anyway. MCP clients follow the redirect and hang until they time
+    # out. Emitting a relative Location keeps the client on the origin it dialed.
+    absolute_redirect off;
 
     # SSL Configuration - requires user-provided certificates
     # Mount certificates to /etc/ssl/certs/fullchain.pem and /etc/ssl/private/privkey.pem

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -170,6 +170,14 @@ server {
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};
 
+    # nginx answers a directory-style request that is missing its trailing slash
+    # with an automatic 301. With absolute_redirect on (the nginx default) that
+    # Location is rebuilt from this listener -- http:// and the internal 8080/8443
+    # container port -- which is not reachable from outside, and TLS terminates
+    # upstream anyway. MCP clients follow the redirect and hang until they time
+    # out. Emitting a relative Location keeps the client on the origin it dialed.
+    absolute_redirect off;
+
     # NOTE: do NOT add a server-scope `set $backend_url "";` default here.
     # nginx auth_request creates the /validate subrequest via
     # ngx_http_subrequest(), which sets sr->variables = r->variables -- the

--- a/tests/unit/core/test_nginx_absolute_redirect.py
+++ b/tests/unit/core/test_nginx_absolute_redirect.py
@@ -1,0 +1,71 @@
+"""The front-door nginx templates must not emit absolute redirects.
+
+Issue #1606: the #1501 fix made generated location blocks trailing-slash
+terminated, so a request to a registered MCP server *without* the trailing
+slash now hits nginx's automatic "add the slash" 301. With ``absolute_redirect``
+at its nginx default (on), that Location is rebuilt from the listener that
+served the request -- ``http://`` and the internal container port 8080/8443 --
+which is not routable from outside the cluster, and TLS terminates upstream
+anyway. MCP clients follow the redirect and hang until they time out.
+
+``absolute_redirect off`` makes nginx send a relative Location, so the client
+stays on the origin it dialed. It has to be set in every server block: the
+internal port is baked into the redirect by whichever listener answered.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DOCKER_DIR = Path(__file__).resolve().parents[3] / "docker"
+_TEMPLATES = (
+    "nginx_rev_proxy_http_and_https.conf",
+    "nginx_rev_proxy_http_only.conf",
+)
+
+
+def _server_blocks(text: str) -> list[str]:
+    """Split a config into its top-level ``server { ... }`` blocks.
+
+    Top-level only: the templates nest ``location``/``if`` blocks several levels
+    deep, so this brace-counts from each ``server {`` at column 0 rather than
+    trying to match with a regex.
+    """
+    blocks = []
+    for match in re.finditer(r"^server \{", text, re.MULTILINE):
+        depth = 0
+        for index in range(match.start(), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(text[match.start() : index + 1])
+                    break
+    return blocks
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_every_server_block_disables_absolute_redirect(template: str) -> None:
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    blocks = _server_blocks(text)
+    assert blocks, f"no server blocks found in {template}"
+
+    for block in blocks:
+        listen = re.search(r"^\s*listen ([^;]+);", block, re.MULTILINE)
+        listen_desc = listen.group(1) if listen else "unknown"
+        assert re.search(r"^\s*absolute_redirect off;", block, re.MULTILINE), (
+            f"{template}: server block listening on {listen_desc!r} does not set "
+            "'absolute_redirect off', so nginx's automatic trailing-slash 301 "
+            "would leak the internal scheme and port to MCP clients (#1606)"
+        )
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_absolute_redirect_is_never_re_enabled(template: str) -> None:
+    """A later ``absolute_redirect on`` would silently undo this per-scope."""
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    assert not re.search(r"^\s*absolute_redirect\s+on;", text, re.MULTILINE)


### PR DESCRIPTION
Fixes #1606.

## Root cause

#1501 / PR #1507 made the generated location blocks trailing-slash terminated (`location /<server>/`) so a bare prefix could not hijack unrelated routes. A correct fix — but it means a request to a registered MCP server *without* the trailing slash now falls through to nginx's automatic "add the slash" **301**.

`absolute_redirect` is on by default, so nginx rebuilds that `Location` from the listener that answered:

```
Location: http://<gateway-host>:8080/registry/<server>/
```

Two things are wrong with it, and both come from the same place — the internal listener is not the origin the client dialed:

- **`http://`** — TLS terminates upstream (Istio/ALB), so the scheme is wrong
- **`:8080`** — the internal container port, not routable from outside the cluster

MCP clients follow the 301 and hang until they time out. Net effect: the endpoint works only when the caller already includes the trailing slash — which the registry UI's connect dialog does not do.

Confirmed on current `main` (`6d2e6ed4`): `grep -rn absolute_redirect registry/ docker/ charts/` returns nothing, so the nginx default is in force everywhere.

## The fix

`absolute_redirect off;` in each front-door `server` block — both blocks in `nginx_rev_proxy_http_and_https.conf` (`:8080` and `:8443 ssl`) and the one in `nginx_rev_proxy_http_only.conf`.

nginx then emits a **relative** `Location: /registry/<server>/`, which the client resolves against the origin it actually dialed. That is correct no matter how many proxies sit in front and needs no knowledge of the external scheme, host, or port — unlike `port_in_redirect off` or a `server_name_in_redirect` scheme, which would still have to guess the external scheme.

Set per server block rather than once at `http` scope, because what leaks is the answering listener's own scheme and port; scoping it to the listeners makes that relationship explicit.

## Testing

New `tests/unit/core/test_nginx_absolute_redirect.py`, 4 tests:

- `test_every_server_block_disables_absolute_redirect` (parametrized over both templates) — brace-counts the top-level `server { ... }` blocks and asserts each sets `absolute_redirect off`. It reports the offending block's `listen` line, so a future server block added without it fails with a message naming which one.
- `test_absolute_redirect_is_never_re_enabled` (both templates) — guards against a later `absolute_redirect on` silently undoing this in a narrower scope.

**Verified failing on unfixed `main`**: both parametrized cases of the first test fail; the two guard tests pass either way, as intended.

`tests/unit/core/`: **673 passed, 10 failed** — the same 10 (`test_telemetry.py`, `test_config.py`) fail on a clean `main` checkout, unchanged by this PR.

`black --check` clean on the new test file.

One limitation worth flagging: I could not run `nginx -t` against the result, since these are templates containing `{{ROOT_PATH}}` / `{{ADDITIONAL_SERVER_NAMES}}` placeholders and there is no nginx binary in the test environment. `absolute_redirect` is a plain `ngx_http_core_module` directive valid at `http`, `server`, and `location` scope, so it is placement-safe, but a container smoke test on your side would be worth having before merge.