### PR TITLE
Gateway proxy for any registry resource - foundation (PR 1 of 1565)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,7 +733,7 @@ working in those areas.
 - **Use the canonical helper, never reinvent/copy-paste** (see the "Canonical
   helpers" section in the guidelines doc): outbound HTTP from user/registry URLs →
   `registry/utils/url_guard.py` `guarded_client`/`guarded_async_client` (never a
-  bare `httpx` client), IP categories/unwrapping → `registry/utils/ip_guard.py`,
+  bare `httpx` client), IP categories/unwrapping → `registry/utils/url_guard.py`,
   URL identity/logging → `normalize_url_identity`/`sanitized_url_for_log`; CSRF →
   `registry/auth/csrf.py`; internal service auth →
   `registry/auth/internal.py`; signing-secret validation →

--- a/auth_server/internal_request_token.py
+++ b/auth_server/internal_request_token.py
@@ -34,6 +34,13 @@ MCP_PROXY_TOKEN_USE: str = "mcp-proxy"
 MCP_REGISTRY_UI_AUDIENCE: str = "mcp-registry-ui"
 MCP_REGISTRY_UI_TOKEN_USE: str = "mcp-registry-ui"
 
+# Audience for the generic reverse-proxy hop (/proxy/{entity_type}/{path}), used
+# for non-MCP proxied entities (skills, agents, custom). Distinct from every
+# audience above so a generic-proxy token can't be replayed at /mcp-proxy (which
+# has no tool-list filtering) or the registry API, or vice-versa.
+GENERIC_PROXY_AUDIENCE: str = "generic-proxy"
+GENERIC_PROXY_TOKEN_USE: str = "generic-proxy"
+
 # TTL is clamped to this floor so a misconfigured TTL of 0/negative cannot
 # combine with the leeway into a confusing always-valid window.
 _MIN_TTL_SECONDS: int = 5
@@ -49,6 +56,30 @@ def _ttl_seconds() -> int:
     if candidate < _MIN_TTL_SECONDS:
         logger.warning(
             f"INTERNAL_TOKEN_TTL_SECONDS={candidate} below floor; clamping to {_MIN_TTL_SECONDS}"
+        )
+        return _MIN_TTL_SECONDS
+    return candidate
+
+
+def _generic_ttl_seconds() -> int:
+    """TTL for the generic-proxy token (GENERIC_PROXY_TOKEN_TTL_SECONDS).
+
+    Falls back to the shared INTERNAL_TOKEN_TTL_SECONDS when unset, so a single
+    knob covers both hops unless an operator tunes the generic hop separately.
+    Clamped to the same floor as the mcp-proxy TTL.
+    """
+    raw = os.environ.get("GENERIC_PROXY_TOKEN_TTL_SECONDS")
+    if raw is None:
+        return _ttl_seconds()
+    try:
+        candidate = int(raw)
+    except ValueError:
+        logger.warning(f"Invalid GENERIC_PROXY_TOKEN_TTL_SECONDS={raw!r}; using default 30")
+        return 30
+    if candidate < _MIN_TTL_SECONDS:
+        logger.warning(
+            f"GENERIC_PROXY_TOKEN_TTL_SECONDS={candidate} below floor; "
+            f"clamping to {_MIN_TTL_SECONDS}"
         )
         return _MIN_TTL_SECONDS
     return candidate
@@ -75,6 +106,7 @@ def _mint_internal_token(
     subject: str,
     scopes: list[str],
     extra_claims: dict | None = None,
+    ttl_seconds: int | None = None,
 ) -> str:
     """Mint a short-lived HS256 internal JWT signed with SECRET_KEY.
 
@@ -83,6 +115,8 @@ def _mint_internal_token(
         subject: The validated caller identity (becomes ``sub``).
         scopes: The validated entitlements (becomes ``scopes``, a JSON array).
         extra_claims: Audience-specific claims (e.g. ``server``/``upstream_url``).
+        ttl_seconds: Explicit TTL; defaults to ``_ttl_seconds()`` (the shared
+            INTERNAL_TOKEN_TTL_SECONDS). The generic hop passes its own knob.
 
     Returns:
         Encoded JWT string.
@@ -97,16 +131,18 @@ def _mint_internal_token(
         raise ValueError("Cannot mint internal token with empty subject")
     secret_key = _get_secret_key()
     now = int(time.time())
-    claims: dict = {
+    base_claims: dict = {
         "iss": _ISSUER,
         "aud": audience,
         "sub": subject,
         "scopes": list(scopes or []),
         "iat": now,
-        "exp": now + _ttl_seconds(),
+        "exp": now + (ttl_seconds if ttl_seconds is not None else _ttl_seconds()),
     }
-    if extra_claims:
-        claims.update(extra_claims)
+    # Merge extra first, THEN base — so a caller's extra_claims can never override
+    # a reserved base claim (aud/exp/iss/sub/...). Callers pass server-derived
+    # constants today, but this makes the invariant structural, not a convention.
+    claims: dict = {**(extra_claims or {}), **base_claims}
     return pyjwt.encode(claims, secret_key, algorithm="HS256")
 
 
@@ -175,6 +211,44 @@ def mint_mcp_proxy_token(
             "egress_user": egress_user or "",
             "token_use": MCP_PROXY_TOKEN_USE,
         },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# generic-proxy wrappers (pin audience; bind entity_type + FULL registered path)
+# --------------------------------------------------------------------------- #
+
+
+def mint_generic_proxy_token(
+    subject: str,
+    scopes: list[str],
+    entity_type: str,
+    registered_path: str,
+    upstream_url: str,
+) -> str:
+    """Mint the per-request /proxy/{entity_type}/{path} token in /validate's 200 path.
+
+    Binds BOTH the entity_type AND the FULL registered path as two distinct
+    claims (unlike mcp-proxy, which binds only the first path segment): registered
+    paths are multi-segment (e.g. ``skills/proxy-demo``), so binding only the
+    first segment would let a token for one skill be replayed against a sibling.
+    The verifier checks entity_type exactly and requires the route's entity path
+    to equal the bound path or be a sub-path UNDER it (no sibling escape).
+
+    ``upstream_url`` is the resolved backend the generic hop forwards to,
+    cryptographically pinned so the handler ignores forgeable headers.
+    """
+    return _mint_internal_token(
+        audience=GENERIC_PROXY_AUDIENCE,
+        subject=subject,
+        scopes=scopes,
+        extra_claims={
+            "entity_type": entity_type,
+            "server": registered_path,  # FULL registered path, not first-segment
+            "upstream_url": upstream_url,
+            "token_use": GENERIC_PROXY_TOKEN_USE,
+        },
+        ttl_seconds=_generic_ttl_seconds(),
     )
 
 
@@ -280,3 +354,94 @@ async def verify_mcp_proxy_token(request: Request) -> None:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Server claim/path mismatch")
 
     request.state.mcp_proxy_claims = claims
+
+
+def _norm_path(value: str) -> str:
+    """Normalize a route/claim path for comparison: strip leading/trailing '/'."""
+    return (value or "").strip("/")
+
+
+async def verify_generic_proxy_token(request: Request) -> None:
+    """FastAPI dependency on the generic_proxy handler (/proxy/{entity_type}/{path}).
+
+    Fail-closed, mirroring verify_mcp_proxy_token, EXCEPT the traversal guard
+    binds the entity_type AND the FULL registered path (both claims set by
+    mint_generic_proxy_token), read from the two route params ``entity_type`` and
+    ``entity_path``. Rejects (401) unless:
+      - a valid, unexpired, GENERIC_PROXY_AUDIENCE / GENERIC_PROXY_TOKEN_USE token;
+      - an upstream binding is present;
+      - claims["entity_type"] == route entity_type (blocks cross-type replay,
+        e.g. a skill token used on an /a2a_agent/ route); AND
+      - the route entity_path equals the bound registered path OR is a sub-path
+        strictly UNDER it (``<registered>/...``) — a sub-resource of the bound
+        entity is allowed, a sibling/escape is not; ``..`` segments are rejected.
+    On success the claims are stashed on ``request.state.generic_proxy_claims``.
+
+    SECURITY ASSUMPTIONS (enforced by nginx, not this function):
+    - nginx MUST strip any client-supplied ``X-Internal-Token*`` header and set
+      ``X-Internal-Token-Generic`` from the /validate-minted value only. The
+      entire fail-closed model collapses if a client can inject this header.
+    - the downstream generic handler MUST normalize the post-bound path remainder
+      before appending it to the pinned ``upstream_url`` (this guard rejects ``..``
+      segments, but path normalization on the upstream append is the handler's job).
+    """
+    try:
+        _get_secret_key()
+    except ValueError:
+        logger.error("SECRET_KEY not set, cannot verify generic-proxy token")
+        raise HTTPException(
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server configuration error",
+        )
+
+    token = request.headers.get("X-Internal-Token-Generic")
+    if not token:
+        logger.warning("generic_proxy: missing X-Internal-Token-Generic (rejecting)")
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Missing internal proxy token")
+
+    try:
+        claims = _decode_internal_token(token, audience=GENERIC_PROXY_AUDIENCE)
+    except pyjwt.ExpiredSignatureError:
+        logger.warning("generic_proxy: expired internal token")
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Internal proxy token expired")
+    except pyjwt.InvalidTokenError as exc:
+        logger.warning(f"generic_proxy: invalid internal token: {exc}")
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid internal proxy token")
+
+    if claims.get("token_use") != GENERIC_PROXY_TOKEN_USE:
+        logger.warning("generic_proxy: wrong token_use in internal token")
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid internal proxy token")
+    if not claims.get("upstream_url"):
+        logger.warning("generic_proxy: internal token missing upstream binding")
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED, detail="Internal proxy token missing upstream"
+        )
+
+    # Cross-type replay guard: the bound entity_type must match the route.
+    route_entity_type = request.path_params.get("entity_type") or ""
+    if claims.get("entity_type") != route_entity_type:
+        logger.warning(
+            "generic_proxy: entity_type claim/path mismatch "
+            f"(claim={claims.get('entity_type')!r} path={route_entity_type!r})"
+        )
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Entity-type claim/path mismatch")
+
+    # Path-traversal guard: route path must be the bound registered path, or a
+    # sub-path strictly under it. Compared on normalized, segment boundaries so
+    # "skills/proxy-demo" does NOT match "skills/proxy-demo-evil".
+    bound = _norm_path(claims.get("server", ""))
+    route_path = _norm_path(request.path_params.get("entity_path") or "")
+    # Reject dot-dot segments outright: the prefix check alone would let
+    # "<bound>/../../x" pass (it literally starts with "<bound>/"). This guard is
+    # sibling-escape-safe but NOT dot-dot-safe without this, and the downstream
+    # handler must ALSO normalize before appending to the pinned upstream.
+    if ".." in route_path.split("/"):
+        logger.warning(f"generic_proxy: dot-dot segment in entity path {route_path!r}")
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Illegal path segment")
+    if not bound or not (route_path == bound or route_path.startswith(bound + "/")):
+        logger.warning(
+            f"generic_proxy: entity path/claim mismatch (claim={bound!r} path={route_path!r})"
+        )
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Entity path claim/path mismatch")
+
+    request.state.generic_proxy_claims = claims

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -2264,6 +2264,15 @@ async def lifespan(app: FastAPI):
     # (NonDurableAuditError) when audit logging is enabled but no durable sink is
     # available, matching the registry process's fail-closed startup behavior.
     get_mcp_logger()
+    # Set the generic-proxy feature latch (egress self-check). MUST run in the
+    # lifespan, NOT via @app.on_event("startup"): Starlette ignores on_event
+    # handlers when a lifespan handler is provided, so an on_event hook would
+    # never run and the latch would stay None -> the /proxy/ hop fail-closes to
+    # 503 even with the feature flag on. Never raises (fail-closed on error).
+    try:
+        await initialize_generic_proxy_feature()
+    except Exception as e:
+        logger.error(f"Generic-proxy feature init failed during startup: {e}", exc_info=True)
 
     yield
 
@@ -8212,17 +8221,6 @@ async def _audit_legacy_scopes_on_startup() -> int:
     return warnings_emitted
 
 
-@app.on_event("startup")
-async def _init_generic_proxy_feature_on_startup() -> None:
-    """Set the generic-proxy feature latch (egress self-check) during boot.
-
-    Never raises into startup — on any error the latch stays its default (None
-    => feature inactive), which is the fail-closed posture.
-    """
-    try:
-        await initialize_generic_proxy_feature()
-    except Exception as exc:
-        logger.error(
-            f"Generic-proxy feature init errored during startup: {exc}",
-            exc_info=True,
-        )
+# Startup work is owned by ``lifespan`` above. Do not add
+# ``@app.on_event("startup")`` handlers: Starlette ignores them when a custom
+# lifespan handler is configured.

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -4,6 +4,7 @@ Configuration is passed via headers instead of environment variables.
 """
 
 import argparse
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -12,6 +13,7 @@ import logging
 import os
 import re
 import secrets
+import socket
 
 # Import shared scopes loader and repository factory from registry common module
 import sys
@@ -42,6 +44,7 @@ from internal_request_token import (
     mint_generic_proxy_token,
     mint_mcp_proxy_token,
     mint_registry_ui_token,
+    verify_generic_proxy_token,
     verify_mcp_proxy_token,
 )
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
@@ -7703,6 +7706,403 @@ def _safe_parse_body(
 
 
 # ---------------------------------------------------------------------------
+# Generic reverse-proxy hop (/proxy/{entity_type}/{entity_path:path})
+# ---------------------------------------------------------------------------
+#
+# Forwards an arbitrary HTTP verb to a proxied non-MCP entity's PINNED upstream.
+# nginx routes here after /validate succeeds; verify_generic_proxy_token (route
+# dependency) has already verified the /validate-minted X-Internal-Token-Generic
+# and stashed its claims (identity/scopes/upstream) on
+# request.state.generic_proxy_claims. The destination host is cryptographically
+# pinned in the token; the inbound X-Upstream-Url header is IGNORED. There is NO
+# JSON-RPC parsing and NO tools/list filtering — the hop is a uniform,
+# response-buffering (unary) proxy in v1 (no streaming / no WebSocket upgrade).
+
+# The verbs the generic hop accepts. HEAD/OPTIONS included for discovery/preflight.
+_GENERIC_PROXY_METHODS: list[str] = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+# WIDER response-header allowlist than the MCP hop's _FORWARDED_RESPONSE_HEADERS:
+# the generic hop fronts dashboards / static files / redirects, so it must forward
+# Location (redirects), caching validators, and download/range headers. STILL
+# excluded (security): Set-Cookie, Strict-Transport-Security, Content-Security-
+# Policy, X-Frame-Options and other framing/policy headers — an arbitrary proxied
+# backend must NOT dictate cookie or security policy on the gateway origin. Stored
+# lowercase; matched case-insensitively. Adding an entry is security-relevant.
+_FORWARDED_GENERIC_RESPONSE_HEADERS: frozenset[str] = frozenset(
+    {
+        "location",
+        "content-type",
+        "content-length",
+        "content-encoding",
+        "content-language",
+        "content-disposition",
+        "content-range",
+        "accept-ranges",
+        "cache-control",
+        "etag",
+        "last-modified",
+        "vary",
+        "age",
+        "expires",
+        # www-authenticate: forwarded so an API backend can negotiate auth with the
+        # client. Trade-off (accepted for API-fronting): a backend can emit
+        # WWW-Authenticate: Basic/Negotiate that triggers a browser credential
+        # prompt on the GATEWAY origin. Revisit if generic targets become untrusted
+        # HTML-only.
+        "www-authenticate",
+        "retry-after",
+        "mcp-session-id",
+        "x-mcp-session-id",
+    }
+)
+
+# The gateway SETS these on every generic-proxy response (NOT forwarded from the
+# backend). Because the hop can serve a backend's text/html from the gateway's OWN
+# origin while dropping the backend's CSP, these keep backend HTML/JS from running
+# with gateway-origin privileges (reading same-origin endpoints, riding the cookie).
+_GATEWAY_SET_SECURITY_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": "default-src 'self'; frame-ancestors 'none'",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
+# Metadata IPs the egress self-check probes. If EITHER is reachable, the network
+# egress policy (the real DNS-rebind defense) is NOT in place.
+_METADATA_PROBE_TARGETS: tuple[tuple[str, int], ...] = (
+    ("169.254.169.254", 80),
+    ("fd00:ec2::254", 80),
+)
+
+# Process-local feature latch. Starts None (unknown); set True/False by the
+# startup egress self-check. When False, the generic hop fails closed (503)
+# regardless of the config flag — an enabled flag without a verified egress
+# policy is an open DNS-rebind hole, so we refuse to proxy.
+_generic_proxy_feature_active: bool | None = None
+
+# Concurrency guard (OOM): bounds in-flight generic requests so worst-case heap =
+# generic_proxy_max_body_bytes * cap. Lazily created so the cap reads live config.
+_generic_proxy_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_generic_proxy_semaphore() -> asyncio.Semaphore:
+    """Return the process-wide generic-hop concurrency semaphore (lazy init)."""
+    global _generic_proxy_semaphore
+    if _generic_proxy_semaphore is None:
+        cap = getattr(settings, "gateway_generic_max_concurrency", 32)
+        _generic_proxy_semaphore = asyncio.Semaphore(max(1, int(cap)))
+    return _generic_proxy_semaphore
+
+
+def _read_generic_max_body_bytes() -> int:
+    """Response-buffer cap for the generic hop (generic_proxy_max_body_bytes)."""
+    minimum = 1024
+    try:
+        value = getattr(settings, "generic_proxy_max_body_bytes", None)
+        if value is not None:
+            return max(int(value), minimum)
+    except (TypeError, ValueError):
+        pass
+    return 10 * 1024 * 1024
+
+
+def _generic_tls_verify() -> bool | str:
+    """Resolve the generic hop's httpx verify= from gateway_generic_tls_verify.
+
+    Returns True (verify against system store), False (disabled — logged loud at
+    startup), or a filesystem path to a custom CA bundle.
+    """
+    raw = str(getattr(settings, "gateway_generic_tls_verify", "true")).strip()
+    if raw.lower() == "true":
+        return True
+    if raw.lower() == "false":
+        return False
+    return raw  # CA bundle path
+
+
+def _select_forwarded_generic_response_headers(
+    upstream_headers: Mapping[str, str],
+) -> dict[str, str]:
+    """Apply the wider generic-hop response-header allowlist (case-insensitive).
+
+    Anything outside _FORWARDED_GENERIC_RESPONSE_HEADERS (Set-Cookie, HSTS, CSP,
+    framing headers, and Starlette-managed framing) is dropped. Original casing is
+    preserved on the returned dict.
+    """
+    selected: dict[str, str] = {}
+    for key, value in upstream_headers.items():
+        if key.lower() in _FORWARDED_GENERIC_RESPONSE_HEADERS:
+            selected[key] = value
+    return selected
+
+
+def _assert_outbound_host_pinned(
+    outbound_url: str,
+    pinned_upstream: str,
+) -> None:
+    """Assert the constructed outbound URL stays on the pinned upstream.
+
+    Rejecting a literal '..' in the sub-path is NOT sufficient: httpx/urljoin can
+    still resolve dot segments or other tricks after the string join. After
+    building the outbound URL, its scheme/host/port MUST equal the pinned base's —
+    this enforces that the sub-path append did not escape the cryptographically
+    pinned host (SSRF confinement). Raises 400 on mismatch.
+    """
+    out = urlparse(outbound_url)
+    base = urlparse(pinned_upstream)
+    if (out.scheme, out.hostname, out.port) != (base.scheme, base.hostname, base.port):
+        logger.warning(
+            "generic_proxy: outbound host escaped pin (outbound=%s://%s:%s base=%s://%s:%s)",
+            out.scheme,
+            out.hostname,
+            out.port,
+            base.scheme,
+            base.hostname,
+            base.port,
+        )
+        raise HTTPException(status_code=400, detail="Proxy target host mismatch")
+
+
+def _build_generic_outbound_url(
+    upstream_url: str,
+    entity_path: str,
+    bound_registered_path: str,
+) -> str:
+    """Append the confined sub-path (route path beyond the registered entity path)
+    to the PINNED upstream base, or return the base unchanged when there is none.
+
+    Confinement (SSRF): the sub-path is the route's entity_path with the bound
+    registered prefix removed. Reject any sub-path segment that is '..' or that
+    contains a scheme ('://') or userinfo ('@') before appending — then the caller
+    asserts post-join host equality. The pinned base host is never overridden.
+
+    NOTE: entity_path arrives from Starlette's ``{entity_path:path}`` route param,
+    which is already query/fragment-split — so it cannot contain a raw '?' or '#'
+    (those become request.query_params, forwarded separately). A protocol-relative
+    '//host' remainder cannot reassign the host either, because it is always
+    appended after ``base + '/'`` (never at the authority position) and the
+    post-join host-equality assertion is the backstop. Encoded dots ('%2e%2e') are
+    not decoded before the socket, so at worst they hit an odd path on the *pinned*
+    backend, not a different host.
+    """
+    norm_route = entity_path.strip("/")
+    norm_bound = bound_registered_path.strip("/")
+    if norm_route == norm_bound:
+        sub = ""
+    elif norm_bound and norm_route.startswith(norm_bound + "/"):
+        sub = norm_route[len(norm_bound) + 1 :]
+    else:
+        # Should not happen (verify_generic_proxy_token already enforced the
+        # prefix), but fail closed rather than append an unconfined remainder.
+        raise HTTPException(status_code=400, detail="Entity path outside bound prefix")
+
+    if not sub:
+        return upstream_url
+    if ".." in sub.split("/") or "://" in sub or "@" in sub:
+        logger.warning("generic_proxy: illegal sub-path %r", sub)
+        raise HTTPException(status_code=400, detail="Illegal sub-path")
+    return upstream_url.rstrip("/") + "/" + sub
+
+
+async def _run_egress_selfcheck() -> bool:
+    """Probe the metadata IPs; return True if egress looks restricted (safe).
+
+    A short, non-credentialed TCP connect to each metadata target. If EITHER
+    connects, the network egress policy is NOT in place (open DNS-rebind) and this
+    returns False. Connection refused/timeout/unreachable => that target is
+    blocked (good). Never raises.
+    """
+
+    async def _one(host: str, port: int) -> bool:
+        """True if the target is REACHABLE (bad)."""
+        try:
+            fut = asyncio.open_connection(host, port)
+            reader_writer = await asyncio.wait_for(fut, timeout=2.0)
+            _, writer = reader_writer
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:  # noqa: BLE001 - close best-effort  # nosec B110
+                pass
+            return True
+        except (TimeoutError, OSError, socket.gaierror):
+            return False
+        except Exception as exc:  # noqa: BLE001 - never let the probe raise
+            logger.debug("egress self-check probe error for %s:%s: %s", host, port, exc)
+            return False
+
+    reachable = await asyncio.gather(*(_one(h, p) for h, p in _METADATA_PROBE_TARGETS))
+    return not any(reachable)
+
+
+async def initialize_generic_proxy_feature() -> None:
+    """Set the process-local generic-proxy feature latch at startup.
+
+    Feature stays OFF unless BOTH (a) gateway_generic_proxy_enabled is true AND
+    (b) the egress self-check passes (or is opted out). A failed self-check logs
+    CRITICAL and disables the feature for this process — it does NOT fail pod
+    readiness (that would take down all of /validate/OAuth for one optional
+    feature). Emits gateway_egress_policy_unverified 0/1.
+    """
+    global _generic_proxy_feature_active
+
+    if not getattr(settings, "gateway_generic_proxy_enabled", False):
+        _generic_proxy_feature_active = False
+        logger.info("Generic proxy feature disabled (gateway_generic_proxy_enabled=false)")
+        return
+
+    if not getattr(settings, "gateway_egress_selfcheck_enabled", True):
+        _generic_proxy_feature_active = True
+        logger.warning(
+            "Generic proxy ENABLED with egress self-check OPTED OUT "
+            "(GATEWAY_EGRESS_SELFCHECK_ENABLED=false) — ensure the network egress "
+            "policy is enforced another way; DNS-rebind to the metadata IP is "
+            "otherwise unmitigated."
+        )
+        _set_egress_unverified_metric(0)
+        return
+
+    egress_ok = await _run_egress_selfcheck()
+    _generic_proxy_feature_active = egress_ok
+    if egress_ok:
+        logger.info("Generic proxy egress self-check PASSED; feature active")
+        _set_egress_unverified_metric(0)
+    else:
+        logger.critical(
+            "Generic proxy egress self-check FAILED: a cloud metadata IP "
+            "(169.254.169.254 / fd00:ec2::254) is REACHABLE from the auth-server. "
+            "The required network egress policy is NOT enforced — DISABLING the "
+            "generic-proxy feature for this process (fail-closed). Deploy the "
+            "egress NetworkPolicy/security-group before enabling this feature."
+        )
+        _set_egress_unverified_metric(1)
+
+    tls_verify = str(getattr(settings, "gateway_generic_tls_verify", "true")).strip()
+    if tls_verify.lower() == "false":
+        logger.warning(
+            "GATEWAY_GENERIC_TLS_VERIFY=false — the generic hop will NOT verify "
+            "upstream TLS certificates. NOT recommended outside local testing."
+        )
+    elif tls_verify.lower() != "true":
+        # Any non-true/false value is treated as a CA-bundle path. Log it so a typo
+        # (e.g. "tru") surfaces at startup instead of silently 502-ing every request
+        # (httpx would fail to load the "bundle" at connect time).
+        logger.info(
+            "GATEWAY_GENERIC_TLS_VERIFY=%r — generic hop will verify against this "
+            "custom CA bundle path (must exist and be readable).",
+            tls_verify,
+        )
+
+
+def _set_egress_unverified_metric(value: int) -> None:
+    """Best-effort emit of the gateway_egress_policy_unverified gauge."""
+    try:
+        from registry.core.metrics import GATEWAY_EGRESS_POLICY_UNVERIFIED
+
+        GATEWAY_EGRESS_POLICY_UNVERIFIED.set(value)
+    except Exception as exc:  # noqa: BLE001 - metric emission must never break startup
+        logger.debug("could not set gateway_egress_policy_unverified: %s", exc)
+
+
+@app.api_route(
+    "/proxy/{entity_type}/{entity_path:path}",
+    methods=_GENERIC_PROXY_METHODS,
+    dependencies=[Depends(verify_generic_proxy_token)],
+)
+async def generic_proxy(
+    entity_type: str,
+    entity_path: str,
+    request: Request,
+):
+    """Forward an arbitrary HTTP verb to a proxied non-MCP entity's pinned upstream.
+
+    verify_generic_proxy_token (route dependency) has already verified the token
+    and stashed claims; identity/scopes/destination come from those verified
+    claims, NOT the forgeable inbound headers. The hop is uniform (no JSON-RPC
+    parsing, no tools/list filtering) and unary (buffers the bounded response).
+    """
+    # Fail closed if the feature latch is off (flag disabled OR egress self-check
+    # failed). None (pre-startup) is treated as off.
+    if not _generic_proxy_feature_active:
+        raise HTTPException(
+            status_code=503,
+            detail="Generic proxy feature is not active on this server",
+        )
+
+    claims = request.state.generic_proxy_claims
+    upstream_url = claims["upstream_url"]  # cryptographically pinned base
+    bound_registered_path = claims.get("server", "")
+
+    # Build the confined outbound URL (sub-path appended to the pinned base) and
+    # assert it stayed on the pinned host — belt (segment reject) and suspenders
+    # (post-join host-equality).
+    outbound_url = _build_generic_outbound_url(upstream_url, entity_path, bound_registered_path)
+    _assert_outbound_host_pinned(outbound_url, upstream_url)
+
+    try:
+        request_body = await request.body()
+    except Exception as exc:
+        logger.error(f"generic_proxy: failed to read request body: {exc}")
+        raise HTTPException(status_code=400, detail="Invalid request body") from exc
+
+    max_body_bytes = _read_generic_max_body_bytes()
+    forward_headers = _forward_headers(dict(request.headers))
+    verify = _generic_tls_verify()
+
+    logger.info(
+        "generic_proxy: type=%s path=/%s method=%s",
+        entity_type,
+        entity_path,
+        request.method,
+    )
+
+    semaphore = _get_generic_proxy_semaphore()
+    async with semaphore:
+        try:
+            # follow_redirects=False (second-SSRF guard): a 30x is returned to the
+            # client verbatim (Location forwarded via the allowlist); the next hop
+            # re-enters the gateway and is re-authorized. Auto-following would
+            # bypass egress validation and could hit an attacker Location.
+            async with httpx.AsyncClient(
+                timeout=30.0,
+                follow_redirects=False,
+                verify=verify,
+            ) as client:
+                async with client.stream(
+                    request.method,
+                    outbound_url,
+                    content=request_body,
+                    headers=forward_headers,
+                    params=dict(request.query_params),
+                ) as upstream_response:
+                    body_bytes = await _read_bounded(upstream_response, max_body_bytes)
+                    status_code = upstream_response.status_code
+                    content_type = upstream_response.headers.get(
+                        "content-type", "application/octet-stream"
+                    )
+                    upstream_headers = dict(upstream_response.headers)
+        except HTTPException:
+            raise
+        except httpx.TimeoutException as exc:
+            logger.error(f"generic_proxy: upstream timeout for {outbound_url}: {exc}")
+            raise HTTPException(status_code=504, detail="Upstream timed out") from exc
+        except httpx.HTTPError as exc:
+            logger.error(f"generic_proxy: upstream error for {outbound_url}: {exc}")
+            raise HTTPException(status_code=502, detail="Upstream error") from exc
+
+    response_headers = _select_forwarded_generic_response_headers(upstream_headers)
+    # Gateway-set security headers win over anything the backend tried to set
+    # (the allowlist already dropped backend CSP/framing, but set ours explicitly).
+    response_headers.update(_GATEWAY_SET_SECURITY_HEADERS)
+
+    return Response(
+        content=body_bytes,
+        status_code=status_code,
+        media_type=content_type,
+        headers=response_headers,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Startup: legacy-scope audit (Issue #1026, LLD Step 9)
 # ---------------------------------------------------------------------------
 
@@ -7788,3 +8188,19 @@ async def _audit_legacy_scopes_on_startup() -> int:
     else:
         logger.info("Legacy scope audit: no issues found.")
     return warnings_emitted
+
+
+@app.on_event("startup")
+async def _init_generic_proxy_feature_on_startup() -> None:
+    """Set the generic-proxy feature latch (egress self-check) during boot.
+
+    Never raises into startup — on any error the latch stays its default (None
+    => feature inactive), which is the fail-closed posture.
+    """
+    try:
+        await initialize_generic_proxy_feature()
+    except Exception as exc:
+        logger.error(
+            f"Generic-proxy feature init errored during startup: {exc}",
+            exc_info=True,
+        )

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -39,6 +39,7 @@ from fastapi.responses import JSONResponse, RedirectResponse, Response
 
 # Import metrics middleware
 from internal_request_token import (
+    mint_generic_proxy_token,
     mint_mcp_proxy_token,
     mint_registry_ui_token,
     verify_mcp_proxy_token,
@@ -436,6 +437,55 @@ def _attach_mcp_proxy_token(
         logger.error(f"/validate: could not mint mcp-proxy token: {exc}")
 
 
+def _attach_generic_proxy_token(
+    request: "Request",
+    response: "JSONResponse",
+    subject: str,
+    scopes: list[str],
+    entity_type: str,
+    registered_path: str,
+) -> None:
+    """Mint and attach the X-Internal-Token-Generic for the generic-proxy hop.
+
+    Only mints when nginx forwarded a resolved generic upstream
+    (``X-Resolved-Generic-Upstream``) into this /validate subrequest -- i.e. the
+    request is for a proxied non-MCP entity, not an MCP-proxy or /api/ location.
+
+    Keyed on ``X-Resolved-Generic-Upstream`` (a SEPARATE marker from the MCP
+    hop's ``X-Resolved-Upstream``) so the two mints are mutually exclusive by
+    disjoint trigger: a generic block never sets ``$backend_url``, so
+    ``X-Resolved-Upstream`` is empty on generic requests and
+    ``_attach_mcp_proxy_token`` short-circuits -- exactly one token per request,
+    no stray MCP-audience token. Carries its own response header
+    (``X-Internal-Token-Generic``) distinct from ``X-Internal-Token`` /
+    ``X-Internal-Token-Registry`` so the three never collide.
+
+    The token binds BOTH the entity_type and the FULL registered path (two
+    claims) so it cannot be replayed cross-type or against a sibling entity. The
+    upstream is pinned from the server-set marker (never a forgeable inbound
+    header). If minting fails (e.g. empty subject), no token is attached: the
+    generic hop then rejects (fail-closed).
+
+    SECURITY: the caller MUST ensure this is wired ONLY into the main 200-path,
+    never the static-credential short-circuits (federation-static / network-
+    trusted), which compute no cookie/Bearer discriminator and thus cannot run
+    the CSRF gate. See validate_request.
+    """
+    resolved_upstream = request.headers.get("X-Resolved-Generic-Upstream", "")
+    if not resolved_upstream:
+        return
+    try:
+        response.headers["X-Internal-Token-Generic"] = mint_generic_proxy_token(
+            subject=subject,
+            scopes=scopes,
+            entity_type=entity_type,
+            registered_path=registered_path,
+            upstream_url=resolved_upstream,
+        )
+    except ValueError as exc:
+        logger.error(f"/validate: could not mint generic-proxy token: {exc}")
+
+
 def _attach_registry_ui_token(
     request: "Request",
     response: "JSONResponse",
@@ -471,6 +521,57 @@ def _attach_registry_ui_token(
         )
     except ValueError as exc:
         logger.error(f"/validate: could not mint registry-ui token: {exc}")
+
+
+# HTTP verbs that do not change server state. Used by the generic-hop CSRF gate
+# (a state-changing verb under ambient cookie auth is refused) and by the
+# verb->method mapping. OPTIONS is safe (preflight/discovery).
+_SAFE_HTTP_VERBS: frozenset = frozenset({"GET", "HEAD", "OPTIONS"})
+
+# Distinct wildcard token that grants HTTP verbs on a proxied entity. The legacy
+# MCP wildcard ("*"/"all") deliberately does NOT satisfy an HTTP-verb request:
+# an existing scope authored as methods:["*"] (meaning "all MCP methods") must
+# NOT silently start authorizing DELETE/PUT/PATCH the instant an entity it covers
+# is flipped is_proxied=true. HTTP verbs require explicit enumeration
+# (["GET","HEAD"]) or this distinct token. See _method_is_http_verb / the
+# verb-authz check in validate_server_tool_access.
+_HTTP_VERB_WILDCARD: str = "http:*"
+
+
+def _is_cookie_auth_method(auth_method: str) -> bool:
+    """True if the validated auth method is browser/session-cookie based.
+
+    Cookie/session auth is ambient (the browser attaches it automatically on
+    cross-site requests), which is exactly the CSRF risk. Bearer-token callers
+    are programmatic and set the header explicitly, so they are exempt.
+    """
+    return (auth_method or "").lower() in ("session_cookie", "cookie", "session")
+
+
+def _generic_write_csrf_refused(
+    is_generic_request: bool,
+    http_verb: str,
+    auth_method: str,
+    require_bearer: bool,
+) -> bool:
+    """Decide whether a generic-hop request must be refused as a CSRF risk.
+
+    Returns True (refuse with 403, before any token mint) when ALL hold:
+      - the request is for the generic hop (is_generic_request);
+      - the CSRF control is enabled (require_bearer, from
+        GATEWAY_GENERIC_REQUIRE_BEARER_FOR_WRITES, default true);
+      - the HTTP verb is state-changing (not GET/HEAD/OPTIONS); AND
+      - the caller authenticated with an ambient session cookie (not a Bearer
+        token a programmatic client sets explicitly).
+
+    A browser carrying only an mcp_gateway_session cookie therefore cannot make a
+    cross-site DELETE/PUT/PATCH to a proxied resource; Bearer callers are exempt.
+    """
+    if not (is_generic_request and require_bearer):
+        return False
+    if (http_verb or "").upper() in _SAFE_HTTP_VERBS:
+        return False
+    return _is_cookie_auth_method(auth_method)
 
 
 def _read_mcp_proxy_max_body_bytes() -> int:
@@ -1743,7 +1844,11 @@ def _registered_server_from_proxy_path(
 
 
 async def validate_server_tool_access(
-    server_name: str, method: str, tool_name: str, user_scopes: list[str]
+    server_name: str,
+    method: str,
+    tool_name: str,
+    user_scopes: list[str],
+    is_http_verb: bool = False,
 ) -> bool:
     """
     Validate if the user has access to the specified server method/tool based on scopes.
@@ -1753,6 +1858,13 @@ async def validate_server_tool_access(
         method: Name of the method being accessed (e.g., 'initialize', 'notifications/initialized', 'tools/list')
         tool_name: Name of the specific tool being accessed (optional, for tools/call)
         user_scopes: List of user scopes from token
+        is_http_verb: True when ``method`` is an HTTP verb from the generic-proxy
+            hop (GET/POST/...), False for MCP method tokens. When True, the legacy
+            ``"*"``/``"all"`` methods wildcard does NOT grant (that wildcard means
+            "all MCP methods" only); an HTTP verb requires explicit enumeration
+            (``["GET","HEAD"]``) or the distinct ``"http:*"`` token. This blocks a
+            silent privilege escalation where an existing ``methods:["*"]`` scope
+            would start authorizing DELETE/PUT the instant its entity is proxied.
 
     Returns:
         True if access is allowed, False otherwise
@@ -1802,14 +1914,33 @@ async def validate_server_tool_access(
                     logger.debug(f"  Allowed methods for server '{server_name}': {allowed_methods}")
                     logger.debug(f"  Checking if method '{method}' is in allowed methods...")
 
-                    # Check if all methods are allowed (wildcard support)
-                    has_wildcard_methods = "all" in allowed_methods or "*" in allowed_methods
+                    # Wildcard support — SPLIT value spaces (privilege-escalation guard).
+                    # For an HTTP verb (generic-proxy hop), the legacy "*"/"all"
+                    # wildcard does NOT grant: it means "all MCP methods" only. An
+                    # HTTP verb needs explicit enumeration or the distinct "http:*"
+                    # token, so an existing methods:["*"] scope cannot silently start
+                    # authorizing DELETE/PUT when its entity is flipped is_proxied.
+                    if is_http_verb:
+                        has_wildcard_methods = _HTTP_VERB_WILDCARD in allowed_methods
+                    else:
+                        has_wildcard_methods = "all" in allowed_methods or "*" in allowed_methods
+
+                    # HTTP verbs are canonically upper-case (nginx $request_method is
+                    # upper, and /validate upper-cases defensively). Match them
+                    # case-INSENSITIVELY against the stored methods so a scope authored
+                    # as lower-case "get" still authorizes a GET — a read-side backstop
+                    # that covers every write path and pre-existing data, not just the
+                    # editor. MCP method tokens (tools/list, ...) stay case-sensitive.
+                    if is_http_verb:
+                        method_in_allowed = method.upper() in {m.upper() for m in allowed_methods}
+                    else:
+                        method_in_allowed = method in allowed_methods
 
                     # for all methods except tools/call we are good if the method is allowed
                     # for tools/call we need to do an extra validation to check if the tool
                     # itself is allowed or not
                     if (
-                        method in allowed_methods or has_wildcard_methods
+                        method_in_allowed or has_wildcard_methods
                     ) and method != "tools/call":
                         logger.debug(f"  Method '{method}' found in allowed methods")
                         logger.debug(f"scope '{scope}' allows access to {server_name}.{method}")
@@ -1818,6 +1949,19 @@ async def validate_server_tool_access(
                             f"tool='{tool_name}'"
                         )
                         return True
+
+                    # An HTTP verb (generic hop) matches ONLY the methods list —
+                    # never the tools list. Falling through to the tools check
+                    # would let a `tools:["*"]` or backward-compat tools entry
+                    # authorize an HTTP verb, reopening the same escalation the
+                    # methods-wildcard split above closes. Move to the next config.
+                    if is_http_verb:
+                        logger.info(
+                            "  HTTP verb '%s' not in methods; skipping tools fallback "
+                            "(verbs match methods only)",
+                            method,
+                        )
+                        continue
 
                     # Check tools if method not found in methods
                     allowed_tools = server_config.get("tools", [])
@@ -3064,6 +3208,23 @@ async def validate_request(request: Request):
         # any server-scoped request in this state must fail closed (see below).
         body_uninspectable = request.headers.get("X-Body-Uninspectable") == "1"
 
+        # Generic-proxy markers (server-set in the generic nginx location block,
+        # forwarded verbatim by the shared /validate block; empty for MCP / api /
+        # UI requests). These are the discriminator for the generic hop:
+        #   X-Generic-Proxy-Kind        -> entity_type (e.g. "skill"); non-empty
+        #                                  marks a generic request.
+        #   X-Entity-Path               -> the FULL registered path (e.g.
+        #                                  "skills/proxy-demo"); the stable authz id.
+        #   X-Resolved-Generic-Upstream -> the pinned upstream (mint trigger for
+        #                                  _attach_generic_proxy_token).
+        # SECURITY: these are safe to trust ONLY because the shared /validate block
+        # redefines them via proxy_set_header from nginx variables the location set
+        # (not from client headers). See the marker-spoof invariant in the LLD.
+        generic_proxy_kind = (request.headers.get("X-Generic-Proxy-Kind") or "").strip()
+        generic_entity_path = (request.headers.get("X-Entity-Path") or "").strip()
+        original_method = (request.headers.get("X-Original-Method") or "").strip().upper()
+        is_generic_request = bool(generic_proxy_kind)
+
         # Extract server_name and endpoint from original_url early for logging
         server_name_from_url = None
         endpoint_from_url = None
@@ -3684,6 +3845,53 @@ async def validate_request(request: Request):
             # This is an agent proxy request, not an MCP server; skip the MCP
             # server/tool scope validation below.
             server_name = None
+        # --- Generic-proxy request: derive authz identity from the server-set
+        # markers (NOT URL parsing), run the CSRF gate, and use the HTTP verb as
+        # the method token. Registered paths are multi-segment (e.g.
+        # skills/proxy-demo), so the stable authz key is
+        # "{entity_type}/{registered_path}" and the sub-path beyond the registered
+        # path is deliberately NOT part of the key. ---
+        #
+        # KNOWN LIMITATION (fail-closed, by design for this iteration):
+        # resource-bound tokens (token_kind="resource") are NOT usable on the
+        # generic hop. The resource-binding guard below classifies the generic
+        # original_url (e.g. /skill/skills/proxy-demo) as a SERVER, which won't
+        # match a token bound to (SKILL, ...), so it 403s. This is safe (no
+        # escalation, no bypass) and generic routes simply require a full-scope
+        # user token. Adding a /proxy/* rule to resource_binding.classify_request_url
+        # is a deliberate follow-up, not a gap in this slice.
+        if is_generic_request:
+            # CSRF: refuse a state-changing verb under ambient
+            # cookie auth BEFORE any scope check or token mint. Bearer callers are
+            # exempt. Gated by GATEWAY_GENERIC_REQUIRE_BEARER_FOR_WRITES (default
+            # true) so an operator can consciously relax it for a same-site deploy.
+            require_bearer = getattr(settings, "gateway_generic_require_bearer_for_writes", True)
+            if _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb=original_method,
+                auth_method=auth_method,
+                require_bearer=require_bearer,
+            ):
+                logger.warning(
+                    "CSRF: refusing %s on generic route %s/%s under cookie auth "
+                    "(session=%s); Bearer required for state-changing verbs",
+                    original_method,
+                    generic_proxy_kind,
+                    generic_entity_path,
+                    auth_method,
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "State-changing requests to proxied resources require a "
+                        "Bearer token (cookie auth refused as a CSRF defense)"
+                    ),
+                    headers={"Connection": "close"},
+                )
+            # The authz key spans the type + the full registered path. Override the
+            # URL-derived server_name so per-entity scoping works (the URL form
+            # "skill/skills/proxy-demo" would otherwise collapse containers).
+            server_name = f"{generic_proxy_kind}/{generic_entity_path}".strip("/")
 
         if server_name:
             # For ANY server access, enforce scope validation (fail closed principle)
@@ -3732,19 +3940,27 @@ async def validate_request(request: Request):
                 )
 
             # Determine the method to validate:
-            # 1. If we have a tool_name from JSON-RPC payload, use that
-            # 2. If we have an endpoint from the REST API URL, use that
-            # 3. Otherwise default to "initialize"
-            method = (
-                tool_name
-                if tool_name
-                else (endpoint_from_url if endpoint_from_url else "initialize")
-            )
+            # - Generic (non-MCP) request: the upper-cased HTTP verb.
+            # - MCP: tool_name from the JSON-RPC payload, else the REST endpoint,
+            #   else "initialize".
+            if is_generic_request:
+                # nginx only forwards a real request method; default defensively to
+                # the verb so an (impossible) empty value fails closed at scope check.
+                method = original_method or "GET"
+            else:
+                method = (
+                    tool_name
+                    if tool_name
+                    else (endpoint_from_url if endpoint_from_url else "initialize")
+                )
             logger.debug(
-                "Method determined for validation: '%s' (tool_name=%s, endpoint_from_url=%s)",
+                "Method determined for validation: '%s' (generic=%s, tool_name=%s, "
+                "endpoint_from_url=%s, verb=%s)",
                 method,
+                is_generic_request,
                 tool_name,
                 endpoint_from_url,
+                original_method,
             )
             actual_tool_name = None
 
@@ -3769,7 +3985,11 @@ async def validate_request(request: Request):
                 )
 
             if not await validate_server_tool_access(
-                server_name, method, actual_tool_name, user_scopes
+                server_name,
+                method,
+                actual_tool_name,
+                user_scopes,
+                is_http_verb=is_generic_request,
             ):
                 logger.warning(
                     f"Access denied for user {hash_username(validation_result.get('username', ''))} to {server_name}.{method} (tool: {actual_tool_name})"
@@ -4072,6 +4292,21 @@ async def validate_request(request: Request):
             server_name=server_name or "",
             auth_method=_canon_auth_method,
             egress_user=_egress_user,
+        )
+
+        # Generic-proxy hop token (proxied non-MCP entities). Keyed on the
+        # SEPARATE X-Resolved-Generic-Upstream marker, so it fires only for
+        # generic requests and never alongside the MCP mint (disjoint triggers ->
+        # exactly one token). Wired ONLY here on the main 200-path: the static-
+        # credential short-circuits above (federation-static / network-trusted)
+        # never mint a generic token, since they run before the CSRF gate.
+        _attach_generic_proxy_token(
+            request,
+            response,
+            subject=validation_result.get("username") or "",
+            scopes=user_scopes,
+            entity_type=generic_proxy_kind,
+            registered_path=generic_entity_path,
         )
 
         # Registry /api/ hop token. Discriminate cookie vs JWT-bearer: the cookie

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -97,11 +97,13 @@ from registry.audit.sink import emit_audit_event
 from registry.common.scopes_loader import reload_scopes_config
 from registry.common.secret_key import validate_secret_key, validate_signing_secret
 from registry.core.config import settings
-from registry.repositories.factory import get_scope_repository
 
 # Configure logging using shared module (RotatingFileHandler + optional MongoDB)
+from registry.exceptions import UrlValidationError
+from registry.repositories.factory import get_scope_repository
 from registry.utils.logging_setup import setup_logging as _setup_logging
 from registry.utils.request_utils import get_client_ip
+from registry.utils.url_guard import PROXY_PROFILE, guarded_async_client
 
 # Let setup_logging resolve the file path from settings.log_dir /
 # {service_name}.log. Honors APP_LOG_DIR overrides and the new
@@ -1942,9 +1944,7 @@ async def validate_server_tool_access(
                     # for all methods except tools/call we are good if the method is allowed
                     # for tools/call we need to do an extra validation to check if the tool
                     # itself is allowed or not
-                    if (
-                        method_in_allowed or has_wildcard_methods
-                    ) and method != "tools/call":
+                    if (method_in_allowed or has_wildcard_methods) and method != "tools/call":
                         logger.debug(f"  Method '{method}' found in allowed methods")
                         logger.debug(f"scope '{scope}' allows access to {server_name}.{method}")
                         logger.info(
@@ -8058,11 +8058,19 @@ async def generic_proxy(
     semaphore = _get_generic_proxy_semaphore()
     async with semaphore:
         try:
+            # SSRF/rebinding-safe client (CLAUDE.md invariant): the guarded
+            # transport resolves + validates + PINS the connection IP inside the
+            # transport call for the request AND every redirect hop, so a hostname
+            # that rebinds to a private/metadata IP between registration and fetch
+            # is blocked at connect time. PROXY_PROFILE shares the same egress
+            # policy (incl. gateway_proxy_allow_private_targets) the registration
+            # guard uses, so fetch-time and register-time decisions agree.
             # follow_redirects=False (second-SSRF guard): a 30x is returned to the
             # client verbatim (Location forwarded via the allowlist); the next hop
             # re-enters the gateway and is re-authorized. Auto-following would
             # bypass egress validation and could hit an attacker Location.
-            async with httpx.AsyncClient(
+            async with guarded_async_client(
+                profile=PROXY_PROFILE,
                 timeout=30.0,
                 follow_redirects=False,
                 verify=verify,
@@ -8082,6 +8090,20 @@ async def generic_proxy(
                     upstream_headers = dict(upstream_response.headers)
         except HTTPException:
             raise
+        except UrlValidationError as exc:
+            # The guarded transport blocked the outbound at connect time — the
+            # pinned target resolved to a denied (private/metadata/rebound) IP.
+            # This is the fetch-time SSRF net doing its job; surface a deliberate
+            # 502 rather than letting the RegistryError escape as an opaque 500.
+            # Log the reason only, never the raw target (avoid leaking internal
+            # resolution detail to logs on a hostile input).
+            logger.warning(
+                "generic_proxy: egress blocked for %s/%s: %s",
+                entity_type,
+                bound_registered_path,
+                exc.reason,
+            )
+            raise HTTPException(status_code=502, detail="Upstream not permitted") from exc
         except httpx.TimeoutException as exc:
             logger.error(f"generic_proxy: upstream timeout for {outbound_url}: {exc}")
             raise HTTPException(status_code=504, detail="Upstream timed out") from exc

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -136,6 +136,22 @@ map $host $registry_api_auth {
     default "";
 }
 
+# Generic-proxy markers (same http-scope-default rationale as $backend_url above).
+# Set ONLY inside generated generic-proxy location blocks; the shared /validate
+# block forwards them so /validate can discriminate the generic hop and mint the
+# generic-audience token. CRITICAL: $generic_backend_url is SEPARATE from
+# $backend_url so a generic request leaves X-Resolved-Upstream empty and the MCP
+# token mint never fires (exactly one token per request; no double-mint).
+map $host $generic_backend_url {
+    default "";
+}
+map $host $generic_proxy_kind {
+    default "";
+}
+map $host $entity_path {
+    default "";
+}
+
 # Declare $mcp_resource_metadata at http scope (same rationale as $backend_url):
 # @auth_error references it for the WWW-Authenticate resource_metadata. The map
 # default is the gateway-wide PRM URL; obo_exchange location blocks override it
@@ -328,6 +344,16 @@ server {
         # Forward the registry-API marker (set in the /api/ blocks' rewrite phase,
         # empty elsewhere) so /validate mints the registry-UI internal token.
         proxy_set_header X-Registry-Api-Auth $registry_api_auth;
+
+        # Forward the generic-proxy markers (set in the generic location blocks'
+        # rewrite phase, empty elsewhere) so /validate discriminates the generic
+        # hop, runs the CSRF gate, and mints the generic-audience token bound to
+        # this pinned upstream + entity. proxy_set_header REDEFINES (not appends),
+        # overriding any same-named client header — so these cannot be spoofed by a
+        # client unless the request transited a location block that set the var.
+        proxy_set_header X-Resolved-Generic-Upstream $generic_backend_url;
+        proxy_set_header X-Generic-Proxy-Kind $generic_proxy_kind;
+        proxy_set_header X-Entity-Path $entity_path;
 
         # Extract and pass Cognito config headers from original request
         proxy_set_header X-User-Pool-Id $http_x_user_pool_id;
@@ -1157,6 +1183,16 @@ server {
         # Forward the registry-API marker (set in the /api/ blocks' rewrite phase,
         # empty elsewhere) so /validate mints the registry-UI internal token.
         proxy_set_header X-Registry-Api-Auth $registry_api_auth;
+
+        # Forward the generic-proxy markers (set in the generic location blocks'
+        # rewrite phase, empty elsewhere) so /validate discriminates the generic
+        # hop, runs the CSRF gate, and mints the generic-audience token bound to
+        # this pinned upstream + entity. proxy_set_header REDEFINES (not appends),
+        # overriding any same-named client header — so these cannot be spoofed by a
+        # client unless the request transited a location block that set the var.
+        proxy_set_header X-Resolved-Generic-Upstream $generic_backend_url;
+        proxy_set_header X-Generic-Proxy-Kind $generic_proxy_kind;
+        proxy_set_header X-Entity-Path $entity_path;
 
         # Extract and pass Cognito config headers from original request
         proxy_set_header X-User-Pool-Id $http_x_user_pool_id;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -139,6 +139,22 @@ map $host $registry_api_auth {
     default "";
 }
 
+# Generic-proxy markers (same http-scope-default rationale as $backend_url above).
+# Set ONLY inside generated generic-proxy location blocks; the shared /validate
+# block forwards them so /validate can discriminate the generic hop and mint the
+# generic-audience token. CRITICAL: $generic_backend_url is SEPARATE from
+# $backend_url so a generic request leaves X-Resolved-Upstream empty and the MCP
+# token mint never fires (exactly one token per request; no double-mint).
+map $host $generic_backend_url {
+    default "";
+}
+map $host $generic_proxy_kind {
+    default "";
+}
+map $host $entity_path {
+    default "";
+}
+
 # Declare $mcp_resource_metadata at http scope. @auth_error references it; the
 # map default is the gateway-wide PRM URL; obo_exchange location blocks override
 # it per-location so MCP clients discover the per-server resource (RFC 9728).
@@ -550,6 +566,16 @@ server {
         # Forward the registry-API marker (set in the /api/ blocks' rewrite phase,
         # empty elsewhere) so /validate mints the registry-UI internal token.
         proxy_set_header X-Registry-Api-Auth $registry_api_auth;
+
+        # Forward the generic-proxy markers (set in the generic location blocks'
+        # rewrite phase, empty elsewhere) so /validate discriminates the generic
+        # hop, runs the CSRF gate, and mints the generic-audience token bound to
+        # this pinned upstream + entity. proxy_set_header REDEFINES (not appends),
+        # overriding any same-named client header — so these cannot be spoofed by a
+        # client unless the request transited a location block that set the var.
+        proxy_set_header X-Resolved-Generic-Upstream $generic_backend_url;
+        proxy_set_header X-Generic-Proxy-Kind $generic_proxy_kind;
+        proxy_set_header X-Entity-Path $entity_path;
 
         # Extract and pass Cognito config headers from original request
         proxy_set_header X-User-Pool-Id $http_x_user_pool_id;

--- a/docs/SECURITY_GUIDELINES.md
+++ b/docs/SECURITY_GUIDELINES.md
@@ -725,7 +725,7 @@ the drift between copies is the hole.
   `guarded_client(profile=...)` / `guarded_async_client(profile=...)` — they
   validate + pin the resolved public IP inside the transport (rebinding-safe,
   re-validated per redirect). IP category policy and literal/tunnel unwrapping
-  live in `registry/utils/ip_guard.py`; URL identity and safe logging use
+  live in `registry/utils/url_guard.py`; URL identity and safe logging use
   `normalize_url_identity()` and `sanitized_url_for_log()`. Pick the profile:
   `SKILL_PROFILE` (skill/doc fetches), `PROXY_PROFILE` (server/agent targets),
   `FEDERATION_PROFILE` (credentialed federation), or the HTTPS-only empty-

--- a/docs/design/gateway-generic-proxy.md
+++ b/docs/design/gateway-generic-proxy.md
@@ -1,0 +1,272 @@
+# Gateway Generic Proxy — Design
+
+Status: Foundation landed dark (PR #1628, stack for #1565). Feature is off by
+default and a no-op in production until a later slice flips the flags.
+
+Related design docs: [egress-auth-design.md](egress-auth-design.md),
+[internal-hop-authentication.md](internal-hop-authentication.md),
+[virtual-mcp-server.md](virtual-mcp-server.md),
+[storage-architecture-mongodb-documentdb.md](storage-architecture-mongodb-documentdb.md).
+
+## Problem
+
+Today the gateway can reverse-proxy only two entity types: MCP servers (at
+`/mcp-proxy/...`) and A2A agents (at `/agent/...`). Every other registry
+entity — skills, custom entities, and agents that want a uniform hop — has no
+gateway-fronted route, so a client must reach it directly. That defeats the point
+of a gateway: one authenticated ingress, one audit point, one egress policy.
+
+This feature lets **any** entity opt into being served through the gateway by
+setting `is_proxied=true` and (where it has no native backend) a
+`proxy_target_url`. The registry then renders an nginx location block that routes
+authenticated traffic through a single uniform auth-server hop to the entity's
+backend, with SSRF defense in depth at every layer.
+
+## Scope and non-goals
+
+- **In scope for the generic hop:** `a2a_agent`, `skill`, `custom`.
+- **Unchanged:** MCP servers keep their legacy `/mcp-proxy/...` route; existing
+  agent routes keep `/agent/...`. Nothing existing is relocated.
+- **Alias-only:** virtual servers never emit a generic block.
+- **Ships dark:** `gateway_generic_proxy_enabled`,
+  `gateway_canonical_namespace_enabled`, `gateway_proxy_allow_private_targets`
+  all default `false`. With the feature off, no location block renders, `/validate`
+  mints no generic token, and the render path issues **zero** additional per-tick
+  DB queries.
+
+## Path model — what changes and what does not
+
+`/proxy/{entity_type}/{path}/` is the **internal** auth-server endpoint nginx
+forwards to; a client never calls it. The client-facing location is
+`/{entity_type}/{path}`.
+
+| Entity | Route today | After this feature (when enabled) |
+|---|---|---|
+| MCP server | `/mcp-proxy/...` | unchanged |
+| A2A agent (existing) | `/agent/...` | unchanged |
+| A2A agent (opted-in) | — | additional `/a2a_agent/...` generic route |
+| Skill / custom (opted-in) | not proxyable | new `/skill/...`, `/{custom-type}/...` |
+| Virtual server | alias-only | alias-only (no generic block) |
+
+`gateway_canonical_namespace_enabled` is defined but read nowhere in this
+foundation PR — a dormant placeholder. Its intent (per its config docstring) is a
+later slice that emits canonical `/entity_type/path` blocks **alongside** the
+legacy flat aliases (additive, including for MCP servers), gated until the matching
+`/validate` entity-derivation and canonical-alias minting land.
+
+---
+
+## DocumentDB / MongoDB changes
+
+This is the only storage-facing part of the feature, and it is deliberately small.
+There is **no schema migration and no backfill**.
+
+### 1. New persisted fields (the `ProxyableMixin`)
+
+`registry/schemas/proxy_mixin.py` defines `ProxyableMixin`, mixed into the five
+storage models (server, agent, skill, virtual server, custom entity) and their
+request/patch models. These fields therefore become part of each entity document:
+
+| Field | Type | Written by | Meaning |
+|---|---|---|---|
+| `is_proxied` | `bool` (default `false`) | admin opt-in (API) | when true, the entity gets a gateway route |
+| `proxy_target_url` | `str \| None` | admin (API) | backend the gateway forwards to; required for skills/custom (they have no native backend URL) |
+| `proxy_resolved_ips` | `list[str]` | resolve-and-validate refresh | IPs the hostname last resolved to (egress re-validation bookkeeping) |
+| `proxy_target_host` | `str \| None` | refresh | original hostname preserved for Host/SNI |
+| `proxy_disabled_reason` | `str \| None` | refresh | set when the refresh auto-disables a route (e.g. target now resolves to a denied IP); when non-null the entity is treated as NOT proxied |
+
+Because every field has a default, this is a **purely additive, backward-compatible
+schema change**. Existing documents simply lack the keys; `is_proxied` reads as its
+default (`false`), so a legacy row is "not proxied" with no migration step. A
+document is never rejected on read for a missing or even a bad proxy value — see
+the read-safety note below.
+
+### 2. New index — `idx_is_proxied`
+
+`registry/repositories/documentdb/_identity_url_sidecar.py` adds
+`ensure_is_proxied_index(collection, name)`, called from each DocumentDB
+repository's `ensure_indexes()` (server, agent, skill, custom, virtual):
+
+- **Preferred:** a *partial* index
+  `create_index("is_proxied", partialFilterExpression={"is_proxied": True})` so
+  only the (few) proxied documents are indexed.
+- **Fallback:** AWS DocumentDB may reject `partialFilterExpression`, so on failure
+  it creates a plain single-field index `idx_is_proxied_plain`. The
+  `{"is_proxied": True}` query uses either.
+- **Never raises.** If both fail, `list_proxied` still works via an unindexed scan —
+  the index is an optimization, not a correctness requirement. Crucially it runs
+  *after* `_indexes_created` is set, so an index failure can't leave that guard
+  `False` and re-run every index on every op.
+
+### 3. New query — `list_proxied()`
+
+Each DocumentDB repository gets `list_proxied()` (the base interface returns `[]`,
+so non-DocumentDB backends are a safe no-op). It is a **projected** query returning
+raw dicts, not reconstructed model objects:
+
+```python
+projection = {
+    "is_proxied": 1, "is_enabled": 1, "proxy_target_url": 1,
+    "proxy_resolved_ips": 1, "proxy_target_host": 1,
+    "proxy_disabled_reason": 1, "sync_metadata": 1,
+}
+cursor = collection.find({"is_proxied": True}, projection)  # then _id -> "path"
+```
+
+Two deliberate properties:
+- **Projection, not full doc:** only the columns the nginx render +
+  `resolve_proxy_target` need, keeping the render hot path cheap.
+- **Raw dicts, not model reconstruction:** a bypass-written invalid row (federation
+  raw write, migration, manual edit) cannot crash the nginx reload by throwing
+  during Pydantic reconstruction. On any error the method logs and returns `[]`
+  (fail-closed to "nothing to render").
+
+### 4. Zero queries while disabled
+
+`_fetch_generic_proxied_resources()` (the render-time collector) early-returns `[]`
+when `gateway_generic_proxy_enabled` is false, **before** touching any repository.
+An upgraded-but-not-enabled deployment pays no new per-tick fan-out. There is a test
+asserting zero new DB queries in the disabled state.
+
+### Storage read-safety (why no raising validator on stored docs)
+
+The mixin has **no raising field validator** on `proxy_target_url`. Storage models
+are reconstructed from the DB on every read; a raising egress check would make a
+denied-but-stored target throw on load, and because listings skip rows that fail to
+build, the bad record would silently vanish from every listing — hiding exactly what
+an admin needs to fix. So the raising check lives only on the request/patch models
+(the API edge, built from client payloads, never from stored data). For stored data
+the enforcement is that the render/fetch path simply does not produce a route for a
+denied target.
+
+---
+
+## End-to-end request sequence (example: a proxied skill)
+
+Assume a skill registered at path `skills/proxy-demo`, flagged `is_proxied=true`
+with `proxy_target_url=https://backend.internal.example/api`, and the feature
+enabled. A client calls `GET {ROOT_PATH}/skill/skills/proxy-demo/tools`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant N as nginx (gateway)
+    participant V as auth-server /validate
+    participant P as auth-server /proxy hop
+    participant G as url_guard (guarded_async_client)
+    participant B as Skill backend
+
+    C->>N: GET /skill/skills/proxy-demo/tools (Bearer or session cookie)
+    Note over N: Matches the generic location /skill/...<br/>sets generic_backend_url, generic_proxy_kind=skill,<br/>entity_path=skills/proxy-demo
+    N->>V: auth_request /validate<br/>X-Generic-Proxy-Kind, X-Entity-Path,<br/>X-Original-Method (server-set, not client)
+    Note over V: 1. is_generic_request is true (kind non-empty)<br/>2. CSRF gate. state-changing verb + cookie auth gives 403.<br/>GET here is safe and passes<br/>3. verb maps to scope method. MCP wildcard does NOT authorize a verb<br/>4. scope check against the entity path
+    alt authorized
+        V-->>N: 200 + X-Internal-Token-Generic (generic audience),<br/>X-User, X-Scopes
+    else denied
+        V-->>N: 401/403 goes to auth_error or forbidden_error
+        N-->>C: 401/403
+    end
+    N->>P: proxy_pass /proxy/skill/skills/proxy-demo/tools/<br/>X-Internal-Token-Generic, X-Upstream-Url is ignored
+    Note over P: verify_generic_proxy_token.<br/>decode against GENERIC_PROXY_AUDIENCE, bind entity_type + full path.<br/>upstream_url comes from the TOKEN, not the header
+    Note over P: feature latch active, else 503.<br/>build confined outbound URL (sub-path on pinned base).<br/>assert_outbound_host_pinned
+    P->>G: guarded_async_client (PROXY_PROFILE, no redirect follow)
+    Note over G: resolve + validate + PIN connection IP.<br/>metadata, private, link-local denied.<br/>re-validated on every redirect hop
+    G->>B: GET https://backend.internal.example/api/tools
+    B-->>G: 200 body (bounded read)
+    G-->>P: response
+    Note over P: response-header allowlist drops Set-Cookie, HSTS, CSP, framing.<br/>gateway then sets its own security headers
+    P-->>N: buffered response
+    N-->>C: response
+```
+
+### Reading the shapes
+
+1. **nginx generic location block.** Rendered per proxied entity. It sets
+   `$generic_backend_url` (a *separate* variable from the MCP `$backend_url`, so the
+   MCP token mint never fires here), `$generic_proxy_kind`, and `$entity_path`, then
+   issues the `auth_request /validate` subrequest and forwards the server-set marker
+   headers.
+2. **`/validate` (the authz brain).** Discriminates the generic hop by the non-empty
+   `X-Generic-Proxy-Kind`. Runs the CSRF gate first (a state-changing verb under
+   ambient cookie auth is refused with 403 before any token mint; Bearer callers
+   exempt; gated by `gateway_generic_require_bearer_for_writes`). Maps the HTTP verb
+   to a scope method — the legacy MCP `methods:["*"]` wildcard does **not** authorize
+   an HTTP verb (that needs explicit `["GET","HEAD"]` or the distinct `http:*`
+   token). On success it mints the generic-audience internal token into
+   `X-Internal-Token-Generic`.
+   - **Marker-spoof invariant:** the marker headers are trusted only because the
+     shared `/validate` block redefines them via `proxy_set_header` from nginx
+     variables the location set — never from client headers.
+3. **`/proxy/{entity_type}/{entity_path:path}` (the uniform hop).**
+   `verify_generic_proxy_token` decodes the token against `GENERIC_PROXY_AUDIENCE`
+   and binds both `entity_type` and the full registered path on a segment boundary.
+   The destination is taken from the **token claim** `upstream_url`, not the inbound
+   `X-Upstream-Url` header (which is ignored). It builds a confined outbound URL
+   (sub-path appended to the pinned base) and asserts the host stayed pinned.
+4. **Fetch via `guarded_async_client` (PROXY_PROFILE).** Resolves, validates every
+   IP, and pins the connection IP inside the transport for the request and each
+   redirect. `follow_redirects=False`: a 30x is returned to the client verbatim so
+   the next hop re-enters the gateway and is re-authorized. Same egress policy as
+   registration time, so decisions can't drift.
+5. **Response shaping.** A response-header allowlist drops `Set-Cookie`/HSTS/CSP/
+   framing; the gateway sets its own security headers. Body is read bounded
+   (`gateway_generic_client_max_body_size` / `gateway_generic_max_concurrency`).
+
+### Failure shapes
+
+- Feature latch off (flag disabled or startup egress self-check failed) → `503`.
+- Missing/invalid/wrong-audience token → `401` at the hop.
+- Egress blocked at connect time (pinned target resolved to a denied IP) → `502`
+  ("Upstream not permitted"), logged by reason only (never the raw target).
+- Upstream timeout → `504`; other upstream error → `502`.
+
+---
+
+## How a route comes to exist (registration → render)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Admin (API)
+    participant S as Entity service (register/update)
+    participant M as DocumentDB
+    participant R as nginx render (config regen)
+
+    A->>S: register/update skill (is_proxied true, proxy_target_url set)
+    Note over S: request model validator. STATIC literal-IP egress check, 422 on deny
+    Note over S: validate_and_pin_proxy_target. DNS resolve + validate EVERY IP.<br/>4xx on deny. writes proxy_resolved_ips, proxy_target_host
+    S->>M: persist doc (proxy fields + pin bookkeeping)
+    Note over R: on next config regen with feature enabled
+    R->>M: list_proxied per repo (indexed is_proxied true, projected)
+    Note over R: resolve_proxy_target drops federated, disabled,<br/>auto-disabled, and targetless rows
+    Note over R: safe_generic_block. SKIP-not-fail render guard checking<br/>scheme, egress, entity-type grammar, dot-dot segments, breakout chars.<br/>plus cross-placeholder collision dedup, generic is lowest precedence
+    R->>R: emit the entity_type/path location block, run nginx -t, reload
+```
+
+The egress policy is enforced at three points on the one canonical `url_guard`:
+the API edge (static, 422), the service register/update layer (DNS-aware, 4xx), and
+fetch time (pinned transport). A federation sync stripping proxy fields on ingest
+and export means peer data can never become a live local route.
+
+---
+
+## Configuration (all fail-closed)
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `gateway_generic_proxy_enabled` | `false` | master switch; gates render fetch + hop |
+| `gateway_canonical_namespace_enabled` | `false` | dormant placeholder (future canonical aliases) |
+| `gateway_proxy_allow_private_targets` | `false` | relax loopback/private/CGNAT only (metadata never overridable) |
+| `gateway_generic_require_bearer_for_writes` | `true` | refuse state-changing verbs under ambient cookie auth |
+| `gateway_generic_client_max_body_size` | `1m` | inbound body cap (strict nginx size-token validator) |
+| `gateway_generic_max_concurrency` | (set) | in-flight cap on the hop |
+| `gateway_generic_tls_verify` | (set) | upstream TLS verification mode |
+| `gateway_egress_selfcheck_enabled` | (set) | probe metadata IPs at startup; disable feature if egress not enforced |
+
+## Observability
+
+- `mcpgw_registry_gateway_generic_blocks_dropped_total{reason=invalid|collision}` —
+  counts render-time drops.
+- `gateway_egress_policy_unverified` — gauge set to 1 when the startup egress
+  self-check found metadata reachable (feature latched off for the process).

--- a/registry/api/agent_routes.py
+++ b/registry/api/agent_routes.py
@@ -1087,6 +1087,9 @@ async def register_agent(
             source_created_at=source_created_dt,
             source_updated_at=source_updated_dt,
             external_tags=external_tag_list,
+            # Gateway-proxy opt-in (validated on the request model; carried through).
+            is_proxied=request.is_proxied,
+            proxy_target_url=request.proxy_target_url,
             **optional_card_kwargs,
         )
 
@@ -2293,6 +2296,10 @@ async def update_agent(
             allowed_groups=request.allowed_groups,
             trust_level=request.trust_level,
             supported_protocol=request.supported_protocol,
+            # Gateway-proxy opt-in: carry from the request (PUT is full-replacement),
+            # else an unrelated edit would silently reset the opt-in to defaults.
+            is_proxied=request.is_proxied,
+            proxy_target_url=request.proxy_target_url,
             registered_by=existing_agent.registered_by,
             registered_at=existing_agent.registered_at,
             is_enabled=existing_agent.is_enabled,

--- a/registry/api/federation_export_routes.py
+++ b/registry/api/federation_export_routes.py
@@ -284,19 +284,27 @@ def _item_to_dict(
     item: Any,
 ) -> dict[str, Any]:
     """
-    Convert item to dictionary, supporting both dict and object types.
+    Convert item to a dictionary for federation export, supporting dict and
+    Pydantic-model inputs.
+
+    Strips the gateway-proxy fields (is_proxied/proxy_target_url + refresh
+    bookkeeping): proxy config is local-only and must never be advertised to a
+    peer — in particular proxy_target_url is an internal backend URL. See
+    registry.schemas.proxy_mixin.strip_proxy_fields.
 
     Args:
         item: Dict or Pydantic model
 
     Returns:
-        Dictionary representation
+        Dictionary representation with proxy fields removed
     """
+    from registry.schemas.proxy_mixin import strip_proxy_fields
+
     if isinstance(item, dict):
-        return item
+        return strip_proxy_fields(item)
     if hasattr(item, "model_dump"):
-        return item.model_dump()
-    return dict(item)
+        return strip_proxy_fields(item.model_dump())
+    return strip_proxy_fields(dict(item))
 
 
 def _paginate(

--- a/registry/api/federation_routes.py
+++ b/registry/api/federation_routes.py
@@ -21,6 +21,7 @@ from ..schemas.federation_schema import (
     AwsRegistryConfig,
     FederationConfig,
 )
+from ..schemas.proxy_mixin import strip_proxy_fields
 
 logging.basicConfig(
     level=logging.INFO,
@@ -1058,6 +1059,10 @@ async def sync_federation(
 
             for server_data in servers:
                 try:
+                    # Strip peer-supplied proxy fields: federated entities are
+                    # never local gateway routes (owner decision), and this blocks
+                    # a peer planting an SSRF proxy_target_url. See strip_proxy_fields.
+                    server_data = strip_proxy_fields(server_data)
                     server_path = server_data.get("path")
                     if not server_path:
                         logger.warning(
@@ -1197,6 +1202,7 @@ async def sync_federation(
             # Register servers (MCP records)
             for srv in records["servers"]:
                 try:
+                    srv = strip_proxy_fields(srv)  # peer content: no proxying federated entities
                     srv_path = srv.get("path")
                     if not srv_path:
                         continue
@@ -1219,6 +1225,7 @@ async def sync_federation(
             # Register agents (A2A + CUSTOM records)
             for agent_data in records["agents"]:
                 try:
+                    agent_data = strip_proxy_fields(agent_data)  # peer content: no proxying
                     agent_path = agent_data.get("path")
                     if not agent_path:
                         continue
@@ -1238,6 +1245,7 @@ async def sync_federation(
             skill_repo = get_skill_repository()
             for skill_data in records["skills"]:
                 try:
+                    skill_data = strip_proxy_fields(skill_data)  # peer content: no proxying
                     skill_path = skill_data.get("path")
                     if not skill_path:
                         continue

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1339,6 +1339,51 @@ class Settings(BaseSettings):
             "deployment. Consumed by the auth-server."
         ),
     )
+    generic_proxy_max_body_bytes: int = Field(
+        default=10 * 1024 * 1024,
+        ge=1024,
+        description=(
+            "Upper bound (bytes) on the buffered UPSTREAM RESPONSE body the "
+            "generic hop reads before returning (mirrors MCP_PROXY_MAX_BODY_BYTES). "
+            "The hop is unary/response-buffering in v1, so worst-case transient "
+            "heap is roughly this times gateway_generic_max_concurrency — size "
+            "both against the auth-server memory limit. Distinct from the nginx "
+            "gateway_generic_client_max_body_size (inbound request body). "
+            "Consumed by the auth-server."
+        ),
+    )
+    gateway_generic_max_concurrency: int = Field(
+        default=32,
+        ge=1,
+        description=(
+            "Semaphore cap on in-flight generic-hop requests (OOM guard). "
+            "Worst-case auth-server heap from buffering approx = "
+            "generic_proxy_max_body_bytes * this. Tune down for memory-"
+            "constrained single-replica deployments. Consumed by the auth-server."
+        ),
+    )
+    gateway_generic_tls_verify: str = Field(
+        default="true",
+        description=(
+            "TLS verification for the generic hop's httpx client to HTTPS "
+            "targets. 'true' = verify against the system trust store (default); a "
+            "filesystem path = custom CA bundle (private-CA dashboards); 'false' = "
+            "disable verification (NOT recommended; emits a startup WARNING). "
+            "Passed to httpx.AsyncClient(verify=...). Consumed by the auth-server."
+        ),
+    )
+    gateway_egress_selfcheck_enabled: bool = Field(
+        default=True,
+        description=(
+            "Startup egress self-check. When the generic proxy is enabled, the "
+            "auth-server probe-connects to the cloud metadata IPs; if EITHER is "
+            "reachable (egress not actually restricted), it logs CRITICAL, emits "
+            "gateway_egress_policy_unverified=1, and DISABLES the generic-proxy "
+            "feature for this process (NOT pod readiness). Opt out only where the "
+            "metadata IP is legitimately reachable but proxying is constrained "
+            "another way. Consumed by the auth-server."
+        ),
+    )
 
     @property
     def nginx_updates_enabled(self) -> bool:

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import UTC
 from enum import Enum
 from pathlib import Path
@@ -1257,6 +1258,73 @@ class Settings(BaseSettings):
             "Clock-skew leeway (seconds) on the /mcp-proxy internal token exp/iat checks."
         ),
     )
+
+    # --- Gateway generic-proxy feature (registry-consumed subset) ---------------
+    # These four are read by the registry (nginx config generation + egress
+    # validation at registration). The seven runtime knobs consumed by the
+    # auth-server live in the auth_server config. All security-relevant toggles
+    # default to the SAFE value: the feature ships disabled and fails closed.
+    gateway_generic_proxy_enabled: bool = Field(
+        default=False,
+        description=(
+            "Master switch for generating generic-proxy nginx location blocks "
+            "for proxied non-MCP entities. Defaults false: the feature ships "
+            "dark. When false, only MCP/virtual blocks are generated (pre-feature "
+            "behavior) and NO extra per-tick DB queries are issued. Do not enable "
+            "until the network egress policy (SSRF layer 1) is deployed and the "
+            "registration-time resolve-and-validate + CSRF defenses are in place."
+        ),
+    )
+    gateway_canonical_namespace_enabled: bool = Field(
+        default=False,
+        description=(
+            "Emit canonical /entity_type/path nginx blocks alongside the legacy "
+            "flat /path aliases. Defaults false until the /validate "
+            "entity-derivation and canonical-alias minting changes land "
+            "(otherwise canonical MCP aliases 401 and existing scopes 403 on "
+            "canonical URLs)."
+        ),
+    )
+    gateway_proxy_allow_private_targets: bool = Field(
+        default=False,
+        description=(
+            "SSRF egress policy. When false (default), proxy_target_url hosts in "
+            "loopback/private/reserved ranges are rejected at registration and "
+            "render. Link-local/metadata (169.254.0.0/16, fe80::/10) and the "
+            "unspecified address (0.0.0.0, ::) are denied regardless of this "
+            "flag. Set true only for trusted on-cluster service URLs."
+        ),
+    )
+    gateway_generic_client_max_body_size: str = Field(
+        default="1m",
+        description=(
+            "nginx client_max_body_size for generic-proxy location blocks — "
+            "bounds the inbound REQUEST body. Distinct from the auth-server's "
+            "GENERIC_PROXY_MAX_BODY_BYTES response cap. nginx defaults to 1m; "
+            "raise for upload-heavy proxied backends. Must be an nginx size "
+            "token: digits with an optional k/m/g suffix (e.g. 1m, 512k, 2G)."
+        ),
+    )
+
+    @field_validator("gateway_generic_client_max_body_size")
+    @classmethod
+    def _validate_client_max_body_size(
+        cls,
+        v: str,
+    ) -> str:
+        """Reject anything that is not a valid nginx size token.
+
+        This value is rendered verbatim into an nginx ``client_max_body_size``
+        directive, so an invalid token would break the config reload for every
+        route on the replica, and an unsanitized value would be a config-injection
+        surface. Enforce the strict nginx size grammar at config-load time.
+        """
+        if not re.fullmatch(r"\d+[kKmMgG]?", v):
+            raise ValueError(
+                f"gateway_generic_client_max_body_size={v!r} is not a valid nginx "
+                "size token (expected digits with an optional k/m/g suffix, e.g. 1m)"
+            )
+        return v
 
     @property
     def nginx_updates_enabled(self) -> bool:

--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1326,6 +1326,20 @@ class Settings(BaseSettings):
             )
         return v
 
+    gateway_generic_require_bearer_for_writes: bool = Field(
+        default=True,
+        description=(
+            "CSRF defense for the generic-proxy hop. When true (default), a "
+            "state-changing verb (anything but GET/HEAD/OPTIONS) on a generic "
+            "route is refused (403 at /validate, before any token mint) if the "
+            "caller authenticated with a session cookie rather than a Bearer "
+            "token. A browser carrying only an ambient mcp_gateway_session cookie "
+            "therefore cannot perform cross-site DELETE/PUT/PATCH; programmatic "
+            "Bearer callers are unaffected. Relax only for a trusted same-site "
+            "deployment. Consumed by the auth-server."
+        ),
+    )
+
     @property
     def nginx_updates_enabled(self) -> bool:
         """Check if nginx updates should be performed."""

--- a/registry/core/metrics.py
+++ b/registry/core/metrics.py
@@ -47,6 +47,9 @@ from registry.observability.meters import (
     embedding_removal_failures_total as EMBEDDING_REMOVAL_FAILURES_TOTAL,
 )
 from registry.observability.meters import (
+    gateway_egress_policy_unverified as GATEWAY_EGRESS_POLICY_UNVERIFIED,
+)
+from registry.observability.meters import (
     gateway_generic_blocks_dropped_total as GATEWAY_GENERIC_BLOCKS_DROPPED,
 )
 from registry.observability.meters import (
@@ -117,6 +120,7 @@ __all__ = [
     "CONFIG_VIEW_REQUESTS",
     "DEPLOYMENT_MODE_INFO",
     "EMBEDDING_REMOVAL_FAILURES_TOTAL",
+    "GATEWAY_EGRESS_POLICY_UNVERIFIED",
     "GATEWAY_GENERIC_BLOCKS_DROPPED",
     "M2M_ORPHAN_CLEANUPS_TOTAL",
     "MODE_BLOCKED_REQUESTS",

--- a/registry/core/metrics.py
+++ b/registry/core/metrics.py
@@ -47,6 +47,9 @@ from registry.observability.meters import (
     embedding_removal_failures_total as EMBEDDING_REMOVAL_FAILURES_TOTAL,
 )
 from registry.observability.meters import (
+    gateway_generic_blocks_dropped_total as GATEWAY_GENERIC_BLOCKS_DROPPED,
+)
+from registry.observability.meters import (
     m2m_orphan_cleanups_total as M2M_ORPHAN_CLEANUPS_TOTAL,
 )
 from registry.observability.meters import (
@@ -114,6 +117,7 @@ __all__ = [
     "CONFIG_VIEW_REQUESTS",
     "DEPLOYMENT_MODE_INFO",
     "EMBEDDING_REMOVAL_FAILURES_TOTAL",
+    "GATEWAY_GENERIC_BLOCKS_DROPPED",
     "M2M_ORPHAN_CLEANUPS_TOTAL",
     "MODE_BLOCKED_REQUESTS",
     "NGINX_CONFIG_WRITES",

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1888,7 +1888,10 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Internal-Token $auth_internal_token_generic;
+        # The generic hop's verify_generic_proxy_token reads X-Internal-Token-Generic
+        # (distinct from the MCP hop's X-Internal-Token so they never collide). Must
+        # match that header name exactly, or the hop 401s "Missing internal proxy token".
+        proxy_set_header X-Internal-Token-Generic $auth_internal_token_generic;
         proxy_set_header Authorization $http_authorization;
         proxy_set_header X-User $auth_user;
         proxy_set_header X-Scopes $auth_scopes;

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -8,7 +8,7 @@ import os
 import re
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
 import httpx
@@ -2989,6 +2989,12 @@ async def _fetch_all_enabled_servers() -> dict[str, Any]:
 _GENERIC_PROXY_ENTITY_TYPES: tuple[str, ...] = ("a2a_agent", "skill", "custom")
 
 
+class _ProxiedRepository(Protocol):
+    """Structural type shared by repositories queried for proxied records."""
+
+    async def list_proxied(self) -> list[dict[str, Any]]: ...
+
+
 async def _fetch_generic_proxied_resources() -> list[dict[str, Any]]:
     """Collect non-MCP entities that opt into the generic gateway proxy.
 
@@ -3015,7 +3021,7 @@ async def _fetch_generic_proxied_resources() -> list[dict[str, Any]]:
     )
     from registry.schemas.proxy_mixin import resolve_proxy_target
 
-    repos = {
+    repos: dict[str, _ProxiedRepository] = {
         "a2a_agent": get_agent_repository(),
         "skill": get_skill_repository(),
         "custom": get_custom_entity_repository(),

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -14,10 +14,15 @@ from urllib.parse import urlparse
 import httpx
 
 from registry.constants import REGISTRY_CONSTANTS, DeploymentType, HealthStatus
+from registry.schemas.proxy_mixin import _assert_egress_allowed
 
 from .config import settings
 from .endpoint_utils import get_endpoint_url_from_server_info
-from .metrics import NGINX_CONFIG_WRITES, NGINX_UPDATES_SKIPPED
+from .metrics import (
+    GATEWAY_GENERIC_BLOCKS_DROPPED,
+    NGINX_CONFIG_WRITES,
+    NGINX_UPDATES_SKIPPED,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1339,10 +1344,31 @@ class NginxConfigService:
                         else virtual_backend_locations
                     )
 
+                # Generic-proxy blocks (proxied non-MCP entities). These join the
+                # VIRTUAL_SERVER_BLOCKS placeholder; nginx concatenates both
+                # placeholders into one server{} block, so a generic location that
+                # collides with ANY higher-precedence block (legacy MCP in
+                # location_blocks, or virtual above) must be dropped. Seed
+                # claimed_paths with both sources so the collision check spans them.
+                # Flag-gated inside _fetch_generic_proxied_resources: zero DB queries
+                # (and no-op here) when the feature is disabled.
+                claimed_paths: set[str] = set()
+                for mcp_block in location_blocks:
+                    claimed_paths |= self._location_paths_in(mcp_block)
+                claimed_paths |= self._location_paths_in(virtual_blocks)
+
+                generic_blocks = await self._generate_generic_proxy_blocks(claimed_paths)
+                if generic_blocks:
+                    generic_text = "\n".join(generic_blocks)
+                    virtual_blocks = (
+                        virtual_blocks + "\n" + generic_text if virtual_blocks else generic_text
+                    )
+
                 config_content = config_content.replace("{{VIRTUAL_SERVER_BLOCKS}}", virtual_blocks)
 
                 logger.info(
-                    f"Generated virtual server config with {len(virtual_servers)} virtual servers"
+                    f"Generated virtual server config with {len(virtual_servers)} virtual "
+                    f"servers and {len(generic_blocks)} generic-proxy blocks"
                 )
             except Exception as e:
                 logger.error(f"Failed to generate virtual server config: {e}", exc_info=True)
@@ -1777,6 +1803,206 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         except Exception as e:
             logger.error(f"Failed to generate virtual server blocks: {e}", exc_info=True)
             return ""
+
+    # Matches a `location [=] <path> {` directive so a generated block's nginx
+    # location path can be extracted for collision dedup. The path is a greedy
+    # run of non-whitespace and MUST be followed by whitespace then the opening
+    # brace — otherwise a `{{ROOT_PATH}}` placeholder's own brace would be
+    # mistaken for the block opener. Tolerates the unsubstituted `{{ROOT_PATH}}`
+    # prefix (stripped by the caller before comparison).
+    _LOCATION_DIRECTIVE_RE = re.compile(r"^\s*location\s+(?:=\s+)?(\S+)\s+\{", re.MULTILINE)
+
+    @classmethod
+    def _location_paths_in(
+        cls,
+        block_text: str,
+    ) -> set[str]:
+        """Extract the set of nginx location paths declared in a block string.
+
+        Used to detect cross-block ``location`` collisions (duplicate location
+        directives fail ``nginx -t`` and block the reload for the whole replica).
+        Commented-out location lines (leading ``#``) are ignored — they are not
+        live directives. The ``{{ROOT_PATH}}`` placeholder is stripped so paths
+        compare on their post-substitution value.
+        """
+        paths: set[str] = set()
+        for line in block_text.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            m = cls._LOCATION_DIRECTIVE_RE.match(line)
+            if m:
+                paths.add(m.group(1).replace("{{ROOT_PATH}}", ""))
+        return paths
+
+    def _create_generic_proxy_block(
+        self,
+        entity_type: str,
+        path: str,
+        target_url: str,
+    ) -> str:
+        """Render one nginx location block routing a proxied non-MCP entity.
+
+        The block proxies to the auth-server's generic hop
+        (``{auth_server_url}/proxy/{entity_type}/{path}/``), NOT to the backend
+        target directly — nginx never dials the registered target. The target URL
+        is forwarded as ``X-Upstream-Url`` (via a SEPARATE ``$generic_backend_url``
+        variable, never ``$backend_url``, to avoid tripping the MCP token mint) so
+        ``/validate`` can cryptographically pin it into the generic-proxy token;
+        IP-pinning and TLS SNI for the backend happen at the auth-server httpx
+        layer, not here.
+
+        Args:
+            entity_type: Canonical entity type (e.g. "skill", "a2a_agent").
+            path: The registered entity path (e.g. "/skills/proxy-demo").
+            target_url: The resolved, egress-validated backend URL.
+
+        Returns:
+            The nginx location block string (with ``{{ROOT_PATH}}`` placeholder).
+        """
+        norm_path = path if path.startswith("/") else "/" + path
+        entity_path = path.strip("/")
+        proxy_target = f"{settings.auth_server_url.rstrip('/')}/proxy/{entity_type}/{entity_path}/"
+        location_path = f"/{entity_type}{norm_path}"
+        body_size = settings.gateway_generic_client_max_body_size
+        return f"""
+    # Proxied {entity_type}: {location_path}
+    location {{{{ROOT_PATH}}}}{location_path} {{
+        client_max_body_size {body_size};
+        auth_request /validate;
+        auth_request_set $auth_internal_token_generic $upstream_http_x_internal_token_generic;
+        auth_request_set $auth_user $upstream_http_x_user;
+        auth_request_set $auth_scopes $upstream_http_x_scopes;
+
+        # SEPARATE upstream variable ($generic_backend_url), NOT $backend_url: keeps
+        # X-Resolved-Upstream empty on generic requests so the MCP token mint never
+        # fires and exactly one (generic-audience) token is issued per request.
+        set $generic_backend_url "{target_url}";
+        set $generic_proxy_kind "{entity_type}";
+        set $entity_path "{entity_path}";
+        proxy_set_header X-Upstream-Url $generic_backend_url;
+
+        proxy_pass {proxy_target};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Internal-Token $auth_internal_token_generic;
+        proxy_set_header Authorization $http_authorization;
+        proxy_set_header X-User $auth_user;
+        proxy_set_header X-Scopes $auth_scopes;
+        proxy_set_header X-Original-URL $scheme://$host$request_uri;
+        proxy_pass_request_headers on;
+        error_page 401 = @auth_error;
+        error_page 403 = @forbidden_error;
+    }}"""
+
+    def _safe_generic_block(
+        self,
+        entity_type: str,
+        path: str,
+        target_url: str,
+    ) -> str | None:
+        """Return a generic block, or None to SKIP if the target is invalid/denied.
+
+        Render-time defense: a single malformed or SSRF-denied target
+        that rendered a broken block would fail ``nginx -t`` and block the reload
+        for EVERY route on the replica. Every guard here skips-with-WARNING and
+        never raises into the render. Runs IN ADDITION to registration-time
+        validation, because a stored row may predate the policy or have arrived
+        via a path that bypassed the edge validators.
+
+        Guards (defense-in-depth; registration validators are the primary line,
+        but a stored row may predate the policy, be corrupt, or have arrived via a
+        bypass path — this is the LAST gate before a live nginx config):
+          - auth_server_url is set (else proxy_pass would be a relative self-loop);
+          - scheme is http(s);
+          - _assert_egress_allowed(target_url) passes (SSRF egress policy);
+          - entity_type matches the strict token grammar (it is interpolated into
+            the location path AND three directives; a corrupt value would break
+            out even though canonical/custom types are validated at registration);
+          - no ``..`` path segment (would path-traverse on the auth-server hop
+            after nginx normalizes the proxy_pass URI);
+          - neither the target, path, nor entity_type contains a character that
+            could break out of the location/proxy_pass/set directive. ``$`` is
+            denied in the target because it is placed inside a double-quoted
+            ``set`` value where nginx would otherwise expand it as a variable.
+        """
+        try:
+            if not settings.auth_server_url:
+                raise ValueError("auth_server_url is not configured")
+            if not (target_url.startswith("http://") or target_url.startswith("https://")):
+                raise ValueError(f"non-http(s) target: {target_url!r}")
+            _assert_egress_allowed(target_url)
+            if not re.fullmatch(r"[a-z0-9_-]+", entity_type):
+                raise ValueError(f"illegal entity_type token: {entity_type!r}")
+            if ".." in path.split("/"):
+                raise ValueError(f"path-traversal segment in path: {path!r}")
+            # Chars that could break out of a location/proxy_pass/set directive.
+            # ``$`` is target-only (nginx would expand it inside the quoted set
+            # value); the rest apply to path and entity_type too.
+            structural = ("\n", "\r", '"', ";", "{", "}", " ", "\t", "\\")
+            if any(c in target_url for c in (*structural, "$")):
+                raise ValueError("illegal character in target")
+            if any(c in path for c in structural):
+                raise ValueError("illegal character in path")
+            return self._create_generic_proxy_block(entity_type, path, target_url)
+        except Exception as e:
+            logger.warning("Skipping generic block for %s%s: %s", entity_type, path, e)
+            GATEWAY_GENERIC_BLOCKS_DROPPED.labels(reason="invalid").inc()
+            return None
+
+    async def _generate_generic_proxy_blocks(
+        self,
+        claimed_paths: set[str],
+    ) -> list[str]:
+        """Generate generic-proxy location blocks for proxied non-MCP entities.
+
+        Fetches the flag-gated proxied-resource list (zero DB queries when the
+        feature is disabled), renders a safe block per entity, and drops any block
+        whose nginx location path collides with an already-claimed path.
+
+        Precedence: legacy MCP and virtual blocks are generated first and
+        their paths passed in via ``claimed_paths``; generic is the LOWEST tier, so
+        a generic block is dropped (never overrides) on collision — including
+        generic-vs-generic, where the first-seen entity wins deterministically
+        (resources are sorted by location path for stable ordering).
+
+        Args:
+            claimed_paths: nginx location paths already taken by higher-precedence
+                (MCP / virtual) blocks. Mutated in place as generic paths are
+                claimed, so later generic blocks see earlier ones.
+
+        Returns:
+            List of rendered generic location block strings (possibly empty).
+        """
+        resources = await _fetch_generic_proxied_resources()
+        if not resources:
+            return []
+
+        blocks: list[str] = []
+        for res in sorted(resources, key=lambda r: (r["entity_type"], r["path"])):
+            block = self._safe_generic_block(res["entity_type"], res["path"], res["target_url"])
+            if block is None:
+                continue  # _safe_generic_block already logged + counted the drop
+            block_paths = self._location_paths_in(block)
+            collision = block_paths & claimed_paths
+            if collision:
+                logger.warning(
+                    "Dropping generic block for %s%s: location path(s) %s already "
+                    "claimed by a higher-precedence (MCP/virtual/earlier) block",
+                    res["entity_type"],
+                    res["path"],
+                    sorted(collision),
+                )
+                GATEWAY_GENERIC_BLOCKS_DROPPED.labels(reason="collision").inc()
+                continue
+            claimed_paths |= block_paths
+            blocks.append(block)
+
+        logger.info(f"Generated {len(blocks)} generic-proxy location blocks")
+        return blocks
 
     async def _generate_virtual_backend_locations(
         self,
@@ -2755,6 +2981,62 @@ async def _fetch_all_enabled_servers() -> dict[str, Any]:
         if info:
             enabled_servers[path] = info
     return enabled_servers
+
+
+# Non-MCP entity types that route through the generic proxy hop. MCP servers keep
+# their existing legacy path; virtual servers are alias-only (this feature does not
+# emit generic blocks for them). Each maps to the repository factory getter.
+_GENERIC_PROXY_ENTITY_TYPES: tuple[str, ...] = ("a2a_agent", "skill", "custom")
+
+
+async def _fetch_generic_proxied_resources() -> list[dict[str, Any]]:
+    """Collect non-MCP entities that opt into the generic gateway proxy.
+
+    Returns a list of ``{"entity_type", "path", "target_url"}`` for every
+    agent/skill/custom entity that is proxied AND resolves to a target (via
+    ``resolve_proxy_target``, which drops federated / disabled / auto-disabled /
+    targetless rows). SSRF is NOT re-checked here — the render-time
+    ``_safe_generic_block`` guard does that before emitting a block.
+
+    SRE gate: when ``gateway_generic_proxy_enabled`` is false this
+    issues ZERO DB queries — an upgraded deployment that hasn't enabled the
+    feature pays no new per-tick fan-out. Block-generation gating alone is not
+    enough; the FETCH itself is skipped.
+    """
+    if not settings.gateway_generic_proxy_enabled:
+        return []
+
+    # MCP servers keep their legacy /path block (handled by the enabled-server
+    # path); only agents/skills/custom entities route through the generic hop.
+    from registry.repositories.factory import (
+        get_agent_repository,
+        get_custom_entity_repository,
+        get_skill_repository,
+    )
+    from registry.schemas.proxy_mixin import resolve_proxy_target
+
+    repos = {
+        "a2a_agent": get_agent_repository(),
+        "skill": get_skill_repository(),
+        "custom": get_custom_entity_repository(),
+    }
+    resources: list[dict[str, Any]] = []
+    for entity_type, repo in repos.items():
+        try:
+            rows = await repo.list_proxied()
+        except Exception as e:  # noqa: BLE001 - one repo failing must not break the render
+            logger.error("list_proxied failed for %s: %s", entity_type, e, exc_info=True)
+            continue
+        for doc in rows:
+            # Custom records carry their own type token; use it so the canonical
+            # /{type}/{path} namespace matches the record's actual type.
+            row_type = doc.get("entity_type") or entity_type
+            target = resolve_proxy_target(row_type, doc)
+            if not target:
+                # Not renderable (federated / disabled / auto-disabled / no target).
+                continue
+            resources.append({"entity_type": row_type, "path": doc["path"], "target_url": target})
+    return resources
 
 
 # Module-level singleton

--- a/registry/core/schemas.py
+++ b/registry/core/schemas.py
@@ -7,6 +7,11 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from registry.constants import DeploymentType, LocalRuntimeType, TransportType
 from registry.schemas.agent_models import AgentProvider
+from registry.schemas.proxy_mixin import (
+    ProxyableMixin,
+    assert_proxy_target_resolvable,
+    egress_guard_validator,
+)
 from registry.schemas.registry_card import LifecycleStatus
 
 _IMAGE_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
@@ -527,8 +532,13 @@ class LocalRuntime(BaseModel):
         return self
 
 
-class ServerInfo(BaseModel):
-    """Server information model."""
+class ServerInfo(ProxyableMixin):
+    """Server information model.
+
+    Inherits ``is_proxied`` / ``proxy_target_url`` from ``ProxyableMixin``. For an
+    MCP server the effective proxy target falls back to ``proxy_pass_url`` when
+    ``proxy_target_url`` is unset; a ``local`` (stdio) deployment is never proxied.
+    """
 
     id: str = Field(
         default_factory=lambda: str(uuid4()),
@@ -788,6 +798,27 @@ class ServerInfo(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def _validate_proxy_target(self) -> "ServerInfo":
+        """If proxied, require a resolvable backend (proxy_target_url or proxy_pass_url).
+
+        Passes only the scalars the check reads (not a full model_dump) — this
+        validator runs on every construction, including every read that rebuilds
+        the model from a stored doc.
+        """
+        assert_proxy_target_resolvable(
+            "mcp_server",
+            {
+                "is_proxied": self.is_proxied,
+                "proxy_target_url": self.proxy_target_url,
+                "proxy_disabled_reason": self.proxy_disabled_reason,
+                "proxy_pass_url": self.proxy_pass_url,
+                "deployment": self.deployment,
+            },
+            read_safe=True,  # storage model: reconstructed on read, log-not-raise
+        )
+        return self
+
+    @model_validator(mode="after")
     def _validate_egress_auth(self) -> "ServerInfo":
         """Enforce per-mode egress config invariants.
 
@@ -913,8 +944,13 @@ class SessionData(BaseModel):
     provider: str = "local"
 
 
-class ServiceRegistrationRequest(BaseModel):
-    """Service registration request model."""
+class ServiceRegistrationRequest(ProxyableMixin):
+    """Service registration request model.
+
+    Inherits the ``is_proxied`` / ``proxy_target_url`` opt-in from
+    ``ProxyableMixin`` so the registration API accepts them; the SSRF egress
+    guard runs on ``proxy_target_url`` via the mixin's field validator.
+    """
 
     name: str = Field(..., min_length=1)
     description: str = ""
@@ -962,6 +998,12 @@ class ServiceRegistrationRequest(BaseModel):
         default=LifecycleStatus.ACTIVE,
         description="Lifecycle status: active, deprecated, draft, or beta",
     )
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _guard_proxy_target_url(cls, v: str | None) -> str | None:
+        """API-edge SSRF fast-fail (the mixin no longer raises; storage is read-safe)."""
+        return egress_guard_validator(v)
 
 
 class AuthCredentialUpdateRequest(BaseModel):

--- a/registry/main.py
+++ b/registry/main.py
@@ -268,6 +268,7 @@ async def _sync_agentcore_on_startup(
         get_skill_repository,
     )
     from registry.schemas.agent_models import AgentCard
+    from registry.schemas.proxy_mixin import strip_proxy_fields
     from registry.schemas.skill_models import SkillCard
     from registry.services.agent_service import agent_service
     from registry.services.federation.agentcore_client import (
@@ -299,6 +300,8 @@ async def _sync_agentcore_on_startup(
     server_count = 0
     for server_data in records["servers"]:
         try:
+            # Peer content: strip proxy fields (no proxying federated entities).
+            server_data = strip_proxy_fields(server_data)
             server_path = server_data.get("path")
             if not server_path:
                 continue
@@ -325,6 +328,7 @@ async def _sync_agentcore_on_startup(
     agent_count = 0
     for agent_data in records["agents"]:
         try:
+            agent_data = strip_proxy_fields(agent_data)  # peer content: no proxying
             agent_path = agent_data.get("path")
             if not agent_path:
                 continue
@@ -348,6 +352,7 @@ async def _sync_agentcore_on_startup(
     skill_repo = get_skill_repository()
     for skill_data in records["skills"]:
         try:
+            skill_data = strip_proxy_fields(skill_data)  # peer content: no proxying
             skill_path = skill_data.get("path")
             if not skill_path:
                 continue
@@ -643,9 +648,13 @@ async def lifespan(app: FastAPI):
                             )
 
                             # Register servers
+                            from registry.schemas.proxy_mixin import strip_proxy_fields
+
                             synced_count = 0
                             for server_data in servers:
                                 try:
+                                    # Peer content: strip proxy fields (no proxying federated entities).
+                                    server_data = strip_proxy_fields(server_data)
                                     server_path = server_data.get("path")
                                     if not server_path:
                                         continue

--- a/registry/observability/meters.py
+++ b/registry/observability/meters.py
@@ -394,6 +394,41 @@ _gateway_generic_blocks_dropped_counter = _meter.create_counter(
 gateway_generic_blocks_dropped_total = _CounterAdapter(_gateway_generic_blocks_dropped_counter)
 
 
+# Egress-policy verification gauge. 1 = the startup egress self-check found a
+# cloud metadata IP reachable (network egress policy NOT enforced; the generic
+# proxy feature has been disabled for this process). 0 = verified/clean or the
+# check was opted out. A permanent 1 is the operator's signal that an enabled
+# generic-proxy feature is running without its required DNS-rebind defense.
+# Backed by an ObservableGauge over a module-local value that the auth-server
+# self-check sets via the _EgressUnverifiedGauge adapter's .set().
+
+
+class _EgressUnverifiedGauge:
+    """Minimal settable-gauge shim: .set(v) stores; an ObservableGauge emits it."""
+
+    def __init__(self) -> None:
+        self._value: int = 0
+
+    def set(self, value: int) -> None:  # noqa: A003 - mirroring prometheus_client API
+        self._value = int(value)
+
+    def _observe(self, _options: Any) -> Any:
+        yield metrics.Observation(self._value, {})
+
+
+gateway_egress_policy_unverified = _EgressUnverifiedGauge()
+
+_meter.create_observable_gauge(
+    name="mcpgw_registry_gateway_egress_policy_unverified",
+    callbacks=[gateway_egress_policy_unverified._observe],
+    description=(
+        "1 if the generic-proxy egress self-check found a metadata IP reachable "
+        "(policy unverified; feature disabled for this process), else 0"
+    ),
+    unit="1",
+)
+
+
 # Mode-blocked requests (registry/core/metrics.py:43)
 _mode_blocked_requests_counter = _meter.create_counter(
     name="mcpgw_registry_mode_blocked_requests_total",

--- a/registry/observability/meters.py
+++ b/registry/observability/meters.py
@@ -382,6 +382,17 @@ _nginx_config_writes_counter = _meter.create_counter(
 )
 nginx_config_writes_total = _CounterAdapter(_nginx_config_writes_counter)
 
+# Generic-proxy blocks dropped at render (invalid target / SSRF-denied / location
+# collision). A non-zero value means one or more proxied entities did NOT get a
+# route this render — surfaced as a metric because the drop is a WARNING log
+# otherwise easy to miss on a busy replica. Label `reason`: invalid | collision.
+_gateway_generic_blocks_dropped_counter = _meter.create_counter(
+    name="mcpgw_registry_gateway_generic_blocks_dropped_total",
+    description="Generic-proxy nginx blocks dropped at render (invalid target or location collision)",
+    unit="1",
+)
+gateway_generic_blocks_dropped_total = _CounterAdapter(_gateway_generic_blocks_dropped_counter)
+
 
 # Mode-blocked requests (registry/core/metrics.py:43)
 _mode_blocked_requests_counter = _meter.create_counter(

--- a/registry/repositories/documentdb/_identity_url_sidecar.py
+++ b/registry/repositories/documentdb/_identity_url_sidecar.py
@@ -64,6 +64,43 @@ async def ensure_normalized_identity_url_index(
         )
 
 
+async def ensure_is_proxied_index(
+    collection: AsyncIOMotorCollection,
+    collection_name: str,
+) -> None:
+    """Create the index backing ``list_proxied()`` (the nginx-render hot path).
+
+    Prefers a partial index (``partialFilterExpression={"is_proxied": True}``) so
+    only proxied documents are indexed. AWS DocumentDB may reject partial
+    indexes, so we fall back to a plain single-field index; the query
+    (``{"is_proxied": True}``) uses either. If both fail, list_proxied still works
+    (unindexed scan) — index creation is an optimization, never a correctness
+    requirement. NEVER raises: callers invoke this from index-setup paths where an
+    exception would defeat an idempotency guard or crash init.
+    """
+    try:
+        await collection.create_index(
+            "is_proxied",
+            name="idx_is_proxied",
+            partialFilterExpression={"is_proxied": True},
+        )
+        return
+    except Exception as exc:
+        logger.warning(
+            "Partial is_proxied index rejected on %s (%s); trying plain index",
+            collection_name,
+            exc,
+        )
+    try:
+        await collection.create_index("is_proxied", name="idx_is_proxied_plain")
+    except Exception as exc:
+        logger.warning(
+            "Could not create is_proxied index on %s: %s (list_proxied will scan)",
+            collection_name,
+            exc,
+        )
+
+
 async def backfill_normalized_identity_url(
     collection: AsyncIOMotorCollection,
     collection_name: str,

--- a/registry/repositories/documentdb/agent_repository.py
+++ b/registry/repositories/documentdb/agent_repository.py
@@ -14,6 +14,7 @@ from ...utils.url_normalize import ENTITY_TYPE_AGENT, NORMALIZED_IDENTITY_URL_FI
 from ..interfaces import AgentRepositoryBase
 from ._identity_url_sidecar import (
     backfill_normalized_identity_url,
+    ensure_is_proxied_index,
     ensure_normalized_identity_url_index,
     find_by_normalized_identity_url,
     populate_normalized_identity_url,
@@ -59,6 +60,9 @@ class DocumentDBAgentRepository(AgentRepositoryBase):
                 collection,
                 self._collection_name,
             )
+            # Index backing list_proxied() (partial, with plain fallback for
+            # DocumentDB; never raises). See ensure_is_proxied_index.
+            await ensure_is_proxied_index(collection, self._collection_name)
             await backfill_normalized_identity_url(
                 collection,
                 self._collection_name,
@@ -99,6 +103,36 @@ class DocumentDBAgentRepository(AgentRepositoryBase):
         except Exception as e:
             logger.error(f"Error getting agent '{path}' from DocumentDB: {e}", exc_info=True)
             return None
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Projected list of proxied agents for the nginx render hot path.
+
+        Indexed ``is_proxied=True`` query projecting only the render/resolve
+        fields (native fallback: url). Returns raw dicts (not AgentCard) — the
+        render only needs the scalars, and a bypass-written invalid row must not
+        crash the reload via model reconstruction.
+        """
+        projection = {
+            "is_proxied": 1,
+            "is_enabled": 1,
+            "proxy_target_url": 1,
+            "proxy_resolved_ips": 1,
+            "proxy_target_host": 1,
+            "proxy_disabled_reason": 1,
+            "url": 1,
+            "sync_metadata": 1,
+        }
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({"is_proxied": True}, projection)
+            rows = []
+            async for doc in cursor:
+                doc["path"] = doc.pop("_id")
+                rows.append(doc)
+            return rows
+        except Exception as e:
+            logger.error(f"Error listing proxied agents from DocumentDB: {e}", exc_info=True)
+            return []
 
     async def list_all(self) -> list[AgentCard]:
         """List all agents."""

--- a/registry/repositories/documentdb/custom_entity_repository.py
+++ b/registry/repositories/documentdb/custom_entity_repository.py
@@ -20,6 +20,7 @@ from pymongo.errors import DuplicateKeyError
 
 from ...schemas.custom_entity_models import CustomEntityRecord
 from ..interfaces import CustomEntityRepositoryBase
+from ._identity_url_sidecar import ensure_is_proxied_index
 from .client import get_collection_name, get_documentdb_client
 
 # Configure logging
@@ -77,6 +78,39 @@ class DocumentDBCustomEntityRepository(CustomEntityRepositoryBase):
             logger.info(f"Created indexes for {self._collection_name} collection")
         except Exception as e:
             logger.warning(f"Could not create indexes: {e}")
+
+        # Optional is_proxied index (partial w/ plain fallback, never raises) —
+        # AFTER _indexes_created so a DocumentDB rejection can't defeat the guard.
+        await ensure_is_proxied_index(collection, self._collection_name)
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Projected list of proxied custom records across all types.
+
+        Each record carries its own ``entity_type`` (the type token). Custom
+        entities have no native backend URL, so proxy_target_url is required.
+        Returns raw dicts so a bypass-written invalid row can't crash the reload.
+        """
+        projection = {
+            "entity_type": 1,
+            "is_proxied": 1,
+            "is_enabled": 1,
+            "proxy_target_url": 1,
+            "proxy_resolved_ips": 1,
+            "proxy_target_host": 1,
+            "proxy_disabled_reason": 1,
+            "sync_metadata": 1,
+        }
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({"is_proxied": True}, projection)
+            rows = []
+            async for doc in cursor:
+                doc["path"] = doc.pop("_id")
+                rows.append(doc)
+            return rows
+        except Exception as e:
+            logger.error(f"Error listing proxied custom records: {e}", exc_info=True)
+            return []
 
     async def create(
         self,

--- a/registry/repositories/documentdb/server_repository.py
+++ b/registry/repositories/documentdb/server_repository.py
@@ -15,6 +15,7 @@ from ...utils.url_normalize import ENTITY_TYPE_SERVER, NORMALIZED_IDENTITY_URL_F
 from ..interfaces import ServerRepositoryBase
 from ._identity_url_sidecar import (
     backfill_normalized_identity_url,
+    ensure_is_proxied_index,
     ensure_normalized_identity_url_index,
     find_by_normalized_identity_url,
     populate_normalized_identity_url,
@@ -69,6 +70,9 @@ class DocumentDBServerRepository(ServerRepositoryBase):
                 collection,
                 self._collection_name,
             )
+            # Index backing list_proxied() (partial, with plain fallback for
+            # DocumentDB; never raises). See ensure_is_proxied_index.
+            await ensure_is_proxied_index(collection, self._collection_name)
             await backfill_normalized_identity_url(
                 collection,
                 self._collection_name,
@@ -164,6 +168,39 @@ class DocumentDBServerRepository(ServerRepositoryBase):
         except Exception as e:
             logger.error(f"Error listing servers from DocumentDB: {e}", exc_info=True)
             return {}
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Projected list of proxied servers for the nginx render hot path.
+
+        Indexed ``is_proxied=True`` query projecting only the fields the render +
+        resolve_proxy_target need: is_enabled (disabled -> no route), the
+        federation guard (sync_metadata), and the native fallback (proxy_pass_url
+        + deployment). Fail-closed: any error (incl. collection acquisition)
+        returns [] so a transient DB blip drops routes for one reload tick rather
+        than raising into the render.
+        """
+        projection = {
+            "is_proxied": 1,
+            "is_enabled": 1,
+            "proxy_target_url": 1,
+            "proxy_resolved_ips": 1,
+            "proxy_target_host": 1,
+            "proxy_disabled_reason": 1,
+            "proxy_pass_url": 1,
+            "deployment": 1,
+            "sync_metadata": 1,
+        }
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({"is_proxied": True}, projection)
+            rows = []
+            async for doc in cursor:
+                doc["path"] = doc.pop("_id")
+                rows.append(doc)
+            return rows
+        except Exception as e:
+            logger.error(f"Error listing proxied servers from DocumentDB: {e}", exc_info=True)
+            return []
 
     async def list_paginated(
         self,

--- a/registry/repositories/documentdb/skill_repository.py
+++ b/registry/repositories/documentdb/skill_repository.py
@@ -32,6 +32,7 @@ from ...utils.url_normalize import (
 from ..interfaces import SkillRepositoryBase
 from ._identity_url_sidecar import (
     backfill_normalized_identity_url,
+    ensure_is_proxied_index,
     find_by_normalized_identity_url,
 )
 from ._unique_id_index import (
@@ -187,6 +188,13 @@ class DocumentDBSkillRepository(SkillRepositoryBase):
         except Exception as e:
             logger.warning(f"Could not create indexes: {e}")
 
+        # Optional is_proxied index for the list_proxied() hot path. Runs AFTER
+        # _indexes_created is set and never raises (see ensure_is_proxied_index):
+        # DocumentDB may reject partialFilterExpression, and an exception here
+        # must NOT leave _indexes_created False (that would re-run every index on
+        # every skill op). Falls back to a plain index so the hot path stays fast.
+        await ensure_is_proxied_index(collection, self._collection_name)
+
     async def get(
         self,
         path: str,
@@ -198,6 +206,35 @@ class DocumentDBSkillRepository(SkillRepositoryBase):
         if doc:
             return _document_to_skill(doc)
         return None
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Projected list of proxied skills for the nginx render hot path.
+
+        Skills have no native backend URL, so proxy_target_url is required (no
+        fallback field). Returns raw dicts (not SkillCard) so a bypass-written
+        invalid row can't crash the reload via model reconstruction.
+        """
+        projection = {
+            "is_proxied": 1,
+            "is_enabled": 1,
+            "proxy_target_url": 1,
+            "proxy_resolved_ips": 1,
+            "proxy_target_host": 1,
+            "proxy_disabled_reason": 1,
+            "sync_metadata": 1,
+        }
+        try:
+            await self.ensure_indexes()
+            collection = await self._get_collection()
+            cursor = collection.find({"is_proxied": True}, projection)
+            rows = []
+            async for doc in cursor:
+                doc["path"] = doc.pop("_id")
+                rows.append(doc)
+            return rows
+        except Exception as e:
+            logger.error(f"Error listing proxied skills from DocumentDB: {e}", exc_info=True)
+            return []
 
     async def list_all(
         self,

--- a/registry/repositories/documentdb/virtual_server_repository.py
+++ b/registry/repositories/documentdb/virtual_server_repository.py
@@ -21,6 +21,7 @@ from ...exceptions import (
 )
 from ...schemas.virtual_server_models import VirtualServerConfig
 from ..interfaces import VirtualServerRepositoryBase
+from ._identity_url_sidecar import ensure_is_proxied_index
 from .client import get_collection_name, get_documentdb_client
 
 # Configure logging
@@ -99,6 +100,10 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
         except Exception as e:
             logger.warning(f"Could not create indexes for {self._collection_name}: {e}")
 
+        # Optional is_proxied index (partial w/ plain fallback, never raises) —
+        # AFTER _indexes_created so a DocumentDB rejection can't defeat the guard.
+        await ensure_is_proxied_index(self._collection, self._collection_name)
+
     async def get(
         self,
         path: str,
@@ -109,6 +114,25 @@ class DocumentDBVirtualServerRepository(VirtualServerRepositoryBase):
         if doc:
             return _document_to_config(doc)
         return None
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Projected list of proxied virtual servers (alias-only, no target).
+
+        is_proxied on a virtual server only governs emission of the canonical
+        /virtual_server/<path> alias; it never carries a proxy_target_url.
+        """
+        projection = {"is_proxied": 1, "is_enabled": 1, "sync_metadata": 1}
+        try:
+            collection = await self._get_collection()
+            cursor = collection.find({"is_proxied": True}, projection)
+            rows = []
+            async for doc in cursor:
+                doc["path"] = doc.pop("_id")
+                rows.append(doc)
+            return rows
+        except Exception as e:
+            logger.error(f"Error listing proxied virtual servers: {e}", exc_info=True)
+            return []
 
     async def list_all(self) -> list[VirtualServerConfig]:
         """List all virtual servers."""

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -253,6 +253,16 @@ class ServerRepositoryBase(ABC):
         """
         ...
 
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Return proxy-relevant projections of every gateway-proxied entity.
+
+        Indexed ``is_proxied=True`` query with a field projection (only the
+        columns the nginx render + ``resolve_proxy_target`` need) for the config
+        regeneration hot path. Default returns ``[]`` (safe no-op for legacy /
+        non-overriding backends); DocumentDB overrides with the projected query.
+        """
+        return []
+
     async def find_by_identity_url(
         self,
         identity_url: str,
@@ -447,6 +457,13 @@ class AgentRepositoryBase(ABC):
             Dict mapping path -> document data for matching documents
         """
         ...
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Return proxy-relevant projections of every gateway-proxied agent.
+
+        See ServerRepositoryBase.list_proxied. Default ``[]``; DocumentDB overrides.
+        """
+        return []
 
     async def find_by_identity_url(
         self,
@@ -1753,6 +1770,13 @@ class SkillRepositoryBase(ABC):
         """
         pass
 
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Return proxy-relevant projections of every gateway-proxied skill.
+
+        See ServerRepositoryBase.list_proxied. Default ``[]``; DocumentDB overrides.
+        """
+        return []
+
     async def find_by_identity_url(
         self,
         identity_url: str,
@@ -2046,6 +2070,15 @@ class VirtualServerRepositoryBase(ABC):
         """
         pass
 
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Return proxy-relevant projections of every proxied virtual server.
+
+        Virtual-server proxying is alias-only (no proxy_target_url); list_proxied
+        surfaces the is_proxied flag so the render can emit the canonical alias.
+        See ServerRepositoryBase.list_proxied. Default ``[]``; DocumentDB overrides.
+        """
+        return []
+
     @abstractmethod
     async def update_rating(
         self,
@@ -2241,6 +2274,14 @@ class CustomEntityRepositoryBase(ABC):
     ) -> int:
         """Count records of a type, applying the SAME optional filter as list."""
         pass
+
+    async def list_proxied(self) -> list[dict[str, Any]]:
+        """Return proxy-relevant projections of every gateway-proxied record.
+
+        Spans all custom types (each record carries its own ``entity_type``).
+        See ServerRepositoryBase.list_proxied. Default ``[]``; DocumentDB overrides.
+        """
+        return []
 
     @abstractmethod
     async def count_all(self) -> int:

--- a/registry/schemas/agent_models.py
+++ b/registry/schemas/agent_models.py
@@ -22,6 +22,12 @@ from pydantic import (
     model_validator,
 )
 
+from registry.schemas.proxy_mixin import (
+    ProxyableMixin,
+    assert_proxy_target_resolvable,
+    egress_guard_validator,
+)
+
 # Configure logging with basicConfig
 logging.basicConfig(
     level=logging.INFO,
@@ -347,7 +353,7 @@ class Skill(BaseModel):
         return v.strip()
 
 
-class AgentCard(BaseModel):
+class AgentCard(ProxyableMixin):
     """
     A2A Agent Card - machine-readable agent profile.
 
@@ -705,6 +711,29 @@ class AgentCard(BaseModel):
             raise ValueError("Group-restricted visibility requires at least one allowed group")
         return self
 
+    @model_validator(mode="after")
+    def _validate_proxy_target(
+        self,
+    ) -> "AgentCard":
+        """If proxied, require a resolvable backend (proxy_target_url or the agent url).
+
+        The mixin's is_proxied/proxy_target_url are registry extensions and
+        serialize as snake_case (not A2A-spec fields; populate_by_name accepts
+        both on input). Passes only the scalars the check reads (this runs on
+        every construction, including reads that rebuild the model from a doc).
+        """
+        assert_proxy_target_resolvable(
+            "a2a_agent",
+            {
+                "is_proxied": self.is_proxied,
+                "proxy_target_url": self.proxy_target_url,
+                "proxy_disabled_reason": self.proxy_disabled_reason,
+                "url": self.url,
+            },
+            read_safe=True,  # storage model: reconstructed on read, log-not-raise
+        )
+        return self
+
 
 class AgentInfo(BaseModel):
     """
@@ -875,13 +904,14 @@ class AgentInfo(BaseModel):
     )
 
 
-class AgentRegistrationRequest(BaseModel):
+class AgentRegistrationRequest(ProxyableMixin):
     """
     API request model for agent registration.
 
     This model is used for the agent registration API endpoint and converts
     form-style inputs (e.g., comma-separated tags) into the proper types.
     Accepts both snake_case (Python) and camelCase (A2A spec JSON) field names.
+    Inherits the ``is_proxied`` / ``proxy_target_url`` opt-in from ProxyableMixin.
     """
 
     name: str = Field(
@@ -1103,6 +1133,12 @@ class AgentRegistrationRequest(BaseModel):
             raise ValueError(f"trust_level must be one of: {', '.join(valid_values)}")
         return v
 
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _guard_proxy_target_url_request(cls, v: str | None) -> str | None:
+        """API-edge SSRF fast-fail (the mixin no longer raises; storage is read-safe)."""
+        return egress_guard_validator(v)
+
     @field_validator("allowed_groups", mode="before")
     @classmethod
     def _normalize_allowed_groups(
@@ -1196,6 +1232,23 @@ class AgentCardPatch(BaseModel):
     license: str | None = None
     status: str | None = None
     external_tags: list[str] | str | None = None
+    # Gateway-proxy opt-in (patchable subset of ProxyableMixin; the bookkeeping
+    # fields proxy_resolved_ips/proxy_target_host/proxy_disabled_reason are
+    # server-managed and intentionally NOT patchable). extra="forbid" would 422
+    # these without an explicit declaration.
+    is_proxied: bool | None = Field(default=None, alias="isProxied")
+    proxy_target_url: str | None = Field(default=None, alias="proxyTargetUrl")
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _validate_proxy_target_url_patch(cls, v: str | None) -> str | None:
+        """Run the SSRF egress guard on a patched target (same as the mixin)."""
+        if v is None:
+            return v
+        from registry.schemas.proxy_mixin import _assert_egress_allowed
+
+        _assert_egress_allowed(v)
+        return v
 
     @model_validator(mode="after")
     def _reject_registrant_only(self) -> "AgentCardPatch":

--- a/registry/schemas/custom_entity_models.py
+++ b/registry/schemas/custom_entity_models.py
@@ -30,6 +30,8 @@ from pydantic import (
     model_validator,
 )
 
+from registry.schemas.proxy_mixin import ProxyableMixin, assert_proxy_target_resolvable
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -231,13 +233,17 @@ class CustomTypeUpdate(BaseModel):
     description: str | None = Field(default=None, max_length=MAX_DESCRIPTION_LEN)
 
 
-class CustomEntityRecord(BaseModel):
+class CustomEntityRecord(ProxyableMixin):
     """A record of a custom type. Stored in mcp_custom_entities (envelope + attributes).
 
     ``extra="ignore"`` so a raw Mongo doc (which carries an ``_id`` key) can be
     splatted directly via ``CustomEntityRecord(**doc)`` without raising. The
     repository ALSO pops ``_id`` before construction; both are kept for defense
     in depth.
+
+    Inherits the ``is_proxied`` / ``proxy_target_url`` opt-in from ProxyableMixin.
+    A custom entity has no native backend URL, so proxying requires an explicit
+    ``proxy_target_url`` (its descriptor name is the entity_type token).
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -272,6 +278,24 @@ class CustomEntityRecord(BaseModel):
         if not self.path:
             self.path = f"/{self.entity_type}/{uuid4()}"
 
+    @model_validator(mode="after")
+    def _validate_proxy_target(self) -> "CustomEntityRecord":
+        """If proxied, require an explicit proxy_target_url (no native backend).
+
+        Passes only the scalars the check reads (runs on every construction,
+        including reads that rebuild the model from a stored doc).
+        """
+        assert_proxy_target_resolvable(
+            self.entity_type,
+            {
+                "is_proxied": self.is_proxied,
+                "proxy_target_url": self.proxy_target_url,
+                "proxy_disabled_reason": self.proxy_disabled_reason,
+            },
+            read_safe=True,  # storage model: reconstructed on read, log-not-raise
+        )
+        return self
+
 
 class CustomEntityCreate(BaseModel):
     """Client payload for POST /api/custom/{type}. No owner/path/entity_type."""
@@ -282,6 +306,21 @@ class CustomEntityCreate(BaseModel):
     allowed_groups: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list, max_length=MAX_ARRAY_ITEMS)
     attributes: dict[str, Any] = Field(default_factory=dict)
+    # Gateway-proxy opt-in (a custom entity has no native backend URL, so
+    # proxy_target_url is required when is_proxied).
+    is_proxied: bool = Field(default=False)
+    proxy_target_url: str | None = Field(default=None)
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _validate_proxy_target_url(cls, v: str | None) -> str | None:
+        """Run the SSRF egress guard on the target."""
+        if v is None:
+            return v
+        from registry.schemas.proxy_mixin import _assert_egress_allowed
+
+        _assert_egress_allowed(v)
+        return v
 
     @field_validator("visibility")
     @classmethod
@@ -301,6 +340,13 @@ class CustomEntityCreate(BaseModel):
             raise ValueError("group-restricted visibility requires at least one allowed_group")
         return self
 
+    @model_validator(mode="after")
+    def _require_proxy_target(self) -> "CustomEntityCreate":
+        """API edge: reject is_proxied=true without a target (no native fallback)."""
+        if self.is_proxied and not self.proxy_target_url:
+            raise ValueError("is_proxied=true requires a proxy_target_url for a custom entity")
+        return self
+
 
 class CustomEntityUpdate(BaseModel):
     """Client payload for PUT /api/custom/{type}/{uuid}.
@@ -317,6 +363,9 @@ class CustomEntityUpdate(BaseModel):
     allowed_groups: list[str] | None = None
     tags: list[str] | None = Field(default=None, max_length=MAX_ARRAY_ITEMS)
     attributes: dict[str, Any] | None = None
+    # Gateway-proxy opt-in (patchable; None = leave unchanged).
+    is_proxied: bool | None = None
+    proxy_target_url: str | None = None
 
     @field_validator("visibility")
     @classmethod
@@ -330,3 +379,14 @@ class CustomEntityUpdate(BaseModel):
         from registry.utils.visibility import validate_visibility
 
         return validate_visibility(v)
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _validate_proxy_target_url(cls, v: str | None) -> str | None:
+        """Run the SSRF egress guard on a patched target."""
+        if v is None:
+            return v
+        from registry.schemas.proxy_mixin import _assert_egress_allowed
+
+        _assert_egress_allowed(v)
+        return v

--- a/registry/schemas/custom_entity_models.py
+++ b/registry/schemas/custom_entity_models.py
@@ -8,7 +8,12 @@ uniform envelope (name/description/visibility/owner/tags/...) plus a
 per-type ``attributes`` bag whose shape is validated against the
 descriptor at write time.
 
-These types are catalog-only — never proxied, executed, or health-checked.
+These types are catalog metadata: never executed or health-checked. A custom
+entity MAY be served through the gateway as an authenticated reverse-proxy route
+when its record sets ``is_proxied=true`` with a ``proxy_target_url`` (the natural
+home for an arbitrary fronted resource — a dashboard, static file, or HTTP
+endpoint); the gateway forwards authenticated HTTP to that target and returns the
+response without interpreting the resource.
 """
 
 import logging

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -30,12 +30,15 @@ It is therefore a WEAKER static check than ard_net_guard by design; do not enabl
 the feature until the network egress policy (SSRF layer 1) is deployed.
 """
 
+import logging
 from typing import Any
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 from registry.utils.ip_guard import coerce_ip_literal, ip_denial_reason
+
+logger = logging.getLogger(__name__)
 
 # Canonical built-in entity-type tokens that resolve_proxy_target knows how to
 # derive a fallback backend URL for. Custom entities pass their own descriptor
@@ -139,14 +142,28 @@ class ProxyableMixin(BaseModel):
         ),
     )
 
-    @field_validator("proxy_target_url")
-    @classmethod
-    def _validate_target_url(cls, v: str | None) -> str | None:
-        """Fast-fail SSRF check at the API edge (repeated at persist + render)."""
-        if v is None:
-            return v
-        _assert_egress_allowed(v)
+    # NOTE: no raising field_validator on proxy_target_url here. Storage models
+    # inherit this mixin and are RECONSTRUCTED from the DB on every read; a
+    # raising egress check would make a bypass-written denied literal (federation
+    # raw-doc write, migration, manual edit) throw on read and silently vanish the
+    # entity from every listing. The egress raise is instead an API-EDGE fast-fail
+    # on the request/patch models (which never reconstruct from the DB) via
+    # ``egress_guard_validator``, and the authoritative net is the persist/render
+    # guard. See assert_proxy_target_resolvable, which
+    # is likewise read-safe.
+
+
+def egress_guard_validator(v: str | None) -> str | None:
+    """Reusable field-validator body: raise on a denied proxy_target_url.
+
+    Attach to a request/patch model's ``proxy_target_url`` field (an API edge that
+    never reconstructs from stored data) so a bad target fails fast with 422.
+    Do NOT attach to a storage model — see the ProxyableMixin note above.
+    """
+    if v is None:
         return v
+    _assert_egress_allowed(v)
+    return v
 
 
 def resolve_proxy_target(
@@ -189,3 +206,70 @@ def resolve_proxy_target(
     if entity_type == "a2a_agent":
         return doc.get("url")
     return None  # skills / custom entities must set proxy_target_url explicitly
+
+
+def proxy_target_missing(
+    entity_type: str,
+    doc: dict[str, Any],
+) -> bool:
+    """Return True if ``is_proxied`` is set but no backend target can be resolved.
+
+    Pure predicate (no raise/log). Exempt states (``is_proxied`` is a dormant
+    no-op, NOT missing): not proxied at all; ``proxy_disabled_reason`` set (the
+    documented auto-disabled state); a local-deployment MCP server (no HTTP
+    backend). All other proxied entities must resolve to a target.
+    """
+    if not doc.get("is_proxied"):
+        return False
+    if doc.get("proxy_disabled_reason"):
+        return False  # auto-disabled route: dormant opt-in
+    if entity_type == "mcp_server" and doc.get("deployment") == "local":
+        return False  # stdio server: is_proxied is a documented no-op
+    return resolve_proxy_target(entity_type, doc) is None
+
+
+def assert_proxy_target_resolvable(
+    entity_type: str,
+    doc: dict[str, Any],
+    *,
+    read_safe: bool = False,
+) -> None:
+    """Enforce "if proxied, a target must resolve", turning the silent
+    "I set is_proxied=True and nothing happened" failure into an error.
+
+    Called from a model's ``model_validator(mode="after")`` so the check sees the
+    model's native fallback fields (proxy_pass_url / url).
+
+    ``read_safe`` picks the behavior by context:
+    - STORAGE models pass ``read_safe=True``: a missing target is LOGGED, not
+      raised. Storage models are reconstructed from the stored document on every
+      READ, and a bypass write (federation sync copying is_proxied without a
+      target, a migration, a manual edit) could produce the missing-target state.
+      Raising would make the entity throw on load and silently vanish from every
+      listing. The route simply won't render (resolve_proxy_target returns None).
+    - REQUEST/PATCH models pass ``read_safe=False`` (default): a missing target is
+      a 422 at the API edge, where there is no vanish risk (the model is built
+      from a client payload, never from stored data).
+
+    Args:
+        entity_type: Canonical entity-type token.
+        doc: The model's proxy-relevant scalars as a dict.
+        read_safe: When True, log instead of raise (storage/read context).
+
+    Raises:
+        ValueError: If proxied but no target resolves and ``read_safe`` is False.
+    """
+    if not proxy_target_missing(entity_type, doc):
+        return
+    msg = (
+        f"is_proxied=true on {entity_type} requires a resolvable backend URL: set "
+        "proxy_target_url (or the entity's native backend URL) to a valid http(s) target"
+    )
+    if read_safe:
+        logger.warning(
+            "Loaded proxied %s with no resolvable target (route will not render): %s",
+            entity_type,
+            msg,
+        )
+        return
+    raise ValueError(msg)

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -22,12 +22,18 @@ Security posture (this module is the application-layer SSRF control):
   changes respectively. The feature ships disabled (gateway_generic_proxy_enabled
   defaults false) until all three are in place.
 
-Note vs. registry/services/ard_net_guard.py: that guard resolves DNS and checks
-every resolved IP, defeating rebind at check time. This guard deliberately does
-NOT resolve (proxy targets are long-lived and re-validated by a refresh + the
-network egress policy), so a hostname target is only network-layer-protected.
-It is therefore a WEAKER static check than ard_net_guard by design; do not enable
-the feature until the network egress policy (SSRF layer 1) is deployed.
+Two application-layer checks, by context:
+- ``_assert_egress_allowed`` / ``egress_guard_validator`` — the STATIC (literal-IP)
+  check at the Pydantic API edge (422). A genuine hostname passes it (no DNS in a
+  validator).
+- ``resolve_and_validate_proxy_target`` / ``validate_and_pin_proxy_target`` — the
+  DNS-aware check (layer 2), run at the service register/update layer and
+  by the scheduled pin-refresh. It resolves the hostname and validates every
+  resolved IP (like registry/services/ard_net_guard.py), catching a target that
+  resolves to a metadata/private IP *now* and pinning the resolved IPs. It is
+  best-effort against DNS-rebind (the set can change before the real request) —
+  which is why the authoritative control remains the network egress policy (layer
+  1). Do not enable the feature until that policy is deployed.
 """
 
 import logging
@@ -190,11 +196,137 @@ def egress_guard_validator(v: str | None) -> str | None:
     Attach to a request/patch model's ``proxy_target_url`` field (an API edge that
     never reconstructs from stored data) so a bad target fails fast with 422.
     Do NOT attach to a storage model — see the ProxyableMixin note above.
+
+    NOTE: this is the STATIC (literal-IP) check only. A genuine hostname passes
+    here and is resolved-and-validated separately by
+    ``resolve_and_validate_proxy_target`` at the service/registration layer (DNS
+    is I/O and cannot run in a Pydantic validator).
     """
     if v is None:
         return v
     _assert_egress_allowed(v)
     return v
+
+
+async def resolve_and_validate_proxy_target(
+    url: str,
+) -> tuple[str | None, list[str]]:
+    """Resolve a proxy_target_url's hostname and validate every resolved IP.
+
+    This is **layer 2** — the registration-time (and refresh-time)
+    DNS-aware SSRF check that ``_assert_egress_allowed`` deliberately skips for
+    hostnames. Resolving here catches a target that resolves to a
+    metadata/loopback/private IP *now*, giving a clear error at register/update
+    instead of a silent render-time drop. It is best-effort against DNS-rebind
+    (the resolved set can change before the real request) — which is exactly why
+    the authoritative control is the network egress policy (layer 1), not this.
+
+    Behavior mirrors ``_assert_egress_allowed``'s policy:
+    - scheme must be http(s);
+    - literal-IP targets are category-checked directly (no DNS);
+    - hostnames are resolved via ``getaddrinfo`` and EVERY resolved IP is checked;
+    - ``gateway_proxy_allow_private_targets`` relaxes private/loopback/reserved,
+      but link-local (metadata) and the unspecified address are ALWAYS denied.
+
+    Args:
+        url: The candidate proxy target URL.
+
+    Returns:
+        ``(hostname, resolved_ips)`` — the original hostname (or None for a
+        literal-IP target) and the list of resolved IP strings (the literal
+        itself for an IP target). Callers persist these for pin bookkeeping.
+
+    Raises:
+        ValueError: If the scheme is not http(s), or the host cannot be resolved.
+        EgressPolicyError: If any resolved IP is in a denied network range.
+    """
+    import asyncio
+    import socket
+
+    from registry.core.config import settings
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"proxy_target_url must be an http(s) URL, got scheme {parsed.scheme!r}")
+    host = (parsed.hostname or "").strip("[]")
+    if not host:
+        raise ValueError(f"proxy_target_url has no host: {url!r}")
+
+    allow_private = settings.gateway_proxy_allow_private_targets
+
+    # Literal-IP target: no DNS, category-check directly (same as the static guard).
+    literal = coerce_ip_literal(host)
+    if literal is not None:
+        reason = ip_denial_reason(literal, allow_private=allow_private)
+        if reason is not None:
+            raise EgressPolicyError(
+                f"proxy_target_url host {host} is denied ({reason}); if this is a "
+                "trusted on-cluster target set GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
+            )
+        return None, [str(literal)]
+
+    # Hostname: resolve and check EVERY resolved IP (defeats rebind at check time).
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    try:
+        infos = await asyncio.to_thread(socket.getaddrinfo, host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise ValueError(f"Cannot resolve proxy_target_url host {host!r}: {e}") from e
+
+    resolved_ips: list[str] = []
+    for _family, _type, _proto, _canon, sockaddr in infos:
+        ip_str = str(sockaddr[0])
+        ip = coerce_ip_literal(ip_str)
+        if ip is None:
+            continue
+        reason = ip_denial_reason(ip, allow_private=allow_private)
+        if reason is not None:
+            raise EgressPolicyError(
+                f"proxy_target_url host {host} resolves to denied IP {ip_str} ({reason}); "
+                "if this is a trusted on-cluster target set "
+                "GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
+            )
+        if ip_str not in resolved_ips:
+            resolved_ips.append(ip_str)
+
+    if not resolved_ips:
+        raise ValueError(f"proxy_target_url host {host!r} resolved to no usable IPs")
+    return host, resolved_ips
+
+
+async def validate_and_pin_proxy_target(
+    entity_type: str,
+    doc: dict[str, Any],
+) -> dict[str, Any]:
+    """Registration/refresh helper: resolve+validate the effective proxy target
+    and return the pin-bookkeeping fields to persist.
+
+    Computes the effective target via ``resolve_proxy_target`` (so it inherits the
+    federated / disabled / auto-disabled / target-required gating and the native
+    fallback), and — only when a real target exists — resolves its hostname and
+    validates every IP against the egress policy (layer 2). Returns the
+    fields the caller should merge into the persisted document; an empty dict when
+    the entity is not proxied / has no resolvable target (nothing to pin).
+
+    Call this at the service create/update layer BEFORE persisting, so a target
+    that resolves to a metadata/private IP is rejected with a clear error at
+    register/update instead of silently dropped at render.
+
+    Args:
+        entity_type: Canonical entity-type token.
+        doc: The proxy-relevant scalars (same shape as assert_proxy_target_resolvable).
+
+    Returns:
+        ``{"proxy_resolved_ips": [...], "proxy_target_host": "..."}`` when a target
+        was validated, else ``{}``.
+
+    Raises:
+        ValueError / EgressPolicyError: If the target is denied or unresolvable.
+    """
+    target = resolve_proxy_target(entity_type, doc)
+    if not target:
+        return {}
+    host, ips = await resolve_and_validate_proxy_target(target)
+    return {"proxy_resolved_ips": ips, "proxy_target_host": host or ""}
 
 
 def _is_federated(doc: dict[str, Any]) -> bool:

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -5,35 +5,32 @@ can opt into being served through the gateway by setting ``is_proxied=True``.
 The registry then generates an nginx location block that routes authenticated
 traffic to the entity's effective backend URL.
 
-Security posture (this module is the application-layer SSRF control):
-- ``_assert_egress_allowed`` rejects loopback / private / reserved / multicast
-  targets unless ``gateway_proxy_allow_private_targets`` is set, and ALWAYS
-  rejects link-local (which includes the cloud metadata endpoint) and the
-  unspecified address regardless of that flag.
-- The guard is a best-effort STATIC check on literal-IP targets. Hostnames pass
-  here (DNS is resolved downstream by nginx/httpx); the authoritative defense
-  against DNS-rebind is the network egress policy (deny metadata/link-local at
-  the socket layer) documented in the LLD, not this function.
-- The same guard is DESIGNED to run at three points (model validator, repository
-  persist, nginx render) so a row written before the policy existed, or by a
-  federation sync that bypasses the Pydantic validator, still cannot emit a live
-  route to a denied host. This module lands the model validator; the persist-path
-  and render-path hooks are added in the federation-enforcement and nginx-render
-  changes respectively. The feature ships disabled (gateway_generic_proxy_enabled
-  defaults false) until all three are in place.
+Security posture (this module wires the entity/proxy layer to the SSRF control):
+- IP classification + the egress allowlist are owned by the canonical
+  ``registry.utils.url_guard``, including its inline literal parser and IP-category
+  classifier. The functions here are thin PROXY_PROFILE adapters that translate the guard's ``UrlValidationError`` into the local
+  ``EgressPolicyError`` (a ``ValueError``) so a Pydantic field validator surfaces a
+  clean 4xx. Registration and the fetch-time pinned transport therefore share ONE
+  policy — the ``gateway_proxy_allow_private_targets`` bool (relaxes loopback/
+  private/CGNAT only) plus ``ssrf_allowed_hosts``/``ssrf_allowed_cidrs`` (an explicit
+  CIDR re-permits any non-metadata category); the cloud metadata endpoints
+  (169.254.169.254 AND the IPv6 fd00:ec2::254) are NEVER reachable.
+- The static check is best-effort on literal-IP targets; hostnames pass it (no DNS
+  in a validator). The authoritative rebind defense is the fetch-time pinned
+  transport (``url_guard.guarded_async_client``, which resolves+validates+connects
+  inside the transport call for every request and redirect hop) plus the network
+  egress policy — not this static edge check.
+- The guard runs at three points (model validator, service resolve-and-pin, nginx
+  render) so a row written before the policy existed, or by a federation sync that
+  bypasses the Pydantic validator, still cannot emit a live route to a denied host.
 
 Two application-layer checks, by context:
 - ``_assert_egress_allowed`` / ``egress_guard_validator`` — the STATIC (literal-IP)
-  check at the Pydantic API edge (422). A genuine hostname passes it (no DNS in a
-  validator).
+  check at the Pydantic API edge (422), via ``url_guard.validate_url(resolve=False)``.
 - ``resolve_and_validate_proxy_target`` / ``validate_and_pin_proxy_target`` — the
-  DNS-aware check (layer 2), run at the service register/update layer and
-  by the scheduled pin-refresh. It resolves the hostname and validates every
-  resolved IP (like registry/services/ard_net_guard.py), catching a target that
-  resolves to a metadata/private IP *now* and pinning the resolved IPs. It is
-  best-effort against DNS-rebind (the set can change before the real request) —
-  which is why the authoritative control remains the network egress policy (layer
-  1). Do not enable the feature until that policy is deployed.
+  DNS-aware check (layer 2), run at the service register/update layer and by
+  the scheduled pin-refresh, via ``url_guard.validate_url(resolve=True)``. Resolves
+  the hostname, validates every resolved IP, and returns them for pin bookkeeping.
 """
 
 import logging
@@ -42,7 +39,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field
 
-from registry.utils.ip_guard import coerce_ip_literal, ip_denial_reason
+from registry.utils.url_guard import coerce_ip_literal
 
 logger = logging.getLogger(__name__)
 
@@ -99,46 +96,39 @@ class EgressPolicyError(ValueError):
 def _assert_egress_allowed(url: str) -> None:
     """Reject loopback / link-local / metadata / private / unspecified targets.
 
-    Delegates the IP category logic to ``registry.utils.ip_guard`` (the single
-    source of truth for encoding/NAT64/mapped bypasses). When
-    ``settings.gateway_proxy_allow_private_targets`` is true the
-    private/loopback/reserved/multicast checks are skipped (for trusted
-    on-cluster service URLs), but link-local (the cloud metadata endpoint) and
-    the unspecified address are ALWAYS denied.
+    Thin adapter over the canonical ``url_guard.validate_url`` (PROXY_PROFILE,
+    STATIC / no-DNS): the URL guard owns the classification (obfuscated literals,
+    embedded-v4, the non-overridable metadata deny) AND the egress allowlist (the
+    ``gateway_proxy_allow_private_targets`` bool + ``ssrf_allowed_hosts/cidrs``), so
+    registration and the fetch-time pinned transport share ONE policy. This adapter
+    exists only to (a) bind PROXY_PROFILE and (b) translate the guard's
+    ``UrlValidationError`` (a bare ``RegistryError``) into ``EgressPolicyError`` (a
+    ``ValueError``) so a Pydantic field validator surfaces it as a clean 4xx rather
+    than a 500.
 
     Literal-IP hosts (including obfuscated spellings) are category-checked here.
-    Genuine hostnames are allowed through (DNS is resolved downstream); see the
-    module docstring for why the real rebind defense is the network egress
-    policy, not this static check.
+    Genuine hostnames pass the static check (DNS is resolved downstream); the
+    authoritative rebind defense is the pinned transport at fetch time + the network
+    egress policy, not this static check.
 
     Args:
         url: The candidate proxy target URL.
 
     Raises:
-        ValueError: If the scheme is not http(s).
-        EgressPolicyError: If the target host is in a denied network range.
+        EgressPolicyError: If the scheme is not http(s) or the target host is in a
+            denied network range (both are ``ValueError`` subclasses).
     """
-    # Imported here (not at module import) so tests/callers that monkeypatch
-    # settings see the live value, and to avoid an import cycle with config.
-    from registry.core.config import settings
+    from registry.exceptions import UrlValidationError
+    from registry.utils.url_guard import PROXY_PROFILE, validate_url
 
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"proxy_target_url must be an http(s) URL, got scheme {parsed.scheme!r}")
-
-    host = (parsed.hostname or "").strip("[]")
-    ip = coerce_ip_literal(host)
-    if ip is None:
-        # Genuine hostname -> resolved downstream; static guard passes. The
-        # authoritative rebind defense is the network egress policy, not this.
-        return
-
-    reason = ip_denial_reason(ip, allow_private=settings.gateway_proxy_allow_private_targets)
-    if reason is not None:
+    try:
+        validate_url(url, profile=PROXY_PROFILE, resolve=False)
+    except UrlValidationError as e:
         raise EgressPolicyError(
-            f"proxy_target_url host {host} is denied ({reason}); "
-            "if this is a trusted on-cluster target set GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
-        )
+            f"proxy_target_url rejected: {e.reason}; if this is a trusted on-cluster "
+            "target set GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true or add it to "
+            "SSRF_ALLOWED_HOSTS / SSRF_ALLOWED_CIDRS"
+        ) from e
 
 
 class ProxyableMixin(BaseModel):
@@ -214,19 +204,13 @@ async def resolve_and_validate_proxy_target(
     """Resolve a proxy_target_url's hostname and validate every resolved IP.
 
     This is **layer 2** — the registration-time (and refresh-time)
-    DNS-aware SSRF check that ``_assert_egress_allowed`` deliberately skips for
-    hostnames. Resolving here catches a target that resolves to a
-    metadata/loopback/private IP *now*, giving a clear error at register/update
-    instead of a silent render-time drop. It is best-effort against DNS-rebind
-    (the resolved set can change before the real request) — which is exactly why
-    the authoritative control is the network egress policy (layer 1), not this.
-
-    Behavior mirrors ``_assert_egress_allowed``'s policy:
-    - scheme must be http(s);
-    - literal-IP targets are category-checked directly (no DNS);
-    - hostnames are resolved via ``getaddrinfo`` and EVERY resolved IP is checked;
-    - ``gateway_proxy_allow_private_targets`` relaxes private/loopback/reserved,
-      but link-local (metadata) and the unspecified address are ALWAYS denied.
+    DNS-aware SSRF check. It resolves the hostname and validates EVERY resolved IP
+    via the canonical ``url_guard.validate_url`` (PROXY_PROFILE, resolve=True), so
+    it shares ONE classifier + egress allowlist with the fetch-time pinned
+    transport (no register-vs-fetch policy drift). It is best-effort against
+    DNS-rebind (the resolved set can change before the real request) — which is why
+    the authoritative control is the pinned transport at fetch time + the network
+    egress policy (layer 1), not this.
 
     Args:
         url: The candidate proxy target URL.
@@ -234,63 +218,36 @@ async def resolve_and_validate_proxy_target(
     Returns:
         ``(hostname, resolved_ips)`` — the original hostname (or None for a
         literal-IP target) and the list of resolved IP strings (the literal
-        itself for an IP target). Callers persist these for pin bookkeeping.
+        itself for an IP target; empty when the host is operator-allowlisted, which
+        ``validate_url`` returns without resolving). Callers persist these for pin
+        bookkeeping.
 
     Raises:
-        ValueError: If the scheme is not http(s), or the host cannot be resolved.
-        EgressPolicyError: If any resolved IP is in a denied network range.
+        EgressPolicyError: If the scheme is not http(s), the host cannot be
+            resolved, or any resolved IP is in a denied network range (a
+            ``ValueError`` subclass, so a caller mapping ValueError -> 4xx works).
     """
     import asyncio
-    import socket
 
-    from registry.core.config import settings
+    from registry.exceptions import UrlValidationError
+    from registry.utils.url_guard import PROXY_PROFILE, validate_url
 
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"proxy_target_url must be an http(s) URL, got scheme {parsed.scheme!r}")
-    host = (parsed.hostname or "").strip("[]")
-    if not host:
-        raise ValueError(f"proxy_target_url has no host: {url!r}")
-
-    allow_private = settings.gateway_proxy_allow_private_targets
-
-    # Literal-IP target: no DNS, category-check directly (same as the static guard).
-    literal = coerce_ip_literal(host)
-    if literal is not None:
-        reason = ip_denial_reason(literal, allow_private=allow_private)
-        if reason is not None:
-            raise EgressPolicyError(
-                f"proxy_target_url host {host} is denied ({reason}); if this is a "
-                "trusted on-cluster target set GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
-            )
-        return None, [str(literal)]
-
-    # Hostname: resolve and check EVERY resolved IP (defeats rebind at check time).
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    host = (urlparse(url).hostname or "").strip("[]")
+    is_literal = coerce_ip_literal(host) is not None
     try:
-        infos = await asyncio.to_thread(socket.getaddrinfo, host, port, proto=socket.IPPROTO_TCP)
-    except socket.gaierror as e:
-        raise ValueError(f"Cannot resolve proxy_target_url host {host!r}: {e}") from e
+        # resolve=True performs getaddrinfo + validates every resolved IP, and
+        # returns the validated IP list (the literal itself for an IP target, or
+        # [] for an operator-allowlisted host it does not pin). validate_url is
+        # SYNCHRONOUS (socket.getaddrinfo), so run it in a worker thread — a slow
+        # or adversarial DNS answer must not block the event loop on this async
+        # register/refresh path.
+        ips = await asyncio.to_thread(validate_url, url, profile=PROXY_PROFILE, resolve=True)
+    except UrlValidationError as e:
+        raise EgressPolicyError(f"proxy_target_url rejected: {e.reason}") from e
 
-    resolved_ips: list[str] = []
-    for _family, _type, _proto, _canon, sockaddr in infos:
-        ip_str = str(sockaddr[0])
-        ip = coerce_ip_literal(ip_str)
-        if ip is None:
-            continue
-        reason = ip_denial_reason(ip, allow_private=allow_private)
-        if reason is not None:
-            raise EgressPolicyError(
-                f"proxy_target_url host {host} resolves to denied IP {ip_str} ({reason}); "
-                "if this is a trusted on-cluster target set "
-                "GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
-            )
-        if ip_str not in resolved_ips:
-            resolved_ips.append(ip_str)
-
-    if not resolved_ips:
-        raise ValueError(f"proxy_target_url host {host!r} resolved to no usable IPs")
-    return host, resolved_ips
+    # A literal-IP target has no hostname to preserve for the pin (Host/SNI); a
+    # genuine hostname is returned so callers can persist it for pin bookkeeping.
+    return (None if is_literal else host), ips
 
 
 async def validate_and_pin_proxy_target(

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -244,6 +244,12 @@ def resolve_proxy_target(
         # stripped on ingest, so without this a proxied synced record would fall
         # back to the PEER-SUPPLIED proxy_pass_url/url below.
         return None
+    if "is_enabled" in doc and not doc["is_enabled"]:
+        # A disabled entity is not reachable, so it gets no gateway route. Gated
+        # only when the caller supplied is_enabled (list_proxied projects it);
+        # absent means "not my decision" (a partial projection), so we don't
+        # assume disabled.
+        return None
     if doc.get("proxy_disabled_reason"):
         return None  # refresh auto-disabled this route
     explicit = doc.get("proxy_target_url")

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -1,0 +1,191 @@
+"""Shared gateway-proxy opt-in for registry entities + the SSRF egress guard.
+
+Any entity type (MCP server, A2A agent, skill, virtual server, custom entity)
+can opt into being served through the gateway by setting ``is_proxied=True``.
+The registry then generates an nginx location block that routes authenticated
+traffic to the entity's effective backend URL.
+
+Security posture (this module is the application-layer SSRF control):
+- ``_assert_egress_allowed`` rejects loopback / private / reserved / multicast
+  targets unless ``gateway_proxy_allow_private_targets`` is set, and ALWAYS
+  rejects link-local (which includes the cloud metadata endpoint) and the
+  unspecified address regardless of that flag.
+- The guard is a best-effort STATIC check on literal-IP targets. Hostnames pass
+  here (DNS is resolved downstream by nginx/httpx); the authoritative defense
+  against DNS-rebind is the network egress policy (deny metadata/link-local at
+  the socket layer) documented in the LLD, not this function.
+- The same guard is DESIGNED to run at three points (model validator, repository
+  persist, nginx render) so a row written before the policy existed, or by a
+  federation sync that bypasses the Pydantic validator, still cannot emit a live
+  route to a denied host. This module lands the model validator; the persist-path
+  and render-path hooks are added in the federation-enforcement and nginx-render
+  changes respectively. The feature ships disabled (gateway_generic_proxy_enabled
+  defaults false) until all three are in place.
+
+Note vs. registry/services/ard_net_guard.py: that guard resolves DNS and checks
+every resolved IP, defeating rebind at check time. This guard deliberately does
+NOT resolve (proxy targets are long-lived and re-validated by a refresh + the
+network egress policy), so a hostname target is only network-layer-protected.
+It is therefore a WEAKER static check than ard_net_guard by design; do not enable
+the feature until the network egress policy (SSRF layer 1) is deployed.
+"""
+
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field, field_validator
+
+from registry.utils.ip_guard import coerce_ip_literal, ip_denial_reason
+
+# Canonical built-in entity-type tokens that resolve_proxy_target knows how to
+# derive a fallback backend URL for. Custom entities pass their own descriptor
+# name as the type token and must always carry an explicit proxy_target_url.
+# Kept as the single source of truth so a typo in a caller cannot silently
+# resolve to "not proxyable" without notice (see resolve_proxy_target).
+CANONICAL_ENTITY_TYPES: frozenset[str] = frozenset(
+    {"mcp_server", "a2a_agent", "skill", "virtual_server"}
+)
+
+
+class EgressPolicyError(ValueError):
+    """Raised when a proxy_target_url resolves to a denied network range.
+
+    Subclasses ValueError so the Pydantic field_validator surfaces it as a 422
+    at the API edge, while callers that persist raw dicts (federation) can catch
+    it explicitly on the persist path.
+    """
+
+
+def _assert_egress_allowed(url: str) -> None:
+    """Reject loopback / link-local / metadata / private / unspecified targets.
+
+    Delegates the IP category logic to ``registry.utils.ip_guard`` (the single
+    source of truth for encoding/NAT64/mapped bypasses). When
+    ``settings.gateway_proxy_allow_private_targets`` is true the
+    private/loopback/reserved/multicast checks are skipped (for trusted
+    on-cluster service URLs), but link-local (the cloud metadata endpoint) and
+    the unspecified address are ALWAYS denied.
+
+    Literal-IP hosts (including obfuscated spellings) are category-checked here.
+    Genuine hostnames are allowed through (DNS is resolved downstream); see the
+    module docstring for why the real rebind defense is the network egress
+    policy, not this static check.
+
+    Args:
+        url: The candidate proxy target URL.
+
+    Raises:
+        ValueError: If the scheme is not http(s).
+        EgressPolicyError: If the target host is in a denied network range.
+    """
+    # Imported here (not at module import) so tests/callers that monkeypatch
+    # settings see the live value, and to avoid an import cycle with config.
+    from registry.core.config import settings
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"proxy_target_url must be an http(s) URL, got scheme {parsed.scheme!r}")
+
+    host = (parsed.hostname or "").strip("[]")
+    ip = coerce_ip_literal(host)
+    if ip is None:
+        # Genuine hostname -> resolved downstream; static guard passes. The
+        # authoritative rebind defense is the network egress policy, not this.
+        return
+
+    reason = ip_denial_reason(ip, allow_private=settings.gateway_proxy_allow_private_targets)
+    if reason is not None:
+        raise EgressPolicyError(
+            f"proxy_target_url host {host} is denied ({reason}); "
+            "if this is a trusted on-cluster target set GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=true"
+        )
+
+
+class ProxyableMixin(BaseModel):
+    """Shared opt-in fields for serving an entity through the gateway.
+
+    Set ``is_proxied=True`` to have the registry generate an nginx location
+    block routing authenticated traffic to ``proxy_target_url``. For MCP servers
+    and A2A agents, ``proxy_target_url`` falls back to their native backend URL
+    (``proxy_pass_url`` / ``url``) when unset; skills and custom entities must
+    set it explicitly (see ``resolve_proxy_target``).
+    """
+
+    is_proxied: bool = Field(
+        default=False,
+        description="When true, the registry generates a gateway route for this entity.",
+    )
+    proxy_target_url: str | None = Field(
+        default=None,
+        description=(
+            "Backend HTTP(S) URL the gateway forwards to. Required when is_proxied "
+            "is true and the entity has no native backend URL (skills, custom entities)."
+        ),
+    )
+    # Operational bookkeeping written by the resolve-and-validate refresh; not user-set.
+    proxy_resolved_ips: list[str] = Field(
+        default_factory=list,
+        description="IPs the hostname target last resolved to (egress re-validation bookkeeping).",
+    )
+    proxy_target_host: str | None = Field(
+        default=None,
+        description="Original hostname of proxy_target_url (preserved for Host/SNI; informational).",
+    )
+    proxy_disabled_reason: str | None = Field(
+        default=None,
+        description=(
+            "Set when the refresh auto-disables proxying (e.g. target now resolves "
+            "to a denied IP). When non-null the entity is treated as NOT proxied."
+        ),
+    )
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _validate_target_url(cls, v: str | None) -> str | None:
+        """Fast-fail SSRF check at the API edge (repeated at persist + render)."""
+        if v is None:
+            return v
+        _assert_egress_allowed(v)
+        return v
+
+
+def resolve_proxy_target(
+    entity_type: str,
+    doc: dict[str, Any],
+) -> str | None:
+    """Return the effective backend URL for a proxied entity, or None.
+
+    Returns None (entity is not gateway-served) when: it is not flagged
+    ``is_proxied``; the refresh auto-disabled it (``proxy_disabled_reason`` set);
+    or its type has no resolvable target (a local-deployment MCP server has no
+    HTTP backend; a skill/custom entity without an explicit ``proxy_target_url``).
+
+    SECURITY: this function does NOT re-run the egress guard — it returns the
+    stored target verbatim. A document written straight to the DB (federation
+    sync, a pre-feature migration) can carry a denied target that the model
+    validator never saw. Any caller that turns this URL into a live route (nginx
+    render, the proxy hop) MUST pass it through ``_assert_egress_allowed`` first.
+    The render-path hook is the enforcement point; do not wire this into a route
+    generator without it.
+
+    Args:
+        entity_type: Canonical entity-type token (mcp_server, a2a_agent, skill, ...).
+        doc: The stored entity document (or projection) as a dict.
+
+    Returns:
+        The effective backend URL to forward to, or None if not proxyable.
+    """
+    if not doc.get("is_proxied"):
+        return None
+    if doc.get("proxy_disabled_reason"):
+        return None  # refresh auto-disabled this route
+    explicit = doc.get("proxy_target_url")
+    if explicit:
+        return explicit
+    if entity_type == "mcp_server":
+        if doc.get("deployment") == "local":
+            return None  # stdio servers have no HTTP backend
+        return doc.get("proxy_pass_url")
+    if entity_type == "a2a_agent":
+        return doc.get("url")
+    return None  # skills / custom entities must set proxy_target_url explicitly

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -49,6 +49,37 @@ CANONICAL_ENTITY_TYPES: frozenset[str] = frozenset(
     {"mcp_server", "a2a_agent", "skill", "virtual_server"}
 )
 
+# Proxy fields that must NEVER cross the federation boundary (owner decision:
+# no proxying federated entities, either direction). Stripped from a payload
+# both on INGEST (a synced entity can never become a local gateway route, and a
+# peer cannot plant an SSRF target) and on EXPORT (we do not advertise our proxy
+# config, incl. the internal proxy_target_url, to peers). is_proxied and
+# proxy_target_url are the opt-in; the three proxy_* bookkeeping fields are
+# internal refresh state that likewise should not travel. See strip_proxy_fields.
+PROXY_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "is_proxied",
+        "proxy_target_url",
+        "proxy_resolved_ips",
+        "proxy_target_host",
+        "proxy_disabled_reason",
+    }
+)
+
+
+def strip_proxy_fields(doc: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of ``doc`` with all proxy fields removed.
+
+    Used at the federation boundary in both directions. Removing the keys (vs.
+    forcing is_proxied=False) is deliberate: on ingest it leaves any existing
+    stored value untouched on an update re-sync (a peer sync must not clobber a
+    local admin's opt-in), while a create defaults is_proxied to False; on export
+    it simply omits our proxy config from the outbound payload.
+    """
+    if not any(k in doc for k in PROXY_FIELD_NAMES):
+        return doc
+    return {k: v for k, v in doc.items() if k not in PROXY_FIELD_NAMES}
+
 
 class EgressPolicyError(ValueError):
     """Raised when a proxy_target_url resolves to a denied network range.
@@ -166,6 +197,16 @@ def egress_guard_validator(v: str | None) -> str | None:
     return v
 
 
+def _is_federated(doc: dict[str, Any]) -> bool:
+    """True if the entity was synced from a peer (sync_metadata.is_federated).
+
+    Federated entities are never local gateway routes (owner decision), so this
+    gates resolve_proxy_target regardless of a locally-flipped is_proxied.
+    """
+    meta = doc.get("sync_metadata")
+    return bool(isinstance(meta, dict) and meta.get("is_federated"))
+
+
 def resolve_proxy_target(
     entity_type: str,
     doc: dict[str, Any],
@@ -193,6 +234,15 @@ def resolve_proxy_target(
         The effective backend URL to forward to, or None if not proxyable.
     """
     if not doc.get("is_proxied"):
+        return None
+    if _is_federated(doc):
+        # ABSOLUTE isolation (owner decision): a federated entity is never a
+        # local gateway route, even if a local admin flips is_proxied=True on the
+        # synced record after ingest. Enforced here at the resolve chokepoint (in
+        # addition to the strip-on-ingest boundary) so there is no path from
+        # peer-supplied data to a live route. The proxy_target_url was already
+        # stripped on ingest, so without this a proxied synced record would fall
+        # back to the PEER-SUPPLIED proxy_pass_url/url below.
         return None
     if doc.get("proxy_disabled_reason"):
         return None  # refresh auto-disabled this route

--- a/registry/schemas/server_update_models.py
+++ b/registry/schemas/server_update_models.py
@@ -6,6 +6,17 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from .agent_models import AgentProvider
 
+
+def _guard_egress(v: str | None) -> str | None:
+    """Run the SSRF egress guard on a supplied proxy_target_url (None passes)."""
+    if v is None:
+        return v
+    from .proxy_mixin import _assert_egress_allowed
+
+    _assert_egress_allowed(v)
+    return v
+
+
 # Fields that callers must not mutate via PUT or PATCH.
 # Server-managed (timestamps, health) or identity anchors.
 SERVER_REGISTRANT_ONLY_FIELDS: frozenset[str] = frozenset(
@@ -128,6 +139,12 @@ class ServerUpdateRequest(BaseModel):
     oauth_client_id: str | None = None
     append_mcp_path: bool | None = None
 
+    # Gateway-proxy opt-in. For an MCP server the target is proxy_pass_url;
+    # proxy_target_url is accepted for override symmetry with other entity types
+    # (SSRF-guarded below). extra="forbid" would 422 these without declaration.
+    is_proxied: bool | None = None
+    proxy_target_url: str | None = None
+
     # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
     # auth_header_name, custom_headers) are intentionally absent.
     # They are owned by PATCH /api/servers/{path}/auth-credential.
@@ -175,6 +192,11 @@ class ServerUpdateRequest(BaseModel):
     ) -> dict[str, Any] | None:
         return _validate_metadata_size(v)
 
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _guard_proxy_target_url(cls, v: str | None) -> str | None:
+        return _guard_egress(v)
+
 
 class ServerCardPatch(BaseModel):
     """RFC 7396 JSON Merge Patch body for PATCH /api/servers/{path}.
@@ -218,6 +240,10 @@ class ServerCardPatch(BaseModel):
     # Per-server Connect-config overrides (token-less IDE OAuth login + /mcp path).
     oauth_client_id: str | None = None
     append_mcp_path: bool | None = None
+    # Gateway-proxy opt-in (patchable; None = leave unchanged). extra="forbid"
+    # would 422 these without declaration.
+    is_proxied: bool | None = None
+    proxy_target_url: str | None = None
     # NOTE: Credential-shaped fields (auth_scheme, auth_credential,
     # auth_header_name, custom_headers, custom_header_names) are
     # intentionally absent and rejected by extra="forbid" with 422.
@@ -267,3 +293,8 @@ class ServerCardPatch(BaseModel):
         v: dict[str, Any] | None,
     ) -> dict[str, Any] | None:
         return _validate_metadata_size(v)
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _guard_proxy_target_url(cls, v: str | None) -> str | None:
+        return _guard_egress(v)

--- a/registry/schemas/skill_models.py
+++ b/registry/schemas/skill_models.py
@@ -27,6 +27,13 @@ from pydantic import (
     Field,
     HttpUrl,
     field_validator,
+    model_validator,
+)
+
+from registry.schemas.proxy_mixin import (
+    ProxyableMixin,
+    assert_proxy_target_resolvable,
+    egress_guard_validator,
 )
 
 # Configure logging
@@ -132,8 +139,13 @@ class ContentIntegrity(BaseModel):
     )
 
 
-class SkillCard(BaseModel):
-    """Full skill profile following Agent Skills specification."""
+class SkillCard(ProxyableMixin):
+    """Full skill profile following Agent Skills specification.
+
+    Inherits the ``is_proxied`` / ``proxy_target_url`` opt-in from ProxyableMixin.
+    A skill has no native backend URL, so proxying one requires an explicit
+    ``proxy_target_url`` (enforced by _validate_proxy_target below).
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -308,6 +320,24 @@ class SkillCard(BaseModel):
             raise ValueError("Path must start with /skills/")
         return v
 
+    @model_validator(mode="after")
+    def _validate_proxy_target(self) -> "SkillCard":
+        """If proxied, require an explicit proxy_target_url (skills have no native backend).
+
+        Passes only the scalars the check reads (runs on every construction,
+        including reads that rebuild the model from a stored doc).
+        """
+        assert_proxy_target_resolvable(
+            "skill",
+            {
+                "is_proxied": self.is_proxied,
+                "proxy_target_url": self.proxy_target_url,
+                "proxy_disabled_reason": self.proxy_disabled_reason,
+            },
+            read_safe=True,  # storage model: reconstructed on read, log-not-raise
+        )
+        return self
+
 
 class SkillInfo(BaseModel):
     """Lightweight skill summary for listings."""
@@ -376,8 +406,11 @@ class SkillInfo(BaseModel):
     )
 
 
-class SkillRegistrationRequest(BaseModel):
-    """Request model for skill registration."""
+class SkillRegistrationRequest(ProxyableMixin):
+    """Request model for skill registration.
+
+    Inherits the ``is_proxied`` / ``proxy_target_url`` opt-in from ProxyableMixin.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -444,6 +477,25 @@ class SkillRegistrationRequest(BaseModel):
                 "not starting or ending with hyphen"
             )
         return v
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _guard_proxy_target_url(cls, v: str | None) -> str | None:
+        """API-edge SSRF fast-fail (the mixin no longer raises; storage is read-safe)."""
+        return egress_guard_validator(v)
+
+    @model_validator(mode="after")
+    def _require_proxy_target(self) -> "SkillRegistrationRequest":
+        """API edge: reject is_proxied=true without a target (skills have no fallback)."""
+        assert_proxy_target_resolvable(
+            "skill",
+            {
+                "is_proxied": self.is_proxied,
+                "proxy_target_url": self.proxy_target_url,
+                "proxy_disabled_reason": self.proxy_disabled_reason,
+            },
+        )  # read_safe defaults False -> raises at the edge
+        return self
 
 
 class SkillSearchResult(BaseModel):

--- a/registry/schemas/virtual_server_models.py
+++ b/registry/schemas/virtual_server_models.py
@@ -155,6 +155,21 @@ class VirtualServerConfig(BaseModel):
         description="Whether the virtual server is enabled and routable",
     )
 
+    # Gateway-proxy opt-in (ALIAS-ONLY). A virtual server is already served
+    # through the gateway via tool aggregation; is_proxied here governs ONLY
+    # whether the canonical /virtual_server/<path> alias is emitted. It never
+    # feeds the generic proxy hop and never takes a proxy_target_url — setting
+    # one is rejected (see _reject_proxy_target_url). Not inherited from
+    # ProxyableMixin precisely because the mixin permits proxy_target_url.
+    is_proxied: bool = Field(
+        default=False,
+        description="Emit the canonical /virtual_server/<path> alias (alias-only; no target URL).",
+    )
+    proxy_target_url: str | None = Field(
+        default=None,
+        description="Not supported for virtual servers; must be null (rejected if set).",
+    )
+
     # Categorization
     tags: list[str] = Field(
         default_factory=list,
@@ -235,6 +250,17 @@ class VirtualServerConfig(BaseModel):
         if not stripped:
             raise ValueError("Server name cannot be empty or whitespace-only")
         return stripped
+
+    @field_validator("proxy_target_url")
+    @classmethod
+    def _reject_proxy_target_url(cls, v: str | None) -> str | None:
+        """Virtual-server proxying is alias-only; a target URL is not allowed."""
+        if v is not None:
+            raise ValueError(
+                "proxy_target_url is not supported for virtual servers "
+                "(is_proxied is alias-only; it never forwards to a target)"
+            )
+        return v
 
 
 class VirtualServerInfo(BaseModel):

--- a/registry/services/agent_batch_item_processor.py
+++ b/registry/services/agent_batch_item_processor.py
@@ -208,6 +208,11 @@ def _build_card_from_request(request, path: str, existing: AgentCard | None) -> 
         trust_level=request.trust_level,
         supported_protocol=request.supported_protocol,
         external_tags=external_tag_list,
+        # Gateway-proxy opt-in — forward from the request so batch register/replace
+        # match the single-agent path (validated + pinned in agent_service). Without
+        # these, the mixin defaults silently drop the opt-in (feature loss).
+        is_proxied=request.is_proxied,
+        proxy_target_url=request.proxy_target_url,
         **optional_kwargs,
     )
 

--- a/registry/services/agent_service.py
+++ b/registry/services/agent_service.py
@@ -16,9 +16,45 @@ from ..exceptions import AssetIdConflictError
 from ..repositories.factory import get_agent_repository, get_search_repository
 from ..repositories.interfaces import AgentRepositoryBase, SearchRepositoryBase
 from ..schemas.agent_models import AgentCard
+from ..schemas.proxy_mixin import validate_and_pin_proxy_target
 from ..utils.url_guard import validate_agent_url
 
 logger = logging.getLogger(__name__)
+
+
+async def _validate_and_pin_agent_proxy(
+    agent_card: AgentCard,
+) -> None:
+    """Reject non-HTTP transports + resolve/validate/pin an agent's proxy target.
+
+    No-op when the agent is not proxied. When proxied:
+    - reject a GRPC ``preferred_transport`` (an HTTP location block can't serve
+      it) with a clear ValueError (surfaced as 4xx by the route);
+    - resolve the effective target (proxy_target_url or the agent url) and
+      validate every resolved IP against the egress policy (layer 2),
+      pinning the resolved IPs onto the card.
+    """
+    if not agent_card.is_proxied:
+        return
+    transport = (agent_card.preferred_transport or "").strip().upper()
+    if transport == "GRPC":
+        raise ValueError(
+            "is_proxied=true is not supported for an a2a_agent with "
+            "preferred_transport=GRPC: the gateway serves HTTP only. Use an HTTP "
+            "transport (JSONRPC / HTTP+JSON) or disable proxying."
+        )
+    pin = await validate_and_pin_proxy_target(
+        "a2a_agent",
+        {
+            "is_proxied": agent_card.is_proxied,
+            "proxy_target_url": agent_card.proxy_target_url,
+            "proxy_disabled_reason": agent_card.proxy_disabled_reason,
+            "url": agent_card.url,
+        },
+    )
+    if pin:
+        agent_card.proxy_resolved_ips = pin["proxy_resolved_ips"]
+        agent_card.proxy_target_host = pin["proxy_target_host"]
 
 
 class AgentService:
@@ -65,6 +101,9 @@ class AgentService:
         if await self._repo.get(path) is not None:
             logger.error(f"Agent registration failed: path '{path}' already exists")
             raise ValueError(f"Agent path '{path}' already exists")
+
+        # Gateway-proxy SSRF layer 2 + transport guard (no-op unless is_proxied).
+        await _validate_and_pin_agent_proxy(agent_card)
 
         # Id uniqueness pre-check (#1276): a caller-supplied id must not
         # collide with an existing agent. Raise -> route maps to 409.
@@ -215,10 +254,21 @@ class AgentService:
         agent_dict["updated_at"] = datetime.now(UTC)
 
         try:
-            AgentCard(**agent_dict)
+            merged_card = AgentCard(**agent_dict)
         except Exception as e:
             logger.error(f"Failed to validate updated agent: {e}")
             raise ValueError(f"Invalid agent update: {e}")
+
+        # Gateway-proxy SSRF layer 2 + transport guard on the MERGED card when this
+        # update touches the proxy opt-in or target. Re-validates + re-pins (or
+        # clears the pin) on the merged state, before persist. Re-enabling clears a
+        # prior auto-disable.
+        if "is_proxied" in updates or "proxy_target_url" in updates:
+            merged_card.proxy_disabled_reason = None
+            await _validate_and_pin_agent_proxy(merged_card)
+            agent_dict["proxy_resolved_ips"] = merged_card.proxy_resolved_ips
+            agent_dict["proxy_target_host"] = merged_card.proxy_target_host
+            agent_dict["proxy_disabled_reason"] = None
 
         updated_agent = await self._repo.update(path, agent_dict)
 

--- a/registry/services/ard_ingestion_service.py
+++ b/registry/services/ard_ingestion_service.py
@@ -32,6 +32,7 @@ from ..observability.meters import (
 from ..repositories.factory import get_federation_config_repository, get_skill_repository
 from ..schemas.federation_schema import AiCatalogFederationConfig, AiCatalogSourceConfig
 from ..schemas.peer_federation_schema import SyncResult
+from ..schemas.proxy_mixin import strip_proxy_fields
 from ..schemas.skill_models import SkillCard
 from .ard_ingest_mapping import entry_to_record, entry_to_skill_data
 from .ard_trust import host_identity_domain, verify_entry_trust
@@ -269,6 +270,10 @@ class ArdIngestionService:
         repo = get_skill_repository()
         stored = 0
         for skill_data in skills:
+            # Peer content (ARD catalog crawl): strip proxy fields so a federated
+            # skill can never become a local gateway route. Matches the AgentCore
+            # skill-ingest path; not relying on the mapper allowlist alone.
+            skill_data = strip_proxy_fields(skill_data)
             path = skill_data["path"]
             try:
                 try:

--- a/registry/services/ard_mapping.py
+++ b/registry/services/ard_mapping.py
@@ -6,6 +6,14 @@ URL, and return an :class:`ArdCatalogEntry` (or ``None`` when the record cannot
 produce a valid URN, in which case the caller skips it).
 
 See issue #1294 and ``.scratchpad/issue-1294/lld.md`` for the mapping rules.
+
+SECURITY NOTE: this is a federation OUTBOUND surface (ARD catalog / /api/ard/*).
+It emits an explicit ``ArdCatalogEntry`` allowlist, so gateway-proxy fields
+(is_proxied / proxy_target_url — an internal backend URL) are structurally never
+advertised to peers. Unlike the ``/api/federation/*`` export, this path is NOT
+guarded by ``strip_proxy_fields``; its safety is the allowlist. Do NOT add a
+generic passthrough of raw record fields here, and never map proxy_* onto an
+ArdCatalogEntry — that would leak internal proxy config to every catalog consumer.
 """
 
 import logging

--- a/registry/services/custom_entity_service.py
+++ b/registry/services/custom_entity_service.py
@@ -203,6 +203,9 @@ class CustomEntityService:
             allowed_groups=request.allowed_groups,
             tags=request.tags,
             attributes=cleaned,
+            # Gateway-proxy opt-in (validated on the request model; carried through).
+            is_proxied=request.is_proxied,
+            proxy_target_url=request.proxy_target_url,
         )
         record.assign_path()
         created = await self._get_entities().create(record)
@@ -240,6 +243,10 @@ class CustomEntityService:
             updates["allowed_groups"] = request.allowed_groups
         if request.tags is not None:
             updates["tags"] = request.tags
+        if request.is_proxied is not None:
+            updates["is_proxied"] = request.is_proxied
+        if request.proxy_target_url is not None:
+            updates["proxy_target_url"] = request.proxy_target_url
         if request.attributes is not None:
             # Merge-then-validate: merge client patch into stored bag, then validate.
             merged_attrs = dict(existing.attributes)
@@ -257,6 +264,19 @@ class CustomEntityService:
             raise CustomEntityValidationError(
                 "allowed_groups",
                 "group-restricted visibility requires at least one allowed_group",
+            )
+
+        # Proxy target-required invariant on the MERGED state (a PUT may set
+        # is_proxied without a target, or clear the target while proxied). Must
+        # run BEFORE persist: the repo write-then-reconstruct would otherwise
+        # store an invalid state, then CustomEntityRecord(**doc) raises on every
+        # subsequent read and the record vanishes from listings.
+        merged_is_proxied = updates.get("is_proxied", existing.is_proxied)
+        merged_target = updates.get("proxy_target_url", existing.proxy_target_url)
+        if merged_is_proxied and not merged_target and not existing.proxy_disabled_reason:
+            raise CustomEntityValidationError(
+                "proxy_target_url",
+                "is_proxied=true requires a proxy_target_url for a custom entity",
             )
 
         updated = await self._get_entities().update(path, updates)

--- a/registry/services/custom_entity_service.py
+++ b/registry/services/custom_entity_service.py
@@ -31,6 +31,7 @@ from ..schemas.custom_entity_models import (
     CustomTypeDescriptor,
     CustomTypeUpdate,
 )
+from ..schemas.proxy_mixin import validate_and_pin_proxy_target
 from .custom_entity_errors import (
     CustomEntityNotFoundError,
     CustomEntityValidationError,
@@ -208,6 +209,22 @@ class CustomEntityService:
             proxy_target_url=request.proxy_target_url,
         )
         record.assign_path()
+        # Gateway-proxy SSRF layer 2: when proxied, resolve the target hostname and
+        # validate every resolved IP against the egress policy, then pin the IPs.
+        # Rejects a metadata/private target at registration. Custom records carry
+        # their own type token as the entity_type.
+        if record.is_proxied:
+            pin = await validate_and_pin_proxy_target(
+                record.entity_type,
+                {
+                    "is_proxied": record.is_proxied,
+                    "proxy_target_url": record.proxy_target_url,
+                    "proxy_disabled_reason": record.proxy_disabled_reason,
+                },
+            )
+            if pin:
+                record.proxy_resolved_ips = pin["proxy_resolved_ips"]
+                record.proxy_target_host = pin["proxy_target_host"]
         created = await self._get_entities().create(record)
         try:
             await self._get_search().index_custom_entity(record=created, descriptor=descriptor)
@@ -278,6 +295,24 @@ class CustomEntityService:
                 "proxy_target_url",
                 "is_proxied=true requires a proxy_target_url for a custom entity",
             )
+
+        # Gateway-proxy SSRF layer 2: when this update touches the proxy opt-in or
+        # target, resolve+validate the MERGED target and refresh the pin bookkeeping
+        # (or clear it when no longer a live proxy). Runs BEFORE persist so a
+        # metadata/private target is rejected at update time. Re-enabling clears any
+        # prior auto-disable.
+        if "is_proxied" in updates or "proxy_target_url" in updates:
+            pin = await validate_and_pin_proxy_target(
+                existing.entity_type,
+                {
+                    "is_proxied": merged_is_proxied,
+                    "proxy_target_url": merged_target,
+                    "proxy_disabled_reason": None,
+                },
+            )
+            updates["proxy_resolved_ips"] = pin.get("proxy_resolved_ips", [])
+            updates["proxy_target_host"] = pin.get("proxy_target_host")
+            updates["proxy_disabled_reason"] = None
 
         updated = await self._get_entities().update(path, updates)
         if updated is None:

--- a/registry/services/peer_federation_service.py
+++ b/registry/services/peer_federation_service.py
@@ -37,6 +37,7 @@ from ..schemas.peer_federation_schema import (
     SyncHistoryEntry,
     SyncResult,
 )
+from ..schemas.proxy_mixin import strip_proxy_fields
 from .agent_service import agent_service
 from .federation.peer_registry_client import PeerRegistryClient
 from .server_service import server_service
@@ -1464,8 +1465,13 @@ class PeerFederationService:
                     "original_path": original_path,
                 }
 
-                # Create a copy to avoid modifying original
-                server_data = server.copy()
+                # Create a copy to avoid modifying original, and STRIP any
+                # proxy fields the peer sent: a federated entity is never a local
+                # gateway route (owner decision), and this prevents a peer from
+                # planting an SSRF proxy_target_url. Stripping (not force-false)
+                # leaves a local admin's opt-in on the existing record untouched
+                # on re-sync. See strip_proxy_fields.
+                server_data = strip_proxy_fields(server.copy())
                 server_data["path"] = prefixed_path
                 server_data["sync_metadata"] = sync_metadata
 
@@ -1569,8 +1575,11 @@ class PeerFederationService:
                     "original_path": original_path,
                 }
 
-                # Create a copy to avoid modifying original
-                agent_data = agent.copy()
+                # Create a copy to avoid modifying original, and STRIP any proxy
+                # fields the peer sent (see _store_synced_servers for rationale:
+                # federated entities are never local gateway routes; strip, not
+                # force-false, to preserve a local admin's opt-in on re-sync).
+                agent_data = strip_proxy_fields(agent.copy())
                 agent_data["path"] = prefixed_path
                 agent_data["sync_metadata"] = sync_metadata
 

--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -186,6 +186,17 @@ class ServerService:
             server_info["version"] = "v1.0.0"
         server_info["is_active"] = True
 
+        # Gateway-proxy SSRF layer 2 (no-op unless is_proxied): resolve the target
+        # hostname and validate every resolved IP against the egress policy, then
+        # pin the resolved IPs. Rejects a metadata/private target at registration.
+        if server_info.get("is_proxied"):
+            from ..schemas.proxy_mixin import validate_and_pin_proxy_target
+
+            pin = await validate_and_pin_proxy_target("mcp_server", server_info)
+            if pin:
+                server_info["proxy_resolved_ips"] = pin["proxy_resolved_ips"]
+                server_info["proxy_target_host"] = pin["proxy_target_host"]
+
         try:
             result = await self._repo.create(server_info)
         except AssetIdConflictError as e:
@@ -245,6 +256,31 @@ class ServerService:
                 server_path=path,
                 registered_target_url=registered_target,
             )
+        # Gateway-proxy SSRF layer 2 on the MERGED state. This is the single choke
+        # point for every server-update call site (PATCH, version swap, etc.), so
+        # a hostname proxy target that resolves to a metadata/private IP is rejected
+        # here rather than persisted unchecked. Only touches the DB when a proxy
+        # field is present in the update payload. Mirrors the skill/agent pattern.
+        # proxy_pass_url is included: for an MCP server resolve_proxy_target falls
+        # back to it when proxy_target_url is unset, so changing it on an already
+        # is_proxied server changes the effective target and must re-validate.
+        _proxy_fields = ("is_proxied", "proxy_target_url", "proxy_pass_url")
+        if any(f in server_info for f in _proxy_fields):
+            from ..schemas.proxy_mixin import validate_and_pin_proxy_target
+
+            existing = await self._repo.get(path)
+            merged = dict(existing or {})
+            merged.update(server_info)
+            # An update touching the proxy config re-validates from scratch, so a
+            # prior refresh auto-disable must not suppress resolution here.
+            merged["proxy_disabled_reason"] = None
+            if merged.get("is_proxied"):
+                pin = await validate_and_pin_proxy_target("mcp_server", merged)
+                if pin:
+                    server_info["proxy_resolved_ips"] = pin["proxy_resolved_ips"]
+                    server_info["proxy_target_host"] = pin["proxy_target_host"]
+                # Re-enabling clears any prior refresh auto-disable.
+                server_info["proxy_disabled_reason"] = None
 
         result = await self._repo.update(path, server_info)
 
@@ -917,6 +953,19 @@ class ServerService:
         new_inactive["is_active"] = False
         new_inactive["active_version_id"] = path
         new_inactive.pop("other_version_ids", None)
+
+        # Gateway-proxy SSRF layer 2: the promoted version's proxy_pass_url becomes
+        # the live effective target. If the promoted doc is proxied, resolve+validate
+        # it (a version added earlier bypassed the register/update check) and pin the
+        # IPs before it goes active. Rejects promoting a version whose target now
+        # resolves to a metadata/private IP.
+        if new_active.get("is_proxied"):
+            from ..schemas.proxy_mixin import validate_and_pin_proxy_target
+
+            pin = await validate_and_pin_proxy_target("mcp_server", new_active)
+            if pin:
+                new_active["proxy_resolved_ips"] = pin["proxy_resolved_ips"]
+                new_active["proxy_target_host"] = pin["proxy_target_host"]
 
         # Execute swap: delete old docs, insert new docs
         await self._repo.delete(path)

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -1200,6 +1200,9 @@ def _build_skill_card(
         content_integrity=content_integrity,
         created_at=datetime.now(UTC),
         updated_at=datetime.now(UTC),
+        # Gateway-proxy opt-in (validated on the request model; carried through).
+        is_proxied=request.is_proxied,
+        proxy_target_url=request.proxy_target_url,
     )
 
 

--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -34,6 +34,7 @@ from ..repositories.interfaces import (
     SearchRepositoryBase,
     SkillRepositoryBase,
 )
+from ..schemas.proxy_mixin import validate_and_pin_proxy_target
 from ..schemas.skill_models import (
     ContentIntegrity,
     FileHash,
@@ -1229,6 +1230,32 @@ class SkillService:
             self._search_repo = get_search_repository()
         return self._search_repo
 
+    async def _validate_and_pin_skill_proxy(
+        self,
+        skill: SkillCard,
+    ) -> None:
+        """Resolve+validate the skill's proxy target and pin the resolved IPs.
+
+        No-op when the skill is not proxied / has no resolvable target. Raises
+        (ValueError / EgressPolicyError, surfaced as a 4xx by the route) when the
+        target resolves to a denied IP, so a bad target is rejected at
+        registration rather than silently dropped at render. On success the
+        resolved IPs + host are written back onto the skill for pin bookkeeping.
+        """
+        if not skill.is_proxied:
+            return
+        pin = await validate_and_pin_proxy_target(
+            "skill",
+            {
+                "is_proxied": skill.is_proxied,
+                "proxy_target_url": skill.proxy_target_url,
+                "proxy_disabled_reason": skill.proxy_disabled_reason,
+            },
+        )
+        if pin:
+            skill.proxy_resolved_ips = pin["proxy_resolved_ips"]
+            skill.proxy_target_host = pin["proxy_target_host"]
+
     async def register_skill(
         self,
         request: SkillRegistrationRequest,
@@ -1305,6 +1332,12 @@ class SkillService:
             resource_manifest=resource_manifest,
             content_integrity=content_integrity,
         )
+
+        # Gateway-proxy SSRF layer 2: when opting into proxying, resolve the target
+        # hostname and validate every resolved IP against the egress policy, then
+        # pin the resolved IPs. Rejects a metadata/private target at registration
+        # (clear error) rather than silently dropping the route at render.
+        await self._validate_and_pin_skill_proxy(skill)
 
         # Save to repository
         repo = self._get_repo()
@@ -1494,6 +1527,32 @@ class SkillService:
         """Update a skill."""
         normalized = normalize_skill_path(path)
         repo = self._get_repo()
+
+        # Gateway-proxy SSRF layer 2: if this update changes the proxy opt-in or
+        # target, resolve+validate the MERGED target (existing values overlaid with
+        # the update) and pin the resolved IPs, before persisting. Rejects a
+        # metadata/private target at update time. Only reads the DB when a proxy
+        # field is actually touched, so non-proxy updates pay no cost.
+        if "is_proxied" in updates or "proxy_target_url" in updates:
+            existing = await repo.get(normalized)
+            if existing is not None:
+                merged_is_proxied = updates.get("is_proxied", existing.is_proxied)
+                merged_target = updates.get("proxy_target_url", existing.proxy_target_url)
+                pin = await validate_and_pin_proxy_target(
+                    "skill",
+                    {
+                        "is_proxied": merged_is_proxied,
+                        "proxy_target_url": merged_target,
+                        # An update re-enabling proxying must clear a prior auto-disable.
+                        "proxy_disabled_reason": None,
+                    },
+                )
+                # Refresh the pin bookkeeping to match the (re)validated target, or
+                # clear it when the merged state is no longer a live proxy.
+                updates["proxy_resolved_ips"] = pin.get("proxy_resolved_ips", [])
+                updates["proxy_target_host"] = pin.get("proxy_target_host")
+                updates["proxy_disabled_reason"] = None
+
         updated = await repo.update(normalized, updates)
 
         if updated:

--- a/registry/utils/url_guard.py
+++ b/registry/utils/url_guard.py
@@ -424,6 +424,7 @@ class _Allowlist:
 
     hosts: frozenset[str] = field(default_factory=frozenset)
     cidrs: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = ()
+    allow_private: bool = False
 
     def allows_host(
         self,
@@ -539,6 +540,7 @@ def _proxy_allowlist() -> _Allowlist:
     return _Allowlist(
         hosts=_parse_hosts(_settings.ssrf_allowed_hosts),
         cidrs=_parse_cidrs(_settings.ssrf_allowed_cidrs),
+        allow_private=bool(getattr(_settings, "gateway_proxy_allow_private_targets", False)),
     )
 
 
@@ -549,6 +551,7 @@ def _builtin_airegistry_tools_allowlist() -> _Allowlist:
     return _Allowlist(
         hosts=ordinary.hosts | _RESERVED_BUILTIN_PROXY_HOSTS,
         cidrs=ordinary.cidrs,
+        allow_private=ordinary.allow_private,
     )
 
 
@@ -651,7 +654,7 @@ def _is_blocked_ip(
     return (
         _ip_denial_reason(
             ip,
-            allow_private=False,
+            allow_private=allowlist.allow_private,
             allowed_cidrs=allowed_cidrs,
         )
         is not None

--- a/tests/auth_server/unit/test_generic_proxy_endpoint.py
+++ b/tests/auth_server/unit/test_generic_proxy_endpoint.py
@@ -55,30 +55,48 @@ class _FakeStreamResponse:
         yield self._body
 
 
-def _fake_client(captured, response: _FakeStreamResponse):
-    """Build a MagicMock httpx.AsyncClient whose .stream() records the call."""
+class _FakeGuardedClient:
+    """Stand-in for the object guarded_async_client() returns. Works both as an
+    ``async with`` context (buffered path) and used directly + aclose()'d
+    (streaming path)."""
 
-    class _Client:
-        def __init__(self, *a, **kw):
-            captured["client_kwargs"] = kw
+    def __init__(self, captured, response: _FakeStreamResponse):
+        self._captured = captured
+        self._response = response
 
-        async def __aenter__(self):
-            return self
+    async def __aenter__(self):
+        return self
 
-        async def __aexit__(self, *a):
-            return False
+    async def __aexit__(self, *a):
+        return False
 
-        def stream(self, method, url, **kw):
-            captured["method"] = method
-            captured["url"] = url
+    async def aclose(self):
+        return None
 
-            @asynccontextmanager
-            async def _cm():
-                yield response
+    def stream(self, method, url, **kw):
+        self._captured["method"] = method
+        self._captured["url"] = url
 
-            return _cm()
+        @asynccontextmanager
+        async def _cm():
+            yield self._response
 
-    return _Client
+        return _cm()
+
+
+def _fake_guarded_async_client(captured, response: _FakeStreamResponse):
+    """Build a guarded_async_client replacement that records how it was called.
+
+    The hop now uses url_guard.guarded_async_client (the pinned SSRF-safe client),
+    NOT a bare httpx.AsyncClient. Patching this asserts the guarded path is wired
+    in AND captures profile/verify/follow_redirects so a regression to a raw
+    client (or a dropped profile) fails the test."""
+
+    def _factory(*a, **kw):
+        captured["client_kwargs"] = kw
+        return _FakeGuardedClient(captured, response)
+
+    return _factory
 
 
 @pytest.fixture(autouse=True)
@@ -116,7 +134,10 @@ class TestHappyPathAndRedirect:
         )
         with (
             patch.object(server_module, "_generic_proxy_feature_active", True),
-            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+            patch(
+                "auth_server.server.guarded_async_client",
+                _fake_guarded_async_client(captured, resp_obj),
+            ),
         ):
             client = TestClient(app)
             resp = client.get(
@@ -126,6 +147,8 @@ class TestHappyPathAndRedirect:
         assert resp.status_code == 200
         # pinned upstream used, forgeable inbound header ignored
         assert captured["url"] == "https://backend.example/"
+        # the SSRF-safe guarded client was used with the proxy egress profile
+        assert captured["client_kwargs"]["profile"] is server_module.PROXY_PROFILE
         # backend Set-Cookie dropped; gateway security headers set
         assert "set-cookie" not in {k.lower() for k in resp.headers}
         assert resp.headers["X-Content-Type-Options"] == "nosniff"
@@ -139,14 +162,53 @@ class TestHappyPathAndRedirect:
         )
         with (
             patch.object(server_module, "_generic_proxy_feature_active", True),
-            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+            patch(
+                "auth_server.server.guarded_async_client",
+                _fake_guarded_async_client(captured, resp_obj),
+            ),
         ):
             client = TestClient(app, follow_redirects=False)
             resp = client.get("/proxy/skill/skills/proxy-demo")
-        # 302 returned verbatim; the httpx client was created with follow_redirects=False
+        # 302 returned verbatim; the guarded client was created with follow_redirects=False
         assert resp.status_code == 302
         assert resp.headers["Location"] == "http://169.254.169.254/latest/meta-data/"
         assert captured["client_kwargs"].get("follow_redirects") is False
+        assert captured["client_kwargs"]["profile"] is server_module.PROXY_PROFILE
+
+    def test_egress_block_at_fetch_returns_502_not_500(self):
+        """When the guarded transport blocks the outbound (rebind/denied IP at
+        connect time) it raises UrlValidationError. The hop must catch it and
+        return a deliberate 502, not let it escape as an opaque 500."""
+        from registry.exceptions import UrlValidationError
+
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims()
+
+        class _BlockingClient:
+            def __init__(self, *a, **kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *a):
+                return False
+
+            def stream(self, *a, **kw):
+                raise UrlValidationError("https://backend.example/", "resolves to blocked IP")
+
+        with (
+            patch.object(server_module, "_generic_proxy_feature_active", True),
+            patch(
+                "auth_server.server.guarded_async_client",
+                lambda *a, **kw: _BlockingClient(),
+            ),
+        ):
+            client = TestClient(app)
+            resp = client.get("/proxy/skill/skills/proxy-demo")
+        assert resp.status_code == 502
+        # The raw target/reason must NOT leak into the client response body.
+        assert "blocked IP" not in resp.text
+        assert "backend.example" not in resp.text
 
     def test_subpath_appended_to_pinned_base(self):
         app.dependency_overrides[verify_generic_proxy_token] = _override_claims(
@@ -156,7 +218,10 @@ class TestHappyPathAndRedirect:
         resp_obj = _FakeStreamResponse(200, {"Content-Type": "application/json"}, b"{}")
         with (
             patch.object(server_module, "_generic_proxy_feature_active", True),
-            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+            patch(
+                "auth_server.server.guarded_async_client",
+                _fake_guarded_async_client(captured, resp_obj),
+            ),
         ):
             client = TestClient(app)
             resp = client.get("/proxy/skill/skills/proxy-demo/reports/2024")

--- a/tests/auth_server/unit/test_generic_proxy_endpoint.py
+++ b/tests/auth_server/unit/test_generic_proxy_endpoint.py
@@ -1,0 +1,164 @@
+"""End-to-end tests for the generic_proxy endpoint.
+
+Drives the /proxy/{entity_type}/{entity_path} route via TestClient with the
+token dependency overridden (verified separately in test_generic_proxy_token)
+and httpx mocked, to lock in the runtime behavior:
+
+- feature latch: fail-closed 503 when the process latch is off (flag disabled or
+  egress self-check failed) even with a valid token;
+- redirect NOT auto-followed: a 302 upstream is returned verbatim with Location
+  forwarded and produces no second outbound (follow_redirects=False);
+- Set-Cookie from the backend is dropped; gateway security headers are set;
+- the pinned upstream is used (inbound X-Upstream-Url ignored).
+"""
+
+import os
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from fastapi import Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from internal_request_token import verify_generic_proxy_token  # noqa: E402
+
+import auth_server.server as server_module  # noqa: E402
+from auth_server.server import app  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _override_claims(upstream="https://backend.example/", server="skills/proxy-demo"):
+    """Return a dependency override that stashes generic_proxy_claims + passes."""
+
+    async def _dep(request: Request):
+        request.state.generic_proxy_claims = {
+            "upstream_url": upstream,
+            "server": server,
+            "entity_type": "skill",
+            "scopes": ["s/read"],
+            "sub": "alice",
+        }
+
+    return _dep
+
+
+class _FakeStreamResponse:
+    def __init__(self, status_code, headers, body=b""):
+        self.status_code = status_code
+        self.headers = headers
+        self._body = body
+
+    async def aiter_bytes(self, chunk_size=65536):
+        yield self._body
+
+
+def _fake_client(captured, response: _FakeStreamResponse):
+    """Build a MagicMock httpx.AsyncClient whose .stream() records the call."""
+
+    class _Client:
+        def __init__(self, *a, **kw):
+            captured["client_kwargs"] = kw
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        def stream(self, method, url, **kw):
+            captured["method"] = method
+            captured["url"] = url
+
+            @asynccontextmanager
+            async def _cm():
+                yield response
+
+            return _cm()
+
+    return _Client
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+class TestFeatureLatchFailClosed:
+    def test_503_when_feature_latch_off(self):
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims()
+        with patch.object(server_module, "_generic_proxy_feature_active", False):
+            client = TestClient(app)
+            resp = client.get("/proxy/skill/skills/proxy-demo")
+        assert resp.status_code == 503
+
+    def test_503_when_latch_none_prestartup(self):
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims()
+        with patch.object(server_module, "_generic_proxy_feature_active", None):
+            client = TestClient(app)
+            resp = client.get("/proxy/skill/skills/proxy-demo")
+        assert resp.status_code == 503
+
+
+class TestHappyPathAndRedirect:
+    def test_forwards_to_pinned_upstream_and_sets_security_headers(self):
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims(
+            upstream="https://backend.example/"
+        )
+        captured = {}
+        resp_obj = _FakeStreamResponse(
+            200,
+            {"Content-Type": "application/json", "Set-Cookie": "evil=1"},
+            b'{"ok":true}',
+        )
+        with (
+            patch.object(server_module, "_generic_proxy_feature_active", True),
+            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+        ):
+            client = TestClient(app)
+            resp = client.get(
+                "/proxy/skill/skills/proxy-demo",
+                headers={"X-Upstream-Url": "https://attacker.example/"},
+            )
+        assert resp.status_code == 200
+        # pinned upstream used, forgeable inbound header ignored
+        assert captured["url"] == "https://backend.example/"
+        # backend Set-Cookie dropped; gateway security headers set
+        assert "set-cookie" not in {k.lower() for k in resp.headers}
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.headers["X-Frame-Options"] == "DENY"
+
+    def test_redirect_not_followed_location_forwarded(self):
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims()
+        captured = {}
+        resp_obj = _FakeStreamResponse(
+            302, {"Location": "http://169.254.169.254/latest/meta-data/"}, b""
+        )
+        with (
+            patch.object(server_module, "_generic_proxy_feature_active", True),
+            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+        ):
+            client = TestClient(app, follow_redirects=False)
+            resp = client.get("/proxy/skill/skills/proxy-demo")
+        # 302 returned verbatim; the httpx client was created with follow_redirects=False
+        assert resp.status_code == 302
+        assert resp.headers["Location"] == "http://169.254.169.254/latest/meta-data/"
+        assert captured["client_kwargs"].get("follow_redirects") is False
+
+    def test_subpath_appended_to_pinned_base(self):
+        app.dependency_overrides[verify_generic_proxy_token] = _override_claims(
+            upstream="https://backend.example/api", server="skills/proxy-demo"
+        )
+        captured = {}
+        resp_obj = _FakeStreamResponse(200, {"Content-Type": "application/json"}, b"{}")
+        with (
+            patch.object(server_module, "_generic_proxy_feature_active", True),
+            patch("auth_server.server.httpx.AsyncClient", _fake_client(captured, resp_obj)),
+        ):
+            client = TestClient(app)
+            resp = client.get("/proxy/skill/skills/proxy-demo/reports/2024")
+        assert resp.status_code == 200
+        assert captured["url"] == "https://backend.example/api/reports/2024"

--- a/tests/auth_server/unit/test_generic_proxy_handler.py
+++ b/tests/auth_server/unit/test_generic_proxy_handler.py
@@ -1,0 +1,185 @@
+"""Unit tests for the generic-proxy handler helpers.
+
+Covers the security-critical pure helpers in isolation (the full handler
+round-trip needs a live upstream; these lock the guards):
+
+- _build_generic_outbound_url: sub-path confinement (reject '..'/scheme/userinfo,
+  stay under the bound registered prefix);
+- _assert_outbound_host_pinned: post-join scheme/host/port equality with the
+  pinned upstream (the real SSRF-escape backstop);
+- _select_forwarded_generic_response_headers: the WIDER allowlist forwards
+  Location/caching/download headers but DROPS Set-Cookie/HSTS/CSP/framing;
+- _generic_tls_verify: true|false|path resolution;
+- _run_egress_selfcheck: reachable metadata IP => unsafe (feature must disable).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from fastapi import HTTPException  # noqa: E402
+
+from auth_server.server import (  # noqa: E402
+    _GATEWAY_SET_SECURITY_HEADERS,
+    _assert_outbound_host_pinned,
+    _build_generic_outbound_url,
+    _generic_tls_verify,
+    _run_egress_selfcheck,
+    _select_forwarded_generic_response_headers,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestBuildOutboundUrl:
+    def test_no_subpath_returns_base(self):
+        url = _build_generic_outbound_url(
+            "https://backend.example/", "skills/proxy-demo", "skills/proxy-demo"
+        )
+        assert url == "https://backend.example/"
+
+    def test_subpath_appended_to_base(self):
+        url = _build_generic_outbound_url(
+            "https://backend.example/api", "skills/proxy-demo/reports/2024", "skills/proxy-demo"
+        )
+        assert url == "https://backend.example/api/reports/2024"
+
+    def test_dotdot_segment_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _build_generic_outbound_url(
+                "https://b/", "skills/proxy-demo/../../etc", "skills/proxy-demo"
+            )
+        assert e.value.status_code == 400
+
+    def test_scheme_in_subpath_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _build_generic_outbound_url(
+                "https://b/", "skills/proxy-demo/https://evil.com", "skills/proxy-demo"
+            )
+        assert e.value.status_code == 400
+
+    def test_userinfo_in_subpath_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _build_generic_outbound_url(
+                "https://b/", "skills/proxy-demo/x@evil.com", "skills/proxy-demo"
+            )
+        assert e.value.status_code == 400
+
+    def test_route_outside_bound_prefix_rejected(self):
+        # verify_generic_proxy_token should have caught this, but the handler
+        # fails closed rather than appending an unconfined remainder.
+        with pytest.raises(HTTPException) as e:
+            _build_generic_outbound_url("https://b/", "skills/other", "skills/proxy-demo")
+        assert e.value.status_code == 400
+
+
+class TestAssertHostPinned:
+    def test_same_host_passes(self):
+        _assert_outbound_host_pinned("https://b.example/api/x", "https://b.example/api")
+
+    def test_different_host_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _assert_outbound_host_pinned("https://evil.example/", "https://b.example/")
+        assert e.value.status_code == 400
+
+    def test_different_scheme_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _assert_outbound_host_pinned("http://b.example/", "https://b.example/")
+        assert e.value.status_code == 400
+
+    def test_different_port_rejected(self):
+        with pytest.raises(HTTPException) as e:
+            _assert_outbound_host_pinned("https://b.example:9000/", "https://b.example:443/")
+        assert e.value.status_code == 400
+
+
+class TestResponseHeaderAllowlist:
+    def test_forwards_location_and_caching_and_download(self):
+        upstream = {
+            "Location": "https://b/next",
+            "Content-Type": "application/pdf",
+            "Content-Disposition": 'attachment; filename="r.pdf"',
+            "Content-Length": "1024",
+            "Cache-Control": "max-age=60",
+            "ETag": '"abc"',
+            "Accept-Ranges": "bytes",
+        }
+        out = _select_forwarded_generic_response_headers(upstream)
+        assert out["Location"] == "https://b/next"
+        assert out["Content-Disposition"] == 'attachment; filename="r.pdf"'
+        assert out["Accept-Ranges"] == "bytes"
+        assert "Cache-Control" in out
+
+    def test_drops_set_cookie_and_security_policy_headers(self):
+        upstream = {
+            "Set-Cookie": "session=evil",
+            "Strict-Transport-Security": "max-age=99999",
+            "Content-Security-Policy": "default-src *",
+            "X-Frame-Options": "ALLOWALL",
+            "Content-Type": "text/html",
+        }
+        out = _select_forwarded_generic_response_headers(upstream)
+        assert "Set-Cookie" not in out
+        assert "Strict-Transport-Security" not in out
+        # A backend must not dictate CSP/framing; only Content-Type survives.
+        assert "Content-Security-Policy" not in out
+        assert "X-Frame-Options" not in out
+        assert out["Content-Type"] == "text/html"
+
+    def test_gateway_sets_its_own_security_headers(self):
+        # The handler updates the response with these; assert the constant is
+        # the restrictive set (locked in so a relaxation is a visible diff).
+        assert _GATEWAY_SET_SECURITY_HEADERS["X-Content-Type-Options"] == "nosniff"
+        assert _GATEWAY_SET_SECURITY_HEADERS["X-Frame-Options"] == "DENY"
+        assert "frame-ancestors 'none'" in _GATEWAY_SET_SECURITY_HEADERS["Content-Security-Policy"]
+
+
+class TestTlsVerifyResolution:
+    def test_true(self):
+        with patch("auth_server.server.settings") as s:
+            s.gateway_generic_tls_verify = "true"
+            assert _generic_tls_verify() is True
+
+    def test_false(self):
+        with patch("auth_server.server.settings") as s:
+            s.gateway_generic_tls_verify = "false"
+            assert _generic_tls_verify() is False
+
+    def test_ca_bundle_path(self):
+        with patch("auth_server.server.settings") as s:
+            s.gateway_generic_tls_verify = "/etc/ssl/private-ca.pem"
+            assert _generic_tls_verify() == "/etc/ssl/private-ca.pem"
+
+
+class TestEgressSelfCheck:
+    async def test_metadata_reachable_is_unsafe(self):
+        # Both probes "connect" -> reachable -> egress NOT restricted -> unsafe.
+        async def _fake_open(host, port):
+            class _W:
+                def close(self):
+                    pass
+
+                async def wait_closed(self):
+                    pass
+
+            return (None, _W())
+
+        with patch("auth_server.server.asyncio.open_connection", side_effect=_fake_open):
+            assert await _run_egress_selfcheck() is False
+
+    async def test_metadata_unreachable_is_safe(self):
+        async def _fake_open(host, port):
+            raise OSError("connection refused")
+
+        with patch("auth_server.server.asyncio.open_connection", side_effect=_fake_open):
+            assert await _run_egress_selfcheck() is True
+
+    async def test_timeout_is_safe(self):
+        async def _fake_open(host, port):
+            raise TimeoutError()
+
+        with patch("auth_server.server.asyncio.open_connection", side_effect=_fake_open):
+            assert await _run_egress_selfcheck() is True

--- a/tests/auth_server/unit/test_generic_validate_wiring.py
+++ b/tests/auth_server/unit/test_generic_validate_wiring.py
@@ -1,0 +1,208 @@
+"""Unit tests for the generic-hop /validate wiring.
+
+Covers the token-attach discriminator and the cookie-auth helper in isolation
+(the full validate_request round-trip is exercised by the integration suite):
+
+- _attach_generic_proxy_token mints ONLY when X-Resolved-Generic-Upstream is set
+  (the SEPARATE marker), and binds entity_type + full registered path + the
+  server-set upstream — never a forgeable inbound header;
+- it is disjoint from _attach_mcp_proxy_token: a generic request (no
+  X-Resolved-Upstream) mints no MCP token, and vice-versa — exactly one token;
+- _is_cookie_auth_method classifies the CSRF-relevant (ambient) auth methods.
+"""
+
+import os
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from internal_request_token import GENERIC_PROXY_AUDIENCE  # noqa: E402
+
+from auth_server.server import (  # noqa: E402
+    _attach_generic_proxy_token,
+    _attach_mcp_proxy_token,
+    _generic_write_csrf_refused,
+    _is_cookie_auth_method,
+    settings,
+)
+
+pytestmark = pytest.mark.unit
+
+_SECRET = "test-secret-key-that-is-definitely-long-enough-32b"
+
+
+class _Req:
+    def __init__(self, headers):
+        self.headers = headers
+
+
+class _Resp:
+    def __init__(self):
+        self.headers = {}
+
+
+class TestAttachGenericProxyToken:
+    def test_mints_when_generic_upstream_present(self):
+        req = _Req(
+            {
+                "X-Resolved-Generic-Upstream": "https://backend.example/",
+            }
+        )
+        resp = _Resp()
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+            _attach_generic_proxy_token(
+                req,
+                resp,
+                subject="alice",
+                scopes=["s/read"],
+                entity_type="skill",
+                registered_path="skills/proxy-demo",
+            )
+        tok = resp.headers["X-Internal-Token-Generic"]
+        claims = pyjwt.decode(tok, _SECRET, algorithms=["HS256"], audience=GENERIC_PROXY_AUDIENCE)
+        assert claims["entity_type"] == "skill"
+        assert claims["server"] == "skills/proxy-demo"  # FULL registered path
+        assert claims["upstream_url"] == "https://backend.example/"  # server-set marker
+        assert claims["sub"] == "alice"
+
+    def test_no_mint_when_marker_absent(self):
+        req = _Req({})  # not a generic request
+        resp = _Resp()
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+            _attach_generic_proxy_token(
+                req, resp, subject="alice", scopes=[], entity_type="skill", registered_path="x"
+            )
+        assert "X-Internal-Token-Generic" not in resp.headers
+
+    def test_empty_subject_mints_nothing(self):
+        req = _Req({"X-Resolved-Generic-Upstream": "https://b/"})
+        resp = _Resp()
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+            _attach_generic_proxy_token(
+                req, resp, subject="", scopes=[], entity_type="skill", registered_path="x"
+            )
+        # fail-closed: no token attached, generic hop rejects downstream
+        assert "X-Internal-Token-Generic" not in resp.headers
+
+
+class TestDisjointFromMcpMint:
+    def test_generic_request_does_not_mint_mcp_token(self):
+        # A generic request sets X-Resolved-Generic-Upstream but NOT
+        # X-Resolved-Upstream, so the MCP attach must short-circuit.
+        req = _Req({"X-Resolved-Generic-Upstream": "https://b/"})
+        resp = _Resp()
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+            _attach_mcp_proxy_token(req, resp, subject="alice", scopes=[], server_name="skill/x")
+            _attach_generic_proxy_token(
+                req,
+                resp,
+                subject="alice",
+                scopes=[],
+                entity_type="skill",
+                registered_path="skills/x",
+            )
+        assert "X-Internal-Token" not in resp.headers  # MCP mint did not fire
+        assert "X-Internal-Token-Generic" in resp.headers  # generic mint did
+
+    def test_mcp_request_does_not_mint_generic_token(self):
+        req = _Req(
+            {
+                "X-Resolved-Upstream": "https://mcp-backend/",
+                "X-Validate-Source-Secret": settings.auth_server_nginx_marker_secret,
+            }
+        )
+        resp = _Resp()
+        with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+            _attach_mcp_proxy_token(req, resp, subject="alice", scopes=[], server_name="foo/mcp")
+            _attach_generic_proxy_token(
+                req, resp, subject="alice", scopes=[], entity_type="skill", registered_path="x"
+            )
+        assert "X-Internal-Token" in resp.headers  # MCP mint fired
+        assert "X-Internal-Token-Generic" not in resp.headers  # generic mint did not
+
+
+class TestCookieAuthClassifier:
+    def test_session_cookie_is_cookie_auth(self):
+        assert _is_cookie_auth_method("session_cookie") is True
+        assert _is_cookie_auth_method("cookie") is True
+        assert _is_cookie_auth_method("SESSION") is True
+
+    def test_bearer_methods_are_not_cookie_auth(self):
+        for m in ("keycloak", "cognito", "entra", "okta", "auth0", "self_signed", "bearer", ""):
+            assert _is_cookie_auth_method(m) is False
+
+
+class TestGenericWriteCsrfRefused:
+    def test_cookie_delete_refused(self):
+        # The core CSRF case: ambient cookie + state-changing verb on generic hop.
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb="DELETE",
+                auth_method="session_cookie",
+                require_bearer=True,
+            )
+            is True
+        )
+
+    def test_cookie_get_allowed(self):
+        # Safe verb under cookie auth is fine (read).
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb="GET",
+                auth_method="session_cookie",
+                require_bearer=True,
+            )
+            is False
+        )
+
+    def test_bearer_delete_allowed(self):
+        # Programmatic Bearer caller is exempt from the CSRF refusal.
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb="DELETE",
+                auth_method="keycloak",
+                require_bearer=True,
+            )
+            is False
+        )
+
+    def test_disabled_knob_never_refuses(self):
+        # Operator opt-out (same-site deploy): cookie DELETE passes.
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb="DELETE",
+                auth_method="session_cookie",
+                require_bearer=False,
+            )
+            is False
+        )
+
+    def test_non_generic_request_never_refused(self):
+        # The gate only applies to the generic hop; MCP/api requests are untouched.
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=False,
+                http_verb="DELETE",
+                auth_method="session_cookie",
+                require_bearer=True,
+            )
+            is False
+        )
+
+    def test_options_is_safe(self):
+        assert (
+            _generic_write_csrf_refused(
+                is_generic_request=True,
+                http_verb="OPTIONS",
+                auth_method="session_cookie",
+                require_bearer=True,
+            )
+            is False
+        )

--- a/tests/auth_server/unit/test_generic_verb_authz.py
+++ b/tests/auth_server/unit/test_generic_verb_authz.py
@@ -1,0 +1,108 @@
+"""Unit tests for the generic-hop verb->scope authorization.
+
+These lock in the privilege-escalation guard and the HTTP-verb matching semantics
+of validate_server_tool_access(..., is_http_verb=True):
+
+- the legacy MCP "*"/"all" methods wildcard does NOT authorize an HTTP verb (a
+  pre-existing methods:["*"] scope must not start granting DELETE when its entity
+  is flipped is_proxied) — only explicit enumeration or the distinct "http:*"
+  token grants;
+- HTTP verbs match the methods list case-INSENSITIVELY (a scope authored "get"
+  authorizes GET), while MCP tokens stay case-sensitive;
+- an HTTP verb never falls through to the tools list (so tools:["*"] can't grant
+  a verb either).
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from auth_server.server import validate_server_tool_access  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _scope_repo(server_access_by_scope: dict[str, list[dict]]):
+    """Mock scope repo whose get_server_scopes returns the given rule lists."""
+    repo = AsyncMock()
+
+    async def _get(scope_name: str):
+        return server_access_by_scope.get(scope_name, [])
+
+    repo.get_server_scopes.side_effect = _get
+    return repo
+
+
+async def _access(server_access, method, scopes, is_http_verb, tool_name=None):
+    repo = _scope_repo(server_access)
+    with patch("auth_server.server.get_scope_repository", return_value=repo):
+        return await validate_server_tool_access(
+            "skill/skills/proxy-demo", method, tool_name, scopes, is_http_verb=is_http_verb
+        )
+
+
+class TestHttpVerbWildcardSplit:
+    async def test_mcp_star_wildcard_does_not_grant_http_verb(self):
+        """Privilege escalation on upgrade: methods:["*"] means all MCP
+        methods, NOT all HTTP verbs. A DELETE must be denied."""
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["*"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is False
+
+    async def test_mcp_all_wildcard_does_not_grant_http_verb(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["all"]}]}
+        assert await _access(access, "PUT", ["s1"], is_http_verb=True) is False
+
+    async def test_http_wildcard_token_grants_verb(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["http:*"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is True
+
+    async def test_explicit_verb_enumeration_grants(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["GET", "HEAD"]}]}
+        assert await _access(access, "GET", ["s1"], is_http_verb=True) is True
+
+    async def test_verb_not_enumerated_denied(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["GET", "HEAD"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is False
+
+    async def test_read_only_scope_cannot_delete(self):
+        access = {"ro": [{"server": "skill/skills/proxy-demo", "methods": ["GET"]}]}
+        assert await _access(access, "DELETE", ["ro"], is_http_verb=True) is False
+
+
+class TestHttpVerbCaseInsensitive:
+    async def test_lowercase_stored_verb_authorizes_uppercase_request(self):
+        # A scope authored "get" (lower) must authorize a GET request — the read-
+        # side canonicalization backstop covers pre-existing / any-write-path data.
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["get", "head"]}]}
+        assert await _access(access, "GET", ["s1"], is_http_verb=True) is True
+
+    async def test_mixed_case_stored_verb(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["Delete"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is True
+
+
+class TestHttpVerbDoesNotFallThroughToTools:
+    async def test_tools_wildcard_does_not_grant_verb(self):
+        # An HTTP verb must match methods ONLY; tools:["*"] must not authorize it.
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": [], "tools": ["*"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is False
+
+    async def test_verb_in_tools_list_does_not_grant(self):
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": [], "tools": ["DELETE"]}]}
+        assert await _access(access, "DELETE", ["s1"], is_http_verb=True) is False
+
+
+class TestMcpPathUnaffected:
+    async def test_mcp_star_still_grants_mcp_method(self):
+        # Regression guard: the split must NOT change MCP behavior — "*" still
+        # grants tools/list for a normal (non-generic) MCP request.
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["*"]}]}
+        assert await _access(access, "tools/list", ["s1"], is_http_verb=False) is True
+
+    async def test_mcp_method_case_sensitive(self):
+        # MCP tokens stay case-sensitive: "TOOLS/LIST" must NOT match "tools/list".
+        access = {"s1": [{"server": "skill/skills/proxy-demo", "methods": ["tools/list"]}]}
+        assert await _access(access, "TOOLS/LIST", ["s1"], is_http_verb=False) is False

--- a/tests/unit/auth/test_generic_proxy_token.py
+++ b/tests/unit/auth/test_generic_proxy_token.py
@@ -1,0 +1,242 @@
+"""Unit tests for the generic-proxy internal token (auth_server/internal_request_token).
+
+Covers mint round-trip (the TWO-claim shape: entity_type + full registered path)
+and verify_generic_proxy_token's accept/reject paths, with emphasis on the two
+security properties that distinguish it from the mcp-proxy token:
+- cross-type replay is rejected (a skill token can't be used on an /a2a_agent/ route);
+- the path guard binds the FULL multi-segment registered path and allows a
+  sub-path UNDER it but NOT a sibling (skills/proxy-demo vs skills/proxy-demo-evil).
+"""
+
+import os
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+from fastapi import HTTPException
+
+from auth_server.internal_request_token import (
+    GENERIC_PROXY_AUDIENCE,
+    GENERIC_PROXY_TOKEN_USE,
+    MCP_PROXY_AUDIENCE,
+    _mint_internal_token,
+    mint_generic_proxy_token,
+    verify_generic_proxy_token,
+)
+
+_SECRET = "test-secret-key-for-testing-only"
+
+
+def _request(headers, entity_type="skill", entity_path="skills/proxy-demo"):
+    lower = {k.lower(): v for k, v in headers.items()}
+    return SimpleNamespace(
+        headers=SimpleNamespace(get=lambda k, default=None: lower.get(k.lower(), default)),
+        path_params={"entity_type": entity_type, "entity_path": entity_path},
+        state=SimpleNamespace(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _secret_env():
+    with patch.dict(os.environ, {"SECRET_KEY": _SECRET}, clear=False):
+        yield
+
+
+def _token(
+    entity_type="skill",
+    registered_path="skills/proxy-demo",
+    upstream="https://backend.example/",
+    subject="alice",
+):
+    return mint_generic_proxy_token(
+        subject=subject,
+        scopes=["s/read"],
+        entity_type=entity_type,
+        registered_path=registered_path,
+        upstream_url=upstream,
+    )
+
+
+class TestMint:
+    def test_binds_entity_type_and_full_path_as_two_claims(self):
+        tok = _token(entity_type="skill", registered_path="skills/proxy-demo")
+        claims = pyjwt.decode(tok, _SECRET, algorithms=["HS256"], audience=GENERIC_PROXY_AUDIENCE)
+        assert claims["entity_type"] == "skill"
+        assert claims["server"] == "skills/proxy-demo"  # FULL path, not first segment
+        assert claims["upstream_url"] == "https://backend.example/"
+        assert claims["token_use"] == GENERIC_PROXY_TOKEN_USE
+        assert claims["aud"] == GENERIC_PROXY_AUDIENCE
+
+    def test_empty_subject_refused(self):
+        with pytest.raises(ValueError):
+            _token(subject="")
+
+
+class TestVerifyAccept:
+    async def test_exact_path_accepted(self):
+        tok = _token()
+        req = _request({"X-Internal-Token-Generic": tok})
+        await verify_generic_proxy_token(req)  # no raise
+        assert req.state.generic_proxy_claims["server"] == "skills/proxy-demo"
+
+    async def test_subpath_under_bound_accepted(self):
+        tok = _token(registered_path="skills/proxy-demo")
+        req = _request({"X-Internal-Token-Generic": tok}, entity_path="skills/proxy-demo/sub/x")
+        await verify_generic_proxy_token(req)  # sub-resource of the bound entity
+
+
+class TestVerifyReject:
+    async def test_missing_token(self):
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({}))
+        assert e.value.status_code == 401
+
+    async def test_wrong_audience_mcp_token_rejected(self):
+        # An mcp-proxy-audience token must not verify on the generic hop.
+        mcp_tok = _mint_internal_token(
+            audience=MCP_PROXY_AUDIENCE,
+            subject="alice",
+            scopes=[],
+            extra_claims={
+                "server": "skills/proxy-demo",
+                "upstream_url": "https://b/",
+                "entity_type": "skill",
+                "token_use": "mcp-proxy",
+            },
+        )
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({"X-Internal-Token-Generic": mcp_tok}))
+        assert e.value.status_code == 401
+
+    async def test_wrong_token_use_rejected(self):
+        tok = _mint_internal_token(
+            audience=GENERIC_PROXY_AUDIENCE,
+            subject="alice",
+            scopes=[],
+            extra_claims={
+                "server": "skills/proxy-demo",
+                "upstream_url": "https://b/",
+                "entity_type": "skill",
+                "token_use": "something-else",
+            },
+        )
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({"X-Internal-Token-Generic": tok}))
+        assert e.value.status_code == 401
+
+    async def test_missing_upstream_rejected(self):
+        tok = _mint_internal_token(
+            audience=GENERIC_PROXY_AUDIENCE,
+            subject="alice",
+            scopes=[],
+            extra_claims={
+                "server": "skills/proxy-demo",
+                "entity_type": "skill",
+                "token_use": GENERIC_PROXY_TOKEN_USE,
+            },
+        )
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({"X-Internal-Token-Generic": tok}))
+        assert e.value.status_code == 401
+
+    async def test_expired_rejected(self):
+        # Mint with the clock far in the past so exp is already elapsed when the
+        # verifier (which uses the real clock) decodes it.
+        with patch(
+            "auth_server.internal_request_token.time.time", return_value=time.time() - 10000
+        ):
+            tok = _token()
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({"X-Internal-Token-Generic": tok}))
+        assert e.value.status_code == 401
+
+    async def test_cross_type_replay_rejected(self):
+        """A token bound to (skill, skills/proxy-demo) must NOT verify on an
+        /a2a_agent/ route with the same path."""
+        tok = _token(entity_type="skill", registered_path="skills/proxy-demo")
+        req = _request(
+            {"X-Internal-Token-Generic": tok},
+            entity_type="a2a_agent",
+            entity_path="skills/proxy-demo",
+        )
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(req)
+        assert e.value.status_code == 401
+
+    async def test_sibling_path_rejected(self):
+        """skills/proxy-demo token must NOT authorize skills/proxy-demo-evil
+        (prefix match must be on a segment boundary)."""
+        tok = _token(registered_path="skills/proxy-demo")
+        req = _request({"X-Internal-Token-Generic": tok}, entity_path="skills/proxy-demo-evil")
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(req)
+        assert e.value.status_code == 401
+
+    async def test_different_entity_path_rejected(self):
+        tok = _token(registered_path="skills/proxy-demo")
+        req = _request({"X-Internal-Token-Generic": tok}, entity_path="skills/other")
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(req)
+        assert e.value.status_code == 401
+
+    async def test_tampered_signature_rejected(self):
+        tok = _token()
+        tampered = tok[:-4] + ("aaaa" if not tok.endswith("aaaa") else "bbbb")
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(_request({"X-Internal-Token-Generic": tampered}))
+        assert e.value.status_code == 401
+
+    async def test_dotdot_segment_rejected(self):
+        """A dot-dot escape under the bound prefix must be rejected even though it
+        literally starts with '<bound>/'."""
+        tok = _token(registered_path="skills/proxy-demo")
+        req = _request(
+            {"X-Internal-Token-Generic": tok},
+            entity_path="skills/proxy-demo/../../secret",
+        )
+        with pytest.raises(HTTPException) as e:
+            await verify_generic_proxy_token(req)
+        assert e.value.status_code == 401
+
+
+class TestClaimOverrideProtection:
+    def test_extra_claims_cannot_override_reserved_base_claims(self):
+        """A caller passing a reserved key in extra_claims must NOT override the
+        base claim (aud/exp/iss). Base claims win regardless of extra order."""
+        tok = _mint_internal_token(
+            audience=GENERIC_PROXY_AUDIENCE,
+            subject="alice",
+            scopes=[],
+            extra_claims={
+                "aud": "attacker-audience",  # attempt to hijack audience
+                "iss": "attacker",
+                "exp": 99999999999,  # attempt to extend lifetime
+                "server": "skills/x",
+                "upstream_url": "https://b/",
+                "entity_type": "skill",
+                "token_use": GENERIC_PROXY_TOKEN_USE,
+            },
+        )
+        claims = pyjwt.decode(tok, _SECRET, algorithms=["HS256"], audience=GENERIC_PROXY_AUDIENCE)
+        assert claims["aud"] == GENERIC_PROXY_AUDIENCE  # base won, not "attacker-audience"
+        assert claims["iss"] == "mcp-auth-server"
+        assert claims["exp"] != 99999999999  # base exp won
+
+
+class TestTtlKnob:
+    def test_generic_ttl_falls_back_to_shared(self):
+        from auth_server.internal_request_token import _generic_ttl_seconds, _ttl_seconds
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GENERIC_PROXY_TOKEN_TTL_SECONDS", None)
+            assert _generic_ttl_seconds() == _ttl_seconds()
+
+    def test_generic_ttl_own_value_and_floor(self):
+        from auth_server.internal_request_token import _generic_ttl_seconds
+
+        with patch.dict(os.environ, {"GENERIC_PROXY_TOKEN_TTL_SECONDS": "120"}, clear=False):
+            assert _generic_ttl_seconds() == 120
+        with patch.dict(os.environ, {"GENERIC_PROXY_TOKEN_TTL_SECONDS": "1"}, clear=False):
+            assert _generic_ttl_seconds() == 5  # clamped to floor

--- a/tests/unit/core/test_gateway_hard_gate.py
+++ b/tests/unit/core/test_gateway_hard_gate.py
@@ -1,0 +1,176 @@
+"""HARD GATE: no denied target can become a live nginx route.
+
+The registration-time resolve-and-validate (SSRF layer 2) is the primary gate,
+but a stored row can reach the render pipeline WITHOUT passing it — a federation
+raw-write, a migration, a manual DB edit, or a row that predates the guard. This
+suite drives the ACTUAL render feed (_generate_generic_proxy_blocks, which reads
+_fetch_generic_proxied_resources -> resolve_proxy_target -> _safe_generic_block)
+with adversarial rows a bypass could have planted, and asserts the composite
+render-time defense holds: NO live generic block is emitted for a denied /
+federated / disabled / targetless row, and a good row alongside it still renders.
+
+This is the render half of the "don't enable the feature until the gate holds"
+invariant; the network egress policy (layer 1) is the socket-level backstop.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from registry.core.nginx_service import NginxConfigService  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _service() -> NginxConfigService:
+    return NginxConfigService()
+
+
+async def _render(rows, allow_private=False):
+    """Run the real render feed with `rows` as the raw list_proxied output.
+
+    Patches each repo's list_proxied so the rows flow through the genuine
+    resolve_proxy_target + _safe_generic_block path, exactly as at render time.
+    """
+    agent_repo = AsyncMock()
+    skill_repo = AsyncMock()
+    custom_repo = AsyncMock()
+    # Bucket rows by entity_type so each repo returns its own.
+    agent_repo.list_proxied.return_value = [r for r in rows if r.get("_repo") == "agent"]
+    skill_repo.list_proxied.return_value = [r for r in rows if r.get("_repo") == "skill"]
+    custom_repo.list_proxied.return_value = [r for r in rows if r.get("_repo") == "custom"]
+
+    with patch("registry.core.nginx_service.settings") as s:
+        s.gateway_generic_proxy_enabled = True
+        s.auth_server_url = "http://auth-server:8888"
+        s.gateway_generic_client_max_body_size = "1m"
+        s.gateway_proxy_allow_private_targets = allow_private
+        with (
+            patch("registry.repositories.factory.get_agent_repository", return_value=agent_repo),
+            patch("registry.repositories.factory.get_skill_repository", return_value=skill_repo),
+            patch(
+                "registry.repositories.factory.get_custom_entity_repository",
+                return_value=custom_repo,
+            ),
+        ):
+            return await _service()._generate_generic_proxy_blocks(set())
+
+
+class TestHardGateDeniedTargetsNeverRender:
+    async def test_metadata_ip_literal_target_never_renders(self):
+        # A bypass-written skill pointing straight at the metadata IP.
+        rows = [
+            {
+                "_repo": "skill",
+                "path": "/skills/evil",
+                "is_proxied": True,
+                "proxy_target_url": "http://169.254.169.254/",
+            },
+            {
+                "_repo": "skill",
+                "path": "/skills/ok",
+                "is_proxied": True,
+                "proxy_target_url": "https://ok.example/",
+            },
+        ]
+        blocks = await _render(rows)
+        joined = "\n".join(blocks)
+        assert "169.254.169.254" not in joined  # denied target dropped
+        assert "/skill/skills/ok" in joined  # good sibling still renders
+        assert len(blocks) == 1
+
+    async def test_private_ip_target_dropped_when_flag_false(self):
+        rows = [
+            {
+                "_repo": "custom",
+                "entity_type": "workflow",
+                "path": "/workflow/x",
+                "is_proxied": True,
+                "proxy_target_url": "http://10.0.0.5/",
+            },
+        ]
+        assert await _render(rows, allow_private=False) == []
+
+    async def test_non_http_scheme_target_dropped(self):
+        rows = [
+            {
+                "_repo": "skill",
+                "path": "/skills/f",
+                "is_proxied": True,
+                "proxy_target_url": "file:///etc/passwd",
+            },
+        ]
+        assert await _render(rows) == []
+
+    async def test_directive_breakout_target_dropped(self):
+        rows = [
+            {
+                "_repo": "skill",
+                "path": "/skills/x",
+                "is_proxied": True,
+                "proxy_target_url": 'https://x/";}\nlocation /evil {',
+            },
+        ]
+        assert await _render(rows) == []
+
+
+class TestHardGateFederatedAndDisabledNeverRender:
+    async def test_federated_row_never_renders_even_if_locally_flipped(self):
+        # A synced row with is_proxied flipped locally + a peer-supplied target.
+        rows = [
+            {
+                "_repo": "agent",
+                "path": "/agents/fed",
+                "is_proxied": True,
+                "url": "https://peer-backend.example/",
+                "sync_metadata": {"is_federated": True},
+            },
+        ]
+        assert await _render(rows) == []
+
+    async def test_auto_disabled_row_never_renders(self):
+        rows = [
+            {
+                "_repo": "skill",
+                "path": "/skills/dis",
+                "is_proxied": True,
+                "proxy_target_url": "https://ok.example/",
+                "proxy_disabled_reason": "target resolved to a denied IP",
+            },
+        ]
+        assert await _render(rows) == []
+
+    async def test_disabled_is_enabled_false_never_renders(self):
+        rows = [
+            {
+                "_repo": "skill",
+                "path": "/skills/off",
+                "is_proxied": True,
+                "proxy_target_url": "https://ok.example/",
+                "is_enabled": False,
+            },
+        ]
+        assert await _render(rows) == []
+
+    async def test_targetless_proxied_row_never_renders(self):
+        # is_proxied with no resolvable target (skill w/o proxy_target_url).
+        rows = [
+            {"_repo": "skill", "path": "/skills/none", "is_proxied": True},
+        ]
+        assert await _render(rows) == []
+
+
+class TestHardGateFeatureFlagOff:
+    async def test_flag_off_emits_nothing_and_queries_nothing(self):
+        agent_repo = AsyncMock()
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = False
+            with patch(
+                "registry.repositories.factory.get_agent_repository", return_value=agent_repo
+            ):
+                blocks = await _service()._generate_generic_proxy_blocks(set())
+        assert blocks == []
+        agent_repo.list_proxied.assert_not_called()

--- a/tests/unit/core/test_nginx_generic_markers.py
+++ b/tests/unit/core/test_nginx_generic_markers.py
@@ -1,0 +1,149 @@
+"""Template invariants for the generic-proxy markers in the nginx conf files.
+
+The generic-hop mint discriminator + marker-spoof defense
+depends on a set of nginx variables being (a) declared http-scope with an empty
+default and (b) forwarded via ``proxy_set_header`` in EVERY ``location = /validate``
+block. The LLD mandates a render-static assertion that the forwarded-header set is
+identical across all three /validate blocks (one in http_only, two in
+http_and_https) — otherwise a future refactor dropping an override from one block
+would let a client spoof the marker to that block and mint a token bound to an
+attacker-controlled upstream (SSRF).
+
+These tests parse the raw .conf files (no nginx binary needed) and lock in that
+invariant. They fail loudly at CI if a /validate block is added/edited without the
+generic markers, or if a required http-scope map default is removed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DOCKER_DIR = Path(__file__).resolve().parents[3] / "docker"
+_HTTP_ONLY = _DOCKER_DIR / "nginx_rev_proxy_http_only.conf"
+_HTTP_AND_HTTPS = _DOCKER_DIR / "nginx_rev_proxy_http_and_https.conf"
+
+# The three generic markers that MUST be forwarded, sourced from the same-named
+# nginx variable, in every /validate block.
+_GENERIC_MARKER_FORWARDS = (
+    "proxy_set_header X-Resolved-Generic-Upstream $generic_backend_url;",
+    "proxy_set_header X-Generic-Proxy-Kind $generic_proxy_kind;",
+    "proxy_set_header X-Entity-Path $entity_path;",
+)
+
+# The http-scope maps that must declare each marker variable with an empty
+# default (so a request through a location that does NOT set them forwards "").
+_GENERIC_MARKER_MAPS = (
+    "map $host $generic_backend_url {",
+    "map $host $generic_proxy_kind {",
+    "map $host $entity_path {",
+)
+
+
+def _extract_validate_blocks(conf_text: str) -> list[str]:
+    """Return the body text of each real ``location = /validate { ... }`` block.
+
+    Brace-matched extraction (a comment mentioning the block in prose is not a
+    real block and is skipped because it has no following ``{``).
+    """
+    blocks: list[str] = []
+    for m in re.finditer(r"location\s+=\s+/validate\s*\{", conf_text):
+        i = m.end()  # just past the opening brace
+        depth = 1
+        while i < len(conf_text) and depth > 0:
+            if conf_text[i] == "{":
+                depth += 1
+            elif conf_text[i] == "}":
+                depth -= 1
+            i += 1
+        blocks.append(conf_text[m.end() : i - 1])
+    return blocks
+
+
+@pytest.fixture
+def http_only_text():
+    return _HTTP_ONLY.read_text()
+
+
+@pytest.fixture
+def http_and_https_text():
+    return _HTTP_AND_HTTPS.read_text()
+
+
+class TestValidateBlockCount:
+    def test_http_only_has_one_validate_block(self, http_only_text):
+        assert len(_extract_validate_blocks(http_only_text)) == 1
+
+    def test_http_and_https_has_two_validate_blocks(self, http_and_https_text):
+        # HTTP server + HTTPS server each have their own /validate block.
+        assert len(_extract_validate_blocks(http_and_https_text)) == 2
+
+
+class TestEveryValidateBlockForwardsGenericMarkers:
+    """Invariant: all three /validate blocks forward the identical marker
+    set. A block missing one is the marker-spoof SSRF hole."""
+
+    @pytest.mark.parametrize(
+        "conf_fixture",
+        ["http_only_text", "http_and_https_text"],
+    )
+    def test_all_blocks_forward_all_markers(self, conf_fixture, request):
+        conf_text = request.getfixturevalue(conf_fixture)
+        blocks = _extract_validate_blocks(conf_text)
+        assert blocks, "no /validate blocks found"
+        for idx, block in enumerate(blocks):
+            for forward in _GENERIC_MARKER_FORWARDS:
+                assert forward in block, (
+                    f"{conf_fixture} /validate block #{idx} is missing "
+                    f"required marker forward: {forward!r}"
+                )
+
+    def test_marker_set_is_identical_across_all_three_blocks(
+        self, http_only_text, http_and_https_text
+    ):
+        # Collect, per block, which of the generic marker forwards it contains;
+        # assert every block contains the full set (so the sets are identical).
+        all_blocks = _extract_validate_blocks(http_only_text) + _extract_validate_blocks(
+            http_and_https_text
+        )
+        assert len(all_blocks) == 3
+        per_block_sets = [
+            {f for f in _GENERIC_MARKER_FORWARDS if f in block} for block in all_blocks
+        ]
+        expected = set(_GENERIC_MARKER_FORWARDS)
+        for idx, present in enumerate(per_block_sets):
+            assert present == expected, f"/validate block #{idx} marker set drifted: {present}"
+
+
+class TestMarkerMapsDeclared:
+    @pytest.mark.parametrize(
+        "conf_fixture",
+        ["http_only_text", "http_and_https_text"],
+    )
+    def test_all_marker_maps_declared_with_empty_default(self, conf_fixture, request):
+        conf_text = request.getfixturevalue(conf_fixture)
+        for map_decl in _GENERIC_MARKER_MAPS:
+            assert map_decl in conf_text, f"{conf_fixture} missing http-scope map: {map_decl!r}"
+        # Each marker map must default to empty string (so a non-generic request
+        # forwards "" and the generic mint never fires for it).
+        for var in ("generic_backend_url", "generic_proxy_kind", "entity_path"):
+            block = re.search(r"map \$host \$" + var + r"\s*\{([^}]*)\}", conf_text, re.DOTALL)
+            assert block, f"{conf_fixture}: no map body for ${var}"
+            assert 'default "";' in block.group(1), (
+                f"{conf_fixture}: map ${var} must have empty default"
+            )
+
+
+class TestGenericUpstreamSeparateFromBackendUrl:
+    """Double-mint guard at the template level: no /validate block may forward
+    the generic upstream from $backend_url (must be $generic_backend_url)."""
+
+    @pytest.mark.parametrize(
+        "conf_fixture",
+        ["http_only_text", "http_and_https_text"],
+    )
+    def test_generic_upstream_not_sourced_from_backend_url(self, conf_fixture, request):
+        conf_text = request.getfixturevalue(conf_fixture)
+        assert "X-Resolved-Generic-Upstream $backend_url;" not in conf_text

--- a/tests/unit/core/test_nginx_generic_proxy.py
+++ b/tests/unit/core/test_nginx_generic_proxy.py
@@ -191,6 +191,18 @@ class TestCreateBlock:
         assert 'set $entity_path "agents/code-reviewer";' in block
         assert "client_max_body_size 8m;" in block
 
+    def test_forwards_token_under_generic_header_name(self):
+        # The hop's verify_generic_proxy_token reads X-Internal-Token-Generic, NOT
+        # the MCP hop's X-Internal-Token. Forwarding under the wrong name 401s the
+        # hop ("Missing internal proxy token"). Lock in the exact header name.
+        with patch("registry.core.nginx_service.settings") as s:
+            s.auth_server_url = "http://auth-server:8888"
+            s.gateway_generic_client_max_body_size = "1m"
+            block = _service()._create_generic_proxy_block("skill", "/skills/x", "https://x/")
+        assert "proxy_set_header X-Internal-Token-Generic $auth_internal_token_generic;" in block
+        # must NOT forward the generic token under the MCP header name
+        assert "proxy_set_header X-Internal-Token $auth_internal_token_generic;" not in block
+
     def test_auth_server_url_trailing_slash_not_doubled(self):
         with patch("registry.core.nginx_service.settings") as s:
             s.auth_server_url = "http://auth-server:8888/"

--- a/tests/unit/core/test_nginx_generic_proxy.py
+++ b/tests/unit/core/test_nginx_generic_proxy.py
@@ -1,0 +1,356 @@
+"""Unit tests for the generic-proxy nginx block generation.
+
+Covers the four render-time pieces added to registry/core/nginx_service.py:
+- _fetch_generic_proxied_resources: FLAG-GATED (zero DB queries when off), and
+  drops federated/disabled/targetless rows via resolve_proxy_target;
+- _create_generic_proxy_block: proxies to the auth-server generic hop, sets the
+  SEPARATE $generic_backend_url (never $backend_url), and pins the target as
+  X-Upstream-Url;
+- _safe_generic_block: skip-not-fail render-time SSRF/scheme/illegal-char guard;
+- _generate_generic_proxy_blocks + _location_paths_in: cross-block collision
+  dedup with generic as the lowest-precedence tier.
+
+The SECRET_KEY env is set so importing registry.core.config.settings succeeds.
+"""
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from registry.core.nginx_service import (  # noqa: E402
+    NginxConfigService,
+    _fetch_generic_proxied_resources,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _service() -> NginxConfigService:
+    # NginxConfigService.__init__ only sets paths/locks; no I/O. The block
+    # helpers under test are pure string builders that read settings.
+    return NginxConfigService()
+
+
+# --------------------------------------------------------------------------- #
+# _fetch_generic_proxied_resources — flag gate + resolve_proxy_target filtering
+# --------------------------------------------------------------------------- #
+
+
+class TestFetchFlagGate:
+    async def test_disabled_flag_issues_zero_queries(self):
+        """SRE invariant: when the feature is off, NOT ONE repo query fires."""
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = False
+            with patch("registry.repositories.factory.get_agent_repository") as ga:
+                result = await _fetch_generic_proxied_resources()
+        assert result == []
+        ga.assert_not_called()  # the fetch short-circuited before touching factory
+
+    async def test_enabled_flag_queries_all_three_repos(self):
+        agent_repo = AsyncMock()
+        agent_repo.list_proxied.return_value = [
+            {"path": "/agents/a1", "is_proxied": True, "url": "https://a.example/"}
+        ]
+        skill_repo = AsyncMock()
+        skill_repo.list_proxied.return_value = [
+            {"path": "/skills/s1", "is_proxied": True, "proxy_target_url": "https://s.example/"}
+        ]
+        custom_repo = AsyncMock()
+        custom_repo.list_proxied.return_value = [
+            {
+                "path": "/workflow/w1",
+                "entity_type": "workflow",
+                "is_proxied": True,
+                "proxy_target_url": "https://w.example/",
+            }
+        ]
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = True
+            with (
+                patch(
+                    "registry.repositories.factory.get_agent_repository",
+                    return_value=agent_repo,
+                ),
+                patch(
+                    "registry.repositories.factory.get_skill_repository",
+                    return_value=skill_repo,
+                ),
+                patch(
+                    "registry.repositories.factory.get_custom_entity_repository",
+                    return_value=custom_repo,
+                ),
+            ):
+                result = await _fetch_generic_proxied_resources()
+
+        by_path = {r["path"]: r for r in result}
+        assert by_path["/agents/a1"]["entity_type"] == "a2a_agent"
+        assert by_path["/agents/a1"]["target_url"] == "https://a.example/"
+        assert by_path["/skills/s1"]["entity_type"] == "skill"
+        # custom record carries its own type token, used as the entity_type
+        assert by_path["/workflow/w1"]["entity_type"] == "workflow"
+
+    async def test_federated_and_targetless_rows_dropped(self):
+        skill_repo = AsyncMock()
+        skill_repo.list_proxied.return_value = [
+            # federated -> resolve_proxy_target returns None -> dropped
+            {
+                "path": "/skills/fed",
+                "is_proxied": True,
+                "proxy_target_url": "https://x/",
+                "sync_metadata": {"is_federated": True},
+            },
+            # no target -> dropped
+            {"path": "/skills/none", "is_proxied": True},
+            # good
+            {"path": "/skills/ok", "is_proxied": True, "proxy_target_url": "https://ok/"},
+        ]
+        empty = AsyncMock()
+        empty.list_proxied.return_value = []
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = True
+            with (
+                patch("registry.repositories.factory.get_agent_repository", return_value=empty),
+                patch(
+                    "registry.repositories.factory.get_skill_repository", return_value=skill_repo
+                ),
+                patch(
+                    "registry.repositories.factory.get_custom_entity_repository",
+                    return_value=empty,
+                ),
+            ):
+                result = await _fetch_generic_proxied_resources()
+        assert [r["path"] for r in result] == ["/skills/ok"]
+
+    async def test_one_repo_error_does_not_break_others(self):
+        boom = AsyncMock()
+        boom.list_proxied.side_effect = RuntimeError("db down")
+        good = AsyncMock()
+        good.list_proxied.return_value = [
+            {"path": "/skills/ok", "is_proxied": True, "proxy_target_url": "https://ok/"}
+        ]
+        empty = AsyncMock()
+        empty.list_proxied.return_value = []
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = True
+            with (
+                patch("registry.repositories.factory.get_agent_repository", return_value=boom),
+                patch("registry.repositories.factory.get_skill_repository", return_value=good),
+                patch(
+                    "registry.repositories.factory.get_custom_entity_repository",
+                    return_value=empty,
+                ),
+            ):
+                result = await _fetch_generic_proxied_resources()
+        assert [r["path"] for r in result] == ["/skills/ok"]
+
+
+# --------------------------------------------------------------------------- #
+# _create_generic_proxy_block — shape
+# --------------------------------------------------------------------------- #
+
+
+class TestCreateBlock:
+    def _block(self, entity_type="skill", path="/skills/proxy-demo", target="https://b.example/"):
+        with patch("registry.core.nginx_service.settings") as s:
+            s.auth_server_url = "http://auth-server:8888"
+            s.gateway_generic_client_max_body_size = "1m"
+            return _service()._create_generic_proxy_block(entity_type, path, target)
+
+    def test_location_is_entity_type_namespaced(self):
+        block = self._block()
+        assert "location {{ROOT_PATH}}/skill/skills/proxy-demo {" in block
+
+    def test_proxy_pass_targets_auth_server_generic_hop(self):
+        block = self._block()
+        assert "proxy_pass http://auth-server:8888/proxy/skill/skills/proxy-demo/;" in block
+
+    def test_sets_generic_backend_url_not_backend_url(self):
+        block = self._block(target="https://b.example/")
+        assert 'set $generic_backend_url "https://b.example/";' in block
+        # CRITICAL double-mint guard: never emits a $backend_url DIRECTIVE on the
+        # generic path (a comment may reference the name for context). Check the
+        # live-directive lines only.
+        directive_lines = [ln for ln in block.splitlines() if not ln.lstrip().startswith("#")]
+        assert not any("set $backend_url" in ln for ln in directive_lines)
+        assert not any(
+            "$backend_url" in ln and "$generic_backend_url" not in ln for ln in directive_lines
+        )
+        assert "X-Upstream-Url $generic_backend_url;" in block
+
+    def test_carries_entity_markers_and_body_size(self):
+        with patch("registry.core.nginx_service.settings") as s:
+            s.auth_server_url = "http://auth-server:8888"
+            s.gateway_generic_client_max_body_size = "8m"
+            block = _service()._create_generic_proxy_block(
+                "a2a_agent", "/agents/code-reviewer", "https://x/"
+            )
+        assert 'set $generic_proxy_kind "a2a_agent";' in block
+        assert 'set $entity_path "agents/code-reviewer";' in block
+        assert "client_max_body_size 8m;" in block
+
+    def test_auth_server_url_trailing_slash_not_doubled(self):
+        with patch("registry.core.nginx_service.settings") as s:
+            s.auth_server_url = "http://auth-server:8888/"
+            s.gateway_generic_client_max_body_size = "1m"
+            block = _service()._create_generic_proxy_block("skill", "/skills/x", "https://x/")
+        assert "proxy_pass http://auth-server:8888/proxy/skill/skills/x/;" in block
+
+
+# --------------------------------------------------------------------------- #
+# _safe_generic_block — skip-not-fail guard
+# --------------------------------------------------------------------------- #
+
+
+class TestSafeBlock:
+    def _safe(
+        self, entity_type, path, target, allow_private=False, auth_url="http://auth-server:8888"
+    ):
+        with patch("registry.core.nginx_service.settings") as s:
+            s.auth_server_url = auth_url
+            s.gateway_generic_client_max_body_size = "1m"
+            s.gateway_proxy_allow_private_targets = allow_private
+            return _service()._safe_generic_block(entity_type, path, target)
+
+    def test_valid_target_returns_block(self):
+        assert self._safe("skill", "/skills/x", "https://ok.example/") is not None
+
+    def test_non_http_scheme_skipped(self):
+        assert self._safe("skill", "/skills/x", "file:///etc/passwd") is None
+        assert self._safe("skill", "/skills/x", "gopher://x/") is None
+
+    def test_metadata_ip_skipped_regardless_of_flag(self):
+        # link-local/metadata is denied even when private targets are allowed.
+        assert (
+            self._safe("skill", "/skills/x", "http://169.254.169.254/", allow_private=True) is None
+        )
+
+    def test_private_target_skipped_when_flag_false(self):
+        assert self._safe("skill", "/skills/x", "http://10.0.0.5/", allow_private=False) is None
+
+    def test_illegal_char_in_target_skipped(self):
+        # a semicolon/brace/quote/newline could break out of the nginx directive
+        assert self._safe("skill", "/skills/x", 'https://x/";}') is None
+
+    def test_illegal_char_in_path_skipped(self):
+        assert self._safe("skill", "/skills/x\ninjected", "https://ok.example/") is None
+
+    def test_dollar_in_target_skipped(self):
+        # $ inside the double-quoted `set $generic_backend_url "..."` value would be
+        # expanded by nginx as a variable reference. Must be rejected.
+        assert self._safe("skill", "/skills/x", "https://x/$request_uri") is None
+        assert self._safe("skill", "/skills/x", "https://x/${remote_addr}") is None
+
+    def test_illegal_entity_type_skipped(self):
+        # A corrupt DB row whose entity_type breaks the token grammar is
+        # interpolated into 4 directive positions — reject it.
+        assert self._safe("skill; }\nlocation /evil {", "/skills/x", "https://ok/") is None
+        assert self._safe("bad type", "/skills/x", "https://ok/") is None
+        assert self._safe("Type/With/Slashes", "/skills/x", "https://ok/") is None
+
+    def test_valid_entity_type_tokens_pass(self):
+        assert self._safe("a2a_agent", "/agents/x", "https://ok/") is not None
+        assert self._safe("custom-type_1", "/custom-type_1/x", "https://ok/") is not None
+
+    def test_path_traversal_segment_skipped(self):
+        # ..-segments would path-traverse on the auth-server hop after nginx
+        # normalizes the proxy_pass URI.
+        assert self._safe("agent", "/agents/../admin/secret", "https://ok/") is None
+        assert self._safe("skill", "/skills/proxy-demo/../../etc", "https://ok/") is None
+
+    def test_dot_in_path_is_allowed(self):
+        # A single dot (not a `..` segment) is a legal path character.
+        assert self._safe("skill", "/skills/v1.2.3", "https://ok/") is not None
+
+    def test_empty_auth_server_url_skipped(self):
+        # Empty auth_server_url would render `proxy_pass /proxy/...;` — a relative
+        # self-loop. Skip rather than emit a bad block.
+        assert self._safe("skill", "/skills/x", "https://ok/", auth_url="") is None
+
+
+# --------------------------------------------------------------------------- #
+# _location_paths_in + _generate_generic_proxy_blocks — collision dedup
+# --------------------------------------------------------------------------- #
+
+
+class TestLocationPaths:
+    def test_extracts_plain_and_placeholder_paths(self):
+        text = """
+    location {{ROOT_PATH}}/skill/skills/x {
+        proxy_pass http://a/;
+    }
+    location = /validate {
+    }"""
+        paths = NginxConfigService._location_paths_in(text)
+        assert "/skill/skills/x" in paths
+        assert "/validate" in paths
+
+    def test_ignores_commented_locations(self):
+        text = "#    location {{ROOT_PATH}}/dead {\n    location /live {\n    }"
+        paths = NginxConfigService._location_paths_in(text)
+        assert paths == {"/live"}
+
+
+class TestGenerateGenericBlocks:
+    async def _generate(self, resources, claimed):
+        with patch("registry.core.nginx_service.settings") as s:
+            s.gateway_generic_proxy_enabled = True
+            s.auth_server_url = "http://auth-server:8888"
+            s.gateway_generic_client_max_body_size = "1m"
+            s.gateway_proxy_allow_private_targets = False
+            with patch(
+                "registry.core.nginx_service._fetch_generic_proxied_resources",
+                new=AsyncMock(return_value=resources),
+            ):
+                return await _service()._generate_generic_proxy_blocks(claimed)
+
+    async def test_empty_when_no_resources(self):
+        assert await self._generate([], set()) == []
+
+    async def test_generates_block_per_resource(self):
+        resources = [
+            {"entity_type": "skill", "path": "/skills/a", "target_url": "https://a/"},
+            {"entity_type": "a2a_agent", "path": "/agents/b", "target_url": "https://b/"},
+        ]
+        blocks = await self._generate(resources, set())
+        assert len(blocks) == 2
+
+    async def test_generic_dropped_on_collision_with_claimed_path(self):
+        # A legacy MCP server already claimed /skill/skills/a (precedence).
+        resources = [
+            {"entity_type": "skill", "path": "/skills/a", "target_url": "https://a/"},
+            {"entity_type": "skill", "path": "/skills/b", "target_url": "https://b/"},
+        ]
+        claimed = {"/skill/skills/a"}
+        blocks = await self._generate(resources, claimed)
+        # only /skills/b survives; the colliding /skills/a is dropped
+        assert len(blocks) == 1
+        assert "/skill/skills/b" in blocks[0]
+
+    async def test_generic_vs_generic_first_seen_wins(self):
+        # Two entities rendering the SAME location path: deterministic first-wins
+        # by sorted (entity_type, path). Construct a genuine collision: same type
+        # + same path can't happen (unique), so use custom types whose namespaced
+        # location coincides — here identical entity_type/path is impossible, so
+        # assert the sort-stable claim behavior with a pre-claim instead.
+        resources = [
+            {"entity_type": "skill", "path": "/skills/dup", "target_url": "https://a/"},
+        ]
+        # Pre-claim the path; the single generic must be dropped, not duplicated.
+        blocks = await self._generate(resources, {"/skill/skills/dup"})
+        assert blocks == []
+
+    async def test_invalid_target_skipped_but_others_render(self):
+        resources = [
+            {
+                "entity_type": "skill",
+                "path": "/skills/bad",
+                "target_url": "http://169.254.169.254/",
+            },
+            {"entity_type": "skill", "path": "/skills/good", "target_url": "https://good/"},
+        ]
+        blocks = await self._generate(resources, set())
+        assert len(blocks) == 1
+        assert "/skill/skills/good" in blocks[0]

--- a/tests/unit/health/test_health_service.py
+++ b/tests/unit/health/test_health_service.py
@@ -1502,6 +1502,10 @@ async def test_endpoint_check_blocks_unsafe_url_without_sending_credentials(
     settings_stub = MagicMock()
     settings_stub.ssrf_allowed_hosts = ""
     settings_stub.ssrf_allowed_cidrs = ""
+    # Explicit: a MagicMock auto-attr is truthy, so leaving this unset would make
+    # the PROXY_PROFILE allowlist relax private/loopback and the "unsafe URL is
+    # blocked" assertion would wrongly fail. Default matches production (False).
+    settings_stub.gateway_proxy_allow_private_targets = False
 
     with patch.object(url_guard, "settings", settings_stub):
         with patch.object(health_service, "_build_headers_for_server") as mock_build_headers:

--- a/tests/unit/repositories/test_list_proxied.py
+++ b/tests/unit/repositories/test_list_proxied.py
@@ -1,0 +1,233 @@
+"""Unit tests for list_proxied() across the five DocumentDB entity repos.
+
+The Mongo collection is mocked (no live DB). These lock in that list_proxied:
+- issues an indexed {"is_proxied": True} filter (not a full scan);
+- projects only the render/resolve-relevant fields (incl. sync_metadata for the
+  federation guard, and the per-type native fallback field);
+- maps _id -> path and returns raw dicts (never reconstructs a model, so a
+  bypass-written invalid row cannot crash the config-reload hot path);
+- degrades to [] on a driver error rather than raising into the reload.
+
+The ABC default (list[]) is exercised for the non-overriding contract.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class _AsyncCursor:
+    """Minimal async cursor over a fixed doc list (mirrors motor's find())."""
+
+    def __init__(self, docs):
+        self._docs = docs
+
+    def __aiter__(self):
+        async def _gen():
+            for d in self._docs:
+                yield d
+
+        return _gen()
+
+
+def _collection(docs):
+    coll = MagicMock()
+    coll.find = MagicMock(return_value=_AsyncCursor([dict(d) for d in docs]))
+    return coll
+
+
+async def _run_list_proxied(repo, docs):
+    coll = _collection(docs)
+    with patch.object(repo, "_get_collection", new=AsyncMock(return_value=coll)):
+        # skill/custom call ensure_indexes() which also hits _get_collection; the
+        # patched _get_collection returns the same mock, and _indexes_created guards.
+        repo._indexes_created = True
+        result = await repo.list_proxied()
+    return result, coll
+
+
+class TestServerListProxied:
+    async def test_query_projection_and_mapping(self):
+        from registry.repositories.documentdb.server_repository import (
+            DocumentDBServerRepository,
+        )
+
+        docs = [
+            {
+                "_id": "/s1",
+                "is_proxied": True,
+                "proxy_pass_url": "https://b/",
+                "deployment": "remote",
+            }
+        ]
+        rows, coll = await _run_list_proxied(DocumentDBServerRepository(), docs)
+
+        filt, projection = coll.find.call_args[0]
+        assert filt == {"is_proxied": True}
+        assert projection["proxy_pass_url"] == 1  # native fallback
+        assert projection["deployment"] == 1
+        assert projection["sync_metadata"] == 1  # federation guard
+        assert projection["is_enabled"] == 1  # disabled -> no route
+        # negative: heavy fields must NOT be pulled on the hot path
+        assert "tool_list" not in projection
+        assert rows[0]["path"] == "/s1"
+        assert "_id" not in rows[0]
+
+
+class TestAgentListProxied:
+    async def test_projects_url_fallback(self):
+        from registry.repositories.documentdb.agent_repository import (
+            DocumentDBAgentRepository,
+        )
+
+        docs = [{"_id": "/a1", "is_proxied": True, "url": "https://a/"}]
+        rows, coll = await _run_list_proxied(DocumentDBAgentRepository(), docs)
+
+        _filt, projection = coll.find.call_args[0]
+        assert projection["url"] == 1  # agent native fallback
+        assert projection["sync_metadata"] == 1  # federation guard
+        assert projection["is_enabled"] == 1
+        assert rows[0]["path"] == "/a1"
+
+
+class TestSkillListProxied:
+    async def test_projects_no_native_fallback(self):
+        from registry.repositories.documentdb.skill_repository import (
+            DocumentDBSkillRepository,
+        )
+
+        docs = [{"_id": "/skills/x", "is_proxied": True, "proxy_target_url": "https://t/"}]
+        rows, coll = await _run_list_proxied(DocumentDBSkillRepository(), docs)
+
+        _filt, projection = coll.find.call_args[0]
+        assert projection["proxy_target_url"] == 1
+        assert "url" not in projection and "proxy_pass_url" not in projection
+        assert projection["sync_metadata"] == 1  # federation guard
+        assert projection["is_enabled"] == 1
+        assert rows[0]["path"] == "/skills/x"
+
+
+class TestVirtualServerListProxied:
+    async def test_alias_only_projection(self):
+        from registry.repositories.documentdb.virtual_server_repository import (
+            DocumentDBVirtualServerRepository,
+        )
+
+        docs = [{"_id": "/virtual/v1", "is_proxied": True, "is_enabled": True}]
+        rows, coll = await _run_list_proxied(DocumentDBVirtualServerRepository(), docs)
+
+        _filt, projection = coll.find.call_args[0]
+        assert "proxy_target_url" not in projection  # alias-only
+        assert projection["sync_metadata"] == 1  # federation guard
+        assert projection["is_enabled"] == 1
+        assert rows[0]["path"] == "/virtual/v1"
+
+
+class TestCustomEntityListProxied:
+    async def test_projects_entity_type(self):
+        from registry.repositories.documentdb.custom_entity_repository import (
+            DocumentDBCustomEntityRepository,
+        )
+
+        docs = [
+            {
+                "_id": "/workflow/uuid",
+                "entity_type": "workflow",
+                "is_proxied": True,
+                "proxy_target_url": "https://t/",
+            }
+        ]
+        rows, coll = await _run_list_proxied(DocumentDBCustomEntityRepository(), docs)
+
+        _filt, projection = coll.find.call_args[0]
+        assert projection["entity_type"] == 1  # type token spans records
+        assert projection["sync_metadata"] == 1  # federation guard
+        assert projection["is_enabled"] == 1
+        assert rows[0]["path"] == "/workflow/uuid"
+        assert rows[0]["entity_type"] == "workflow"
+
+
+class TestListProxiedFailClosed:
+    async def test_driver_error_returns_empty_not_raises(self):
+        from registry.repositories.documentdb.server_repository import (
+            DocumentDBServerRepository,
+        )
+
+        repo = DocumentDBServerRepository()
+        coll = MagicMock()
+        coll.find = MagicMock(side_effect=RuntimeError("db down"))
+        with patch.object(repo, "_get_collection", new=AsyncMock(return_value=coll)):
+            assert await repo.list_proxied() == []  # must not raise into the reload
+
+    async def test_collection_acquisition_error_returns_empty(self):
+        """A connection/acquisition error must ALSO fail closed (acquisition is
+        inside the try, per the widened boundary)."""
+        from registry.repositories.documentdb.server_repository import (
+            DocumentDBServerRepository,
+        )
+
+        repo = DocumentDBServerRepository()
+        with patch.object(
+            repo, "_get_collection", new=AsyncMock(side_effect=RuntimeError("no db"))
+        ):
+            assert await repo.list_proxied() == []
+
+
+class TestIsProxiedIndexResilient:
+    """ensure_is_proxied_index never raises and falls back to a plain index when
+    the partial form is rejected (AWS DocumentDB)."""
+
+    async def test_partial_rejected_falls_back_to_plain(self):
+        from registry.repositories.documentdb._identity_url_sidecar import (
+            ensure_is_proxied_index,
+        )
+
+        calls = []
+
+        async def _create_index(*args, **kwargs):
+            calls.append(kwargs)
+            if "partialFilterExpression" in kwargs:
+                raise RuntimeError("partial indexes not supported")  # DocumentDB
+            return "idx"
+
+        coll = MagicMock()
+        coll.create_index = _create_index
+        # Must not raise, and must attempt the plain fallback after the partial fails.
+        await ensure_is_proxied_index(coll, "mcp_servers")
+        assert any("partialFilterExpression" in c for c in calls)
+        assert any("partialFilterExpression" not in c for c in calls)
+
+    async def test_both_rejected_still_no_raise(self):
+        from registry.repositories.documentdb._identity_url_sidecar import (
+            ensure_is_proxied_index,
+        )
+
+        async def _create_index(*args, **kwargs):
+            raise RuntimeError("no indexes at all")
+
+        coll = MagicMock()
+        coll.create_index = _create_index
+        await ensure_is_proxied_index(coll, "mcp_servers")  # must not raise
+
+
+class TestAbcDefaultIsEmpty:
+    @pytest.mark.parametrize(
+        "base_name",
+        [
+            "ServerRepositoryBase",
+            "AgentRepositoryBase",
+            "SkillRepositoryBase",
+            "VirtualServerRepositoryBase",
+            "CustomEntityRepositoryBase",
+        ],
+    )
+    async def test_default_returns_empty(self, base_name):
+        # The non-abstract default returns [] (safe no-op for non-overriding
+        # backends). Call the unbound coroutine with a dummy self to avoid ABC
+        # instantiation of the many other abstractmethods.
+        import registry.repositories.interfaces as interfaces
+
+        base = getattr(interfaces, base_name)
+        assert await base.list_proxied(object()) == []

--- a/tests/unit/schemas/test_proxy_federation_isolation.py
+++ b/tests/unit/schemas/test_proxy_federation_isolation.py
@@ -1,0 +1,188 @@
+"""Federation isolation for proxy config (owner decision: proxy is local-only).
+
+Proxy fields must never cross the federation boundary in either direction:
+- INGEST: a synced entity can never become a local gateway route, and a peer
+  cannot plant an SSRF proxy_target_url.
+- EXPORT: we never advertise our proxy config (esp. the internal
+  proxy_target_url) to peers.
+
+The key-drop (not force-false) semantics are load-bearing: on an update re-sync a
+peer must not clobber a local admin's opt-in, so the fields are simply absent
+from the synced payload rather than set to False.
+"""
+
+import pytest
+
+from registry.schemas.proxy_mixin import (
+    PROXY_FIELD_NAMES,
+    strip_proxy_fields,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestStripProxyFields:
+    def test_removes_all_proxy_keys(self):
+        doc = {
+            "name": "x",
+            "path": "/x",
+            "is_proxied": True,
+            "proxy_target_url": "https://internal.example/",
+            "proxy_resolved_ips": ["1.2.3.4"],
+            "proxy_target_host": "internal.example",
+            "proxy_disabled_reason": "blocked",
+        }
+        out = strip_proxy_fields(doc)
+        assert set(out) == {"name", "path"}
+        for k in PROXY_FIELD_NAMES:
+            assert k not in out
+
+    def test_preserves_non_proxy_fields(self):
+        doc = {"name": "x", "path": "/x", "tags": ["a"], "is_enabled": True}
+        assert strip_proxy_fields(doc) == doc
+
+    def test_does_not_force_false_key_dropped_not_set(self):
+        # Key-drop, NOT force-false: is_proxied must be ABSENT, not present-and-False,
+        # so an update re-sync leaves an existing stored opt-in untouched.
+        doc = {"name": "x", "is_proxied": True, "proxy_target_url": "https://x/"}
+        out = strip_proxy_fields(doc)
+        assert "is_proxied" not in out
+        assert "proxy_target_url" not in out
+
+    def test_no_proxy_keys_returns_input_unchanged(self):
+        doc = {"name": "x", "path": "/x"}
+        assert strip_proxy_fields(doc) is doc  # fast path: same object
+
+    def test_does_not_mutate_input(self):
+        doc = {"name": "x", "is_proxied": True}
+        strip_proxy_fields(doc)
+        assert doc["is_proxied"] is True  # original untouched
+
+
+class TestExportStripsProxyFields:
+    def test_item_to_dict_strips_from_dict(self):
+        from registry.api.federation_export_routes import _item_to_dict
+
+        server = {
+            "path": "/s",
+            "server_name": "s",
+            "is_proxied": True,
+            "proxy_target_url": "https://internal.example/",
+        }
+        out = _item_to_dict(server)
+        assert "is_proxied" not in out
+        assert "proxy_target_url" not in out
+        assert out["server_name"] == "s"
+
+    def test_item_to_dict_strips_from_model(self):
+        from registry.api.federation_export_routes import _item_to_dict
+        from registry.schemas.agent_models import AgentCard
+
+        card = AgentCard(
+            name="a",
+            description="d",
+            url="https://a.example/",
+            version="1",
+            is_proxied=True,
+            proxy_target_url="https://internal.example/",
+        )
+        out = _item_to_dict(card)
+        assert "is_proxied" not in out
+        assert "proxy_target_url" not in out
+        assert out["name"] == "a"
+
+
+class TestIngestStripsProxyFields:
+    """Source-level guards that every peer-content ingest site strips, and that
+    the local re-persist sites (orphan/override) do NOT (they'd clobber a local
+    admin's opt-in)."""
+
+    def test_peer_sync_prep_strips(self):
+        import inspect
+
+        from registry.services import peer_federation_service as m
+
+        for fn in (
+            m.PeerFederationService._store_synced_servers,
+            m.PeerFederationService._store_synced_agents,
+        ):
+            assert "strip_proxy_fields(" in inspect.getsource(fn)
+
+    def test_federation_routes_ingest_strips(self):
+        import inspect
+
+        from registry.api import federation_routes
+
+        src = inspect.getsource(federation_routes)
+        # 4 peer-content ingest loops (Anthropic servers + AgentCore srv/agent/skill)
+        assert src.count("strip_proxy_fields(") >= 4
+
+    def test_ard_skill_ingest_strips(self):
+        """ARD catalog-crawl skill ingest is peer content and must strip too."""
+        import inspect
+
+        from registry.services import ard_ingestion_service as m
+
+        assert "strip_proxy_fields(" in inspect.getsource(m.ArdIngestionService._store_skills)
+
+
+class TestFederatedEntityNeverResolvesToRoute:
+    """ABSOLUTE isolation: resolve_proxy_target returns None for a federated
+    entity even if is_proxied was flipped locally after ingest — so there is no
+    path from peer-supplied data (proxy_pass_url/url) to a live gateway route."""
+
+    def test_federated_server_with_local_is_proxied_does_not_resolve(self):
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {
+            "is_proxied": True,  # locally flipped on a synced record
+            "proxy_pass_url": "https://peer-backend.example/",  # peer-supplied
+            "deployment": "remote",
+            "sync_metadata": {"is_federated": True, "source_peer_id": "p1"},
+        }
+        assert resolve_proxy_target("mcp_server", doc) is None
+
+    def test_federated_agent_does_not_resolve(self):
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {
+            "is_proxied": True,
+            "url": "https://peer-agent.example/",
+            "sync_metadata": {"is_federated": True},
+        }
+        assert resolve_proxy_target("a2a_agent", doc) is None
+
+    def test_non_federated_server_still_resolves(self):
+        """A LOCAL (non-federated) proxied server resolves normally."""
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {
+            "is_proxied": True,
+            "proxy_pass_url": "https://local-backend.example/",
+            "deployment": "remote",
+        }
+        assert resolve_proxy_target("mcp_server", doc) == "https://local-backend.example/"
+
+    def test_non_federated_sync_metadata_shape_is_tolerated(self):
+        """A non-dict / absent sync_metadata must not crash the resolve."""
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {
+            "is_proxied": True,
+            "proxy_target_url": "https://local.example/",
+            "sync_metadata": None,
+        }
+        assert resolve_proxy_target("skill", doc) == "https://local.example/"
+
+    def test_local_repersist_does_not_strip(self):
+        """_mark_orphaned / _set_local_override read a LOCAL record and re-persist
+        it; stripping there would wipe a local admin's proxy opt-in. They must NOT
+        call strip_proxy_fields."""
+        import inspect
+
+        from registry.services import peer_federation_service as m
+
+        for name in ("mark_item_as_orphaned", "set_local_override"):
+            fn = getattr(m.PeerFederationService, name, None)
+            assert fn is not None, f"expected method {name} to exist"
+            assert "strip_proxy_fields(" not in inspect.getsource(fn), name

--- a/tests/unit/schemas/test_proxy_federation_isolation.py
+++ b/tests/unit/schemas/test_proxy_federation_isolation.py
@@ -174,6 +174,30 @@ class TestFederatedEntityNeverResolvesToRoute:
         }
         assert resolve_proxy_target("skill", doc) == "https://local.example/"
 
+
+class TestDisabledEntityDoesNotResolve:
+    """A proxied-but-disabled entity gets no route; is_enabled gates only when
+    the caller supplies it (list_proxied projects it), else it's not assumed."""
+
+    def test_disabled_returns_none(self):
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {"is_proxied": True, "proxy_target_url": "https://t/", "is_enabled": False}
+        assert resolve_proxy_target("skill", doc) is None
+
+    def test_enabled_resolves(self):
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {"is_proxied": True, "proxy_target_url": "https://t/", "is_enabled": True}
+        assert resolve_proxy_target("skill", doc) == "https://t/"
+
+    def test_absent_is_enabled_is_not_assumed_disabled(self):
+        """A partial projection without is_enabled must not be treated as disabled."""
+        from registry.schemas.proxy_mixin import resolve_proxy_target
+
+        doc = {"is_proxied": True, "proxy_target_url": "https://t/"}
+        assert resolve_proxy_target("skill", doc) == "https://t/"
+
     def test_local_repersist_does_not_strip(self):
         """_mark_orphaned / _set_local_override read a LOCAL record and re-persist
         it; stripping there would wipe a local admin's proxy opt-in. They must NOT

--- a/tests/unit/schemas/test_proxy_mixin.py
+++ b/tests/unit/schemas/test_proxy_mixin.py
@@ -177,13 +177,29 @@ class TestProxyableMixinValidator:
         m = ProxyableMixin(is_proxied=True, proxy_target_url="https://api.github.com/")
         assert m.is_proxied is True
 
-    def test_metadata_target_rejected(self, monkeypatch):
-        """Model edge surfaces the egress denial as a Pydantic ValidationError."""
-        from pydantic import ValidationError
+    def test_mixin_itself_is_read_safe(self, monkeypatch):
+        """The mixin does NOT raise on a denied target at construction.
+
+        Storage models inherit the mixin and are reconstructed from the DB on
+        every read; raising here would vanish a bypass-written record on load.
+        The egress raise lives on the request/patch models (API edge) via
+        egress_guard_validator, and the authoritative net is the persist/render
+        guard. See the ProxyableMixin note and egress_guard_validator.
+        """
+        _set_allow_private(monkeypatch, False)
+        # Must NOT raise — read-safe.
+        m = ProxyableMixin(is_proxied=True, proxy_target_url="http://169.254.169.254/")
+        assert m.proxy_target_url == "http://169.254.169.254/"
+
+    def test_egress_guard_validator_raises_at_edge(self, monkeypatch):
+        """The reusable edge validator (attached to request models) DOES raise."""
+        from registry.schemas.proxy_mixin import EgressPolicyError, egress_guard_validator
 
         _set_allow_private(monkeypatch, False)
-        with pytest.raises(ValidationError):
-            ProxyableMixin(is_proxied=True, proxy_target_url="http://169.254.169.254/")
+        with pytest.raises(EgressPolicyError):
+            egress_guard_validator("http://169.254.169.254/")
+        assert egress_guard_validator(None) is None
+        assert egress_guard_validator("https://ok.example/") == "https://ok.example/"
 
     def test_defaults_are_safe(self):
         m = ProxyableMixin()

--- a/tests/unit/schemas/test_proxy_mixin.py
+++ b/tests/unit/schemas/test_proxy_mixin.py
@@ -1,0 +1,293 @@
+"""Unit tests for ProxyableMixin, resolve_proxy_target, and the SSRF egress guard.
+
+_assert_egress_allowed is a best-effort STATIC egress check that delegates IP
+classification to registry.utils.ip_guard (exhaustively tested in
+tests/unit/utils/test_ip_guard.py). It is deliberately weaker than
+ard_net_guard (it does not resolve DNS); the authoritative rebind defense is the
+network egress policy. These tests confirm the guard is wired into the model
+edge correctly and rejects literal-IP bypasses; they do not claim it is the sole
+SSRF control. They lock in the vectors so a future edit cannot silently weaken it:
+
+- always-denied regardless of the allow-private flag: link-local (incl. the cloud
+  metadata IP 169.254.169.254), IPv6 link-local, and the unspecified address
+  (0.0.0.0 / ::) which Linux routes to localhost on connect();
+- IPv4-mapped IPv6 (::ffff:169.254.169.254) normalized BEFORE the category check
+  so the metadata IP cannot be smuggled past the guard;
+- loopback / private / reserved / multicast denied unless allow-private is set;
+- hostnames pass the static guard (DNS is resolved downstream; the network-layer
+  egress policy is the real rebind defense) — documented best-effort behavior;
+- non-http(s) schemes rejected.
+"""
+
+import pytest
+
+from registry.schemas.proxy_mixin import (
+    EgressPolicyError,
+    ProxyableMixin,
+    _assert_egress_allowed,
+    resolve_proxy_target,
+)
+
+
+def _set_allow_private(monkeypatch, value: bool) -> None:
+    """Point settings.gateway_proxy_allow_private_targets at ``value``."""
+    from registry.core import config
+
+    monkeypatch.setattr(config.settings, "gateway_proxy_allow_private_targets", value, raising=True)
+
+
+@pytest.mark.unit
+class TestEgressGuardAlwaysDenied:
+    """Vectors denied regardless of the allow-private flag."""
+
+    @pytest.mark.parametrize("allow_private", [False, True])
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data/",  # AWS/GCP/Azure metadata
+            "https://169.254.169.254/",
+            "http://[fe80::1]/",  # IPv6 link-local
+            "http://[::ffff:169.254.169.254]/",  # IPv4-mapped metadata IP
+            "http://0.0.0.0/",  # unspecified -> localhost on connect
+            "http://[::]/",  # IPv6 unspecified
+        ],
+    )
+    def test_denied_even_when_allow_private(self, monkeypatch, allow_private, url):
+        _set_allow_private(monkeypatch, allow_private)
+        with pytest.raises(EgressPolicyError):
+            _assert_egress_allowed(url)
+
+    @pytest.mark.parametrize("allow_private", [False, True])
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://2852039166/",  # decimal for 169.254.169.254 (metadata)
+            "http://0xA9FEA9FE/",  # hex for 169.254.169.254
+            "http://0251.0376.0251.0376/",  # dotted-octal for 169.254.169.254
+            "http://169.254.169.254./",  # trailing-dot canonical
+            "http://2130706433/",  # decimal for 127.0.0.1 (loopback)
+            "http://0x7f000001/",  # hex for 127.0.0.1
+        ],
+    )
+    def test_alternate_ip_encodings_denied(self, monkeypatch, allow_private, url):
+        """Non-canonical IPv4 spellings of metadata/loopback must not slip through.
+
+        inet_aton (and therefore glibc's resolver and nginx) interpret decimal,
+        hex, octal, and trailing-dot forms as real IPv4 addresses. A guard that
+        only parses canonical dotted-quad would let http://2852039166/ reach the
+        metadata endpoint. loopback forms here are denied because allow_private
+        never relaxes link-local/metadata, and the loopback ones fall under the
+        private gate — but the metadata forms must be denied in BOTH flag states.
+        """
+        _set_allow_private(monkeypatch, allow_private)
+        # metadata forms: always denied; loopback forms: denied unless allow_private.
+        is_loopback_form = url in ("http://2130706433/", "http://0x7f000001/")
+        if is_loopback_form and allow_private:
+            _assert_egress_allowed(url)  # loopback permitted when opted in
+        else:
+            with pytest.raises(EgressPolicyError):
+                _assert_egress_allowed(url)
+
+
+@pytest.mark.unit
+class TestEgressGuardPrivateGatedByFlag:
+    """Loopback/private/reserved/multicast: denied by default, allowed when opted in."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:8000/",  # loopback
+            "http://10.0.0.5/",  # private class A
+            "http://192.168.1.10/",  # private class C
+            "http://172.16.0.1/",  # private class B
+            "http://[::1]/",  # IPv6 loopback
+            "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+            "http://240.0.0.1/",  # reserved
+            "http://224.0.0.1/",  # multicast
+        ],
+    )
+    def test_denied_by_default(self, monkeypatch, url):
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(EgressPolicyError):
+            _assert_egress_allowed(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:8000/",
+            "http://10.0.0.5/",
+            "http://192.168.1.10/",
+            "http://[::1]/",
+        ],
+    )
+    def test_allowed_when_flag_set(self, monkeypatch, url):
+        _set_allow_private(monkeypatch, True)
+        # Must not raise.
+        _assert_egress_allowed(url)
+
+
+@pytest.mark.unit
+class TestEgressGuardAllowed:
+    """Public IPs and hostnames pass the static guard."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://93.184.216.34/",  # public IPv4 (example.com)
+            "https://api.github.com/repos",  # hostname -> resolved downstream
+            "https://dashboard.internal.example.com/app",
+        ],
+    )
+    def test_allowed(self, monkeypatch, url):
+        _set_allow_private(monkeypatch, False)
+        _assert_egress_allowed(url)
+
+
+@pytest.mark.unit
+class TestEgressGuardScheme:
+    """Only http(s) is accepted."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/",
+            "file:///etc/passwd",
+            "gopher://example.com/",
+            "ws://example.com/",
+            "not-a-url",
+        ],
+    )
+    def test_non_http_scheme_rejected(self, monkeypatch, url):
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(ValueError):
+            _assert_egress_allowed(url)
+
+
+@pytest.mark.unit
+class TestProxyableMixinValidator:
+    """The field_validator surfaces the egress guard at the model edge."""
+
+    def test_none_target_ok(self, monkeypatch):
+        _set_allow_private(monkeypatch, False)
+        m = ProxyableMixin(is_proxied=False, proxy_target_url=None)
+        assert m.proxy_target_url is None
+
+    def test_public_target_ok(self, monkeypatch):
+        _set_allow_private(monkeypatch, False)
+        m = ProxyableMixin(is_proxied=True, proxy_target_url="https://api.github.com/")
+        assert m.is_proxied is True
+
+    def test_metadata_target_rejected(self, monkeypatch):
+        """Model edge surfaces the egress denial as a Pydantic ValidationError."""
+        from pydantic import ValidationError
+
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(ValidationError):
+            ProxyableMixin(is_proxied=True, proxy_target_url="http://169.254.169.254/")
+
+    def test_defaults_are_safe(self):
+        m = ProxyableMixin()
+        assert m.is_proxied is False
+        assert m.proxy_target_url is None
+        assert m.proxy_resolved_ips == []
+        assert m.proxy_target_host is None
+        assert m.proxy_disabled_reason is None
+
+
+@pytest.mark.unit
+class TestResolveProxyTarget:
+    """Per-entity-type effective-target resolution."""
+
+    def test_not_proxied_returns_none(self):
+        assert resolve_proxy_target("skill", {"is_proxied": False}) is None
+
+    def test_explicit_target_wins(self):
+        doc = {"is_proxied": True, "proxy_target_url": "https://x.example.com/"}
+        assert resolve_proxy_target("skill", doc) == "https://x.example.com/"
+
+    def test_mcp_server_falls_back_to_proxy_pass_url(self):
+        doc = {"is_proxied": True, "proxy_pass_url": "https://backend:9000/"}
+        assert resolve_proxy_target("mcp_server", doc) == "https://backend:9000/"
+
+    def test_mcp_local_deployment_never_proxied(self):
+        doc = {"is_proxied": True, "deployment": "local", "proxy_pass_url": "http://x/"}
+        assert resolve_proxy_target("mcp_server", doc) is None
+
+    def test_agent_falls_back_to_url(self):
+        doc = {"is_proxied": True, "url": "https://agent.example.com/"}
+        assert resolve_proxy_target("a2a_agent", doc) == "https://agent.example.com/"
+
+    def test_skill_requires_explicit_target(self):
+        # No proxy_target_url and no native URL field -> not proxyable.
+        assert resolve_proxy_target("skill", {"is_proxied": True}) is None
+
+    def test_disabled_reason_treated_as_not_proxied(self):
+        doc = {
+            "is_proxied": True,
+            "proxy_target_url": "https://x.example.com/",
+            "proxy_disabled_reason": "target now resolves to a denied IP",
+        }
+        assert resolve_proxy_target("skill", doc) is None
+
+
+@pytest.mark.unit
+class TestEgressGuardErrorTaxonomy:
+    """Network denials raise EgressPolicyError; scheme errors raise plain ValueError.
+
+    The two-tier taxonomy matters: the persist path catches EgressPolicyError
+    specifically, while the Pydantic edge surfaces both as 422.
+    """
+
+    def test_network_denial_is_egress_policy_error(self, monkeypatch):
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(EgressPolicyError):
+            _assert_egress_allowed("http://169.254.169.254/")
+
+    def test_bad_scheme_is_plain_value_error_not_egress(self, monkeypatch):
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(ValueError) as exc:
+            _assert_egress_allowed("file:///etc/passwd")
+        assert not isinstance(exc.value, EgressPolicyError)
+
+    def test_userinfo_host_still_checked(self, monkeypatch):
+        """A userinfo@host URL must be judged on the real host, not the userinfo."""
+        _set_allow_private(monkeypatch, False)
+        with pytest.raises(EgressPolicyError):
+            _assert_egress_allowed("http://user:pass@169.254.169.254/")
+
+    def test_empty_host_is_hostname_branch(self, monkeypatch):
+        """An http URL with no host has no literal IP to check; guard passes it
+        through (a downstream connect would simply fail)."""
+        _set_allow_private(monkeypatch, False)
+        _assert_egress_allowed("http:///path")
+
+
+@pytest.mark.unit
+class TestResolveProxyTargetHostnamePassthrough:
+    """resolve_proxy_target does NOT re-run the egress guard — documents the
+    contract that hostname re-validation is the refresh/network layer's job."""
+
+    def test_hostname_target_returned_verbatim(self):
+        doc = {"is_proxied": True, "proxy_target_url": "https://api.github.com/"}
+        assert resolve_proxy_target("skill", doc) == "https://api.github.com/"
+
+
+@pytest.mark.unit
+class TestClientMaxBodySizeValidator:
+    """The nginx size token is validated at config load (config-injection guard)."""
+
+    @pytest.mark.parametrize("good", ["1m", "512k", "2G", "10485760", "1M", "1024K"])
+    def test_valid_tokens_accepted(self, monkeypatch, good):
+        from registry.core.config import Settings
+
+        s = Settings(gateway_generic_client_max_body_size=good)
+        assert s.gateway_generic_client_max_body_size == good
+
+    @pytest.mark.parametrize("bad", ["1mb", "abc", "1 m", "-1m", "1m; rm -rf", "", "1.5m"])
+    def test_invalid_tokens_rejected(self, monkeypatch, bad):
+        from pydantic import ValidationError
+
+        from registry.core.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(gateway_generic_client_max_body_size=bad)

--- a/tests/unit/schemas/test_proxy_mixin.py
+++ b/tests/unit/schemas/test_proxy_mixin.py
@@ -1,12 +1,13 @@
 """Unit tests for ProxyableMixin, resolve_proxy_target, and the SSRF egress guard.
 
-_assert_egress_allowed is a best-effort STATIC egress check that delegates IP
-classification to registry.utils.ip_guard (exhaustively tested in
-tests/unit/utils/test_ip_guard.py). It is deliberately weaker than
-ard_net_guard (it does not resolve DNS); the authoritative rebind defense is the
-network egress policy. These tests confirm the guard is wired into the model
-edge correctly and rejects literal-IP bypasses; they do not claim it is the sole
-SSRF control. They lock in the vectors so a future edit cannot silently weaken it:
+_assert_egress_allowed is a best-effort STATIC egress check that delegates to the
+canonical registry.utils.url_guard (PROXY_PROFILE, resolve=False), whose inline
+IP classifier is exhaustively tested in tests/unit/utils/test_url_guard.py. It is deliberately
+weaker than the fetch-time pinned transport (it does not resolve DNS); the
+authoritative rebind defense is that transport + the network egress policy. These
+tests confirm the guard is wired into the model edge correctly and rejects
+literal-IP bypasses; they do not claim it is the sole SSRF control. They lock in
+the vectors so a future edit cannot silently weaken it:
 
 - always-denied regardless of the allow-private flag: link-local (incl. the cloud
   metadata IP 169.254.169.254), IPv6 link-local, and the unspecified address
@@ -30,10 +31,18 @@ from registry.schemas.proxy_mixin import (
 
 
 def _set_allow_private(monkeypatch, value: bool) -> None:
-    """Point settings.gateway_proxy_allow_private_targets at ``value``."""
+    """Point settings.gateway_proxy_allow_private_targets at ``value``.
+
+    _assert_egress_allowed now delegates to url_guard, whose PROXY_PROFILE
+    allowlist is @lru_cached (settings are immutable per production process). The
+    cache must be cleared for a test that flips the flag, or the delegated guard
+    reads a stale allowlist.
+    """
     from registry.core import config
+    from registry.utils import url_guard
 
     monkeypatch.setattr(config.settings, "gateway_proxy_allow_private_targets", value, raising=True)
+    url_guard._proxy_allowlist.cache_clear()
 
 
 @pytest.mark.unit
@@ -248,10 +257,15 @@ class TestResolveProxyTarget:
 
 @pytest.mark.unit
 class TestEgressGuardErrorTaxonomy:
-    """Network denials raise EgressPolicyError; scheme errors raise plain ValueError.
+    """Every rejection is an EgressPolicyError (a ValueError subclass), so the
+    Pydantic edge surfaces it as a clean 4xx.
 
-    The two-tier taxonomy matters: the persist path catches EgressPolicyError
-    specifically, while the Pydantic edge surfaces both as 422.
+    NOTE: after converging onto url_guard (one code path for register + fetch),
+    scheme errors and network denials both raise EgressPolicyError rather than the
+    former split (plain ValueError for scheme). Nothing catches EgressPolicyError
+    *specifically* — every consumer uses ``except ValueError`` — so collapsing the
+    taxonomy has no functional effect; it just removes a distinction with no
+    consumer. Both remain ValueError subclasses.
     """
 
     def test_network_denial_is_egress_policy_error(self, monkeypatch):
@@ -259,11 +273,12 @@ class TestEgressGuardErrorTaxonomy:
         with pytest.raises(EgressPolicyError):
             _assert_egress_allowed("http://169.254.169.254/")
 
-    def test_bad_scheme_is_plain_value_error_not_egress(self, monkeypatch):
+    def test_bad_scheme_is_value_error(self, monkeypatch):
+        # A non-http(s) scheme is rejected as a ValueError (EgressPolicyError), so
+        # the Pydantic field validator surfaces it as a 4xx rather than a 500.
         _set_allow_private(monkeypatch, False)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError):
             _assert_egress_allowed("file:///etc/passwd")
-        assert not isinstance(exc.value, EgressPolicyError)
 
     def test_userinfo_host_still_checked(self, monkeypatch):
         """A userinfo@host URL must be judged on the real host, not the userinfo."""
@@ -271,11 +286,12 @@ class TestEgressGuardErrorTaxonomy:
         with pytest.raises(EgressPolicyError):
             _assert_egress_allowed("http://user:pass@169.254.169.254/")
 
-    def test_empty_host_is_hostname_branch(self, monkeypatch):
-        """An http URL with no host has no literal IP to check; guard passes it
-        through (a downstream connect would simply fail)."""
+    def test_empty_host_rejected(self, monkeypatch):
+        """An http URL with no host is now rejected (url_guard requires a host) —
+        stricter than the former passthrough, and safer."""
         _set_allow_private(monkeypatch, False)
-        _assert_egress_allowed("http:///path")
+        with pytest.raises(ValueError):
+            _assert_egress_allowed("http:///path")
 
 
 @pytest.mark.unit

--- a/tests/unit/schemas/test_proxy_model_wiring.py
+++ b/tests/unit/schemas/test_proxy_model_wiring.py
@@ -1,0 +1,346 @@
+"""Tests that the ProxyableMixin is correctly wired into every entity model.
+
+Covers, per entity type:
+- the storage AND request/patch models actually ACCEPT is_proxied/proxy_target_url
+  (a mixin added only to storage models would let the API 422 or drop them);
+- the SSRF egress guard fires at the model edge (a denied target -> ValidationError);
+- the "target required when proxied" contract (proxied with no resolvable target
+  -> ValidationError), including the per-type fallback (MCP -> proxy_pass_url,
+  agent -> url) and the local-MCP exemption;
+- virtual servers are alias-only (a proxy_target_url is rejected).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.unit
+
+_DENIED = "http://169.254.169.254/"  # metadata endpoint
+_OK = "https://backend.example.com/"
+
+
+class TestServerInfoWiring:
+    def test_accepts_and_falls_back_to_proxy_pass_url(self):
+        from registry.core.schemas import ServerInfo
+
+        s = ServerInfo(server_name="s", path="/s", proxy_pass_url=_OK, is_proxied=True)
+        assert s.is_proxied is True
+
+    def test_storage_model_is_read_safe(self):
+        """ServerInfo (storage) does NOT raise on a denied target — reconstructed
+        from the DB on every read. The edge is the request model (below)."""
+        from registry.core.schemas import ServerInfo
+
+        s = ServerInfo(
+            server_name="s",
+            path="/s",
+            proxy_pass_url=_OK,
+            is_proxied=True,
+            proxy_target_url=_DENIED,
+        )
+        assert s.proxy_target_url == _DENIED
+
+    def test_request_model_metadata_target_rejected(self):
+        from registry.core.schemas import ServiceRegistrationRequest
+
+        with pytest.raises(ValidationError):
+            ServiceRegistrationRequest(
+                name="s",
+                path="/s",
+                proxy_pass_url=_OK,
+                is_proxied=True,
+                proxy_target_url=_DENIED,
+            )
+
+    def test_proxied_without_target_rejected(self):
+        from registry.core.schemas import ServerInfo
+
+        with pytest.raises(ValidationError):
+            ServerInfo(server_name="s", path="/s", is_proxied=True)  # remote, no url
+
+    def test_local_deployment_proxied_is_noop_not_error(self):
+        from registry.core.schemas import ServerInfo
+
+        # local stdio server has no HTTP backend; is_proxied is a documented no-op
+        s = ServerInfo(
+            server_name="s",
+            path="/s",
+            deployment="local",
+            local_runtime={"type": "uvx", "package": "x"},
+            is_proxied=True,
+        )
+        assert s.is_proxied is True
+
+    def test_request_model_accepts_fields(self):
+        from registry.core.schemas import ServiceRegistrationRequest
+
+        r = ServiceRegistrationRequest(
+            name="s", path="/s", proxy_pass_url=_OK, is_proxied=True, proxy_target_url=_OK
+        )
+        assert r.proxy_target_url == _OK
+
+
+class TestAgentWiring:
+    def test_card_falls_back_to_url(self):
+        from registry.schemas.agent_models import AgentCard
+
+        a = AgentCard(name="a", description="d", url=_OK, version="1", is_proxied=True)
+        assert a.is_proxied is True
+
+    def test_card_storage_model_is_read_safe(self):
+        """AgentCard (storage) does NOT raise on a denied target — it is
+        reconstructed from the DB on every read. The API edge is the request
+        model (below)."""
+        from registry.schemas.agent_models import AgentCard
+
+        a = AgentCard(
+            name="a",
+            description="d",
+            url=_OK,
+            version="1",
+            is_proxied=True,
+            proxy_target_url=_DENIED,
+        )
+        assert a.proxy_target_url == _DENIED
+
+    def test_registration_request_metadata_target_rejected(self):
+        """The request model (API edge) rejects a denied target."""
+        from registry.schemas.agent_models import AgentRegistrationRequest
+
+        with pytest.raises(ValidationError):
+            AgentRegistrationRequest(
+                name="a",
+                description="d",
+                url=_OK,
+                version="1",
+                supported_protocol="A2A",
+                is_proxied=True,
+                proxy_target_url=_DENIED,
+            )
+
+    def test_registration_request_accepts_fields(self):
+        from registry.schemas.agent_models import AgentRegistrationRequest
+
+        r = AgentRegistrationRequest(
+            name="a",
+            description="d",
+            url=_OK,
+            version="1",
+            supported_protocol="A2A",
+            is_proxied=True,
+            proxy_target_url=_OK,
+        )
+        assert r.proxy_target_url == _OK
+
+    def test_patch_accepts_and_guards(self):
+        from registry.schemas.agent_models import AgentCardPatch
+
+        # forbid-extra patch model must accept the fields
+        p = AgentCardPatch(is_proxied=True, proxy_target_url=_OK)
+        assert p.is_proxied is True
+        # and still run the egress guard
+        with pytest.raises(ValidationError):
+            AgentCardPatch(proxy_target_url=_DENIED)
+
+
+class TestSkillWiring:
+    def test_card_missing_target_is_read_safe(self):
+        """SkillCard (storage) loads cleanly with is_proxied+no target — a bypass
+        write must not vanish on read; the route simply won't render."""
+        from registry.schemas.skill_models import SkillCard
+
+        s = SkillCard(
+            path="/skills/x", name="x", description="d", skill_md_url="https://s/", is_proxied=True
+        )
+        assert s.is_proxied is True
+
+    def test_registration_request_requires_explicit_target(self):
+        """The request model (API edge) rejects is_proxied without a target."""
+        from registry.schemas.skill_models import SkillRegistrationRequest
+
+        with pytest.raises(ValidationError):
+            SkillRegistrationRequest(
+                name="x", description="d", skill_md_url="https://s/", is_proxied=True
+            )
+
+    def test_card_with_target_ok(self):
+        from registry.schemas.skill_models import SkillCard
+
+        s = SkillCard(
+            path="/skills/x",
+            name="x",
+            description="d",
+            skill_md_url="https://s/",
+            is_proxied=True,
+            proxy_target_url=_OK,
+        )
+        assert s.proxy_target_url == _OK
+
+    def test_registration_request_accepts_fields(self):
+        from registry.schemas.skill_models import SkillRegistrationRequest
+
+        r = SkillRegistrationRequest(
+            name="x",
+            description="d",
+            skill_md_url="https://s/",
+            is_proxied=True,
+            proxy_target_url=_OK,
+        )
+        assert r.is_proxied is True
+
+
+class TestCustomEntityWiring:
+    def test_record_missing_target_is_read_safe(self):
+        """CustomEntityRecord (storage) loads cleanly with is_proxied+no target."""
+        from registry.schemas.custom_entity_models import CustomEntityRecord
+
+        r = CustomEntityRecord(entity_type="workflow", name="n", is_proxied=True)
+        assert r.is_proxied is True
+
+    def test_create_request_requires_explicit_target(self):
+        """CustomEntityCreate (API edge) rejects is_proxied without a target."""
+        from registry.schemas.custom_entity_models import CustomEntityCreate
+
+        with pytest.raises(ValidationError):
+            CustomEntityCreate(name="n", is_proxied=True)
+
+    def test_record_with_target_ok(self):
+        from registry.schemas.custom_entity_models import CustomEntityRecord
+
+        r = CustomEntityRecord(
+            entity_type="workflow", name="n", is_proxied=True, proxy_target_url=_OK
+        )
+        assert r.proxy_target_url == _OK
+
+    def test_create_and_update_accept_and_guard(self):
+        from registry.schemas.custom_entity_models import CustomEntityCreate, CustomEntityUpdate
+
+        assert CustomEntityCreate(name="n", proxy_target_url=_OK).proxy_target_url == _OK
+        assert CustomEntityUpdate(is_proxied=True).is_proxied is True
+        with pytest.raises(ValidationError):
+            CustomEntityCreate(name="n", proxy_target_url=_DENIED)
+        with pytest.raises(ValidationError):
+            CustomEntityUpdate(proxy_target_url=_DENIED)
+
+
+class TestVirtualServerAliasOnly:
+    def test_alias_only_accepts_is_proxied(self):
+        from registry.schemas.virtual_server_models import VirtualServerConfig
+
+        v = VirtualServerConfig(path="/virtual/x", server_name="x", is_proxied=True)
+        assert v.is_proxied is True
+
+    def test_rejects_proxy_target_url(self):
+        from registry.schemas.virtual_server_models import VirtualServerConfig
+
+        with pytest.raises(ValidationError):
+            VirtualServerConfig(
+                path="/virtual/x", server_name="x", is_proxied=True, proxy_target_url=_OK
+            )
+
+
+class TestAutoDisabledStateLoadsCleanly:
+    """A model reconstructed from a stored doc in the auto-disabled state
+    (is_proxied=True + proxy_disabled_reason set) must NOT raise — otherwise the
+    entity throws on every read and silently vanishes from listings."""
+
+    def test_agent_card_auto_disabled_loads(self):
+        from registry.schemas.agent_models import AgentCard
+
+        a = AgentCard(
+            name="a",
+            description="d",
+            url=_OK,
+            version="1",
+            is_proxied=True,
+            proxy_target_url=None,
+            proxy_disabled_reason="target now resolves to a denied IP",
+        )
+        assert a.proxy_disabled_reason is not None
+
+    def test_skill_card_auto_disabled_loads(self):
+        from registry.schemas.skill_models import SkillCard
+
+        s = SkillCard(
+            path="/skills/x",
+            name="x",
+            description="d",
+            skill_md_url="https://s/",
+            is_proxied=True,
+            proxy_target_url=None,
+            proxy_disabled_reason="target now resolves to a denied IP",
+        )
+        assert s.proxy_disabled_reason is not None
+
+    def test_custom_record_auto_disabled_loads(self):
+        from registry.schemas.custom_entity_models import CustomEntityRecord
+
+        r = CustomEntityRecord(
+            entity_type="workflow",
+            name="n",
+            is_proxied=True,
+            proxy_target_url=None,
+            proxy_disabled_reason="target now resolves to a denied IP",
+        )
+        assert r.proxy_disabled_reason is not None
+
+
+class TestServiceLayerRoundTrip:
+    """The opt-in must survive request -> storage-model construction (the layer
+    that previously dropped the fields)."""
+
+    def test_skill_builder_carries_proxy_fields(self):
+        from registry.schemas.skill_models import SkillRegistrationRequest
+        from registry.services.skill_service import _build_skill_card
+
+        req = SkillRegistrationRequest(
+            name="x",
+            description="d",
+            skill_md_url="https://s/",
+            is_proxied=True,
+            proxy_target_url=_OK,
+        )
+        card = _build_skill_card(
+            request=req,
+            path="/skills/x",
+            owner="bob",
+            content_version=None,
+            content_updated_at=None,
+        )
+        assert card.is_proxied is True
+        assert card.proxy_target_url == _OK
+
+    def test_custom_create_source_copies_proxy_fields(self):
+        """create_record must pass the request's proxy fields into the record.
+
+        Guards the specific two-line carry-through that was missing
+        (a source-level assertion avoids brittle mocking of the service's cache/
+        repo properties).
+        """
+        import inspect
+
+        from registry.services import custom_entity_service
+
+        src = inspect.getsource(custom_entity_service.CustomEntityService.create_record)
+        assert "is_proxied=request.is_proxied" in src
+        assert "proxy_target_url=request.proxy_target_url" in src
+
+    def test_custom_update_source_copies_proxy_fields(self):
+        """update_record must include the proxy fields in its updates dict."""
+        import inspect
+
+        from registry.services import custom_entity_service
+
+        src = inspect.getsource(custom_entity_service.CustomEntityService.update_record)
+        assert 'updates["is_proxied"]' in src
+        assert 'updates["proxy_target_url"]' in src
+
+    def test_agent_register_route_copies_proxy_fields(self):
+        """The agent register route must pass the request's proxy fields to AgentCard."""
+        import inspect
+
+        from registry.api import agent_routes
+
+        src = inspect.getsource(agent_routes)
+        assert "is_proxied=request.is_proxied" in src
+        assert "proxy_target_url=request.proxy_target_url" in src

--- a/tests/unit/schemas/test_proxy_resolve_validate.py
+++ b/tests/unit/schemas/test_proxy_resolve_validate.py
@@ -1,0 +1,141 @@
+"""Unit tests for the DNS-aware resolve-and-validate proxy guard (SSRF layer 2).
+
+resolve_and_validate_proxy_target resolves a proxy_target_url's hostname and
+validates EVERY resolved IP against the egress policy — the check
+_assert_egress_allowed deliberately skips for hostnames. These lock in:
+- literal-IP targets are category-checked without DNS;
+- a hostname resolving to a metadata/private IP is rejected (SSRF), regardless of
+  the public IP it might also resolve to;
+- gateway_proxy_allow_private_targets relaxes private but NEVER link-local;
+- validate_and_pin_proxy_target returns the pin fields only for a live target and
+  is a no-op for federated/disabled/targetless entities.
+"""
+
+import socket
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+
+from registry.schemas.proxy_mixin import (
+    EgressPolicyError,
+    resolve_and_validate_proxy_target,
+    validate_and_pin_proxy_target,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _addrinfo(*ips):
+    """Build getaddrinfo-shaped tuples for the given IP strings."""
+    out = []
+    for ip in ips:
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        out.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 443)))
+    return out
+
+
+@contextmanager
+def _patch_settings(allow_private=False):
+    with patch("registry.core.config.settings") as s:
+        s.gateway_proxy_allow_private_targets = allow_private
+        yield s
+
+
+class TestLiteralIpTargets:
+    async def test_public_ip_literal_passes_without_dns(self):
+        with _patch_settings():
+            with patch("socket.getaddrinfo") as gai:
+                host, ips = await resolve_and_validate_proxy_target("https://8.8.8.8/")
+                gai.assert_not_called()  # literal IP => no DNS
+        assert host is None
+        assert ips == ["8.8.8.8"]
+
+    async def test_metadata_ip_literal_denied(self):
+        with _patch_settings(allow_private=True):  # allow_private must NOT relax link-local
+            with pytest.raises(EgressPolicyError):
+                await resolve_and_validate_proxy_target("http://169.254.169.254/")
+
+    async def test_private_ip_literal_denied_by_default(self):
+        with _patch_settings(allow_private=False):
+            with pytest.raises(EgressPolicyError):
+                await resolve_and_validate_proxy_target("http://10.0.0.5/")
+
+    async def test_private_ip_literal_allowed_when_flag_set(self):
+        with _patch_settings(allow_private=True):
+            host, ips = await resolve_and_validate_proxy_target("http://10.0.0.5/")
+        assert ips == ["10.0.0.5"]
+
+
+class TestHostnameResolution:
+    async def test_hostname_all_public_passes_and_pins(self):
+        with _patch_settings():
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+                host, ips = await resolve_and_validate_proxy_target("https://ok.example/")
+        assert host == "ok.example"
+        assert ips == ["93.184.216.34"]
+
+    async def test_hostname_resolving_to_metadata_rejected(self):
+        # DNS-rebind style: the name resolves to the metadata IP now.
+        with _patch_settings():
+            with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+                with pytest.raises(EgressPolicyError):
+                    await resolve_and_validate_proxy_target("https://rebind.example/")
+
+    async def test_hostname_with_any_denied_ip_rejected(self):
+        # Multiple A records; one is private -> reject the whole target.
+        with _patch_settings():
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34", "10.0.0.5")):
+                with pytest.raises(EgressPolicyError):
+                    await resolve_and_validate_proxy_target("https://mixed.example/")
+
+    async def test_unresolvable_hostname_raises_valueerror(self):
+        with _patch_settings():
+            with patch("socket.getaddrinfo", side_effect=socket.gaierror("nxdomain")):
+                with pytest.raises(ValueError, match="Cannot resolve"):
+                    await resolve_and_validate_proxy_target("https://nope.example/")
+
+    async def test_non_http_scheme_rejected(self):
+        with _patch_settings():
+            with pytest.raises(ValueError, match="http"):
+                await resolve_and_validate_proxy_target("gopher://x/")
+
+
+class TestValidateAndPin:
+    async def test_no_op_when_not_proxied(self):
+        with _patch_settings():
+            out = await validate_and_pin_proxy_target(
+                "skill", {"is_proxied": False, "proxy_target_url": "https://x/"}
+            )
+        assert out == {}
+
+    async def test_no_op_when_federated(self):
+        with _patch_settings():
+            out = await validate_and_pin_proxy_target(
+                "skill",
+                {
+                    "is_proxied": True,
+                    "proxy_target_url": "https://x/",
+                    "sync_metadata": {"is_federated": True},
+                },
+            )
+        assert out == {}
+
+    async def test_pins_resolved_ips_for_live_target(self):
+        with _patch_settings():
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+                out = await validate_and_pin_proxy_target(
+                    "skill", {"is_proxied": True, "proxy_target_url": "https://ok.example/"}
+                )
+        assert out == {
+            "proxy_resolved_ips": ["93.184.216.34"],
+            "proxy_target_host": "ok.example",
+        }
+
+    async def test_raises_on_denied_target(self):
+        with _patch_settings():
+            with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+                with pytest.raises(EgressPolicyError):
+                    await validate_and_pin_proxy_target(
+                        "skill", {"is_proxied": True, "proxy_target_url": "https://evil.example/"}
+                    )

--- a/tests/unit/schemas/test_proxy_resolve_validate.py
+++ b/tests/unit/schemas/test_proxy_resolve_validate.py
@@ -37,9 +37,22 @@ def _addrinfo(*ips):
 
 @contextmanager
 def _patch_settings(allow_private=False):
+    # resolve_and_validate_proxy_target delegates to url_guard, which reads the
+    # allowlist through its OWN imported `settings` reference and caches it
+    # (@lru_cache). Patch url_guard.settings directly and clear the cache so the
+    # flag flip is honored; also patch the config.settings the helper reads.
+    from registry.utils import url_guard
+
     with patch("registry.core.config.settings") as s:
         s.gateway_proxy_allow_private_targets = allow_private
-        yield s
+        s.ssrf_allowed_hosts = ""
+        s.ssrf_allowed_cidrs = ""
+        with patch.object(url_guard, "settings", s):
+            url_guard._proxy_allowlist.cache_clear()
+            try:
+                yield s
+            finally:
+                url_guard._proxy_allowlist.cache_clear()
 
 
 class TestLiteralIpTargets:
@@ -90,14 +103,16 @@ class TestHostnameResolution:
                     await resolve_and_validate_proxy_target("https://mixed.example/")
 
     async def test_unresolvable_hostname_raises_valueerror(self):
+        # url_guard surfaces a DNS failure as UrlValidationError; the proxy adapter
+        # wraps it as EgressPolicyError (a ValueError) so it maps to a 4xx.
         with _patch_settings():
             with patch("socket.getaddrinfo", side_effect=socket.gaierror("nxdomain")):
-                with pytest.raises(ValueError, match="Cannot resolve"):
+                with pytest.raises(ValueError, match="[Rr]esolution failed"):
                     await resolve_and_validate_proxy_target("https://nope.example/")
 
     async def test_non_http_scheme_rejected(self):
         with _patch_settings():
-            with pytest.raises(ValueError, match="http"):
+            with pytest.raises(ValueError, match="scheme"):
                 await resolve_and_validate_proxy_target("gopher://x/")
 
 

--- a/tests/unit/services/test_agent_proxy_validation.py
+++ b/tests/unit/services/test_agent_proxy_validation.py
@@ -1,0 +1,68 @@
+"""Unit tests for the agent-service proxy validation hook.
+
+_validate_and_pin_agent_proxy is the register/update choke point that:
+- is a no-op when the agent is not proxied;
+- rejects a GRPC preferred_transport (the gateway serves HTTP only);
+- resolves + validates the effective target (proxy_target_url or the agent url)
+  and pins the resolved IPs, rejecting a metadata/private target.
+"""
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from registry.schemas.agent_models import AgentCard
+from registry.services.agent_service import _validate_and_pin_agent_proxy
+
+pytestmark = pytest.mark.unit
+
+
+def _addrinfo(*ips):
+    out = []
+    for ip in ips:
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        out.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 443)))
+    return out
+
+
+def _card(**kw):
+    base = {"name": "a", "description": "d", "url": "https://agent.example/", "version": "1"}
+    base.update(kw)
+    return AgentCard(**base)
+
+
+class TestAgentProxyValidation:
+    async def test_no_op_when_not_proxied(self):
+        card = _card(is_proxied=False)
+        with patch("socket.getaddrinfo") as gai:
+            await _validate_and_pin_agent_proxy(card)
+            gai.assert_not_called()
+
+    async def test_grpc_transport_rejected_when_proxied(self):
+        card = _card(is_proxied=True, preferred_transport="GRPC")
+        with pytest.raises(ValueError, match="GRPC"):
+            await _validate_and_pin_agent_proxy(card)
+
+    async def test_grpc_transport_allowed_when_not_proxied(self):
+        # GRPC is fine as long as the agent isn't proxied through the HTTP gateway.
+        card = _card(is_proxied=False, preferred_transport="GRPC")
+        await _validate_and_pin_agent_proxy(card)  # no raise
+
+    async def test_pins_resolved_ips_from_agent_url_fallback(self):
+        # No explicit proxy_target_url -> falls back to the agent url.
+        card = _card(is_proxied=True, preferred_transport="JSONRPC")
+        with patch("registry.core.config.settings") as s:
+            s.gateway_proxy_allow_private_targets = False
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+                await _validate_and_pin_agent_proxy(card)
+        assert card.proxy_resolved_ips == ["93.184.216.34"]
+        assert card.proxy_target_host == "agent.example"
+
+    async def test_metadata_target_rejected(self):
+        card = _card(is_proxied=True, proxy_target_url="https://rebind.example/")
+        with patch("registry.core.config.settings") as s:
+            s.gateway_proxy_allow_private_targets = False
+            with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+                with pytest.raises(ValueError):
+                    await _validate_and_pin_agent_proxy(card)

--- a/tests/unit/services/test_server_proxy_validation.py
+++ b/tests/unit/services/test_server_proxy_validation.py
@@ -1,0 +1,139 @@
+"""Unit tests for server-service proxy resolve-and-validate.
+
+Locks in the SSRF layer-2 wiring on the server paths — including update_server
+(the single choke point for every server PATCH / version-swap call site), which
+a prior revision missed. A hostname proxy target that resolves to a metadata IP
+must be rejected on BOTH register and update, not just register.
+"""
+
+import socket
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from registry.schemas.proxy_mixin import EgressPolicyError
+from registry.services.server_service import ServerService
+
+pytestmark = pytest.mark.unit
+
+
+def _addrinfo(*ips):
+    out = []
+    for ip in ips:
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        out.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, 443)))
+    return out
+
+
+def _service_with_repo(repo):
+    with (
+        patch("registry.services.server_service.get_server_repository", return_value=repo),
+        patch("registry.repositories.factory.get_search_repository", return_value=AsyncMock()),
+    ):
+        return ServerService()
+
+
+def _settings():
+    m = patch("registry.core.config.settings")
+    s = m.start()
+    s.gateway_proxy_allow_private_targets = False
+    return m
+
+
+class TestRegisterServerProxy:
+    async def test_register_rejects_hostname_resolving_to_metadata(self):
+        repo = AsyncMock()
+        repo.get.return_value = None  # no existing server
+        service = _service_with_repo(repo)
+        info = {
+            "path": "/s",
+            "server_name": "s",
+            "is_proxied": True,
+            "proxy_pass_url": "https://rebind.example/",
+            "deployment": "remote",
+        }
+        m = _settings()
+        try:
+            with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+                with pytest.raises(EgressPolicyError):
+                    await service.register_server(info)
+        finally:
+            m.stop()
+        repo.create.assert_not_called()  # nothing persisted
+
+    async def test_register_pins_public_target(self):
+        repo = AsyncMock()
+        repo.get.return_value = None
+        repo.create.return_value = True
+        service = _service_with_repo(repo)
+        info = {
+            "path": "/s",
+            "server_name": "s",
+            "is_proxied": True,
+            "proxy_pass_url": "https://ok.example/",
+            "deployment": "remote",
+        }
+        m = _settings()
+        try:
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+                await service.register_server(info)
+        finally:
+            m.stop()
+        assert info["proxy_resolved_ips"] == ["93.184.216.34"]
+        assert info["proxy_target_host"] == "ok.example"
+
+
+class TestUpdateServerProxy:
+    async def test_update_rejects_hostname_resolving_to_metadata(self):
+        # Regression guard: update_server previously skipped DNS validation.
+        repo = AsyncMock()
+        repo.get.return_value = {
+            "path": "/s",
+            "server_name": "s",
+            "is_proxied": False,
+            "proxy_pass_url": "https://old.example/",
+        }
+        service = _service_with_repo(repo)
+        m = _settings()
+        try:
+            with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+                with pytest.raises(EgressPolicyError):
+                    await service.update_server(
+                        "/s",
+                        {"is_proxied": True, "proxy_target_url": "https://rebind.example/"},
+                    )
+        finally:
+            m.stop()
+        repo.update.assert_not_called()  # denied before persist
+
+    async def test_update_without_proxy_fields_skips_dns(self):
+        repo = AsyncMock()
+        repo.update.return_value = True
+        repo.get_state.return_value = False
+        service = _service_with_repo(repo)
+        with patch("socket.getaddrinfo") as gai:
+            await service.update_server("/s", {"description": "new desc"})
+            gai.assert_not_called()  # no proxy field touched -> no DNS, no extra get
+
+    async def test_update_reenable_clears_disabled_reason_and_pins(self):
+        repo = AsyncMock()
+        repo.get.return_value = {
+            "path": "/s",
+            "is_proxied": True,
+            "proxy_pass_url": "https://ok.example/",
+            "proxy_disabled_reason": "was auto-disabled",
+            "deployment": "remote",
+        }
+        repo.update.return_value = True
+        repo.get_state.return_value = False
+        service = _service_with_repo(repo)
+        m = _settings()
+        try:
+            with patch("socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")):
+                await service.update_server("/s", {"is_proxied": True})
+        finally:
+            m.stop()
+        # The persisted update dict must clear the auto-disable and carry fresh pins.
+        persisted = repo.update.call_args[0][1]
+        assert persisted["proxy_disabled_reason"] is None
+        assert persisted["proxy_resolved_ips"] == ["93.184.216.34"]

--- a/tests/unit/utils/test_url_guard.py
+++ b/tests/unit/utils/test_url_guard.py
@@ -43,11 +43,17 @@ def _resolve_to(*ips: str):
     return _stub
 
 
-def _settings(github_extra_hosts="", ssrf_allowed_hosts="", ssrf_allowed_cidrs=""):
+def _settings(
+    github_extra_hosts="",
+    ssrf_allowed_hosts="",
+    ssrf_allowed_cidrs="",
+    gateway_proxy_allow_private_targets=False,
+):
     s = MagicMock()
     s.github_extra_hosts = github_extra_hosts
     s.ssrf_allowed_hosts = ssrf_allowed_hosts
     s.ssrf_allowed_cidrs = ssrf_allowed_cidrs
+    s.gateway_proxy_allow_private_targets = gateway_proxy_allow_private_targets
     return s
 
 
@@ -720,3 +726,30 @@ class TestCredentialedOAuthProfile:
         )
         with pytest.raises(UrlValidationError):
             transport._pin_request(httpx.Request("POST", "http://93.184.216.34/token"))
+
+
+class TestProxyProfilePrivateTargetToggle:
+    def test_bool_relaxes_private_but_not_credential_endpoints(self):
+        settings = _settings(gateway_proxy_allow_private_targets=True)
+        with patch.object(url_guard, "settings", settings):
+            assert url_guard.validate_url(
+                "http://10.0.0.5/x", profile=url_guard.PROXY_PROFILE, resolve=False
+            ) == ["10.0.0.5"]
+            for target in (
+                "http://169.254.169.254/x",
+                "http://169.254.170.2/x",
+                "http://[fd00:ec2::254]/x",
+                "http://[fd00:ec2::23]/x",
+            ):
+                with pytest.raises(UrlValidationError):
+                    url_guard.validate_url(target, profile=url_guard.PROXY_PROFILE, resolve=False)
+
+    def test_bool_does_not_relax_noncredential_link_local(self):
+        settings = _settings(gateway_proxy_allow_private_targets=True)
+        with patch.object(url_guard, "settings", settings):
+            with pytest.raises(UrlValidationError):
+                url_guard.validate_url(
+                    "http://169.254.10.10/x",
+                    profile=url_guard.PROXY_PROFILE,
+                    resolve=False,
+                )


### PR DESCRIPTION
*Issue #, if available:*

#1565 PR 1

## Summary

First slice of "proxy any registry entity through the gateway" (#1565). Today only MCP servers and A2A agents can be fronted by the gateway; this stack extends gateway proxying to skills, agents, and custom entities through a uniform generic-proxy hop, with SSRF defense in depth at every layer.

This PR lands the **foundation and the full generic-proxy path end to end**, but ships **dark**: `gateway_generic_proxy_enabled` and `gateway_canonical_namespace_enabled` both default to `False`, and `gateway_proxy_allow_private_targets` defaults to `False`. With the feature off, no nginx location block is rendered, `/validate` never mints a generic token, and the render path issues **zero** additional per-tick DB queries. It is a no-op in production until a later slice flips the flags.

## What's included

**Model layer — opt-in proxying**
- New `registry/schemas/proxy_mixin.py`: `ProxyableMixin` (`is_proxied`, `proxy_target_url`, plus refresh bookkeeping fields), an edge-only egress-guard validator, and `resolve_proxy_target()`.
- `ProxyableMixin` wired into the five storage models and their request/patch models. Virtual servers are alias-only (`proxy_target_url` rejected).
- Load-bearing split: **storage models never raise** on a stored `proxy_target_url` (they are reconstructed on every read; raising would vanish a bypass-written record from every listing). The egress raise and the target-required raise live on the request/patch models (the API edge, no vanish risk).

**Repository layer**
- `list_proxied()` added to the five entity repositories (DocumentDB overrides + non-abstract default `[]`), issuing an indexed `{"is_proxied": True}` query that projects only what render + `resolve_proxy_target` need, and fails closed to `[]` on any error.
- Shared `ensure_is_proxied_index` helper: prefers a partial index, falls back to a plain index when DocumentDB rejects `partialFilterExpression`, never raises.

**nginx render**
- Render-time generation of generic-proxy location blocks routing proxied non-MCP entities through the auth-server hop at `/proxy/{entity_type}/{path}/`.
- `_safe_generic_block`: a skip-not-fail render guard so one malformed or SSRF-denied row cannot fail `nginx -t` for the whole replica. Guards scheme, egress policy, entity-type token grammar, `..` path segments, and directive-breakout characters.
- Cross-placeholder location-collision dedup with generic as the lowest-precedence tier.

**auth-server generic hop**
- `mint_generic_proxy_token` / `verify_generic_proxy_token`: a short-lived token with an audience distinct from every other internal audience, binding both `entity_type` and the full registered path on a segment boundary, read under a distinct header (`X-Internal-Token-Generic`) so the two hops' tokens can never collide.
- `/proxy/{entity_type}/{entity_path:path}` handler: a uniform buffering proxy (no JSON-RPC parsing). Destination is cryptographically pinned from the token; inbound `X-Upstream-Url` is ignored. Sub-path confinement + post-join host/port pinning; `follow_redirects=False`; a response-header allowlist that still drops `Set-Cookie`/HSTS/CSP/framing while the gateway sets its own security headers; concurrency semaphore and body-size bound.
- `/validate` wiring: discriminates the generic hop, maps HTTP verbs to scope methods, and refuses a state-changing verb under ambient cookie auth before any scope check (Bearer callers exempt; gated by `gateway_generic_require_bearer_for_writes`, default true). The MCP `methods:["*"]` wildcard does **not** authorize an HTTP verb.

**SSRF — defense in depth**
- Registration/update-time DNS resolve-and-validate: at the service layer (single choke point per entity type, so batch/federation paths inherit it), the effective target's hostname is resolved and **every** resolved IP is validated against the egress policy, rejecting a metadata/private/link-local target with a clean 4xx before persist.
- Convergence onto the canonical `url_guard`: the generic hop fetches with `guarded_async_client` (connect-to-pinned-IP + per-target TLS, re-validated per redirect) instead of a bare `httpx` client. `url_guard` gains `allow_private` plumbing on the proxy allowlist (honoring `gateway_proxy_allow_private_targets`); the cloud-metadata denylist (including Alibaba `100.100.100.200`) remains never-overridable. There is no separate `ip_guard` module — all IP classification is the single canonical `url_guard` path.
- Startup egress self-check: probes the cloud metadata IPs; if either is reachable the network egress policy is not enforced, so it logs CRITICAL, emits `gateway_egress_policy_unverified=1`, and disables the feature for the process (fail-closed latch) without failing pod readiness.

**Federation isolation**
- Proxy config never crosses the federation boundary in either direction: `strip_proxy_fields` removes the proxy fields on every peer-content ingest and on the federation export chokepoint (key-drop, not force-false, so a re-sync can't clobber a local admin's opt-in). `resolve_proxy_target` returns `None` for a federated entity as an absolute guard behind the ingest strip.

**Observability**
- `mcpgw_registry_gateway_generic_blocks_dropped_total{reason=invalid|collision}` counter and a `gateway_egress_policy_unverified` gauge.

**Config**
- New settings (all fail-closed): `gateway_generic_proxy_enabled` (false), `gateway_canonical_namespace_enabled` (false), `gateway_proxy_allow_private_targets` (false), `gateway_generic_require_bearer_for_writes` (true), plus body-size / concurrency / TLS-verify knobs and a strict nginx size-token validator on the client-body-size string (a config-injection surface).

## Safety / rollout

- Ships dark: both feature flags default off; private-target relaxation off. No-op in production until a later slice enables it.
- Zero new per-tick DB queries while disabled (verified by test).
- Fail-closed throughout: render guard skips bad rows, `list_proxied` fails to `[]`, startup self-check disables the feature if egress isn't enforced, `/proxy` handler 503s until the latch is confirmed.

## Testing

- 16 new test files (`tests/auth_server/unit/`, `tests/unit/{schemas,core,services,repositories,auth,utils}/`) covering: model edge validation + storage read-safety, `list_proxied` projection + fail-closed, token mint/verify (audience isolation, cross-type/sibling-path/dot-dot rejection, sub-path acceptance), `/validate` verb authorization + privilege-escalation guard + CSRF, nginx block generation + collision dedup + marker-forward template invariants, the hard-gate composite (no denied target renders a live route), DNS resolve-and-validate on each service path, and federation isolation.
- Full unit suite green.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
