### PR TITLE
fix(auth,frontend): relay X-Authorization to internal registry-tools + align connect-URL /mcp with PRM resource

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6186,11 +6186,13 @@ def _forward_headers(
     """Copy incoming request headers to the upstream, stripping hop-by-hop and
     proxy-hint headers so httpx can set them correctly for the connection.
 
-    Ingress-auth policy (issue #1266): X-Authorization and Cookie are ALWAYS
-    stripped (never forwarded to any upstream). Authorization is also stripped
-    UNLESS ``relay_authorization`` is True -- set only for the built-in internal
-    registry-tools server (_INTERNAL_INGRESS_RELAY_SERVERS). Every other server
-    gets no client auth header on egress; upstream creds come from the vault.
+    Ingress-auth policy (issue #1266): Cookie is ALWAYS stripped (never
+    forwarded to any upstream). Authorization and X-Authorization are also
+    stripped UNLESS ``relay_authorization`` is True -- set only for the built-in
+    internal registry-tools server (_INTERNAL_INGRESS_RELAY_SERVERS), which
+    receives BOTH forms (the MCP Gateway carries the caller bearer in
+    X-Authorization, not Authorization). Every other server gets no client auth
+    header on egress; upstream creds come from the vault.
     """
     forwarded: dict[str, str] = {}
     for key, value in incoming.items():
@@ -6206,11 +6208,16 @@ def _forward_headers(
             # not a legal HTTP header value (braces/spaces) and must never be
             # forwarded to the upstream.
             continue
-        if lower in ("x-authorization", "cookie"):
-            # Ingress-only credentials; never forwarded to any upstream.
+        if lower == "cookie":
+            # Ingress-only credential; never forwarded to any upstream.
             continue
-        if lower == "authorization" and not relay_authorization:
-            # Ingress token; forwarded only for the internal relay server.
+        if lower in ("authorization", "x-authorization") and not relay_authorization:
+            # Ingress tokens; forwarded ONLY for the built-in internal
+            # registry-tools server (_INTERNAL_INGRESS_RELAY_SERVERS). The MCP
+            # Gateway carries the caller bearer in X-Authorization (not
+            # Authorization), so the internal server must receive X-Authorization
+            # too to identify the user for its registry API calls. Every other
+            # upstream gets neither -- upstream creds come from the egress vault.
             continue
         forwarded[key] = value
     return forwarded

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -444,18 +444,21 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
   //   1. mcp_endpoint (explicit full-URL override) - always wins
   //   2. proxy_pass_url (registry-only mode - client reaches the server directly)
   //   3. gateway URL = origin + base + server.path, optionally + "/mcp"
-  // The trailing "/mcp" transport segment is auto-detected from proxy_pass_url
-  // but can be forced on/off per-server via append_mcp_path (e.g. root-endpoint
-  // servers like AWS Knowledge that serve MCP at the server path itself).
+  // The trailing "/mcp" transport segment is appended UNLESS a server explicitly
+  // sets append_mcp_path=false (e.g. root-endpoint servers like AWS Knowledge
+  // that serve MCP at the server path itself). This mirrors the server-side PRM
+  // resource, which is built as `append_mcp_path is not False` (append when
+  // unset), so the advertised connection URL always equals the PRM resource.
+  // RFC 9728 requires the client's connection URL and the PRM resource to match,
+  // so the two MUST be derived identically. Do NOT reintroduce a proxy_pass_url
+  // heuristic here: the upstream URL shape says nothing about the gateway path.
   const buildConnectUrl = useCallback(() => {
     if (server.mcp_endpoint) return server.mcp_endpoint;
     if (isRegistryOnly && server.proxy_pass_url) return server.proxy_pass_url;
 
     const baseUrl = `${window.location.origin}${getBaseURL()}`;
     const cleanPath = server.path.replace(/\/+$/, '').replace(/^\/+/, '/');
-    const proxyUrl = server.proxy_pass_url || '';
-    const hasMcpPath = /\/(mcp|sse|v1)(\/.*)?$/.test(proxyUrl);
-    const shouldAppend = appendMcpPath ?? !hasMcpPath;
+    const shouldAppend = appendMcpPath ?? true;
     return shouldAppend ? `${baseUrl}${cleanPath}/mcp` : `${baseUrl}${cleanPath}`;
   }, [server.mcp_endpoint, server.proxy_pass_url, server.path, isRegistryOnly, appendMcpPath]);
 

--- a/frontend/src/components/__tests__/ServerConfigModal.test.tsx
+++ b/frontend/src/components/__tests__/ServerConfigModal.test.tsx
@@ -152,6 +152,23 @@ describe('ServerConfigModal per-server append_mcp_path override', () => {
       expect(serverConfig.url).toBe('http://localhost/test-server/mcp');
     });
   });
