### PR TITLE
chore(entra): review follow-ups for #1618 (shared per-server-PRM predicate + config surface)

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2808,10 +2808,12 @@ def _server_advertises_per_server_prm() -> bool:
     accepted audience is path-bound (built from this request's path below), so
     accepting it cannot widen access to a different server.
     """
-    provider = (
-        os.environ.get("AUTH_PROVIDER", "") or getattr(settings, "auth_provider", "") or ""
-    ).lower()
-    if provider == "entra":
+    # `entra_forces_per_server_prm` is the shared source of truth mirrored by the
+    # registry's `server_needs_per_server_prm` (keep the two in sync).
+    from registry.auth.oauth_metadata import entra_forces_per_server_prm
+
+    provider = os.environ.get("AUTH_PROVIDER", "") or getattr(settings, "auth_provider", "") or ""
+    if entra_forces_per_server_prm(provider):
         return True
     return bool(getattr(settings, "egress_auth_enabled", False))
 

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -152,6 +152,8 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
                     ("entra_client_id", "Client ID", True),
                     ("entra_client_secret", "Client Secret", True),
                     ("entra_group_admin_id", "Admin Group ID", False),
+                    ("entra_scope_format", "Scope Format (v1/v2)", False),
+                    ("entra_application_id_uri", "Application ID URI", False),
                 ],
             },
             {

--- a/registry/api/wellknown_routes.py
+++ b/registry/api/wellknown_routes.py
@@ -10,6 +10,7 @@ from ..auth.oauth_metadata import (
     build_resource_documentation_url,
     derive_supported_scopes,
     enforce_https,
+    entra_forces_per_server_prm,
 )
 from ..core.config import settings
 from ..repositories.factory import get_registry_card_repository
@@ -240,7 +241,7 @@ def server_needs_per_server_prm(egress_auth_mode: str | None) -> bool:
     if egress_auth_mode == "obo_exchange":
         return True
     if egress_auth_mode == "oauth_user":
-        return (settings.auth_provider or "").lower() == "entra"
+        return entra_forces_per_server_prm(settings.auth_provider)
     # issue #990: on Entra, EVERY server -- including plain
     # (egress_auth_mode none) servers like airegistry-tools -- needs a per-server
     # PRM, because the bare-origin global PRM's resource is unmatchable to an
@@ -248,7 +249,9 @@ def server_needs_per_server_prm(egress_auth_mode: str | None) -> bool:
     # the exact per-server connection URL satisfies both Claude (RFC 9728 §3.3)
     # and Entra. Requires each connection URL registered as an identifierUri.
     # Non-Entra IdPs keep the lenient origin-based global PRM (unchanged).
-    if (settings.auth_provider or "").lower() == "entra":
+    # `entra_forces_per_server_prm` is the shared source of truth mirrored by the
+    # auth-server's `_server_advertises_per_server_prm` (keep the two in sync).
+    if entra_forces_per_server_prm(settings.auth_provider):
         return True
     return False
 

--- a/registry/auth/oauth_metadata.py
+++ b/registry/auth/oauth_metadata.py
@@ -108,6 +108,24 @@ def build_per_server_resource_url(
     return url
 
 
+def entra_forces_per_server_prm(auth_provider: str | None) -> bool:
+    """Whether the configured IdP forces a per-server PRM for EVERY server.
+
+    Entra's gateway-wide PRM advertises the bare origin, whose resource a
+    spec-compliant client canonicalizes with a trailing slash -- unmatchable to
+    an Entra App ID URI (Entra forbids the trailing slash), which fails token
+    exchange with AADSTS9010010. So on Entra every server (including plain ones
+    with no egress mode) needs a per-server, connection-URL PRM (issue #990).
+    Non-Entra IdPs accept the bare-origin gateway-wide PRM, so this is Entra-only.
+
+    Single source of truth consulted by BOTH the registry's
+    ``server_needs_per_server_prm`` (the advertise side) and the auth-server's
+    ``_server_advertises_per_server_prm`` (the audience-accept side) so the two
+    predicates cannot drift.
+    """
+    return (auth_provider or "").strip().lower() == "entra"
+
+
 def enforce_https(
     resource_url: str,
     https_required: bool,


### PR DESCRIPTION
## Summary

Follow-up to #1618 (Entra v1 / per-server PRM, #990) addressing the two **Should Fix** items from the review. No blockers were raised; these are hygiene/robustness, not correctness. The nice-to-have items are deferred (see below).

## Changes

### 1. Single source of truth for the Entra per-server-PRM predicate (review Should-Fix #2)

The "Entra forces a per-server PRM for **every** server" fact (#990) was an inline `auth_provider == "entra"` compare duplicated in two places:
- registry `server_needs_per_server_prm` (the **advertise** side), and
- auth-server `_server_advertises_per_server_prm` (the **audience-accept** side).

These could drift, and a mismatch between what the gateway advertises and what `/validate` accepts is security-relevant. Extracted `entra_forces_per_server_prm()` into `registry/auth/oauth_metadata.py` (already imported by the auth-server) and consult it from both. **No behavior change** — both predicates now derive the Entra decision from one place, with cross-referencing comments.

### 2. Surface `entra_scope_format` / `entra_application_id_uri` in System Config (review Should-Fix #1)

Both are defined in `registry/core/config.py` and consumed by the auth-server, but were absent from `CONFIG_GROUPS`, so they never appeared in `GET /api/config/full` or the System Config UI (defined-but-invisible). Added to the existing **Entra** group alongside `entra_tenant_id` / `entra_client_id` (same auth-config category), both non-secret.

## Tests

- `py_compile` clean on all four changed files.
- `tests/unit/api/test_wellknown_routes.py` + `tests/auth_server/unit/test_obo_extra_audiences.py`: 46 passed (confirms the predicate refactor is behavior-preserving on both sides).
- `tests/unit/api/` config tests: 85 passed (CONFIG_GROUPS change intact).

## Deferred (review "Consider" / nice-to-have)

Not in this PR, tracked for later:
- Move `build_per_server_resource_url` + `enforce_https` inside the `try` in the per-server PRM route so a misconfig yields 502 not 500.
- Log group/scope counts (not full lists) in the self-signed token path (pre-existing parity nit).
- Docs note on the Entra 999-App-ID-URI-per-app scaling ceiling.
