### PR TITLE
fix(nginx,lua): forward caller identity headers in virtual server backend locations

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -947,6 +947,21 @@ function _M.route()
     -- all ngx.location.capture subrequests to backends inherit it.
     ngx.req.set_header("Accept", "application/json, text/event-stream")
 
+    -- Forward the validated caller identity to backend subrequests.
+    -- auth_request_set variables ($auth_user, $auth_username) are scoped to the
+    -- parent request and do NOT propagate into ngx.location.capture subrequests
+    -- via proxy_set_header. Setting them as request headers here ensures the
+    -- _vs_backend_* locations pass them through to the upstream MCP server,
+    -- enabling backends to enforce write-gates and record audit attribution.
+    local auth_user = ngx.var.auth_user
+    local auth_username = ngx.var.auth_username
+    if auth_user and auth_user ~= "" then
+        ngx.req.set_header("X-User", auth_user)
+    end
+    if auth_username and auth_username ~= "" then
+        ngx.req.set_header("X-Username", auth_username)
+    end
+
     local request_method = ngx.var.request_method
 
     -- Handle HTTP GET: per MCP Streamable HTTP 2025-11-25 spec section 3.3,

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1900,6 +1900,12 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         # forwarding the caller's credential.
         proxy_set_header Authorization "";
         proxy_set_header Cookie "";
+        # Forward the validated caller identity so backends can attribute
+        # write operations to the authenticated user.  These are set as
+        # request headers by virtual_router.lua (ngx.req.set_header) before
+        # the ngx.location.capture subrequest.
+        proxy_set_header X-User $http_x_user;
+        proxy_set_header X-Username $http_x_username;
         proxy_buffering off;
         proxy_set_header Accept "application/json, text/event-stream";
         proxy_set_header Content-Type $content_type;

--- a/tests/unit/test_virtual_server_nginx.py
+++ b/tests/unit/test_virtual_server_nginx.py
@@ -227,6 +227,36 @@ class TestGenerateVirtualBackendLocations:
         assert 'proxy_set_header Cookie "";' in result
 
     @pytest.mark.asyncio
+    async def test_identity_headers_forwarded_via_http_vars(self, mock_server_repository):
+        """Caller identity is forwarded using $http_x_user/$http_x_username variables.
+
+        The Lua virtual_router sets X-User and X-Username as request headers
+        (ngx.req.set_header) before ngx.location.capture subrequests.  The
+        _vs_backend location block then forwards them to the upstream via
+        proxy_set_header using the $http_x_user/$http_x_username variables
+        (which read from incoming request headers, not auth_request_set vars).
+
+        This two-part approach is required because auth_request_set variables
+        ($auth_user) do not propagate into subrequest contexts.
+        """
+        vs = _make_vs_config()
+        mock_server_repository.get.return_value = {
+            "proxy_pass_url": "https://api.github.com",
+        }
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_backend_locations([vs])
+
+        # Identity headers forwarded via $http_x_* (request header vars, set by Lua)
+        assert "proxy_set_header X-User $http_x_user;" in result
+        assert "proxy_set_header X-Username $http_x_username;" in result
+        # Must NOT use $auth_user (doesn't propagate to subrequests)
+        assert "proxy_set_header X-User $auth_user" not in result
+        assert "proxy_set_header X-Username $auth_username" not in result
+
+    @pytest.mark.asyncio
     async def test_bare_hostname_backend_uses_deferred_resolution(self, mock_server_repository):
         """Bare hostnames defer DNS resolution so they cannot crash nginx at startup."""
         vs = _make_vs_config()


### PR DESCRIPTION
…kend locations

Virtual server backends received no caller identity because:
1. auth_request_set variables ($auth_user, $auth_username) are scoped to the parent request and do NOT propagate into ngx.location.capture subrequests via proxy_set_header.
2. The /_vs_backend_* internal locations had no mechanism to receive identity from the Lua router.

Fix (two-part):
- virtual_router.lua: set X-User and X-Username as request headers (ngx.req.set_header) before any ngx.location.capture call. Subrequests inherit these headers from the parent.
- nginx_service.py: add proxy_set_header X-User $http_x_user and proxy_set_header X-Username $http_x_username to the _vs_backend location template so they are forwarded to the upstream MCP server.

This matches the behaviour of direct (non-virtual) server paths, enabling backends behind virtual servers to enforce write-gates and record audit attribution.

Tested: Confluence page update through /virtual/development/mcp with identity correctly resolved by the backend (mcp-atlassian).

*Issue #, if available:*
1626

*Description of changes:*
Forwards X-User/X-Username identity headers through virtual server backend locations to match direct path behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