+
+  test('append_mcp_path unset appends /mcp even when the upstream proxy already ends in /mcp', async () => {
+    // Regression: the UI previously keyed the /mcp suffix on the UPSTREAM
+    // proxy_pass_url shape (ends in /mcp -> skip append), which diverged from
+    // the server-side PRM resource (built as `append_mcp_path is not False`, so
+    // append when unset). A spec-compliant client rejects a PRM whose resource
+    // does not equal its connection URL, so the two MUST match. With
+    // append_mcp_path unset the connect URL must still append /mcp.
+    connectConfig = { custom_headers: [] }; // append_mcp_path unset (null)
+
+    renderModal({ proxy_pass_url: 'http://internal-host:8080/mcp' });
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.url).toBe('http://localhost/test-server/mcp');
+    });
+  });
 });
 
 describe('ServerConfigModal IDE OAuth login (oauth_client_id)', () => {

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -4911,9 +4911,10 @@ class TestSessionCookieSecureDefault:
 
 class TestForwardHeadersIngressStrip:
     """Egress ingress-auth policy (issue #1266): client auth headers are ingress
-    credentials, stripped on egress. X-Authorization and Cookie are ALWAYS
-    stripped; Authorization is stripped unless relay_authorization=True (set only
-    for the built-in internal registry-tools server). No general relay mode --
+    credentials, stripped on egress. Cookie is ALWAYS stripped; Authorization
+    and X-Authorization are stripped unless relay_authorization=True (set only
+    for the built-in internal registry-tools server, which the gateway addresses
+    via the X-Authorization header). No general relay mode -- third-party
     upstream creds come from the egress vault.
     """
 
@@ -4928,10 +4929,17 @@ class TestForwardHeadersIngressStrip:
         assert "authorization" not in {k.lower() for k in out}
         assert out.get("Accept") == "x"
 
-    def test_strips_x_authorization_always_even_when_relaying(self):
-        """X-Authorization is never forwarded, even for the internal relay server."""
-        out = self._forward({"X-Authorization": "Bearer x"}, relay=True)
+    def test_strips_x_authorization_by_default(self):
+        """Non-relay (default): X-Authorization stripped (never to third-party upstreams)."""
+        out = self._forward({"X-Authorization": "Bearer x"}, relay=False)
         assert "x-authorization" not in {k.lower() for k in out}
+
+    def test_relays_x_authorization_when_flag_set(self):
+        """relay_authorization=True keeps X-Authorization: the gateway carries the
+        caller bearer to the internal registry-tools server in this header, so it
+        must be relayed alongside Authorization."""
+        out = self._forward({"X-Authorization": "Bearer x"}, relay=True)
+        assert out.get("X-Authorization") == "Bearer x"
 
     def test_strips_cookie_always_even_when_relaying(self):
         """Cookie is never forwarded, even for the internal relay server."""
@@ -4943,14 +4951,15 @@ class TestForwardHeadersIngressStrip:
         out = self._forward({"Authorization": "Bearer a"}, relay=True)
         assert out.get("Authorization") == "Bearer a"
 
-    def test_relay_flag_does_not_readmit_x_authorization_or_cookie(self):
-        """With relay on, only Authorization is relayed; X-Authorization/Cookie stay stripped."""
+    def test_relay_flag_relays_auth_and_x_authorization_but_not_cookie(self):
+        """With relay on, Authorization AND X-Authorization are relayed (both to the
+        internal registry-tools server); Cookie stays stripped."""
         out = self._forward(
             {"Authorization": "Bearer a", "X-Authorization": "Bearer x", "Cookie": "s=1"},
             relay=True,
         )
         assert out.get("Authorization") == "Bearer a"
-        assert "x-authorization" not in {k.lower() for k in out}
+        assert out.get("X-Authorization") == "Bearer x"
         assert "cookie" not in {k.lower() for k in out}
 
     def test_case_insensitive(self):


### PR DESCRIPTION
## Summary

Two small, independent fixes for the IDE / MCP-client connection path, both surfaced while testing an Entra deployment but **unrelated to the Entra per-server-PRM work (#990)**. Neither touches `#990` code paths.

## Changes

### 1. `fix(auth)` — relay `X-Authorization` to the internal registry-tools server

The `mcp_proxy` relays ingress auth to the built-in registry-tools server (`_INTERNAL_INGRESS_RELAY_SERVERS`) so it can call the registry API as the caller. It relayed only the `Authorization` header, but the gateway carries the caller bearer in **`X-Authorization`**, which `_forward_headers` stripped unconditionally. The internal server then received no bearer and every tool call (e.g. `list_services`) failed with:

```
Bearer token not found in Authorization or X-Authorization header
```

Fix: relay `X-Authorization` for the same allowlisted internal server. It stays stripped for every other upstream, `Cookie` is always stripped, and third-party upstream credentials continue to come from the egress vault. No change to the trust model (same verified `server` claim, same single same-trust-domain component).

### 2. `fix(frontend)` — derive the connect-URL `/mcp` suffix from `append_mcp_path`

The connect-URL builder in `ServerConfigModal` decided the trailing `/mcp` segment from a heuristic on the **upstream** `proxy_pass_url` (skip appending when it ends in `/mcp|sse|v1`). That diverged from the **server-side PRM resource**, which appends `/mcp` unless `append_mcp_path` is explicitly `false`.

For a server whose upstream ends in `/mcp` (e.g. Slack) with `append_mcp_path` unset, the UI emitted `/<path>` while the PRM advertised `/<path>/mcp`, so a spec-compliant client rejected the generated config:

```
Protected resource https://gw/<path>/mcp does not match expected https://gw/<path> (or origin)
```

(RFC 9728 requires the client's connection URL to equal the PRM `resource`.)

Fix: default to appending `/mcp` when `append_mcp_path` is unset, mirroring the server-side default, so the advertised connection URL always equals the PRM resource. Explicit `append_mcp_path=false` (root-endpoint servers like AWS Knowledge) is unchanged. The upstream-URL heuristic is removed (the upstream shape says nothing about the gateway path).

## Tests

- `py_compile` clean on `auth_server/server.py`.
- `frontend` jest: `ServerConfigModal.test.tsx` — 12/12 pass, including a new regression test asserting that an **unset** `append_mcp_path` with an upstream ending in `/mcp` still appends `/mcp` (the Slack case). Existing `append_mcp_path` true/false cases unchanged.

## Not in scope

- Entra per-server-PRM resource work (#990) — separate PR.
- Entra IDE OAuth (DCR / `IDE_OAUTH_CLIENT_ID`) — unrelated auth-server-registration concern.
