### PR TITLE
fix: relative nginx redirects on :8080 and :8443 to prevent internal URL leak (adopts #1610)

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -165,6 +165,8 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
+    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
+    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -1085,6 +1085,8 @@ server {
 
 # Keep the HTTPS server for clients that prefer it
 server {
+    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
+    absolute_redirect off;
     listen 8443 ssl;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -166,6 +166,8 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
+    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
+    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};


### PR DESCRIPTION
## Summary

Makes nginx emit **relative** redirects so the automatic "add trailing slash" 301 no longer leaks the gateway's internal scheme/port, which caused MCP clients to follow the redirect to an unreachable internal address and hang.

This adopts #1610 by @zsxh1990 (commit cherry-picked, authorship preserved) and completes it by also covering the `:8443` ssl server block. Thank you to @zsxh1990 for the diagnosis and original patch.

## Background

After #1507 made the generated location blocks trailing-slash-terminated (`location /<server>/`), a request to a server path **without** the trailing slash triggers nginx's built-in 301. With the default `absolute_redirect on`, the `Location` is built from the internal listener (scheme + port) rather than the external origin:

```
Location: http://<host>:8080/registry/<server>/     # :8080 block (TLS terminated upstream)
Location: https://<host>:8443/registry/<server>/    # :8443 block (nginx terminates TLS)
```

MCP clients follow this 301 and hang on the unreachable internal port. This is the URL the registry UI's "connect" dialog hands out, so the affected server is effectively unusable through the gateway.

## Change

Add `absolute_redirect off;` to the front-door server blocks in both templates so redirects use a relative `Location: /registry/<server>/`, which the client resolves against the original external origin.

- `docker/nginx_rev_proxy_http_and_https.conf`: `:8080` block (from #1610) **and** the `:8443` ssl block (added here).
- `docker/nginx_rev_proxy_http_only.conf`: `:8080` block (from #1610).

The `:8443` addition is the completion: #1610 covered only `:8080`, but a gateway that terminates TLS on `:8443` (e.g. the public deployment) still emitted absolute redirects and still hung. App-issued OAuth redirects and explicit `return 301 https://<url>` are unaffected (the directive only changes nginx's own relative/auto redirects).

## Verification

Deployed to a live stack and tested on both an internal origin and the public TLS-terminated gateway:

- Slash-less redirect `Location` is now relative (`/cloudflare-docs/`) on both the `:8080` and `:8443` paths (previously absolute, leaking `:8080` / `:8443`).
- Following the redirect resolves to the correct external origin and no longer hangs (the public gateway previously timed out).
- Regression: MCP `initialize` / `tools/list` / `tools/call` through the gateway continue to work on both origins for a regular server (`cloudflare-docs`) and a virtual server (`dev-essentials`, 7 tools).
- `nginx -t` passes.

Fixes #1606
