### PR TITLE
Fix virtual tools/list endpoint resolution and partial caching (adopts #1526)

### DIFF
--- a/.github/workflows/lua-test.yml
+++ b/.github/workflows/lua-test.yml
@@ -1,0 +1,44 @@
+name: Lua Router Tests
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'docker/lua/**'
+      - 'tests/lua/**'
+      - '.github/workflows/lua-test.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'docker/lua/**'
+      - 'tests/lua/**'
+      - '.github/workflows/lua-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lua-test:
+    name: "Lua unit tests (OpenResty LuaJIT)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: openresty/openresty:alpine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Syntax check virtual_router.lua
+        run: /usr/local/openresty/luajit/bin/luajit -bl docker/lua/virtual_router.lua /dev/null
+
+      - name: Run Lua router unit tests
+        env:
+          # Point LuaJIT at OpenResty's bundled lua-cjson.
+          LUA_CPATH: "/usr/local/openresty/lualib/?.so;;"
+          LUA_PATH: "/usr/local/openresty/lualib/?.lua;;"
+        run: /usr/local/openresty/luajit/bin/luajit tests/lua/test_virtual_router.lua

--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -468,13 +468,6 @@ local function _handle_tools_list(request_id, mapping, user_scopes_str, client_s
         for _, backend_loc in ipairs(backend_locations) do
             local backend_tools, backend_ok = _fetch_backend_tools_list(
                 backend_loc, client_session_id, server_id)
-            if not backend_ok then
-                all_fetches_ok = false
-                ngx.log(ngx.WARN, "Backend tools/list fetch failed for ", backend_loc,
-                    " -- falling back to mapping file metadata for this backend")
-                _append_mapping_tools_for_backend(enriched_tools, mapping, backend_loc)
-            end
-
             if backend_ok then
                 for _, bt in ipairs(backend_tools) do
                     local mapping_entry = allowed_tools[bt.name]
@@ -494,6 +487,11 @@ local function _handle_tools_list(request_id, mapping, user_scopes_str, client_s
                         }
                     end
                 end
+            else
+                all_fetches_ok = false
+                ngx.log(ngx.WARN, "Backend tools/list fetch failed for ", backend_loc,
+                    " -- falling back to mapping file metadata for this backend")
+                _append_mapping_tools_for_backend(enriched_tools, mapping, backend_loc)
             end
         end
 
@@ -1192,6 +1190,16 @@ function _M.route()
         ngx.status = 200
         ngx.say(_jsonrpc_error(request_id, -32601, "Method not found: " .. tostring(method)))
     end
+end
+
+-- Test hook: when loaded by the Lua unit test (which sets _G._VR_TEST), expose
+-- internal helpers and return the module WITHOUT executing the router. In
+-- production _G._VR_TEST is nil, so this branch is skipped and route() runs.
+if _G._VR_TEST then
+    _M._fetch_backend_tools_list = _fetch_backend_tools_list
+    _M._append_mapping_tools_for_backend = _append_mapping_tools_for_backend
+    _M._handle_tools_list = _handle_tools_list
+    return _M
 end
 
 -- Execute routing

--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -336,8 +336,27 @@ local function _collect_backend_locations(mapping)
 end
 
 
+-- Append mapping-file metadata for one backend when live discovery fails.
+local function _append_mapping_tools_for_backend(enriched_tools, mapping, backend_location)
+    if not mapping.tools then
+        return
+    end
+
+    for _, tool in ipairs(mapping.tools) do
+        if tool.backend_location == backend_location then
+            enriched_tools[#enriched_tools + 1] = {
+                name = tool.name,
+                description = tool.description or "",
+                inputSchema = _ensure_mcp_schema(tool.inputSchema),
+                required_scopes = tool.required_scopes,
+            }
+        end
+    end
+end
+
+
 -- Fetch tools/list from a single backend via ngx.location.capture.
--- Returns the tools array from the backend, or empty table on failure.
+-- Returns the tools array and true on success, or an empty table and false on failure.
 -- On stale session error (status >= 400), invalidates and retries once.
 local function _fetch_backend_tools_list(backend_location, client_session_id, server_id)
     local req_body = cjson.encode({
@@ -384,27 +403,33 @@ local function _fetch_backend_tools_list(backend_location, client_session_id, se
     if not res or res.status ~= 200 then
         ngx.log(ngx.ERR, "Failed to fetch tools/list from ", backend_location,
             " status=", res and res.status or "nil")
-        return {}
+        return {}, false
+    end
+
+    if res.truncated then
+        ngx.log(ngx.ERR, "Truncated tools/list response from ", backend_location)
+        return {}, false
     end
 
     -- Backend may respond with SSE format (text/event-stream) or raw JSON
     local json_body = _parse_sse_body(res.body)
     if not json_body then
         ngx.log(ngx.ERR, "Empty or unparseable tools/list response from ", backend_location)
-        return {}
+        return {}, false
     end
 
     local ok, data = pcall(cjson.decode, json_body)
     if not ok then
         ngx.log(ngx.ERR, "Failed to parse tools/list response from ", backend_location)
-        return {}
+        return {}, false
     end
 
-    if data.result and data.result.tools then
-        return data.result.tools
+    if data.result and type(data.result.tools) == "table" then
+        return data.result.tools, true
     end
 
-    return {}
+    ngx.log(ngx.ERR, "Missing tools array in tools/list response from ", backend_location)
+    return {}, false
 end
 
 
@@ -438,55 +463,47 @@ local function _handle_tools_list(request_id, mapping, user_scopes_str, client_s
     if not enriched_tools then
         enriched_tools = {}
         local backend_locations = _collect_backend_locations(mapping)
-        local fetch_ok = false
+        local all_fetches_ok = true
 
         for _, backend_loc in ipairs(backend_locations) do
-            local backend_tools = _fetch_backend_tools_list(backend_loc, client_session_id, server_id)
-            if #backend_tools > 0 then
-                fetch_ok = true
+            local backend_tools, backend_ok = _fetch_backend_tools_list(
+                backend_loc, client_session_id, server_id)
+            if not backend_ok then
+                all_fetches_ok = false
+                ngx.log(ngx.WARN, "Backend tools/list fetch failed for ", backend_loc,
+                    " -- falling back to mapping file metadata for this backend")
+                _append_mapping_tools_for_backend(enriched_tools, mapping, backend_loc)
             end
 
-            for _, bt in ipairs(backend_tools) do
-                local mapping_entry = allowed_tools[bt.name]
-                if mapping_entry then
-                    -- Use the mapping's display name (alias) instead of original name
-                    local display_name = mapping_entry.name
-                    -- Use mapping's description if non-empty (override), else backend's
-                    local desc = mapping_entry.description
-                    if not desc or desc == "" then
-                        desc = bt.description or ""
+            if backend_ok then
+                for _, bt in ipairs(backend_tools) do
+                    local mapping_entry = allowed_tools[bt.name]
+                    if mapping_entry then
+                        -- Use the mapping's display name (alias) instead of original name
+                        local display_name = mapping_entry.name
+                        -- Use mapping's description if non-empty (override), else backend's
+                        local desc = mapping_entry.description
+                        if not desc or desc == "" then
+                            desc = bt.description or ""
+                        end
+                        enriched_tools[#enriched_tools + 1] = {
+                            name = display_name,
+                            description = desc,
+                            inputSchema = _ensure_mcp_schema(bt.inputSchema or bt.input_schema),
+                            required_scopes = mapping_entry.required_scopes,
+                        }
                     end
-                    enriched_tools[#enriched_tools + 1] = {
-                        name = display_name,
-                        description = desc,
-                        inputSchema = _ensure_mcp_schema(bt.inputSchema or bt.input_schema),
-                        required_scopes = mapping_entry.required_scopes,
-                    }
                 end
             end
         end
 
-        -- Fallback: if all backend fetches failed, use mapping file metadata
-        if not fetch_ok then
-            ngx.log(ngx.WARN, "All backend tools/list fetches failed for server=", server_id,
-                " -- falling back to mapping file metadata")
-            enriched_tools = {}
-            if mapping.tools then
-                for _, tool in ipairs(mapping.tools) do
-                    enriched_tools[#enriched_tools + 1] = {
-                        name = tool.name,
-                        description = tool.description or "",
-                        inputSchema = _ensure_mcp_schema(tool.inputSchema),
-                        required_scopes = tool.required_scopes,
-                    }
-                end
+        -- Cache only fully discovered results. A fallback response remains complete,
+        -- but the next request should retry failed backends instead of serving it for 60s.
+        if all_fetches_ok then
+            local ok_enc, encoded = pcall(cjson.encode, enriched_tools)
+            if ok_enc then
+                session_cache:set(enriched_cache_key, encoded, ENRICHED_CACHE_TTL)
             end
-        end
-
-        -- Cache enriched tools (pre-scope-filtered, 60s TTL)
-        local ok_enc, encoded = pcall(cjson.encode, enriched_tools)
-        if ok_enc then
-            session_cache:set(enriched_cache_key, encoded, ENRICHED_CACHE_TTL)
         end
     end
 

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -16,6 +16,7 @@ import httpx
 from registry.constants import REGISTRY_CONSTANTS, DeploymentType, HealthStatus
 
 from .config import settings
+from .endpoint_utils import get_endpoint_url_from_server_info
 from .metrics import NGINX_CONFIG_WRITES, NGINX_UPDATES_SKIPPED
 
 logger = logging.getLogger(__name__)
@@ -1810,28 +1811,13 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
                 parsed_url = urlparse(proxy_pass_url)
                 upstream_host = parsed_url.netloc
 
-                # Build MCP endpoint URL from the server's mcp_endpoint or proxy_pass_url.
-                # mcp_endpoint is defended by two layers: (1) registration-time
-                # validation rejects an mcp_endpoint containing nginx
-                # metacharacters (including "$") via the same canonical guard as
-                # proxy_pass_url, so a "$" can never legitimately be stored; and
-                # (2) the render-time _sanitize_for_nginx_set below strips "$"
-                # and escapes quotes/backslashes as defense in depth for any
-                # legacy value persisted before validation existed.
-                mcp_endpoint = server_info.get("mcp_endpoint", "")
-                if mcp_endpoint:
-                    mcp_parsed = urlparse(mcp_endpoint)
-                    mcp_path = mcp_parsed.path.rstrip("/")
-                    # Construct full MCP URL from proxy_pass host + mcp path
-                    mcp_proxy_url = f"{parsed_url.scheme}://{parsed_url.netloc}{mcp_path}"
-                else:
-                    # Fallback: use proxy_pass_url, appending /mcp only if needed
-                    bare_url = proxy_pass_url.rstrip("/")
-                    # Check if URL already ends with common MCP endpoint paths
-                    if bare_url.endswith("/mcp") or bare_url.endswith("/sse"):
-                        mcp_proxy_url = bare_url
-                    else:
-                        mcp_proxy_url = f"{bare_url}/mcp"
+                # Resolve custom and nested transport paths centrally, but retain
+                # the proxy host because explicit endpoints may use a public host.
+                # Registration-time validation and the render-time sanitizer below
+                # continue to protect both endpoint sources from nginx metacharacters.
+                resolved_endpoint = get_endpoint_url_from_server_info(server_info)
+                endpoint_path = urlparse(resolved_endpoint).path.rstrip("/")
+                mcp_proxy_url = f"{parsed_url.scheme}://{parsed_url.netloc}{endpoint_path}"
 
                 # Use regular internal location (not named @) so proxy_pass
                 # can include a URI path for the MCP endpoint

--- a/tests/lua/test_virtual_router.lua
+++ b/tests/lua/test_virtual_router.lua
@@ -1,0 +1,160 @@
+-- Regression tests for the virtual MCP server router's tools/list aggregation
+-- (PR #1634 / originally #1526). Covers the fixed behaviors:
+--   * a failed backend falls back to its mapping-file metadata (complete list),
+--   * a genuine empty tools array is a success, not a failure,
+--   * truncated / malformed backend responses are failures,
+--   * partial (fallback) results are NOT cached; fully-discovered results ARE.
+--
+-- Run from the repo root with OpenResty's resty CLI (provides lua-cjson):
+--   resty tests/lua/test_virtual_router.lua
+-- Or via Docker without a local OpenResty install:
+--   docker run --rm -v "$PWD":/app -w /app openresty/openresty:alpine \
+--     resty tests/lua/test_virtual_router.lua
+--
+-- The router file is a content_by_lua script; it exposes its internal helpers
+-- and returns the module (instead of executing) when _G._VR_TEST is set.
+
+_G._VR_TEST = true
+
+local cjson = require("cjson")
+
+local failures = 0
+local function check(cond, msg)
+    if cond then
+        print("  ok   - " .. msg)
+    else
+        failures = failures + 1
+        print("  FAIL - " .. msg)
+    end
+end
+
+-- Minimal ngx.shared dict mock.
+local function _new_dict()
+    local store = {}
+    return {
+        get = function(_, k) return store[k] end,
+        set = function(_, k, v) store[k] = v; return true end,
+        delete = function(_, k) store[k] = nil end,
+        _store = store,
+    }
+end
+
+local dict = _new_dict()
+
+-- Programmable ngx.location.capture responses, keyed by backend location.
+local capture_responses = {}
+
+_G.ngx = {
+    shared = { virtual_server_map = dict },
+    location = {
+        capture = function(loc, _opts) return capture_responses[loc] end,
+    },
+    req = { set_header = function() end },
+    log = function() end,
+    ERR = 4,
+    WARN = 5,
+    HTTP_POST = 8,
+    var = { request_id = "0" },
+    status = 200,
+    say = function() end,
+    exit = function() end,
+}
+
+-- Load the router with the test hook active; it returns the module table.
+local M = assert(loadfile("docker/lua/virtual_router.lua"))()
+
+-- ---------------------------------------------------------------------------
+print("test: _append_mapping_tools_for_backend appends only the given backend")
+do
+    local mapping = { tools = {
+        { name = "a", backend_location = "/b1", inputSchema = { type = "object" } },
+        { name = "b", backend_location = "/b2" },
+    } }
+    local enriched = {}
+    M._append_mapping_tools_for_backend(enriched, mapping, "/b1")
+    check(#enriched == 1, "only one tool appended for /b1")
+    check(enriched[1] and enriched[1].name == "a", "the appended tool is 'a'")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _fetch_backend_tools_list classifies responses correctly")
+do
+    -- success with tools
+    capture_responses["/loc"] = { status = 200,
+        body = cjson.encode({ result = { tools = { { name = "x" } } } }) }
+    local tools, ok = M._fetch_backend_tools_list("/loc", nil, "srv")
+    check(ok == true and #tools == 1, "200 + tools -> (tools, true)")
+
+    -- genuine empty list is success
+    capture_responses["/loc"] = { status = 200,
+        body = cjson.encode({ result = { tools = {} } }) }
+    tools, ok = M._fetch_backend_tools_list("/loc", nil, "srv")
+    check(ok == true and #tools == 0, "200 + empty tools -> ([], true)")
+
+    -- http error is failure
+    capture_responses["/loc"] = { status = 500, body = "" }
+    tools, ok = M._fetch_backend_tools_list("/loc", nil, "srv")
+    check(ok == false, "500 -> (_, false)")
+
+    -- truncated is failure
+    capture_responses["/loc"] = { status = 200, truncated = true,
+        body = cjson.encode({ result = { tools = { { name = "x" } } } }) }
+    tools, ok = M._fetch_backend_tools_list("/loc", nil, "srv")
+    check(ok == false, "truncated -> (_, false)")
+
+    -- missing tools array is failure
+    capture_responses["/loc"] = { status = 200, body = cjson.encode({ result = {} }) }
+    tools, ok = M._fetch_backend_tools_list("/loc", nil, "srv")
+    check(ok == false, "missing tools array -> (_, false)")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _handle_tools_list falls back per-backend and does NOT cache partial")
+do
+    dict._store["tools_enriched:srv1"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "live_tool", original_name = "live_tool", backend_location = "/ok",
+          inputSchema = { type = "object" } },
+        { name = "down_tool", original_name = "down_tool", backend_location = "/down",
+          inputSchema = { type = "object" } },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200,
+        body = cjson.encode({ result = { tools = { { name = "live_tool", description = "live" } } } }) }
+    capture_responses["/down"] = { status = 500, body = "" }
+
+    local resp = M._handle_tools_list("1", mapping, "", nil, "srv1")
+    local decoded = cjson.decode(resp)
+    local names = {}
+    for _, t in ipairs(decoded.result.tools) do names[t.name] = true end
+    check(names["live_tool"] == true, "live backend tool present")
+    check(names["down_tool"] == true, "failed backend tool present via fallback")
+    check(dict._store["tools_enriched:srv1"] == nil, "partial/fallback result is NOT cached")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _handle_tools_list caches when every backend succeeds")
+do
+    dict._store["tools_enriched:srv2"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "live_tool", original_name = "live_tool", backend_location = "/ok",
+          inputSchema = { type = "object" } },
+        { name = "down_tool", original_name = "down_tool", backend_location = "/down",
+          inputSchema = { type = "object" } },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200,
+        body = cjson.encode({ result = { tools = { { name = "live_tool" } } } }) }
+    capture_responses["/down"] = { status = 200,
+        body = cjson.encode({ result = { tools = { { name = "down_tool" } } } }) }
+
+    M._handle_tools_list("1", mapping, "", nil, "srv2")
+    check(dict._store["tools_enriched:srv2"] ~= nil, "fully-discovered result IS cached")
+end
+
+-- ---------------------------------------------------------------------------
+if failures > 0 then
+    print(string.format("\n%d check(s) FAILED", failures))
+    os.exit(1)
+end
+print("\nAll checks passed")

--- a/tests/unit/test_virtual_server_nginx.py
+++ b/tests/unit/test_virtual_server_nginx.py
@@ -229,10 +229,7 @@ class TestGenerateVirtualBackendLocations:
         service = NginxConfigService()
         result = await service._generate_virtual_backend_locations([vs])
 
-        assert (
-            'set $vs_backend_github "http://insights-service:8000/custom/mcp/http"'
-            in result
-        )
+        assert 'set $vs_backend_github "http://insights-service:8000/custom/mcp/http"' in result
         assert "public.example.com" not in result
 
     @pytest.mark.asyncio

--- a/tests/unit/test_virtual_server_nginx.py
+++ b/tests/unit/test_virtual_server_nginx.py
@@ -200,6 +200,42 @@ class TestGenerateVirtualBackendLocations:
         assert "resolver " not in result
 
     @pytest.mark.asyncio
+    async def test_preserves_nested_mcp_transport_path(self, mock_server_repository):
+        """A configured /mcp/... endpoint must not receive a second /mcp suffix."""
+        vs = _make_vs_config()
+        mock_server_repository.get.return_value = {
+            "proxy_pass_url": "https://insights.example.com/mcp/http",
+        }
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_backend_locations([vs])
+
+        assert "proxy_pass https://insights.example.com/mcp/http;" in result
+        assert "/mcp/http/mcp" not in result
+
+    @pytest.mark.asyncio
+    async def test_explicit_mcp_endpoint_keeps_proxy_host(self, mock_server_repository):
+        """Explicit endpoint paths use the private proxy host for internal routing."""
+        vs = _make_vs_config()
+        mock_server_repository.get.return_value = {
+            "proxy_pass_url": "http://insights-service:8000",
+            "mcp_endpoint": "https://public.example.com/custom/mcp/http",
+        }
+
+        from registry.core.nginx_service import NginxConfigService
+
+        service = NginxConfigService()
+        result = await service._generate_virtual_backend_locations([vs])
+
+        assert (
+            'set $vs_backend_github "http://insights-service:8000/custom/mcp/http"'
+            in result
+        )
+        assert "public.example.com" not in result
+
+    @pytest.mark.asyncio
     async def test_credentials_not_forwarded_to_untrusted_backend(self, mock_server_repository):
         """The caller's credential must not be relayed to a registrant-controlled backend.
 


### PR DESCRIPTION
## Summary

Fixes virtual MCP server `tools/list` so a virtual server backed by multiple MCP servers returns the complete tool set even when one backend is temporarily unavailable, and stops caching incomplete results.

This adopts the fix from #1526 by @soheilkhan (commit cherry-picked, authorship preserved) so it can be merged from a branch in this repository. Thank you to @soheilkhan for the investigation and the original patch.

## Changes

- Reuse the centralized endpoint resolver (`get_endpoint_url_from_server_info`) when generating virtual backend routes, so nested transport paths such as `/mcp/http` are not rewritten to `/mcp/http/mcp` (which 404s). Internal routing continues to use the private proxy host even when an explicit `mcp_endpoint` points at a public host.
- Track backend discovery success separately from the returned tool count, so a valid empty tool list is not treated as a failure.
- On a per-backend failure, fall back to that backend's mapping-file metadata instead of dropping the backend whenever another backend succeeds.
- Cache enriched tools only after every backend succeeds, so a fallback response is retried on the next request rather than served from a 60s cache.
- Treat truncated or malformed backend responses as discovery failures.

## Problem

A virtual server aggregating multiple backends could return only the tools from whichever backend responded successfully. Because any non-empty backend response marked the whole aggregation successful, that partial list was cached for 60 seconds. Separately, a virtual-backend route builder appended `/mcp` to valid nested endpoints such as `/mcp/http`, causing a 404 that then triggered the partial-list behavior.

## Verification

Verified against a live local stack using `cli/mcp_client.py` against a virtual server (`/virtual/dev-essentials`) with 7 tool mappings across 5 backends, two of which fail discovery:

- Before: `tools/list` returned 5 of 7 tools; the two failing backends' tools were dropped and the partial list was cached.
- After: `tools/list` returns all 7 tools (the two failing backends fall back to mapping-file metadata), and repeated calls consistently return the complete list rather than a cached partial.

Automated checks:

- `pytest tests/unit/test_virtual_server_nginx.py` — 29 passed (includes new cases: nested `/mcp/http` not double-suffixed; explicit endpoint keeps the private proxy host).
- `docker/lua/virtual_router.lua` parses cleanly under OpenResty LuaJIT.

## Compatibility and security

Explicit MCP endpoint paths still route through the configured private proxy host. Registration-time URL validation and render-time nginx sanitization remain in place.

Closes #1526
