### PR TITLE
fix(lambda): package patched urllib3 via build step so the #1612 pin remediates the CVEs

### DIFF
--- a/terraform/aws-ecs/secret-rotation.tf
+++ b/terraform/aws-ecs/secret-rotation.tf
@@ -290,6 +290,67 @@ resource "aws_cloudwatch_log_group" "rds_rotation" {
 }
 
 #
+# Lambda Function Packaging - build step (urllib3 vendored at package time)
+#
+# AWS Lambda does not install requirements.txt; the function otherwise runs on
+# the runtime-bundled SDK, whose urllib3 is affected by CVE-2025-66471/66418 and
+# CVE-2026-21441/44431. We build each package into a dedicated build directory
+# and pip-install a patched urllib3 into it. urllib3 ships in the deployment
+# package (/var/task), which precedes the runtime (/var/runtime) on sys.path, so
+# botocore imports the patched copy. Only urllib3 is installed (pure-Python, no
+# deps, ~130 KB) because it is the sole vulnerable component; boto3/botocore are
+# provided by the runtime and their floors in requirements.txt document the
+# expected minimum. Building at package time (rather than committing the vendored
+# source) keeps third-party code out of the repo and out of code scanning.
+#
+# Requires python3 + pip on the machine running `terraform apply`.
+#
+locals {
+  documentdb_rotation_build_dir = "${path.module}/.terraform/lambda-build/rotate-documentdb"
+  rds_rotation_build_dir        = "${path.module}/.terraform/lambda-build/rotate-rds"
+}
+
+resource "null_resource" "build_documentdb_rotation" {
+  count = local.is_aws_documentdb ? 1 : 0
+
+  triggers = {
+    index        = filesha256("${path.module}/lambda/rotate-documentdb/index.py")
+    requirements = filesha256("${path.module}/lambda/rotate-documentdb/requirements.txt")
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      build="${local.documentdb_rotation_build_dir}"
+      rm -rf "$build"
+      mkdir -p "$build"
+      cp "${path.module}/lambda/rotate-documentdb/index.py" "$build/"
+      python3 -m pip install "urllib3>=2.7.0" --no-deps --target "$build" --quiet
+    EOT
+  }
+}
+
+resource "null_resource" "build_rds_rotation" {
+  triggers = {
+    index        = filesha256("${path.module}/lambda/rotate-rds/index.py")
+    requirements = filesha256("${path.module}/lambda/rotate-rds/requirements.txt")
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      build="${local.rds_rotation_build_dir}"
+      rm -rf "$build"
+      mkdir -p "$build"
+      cp "${path.module}/lambda/rotate-rds/index.py" "$build/"
+      python3 -m pip install "urllib3>=2.7.0" --no-deps --target "$build" --quiet
+    EOT
+  }
+}
+
+#
 # Lambda Function Package - DocumentDB Rotation
 # Gated via `count` on the data source so the archive is not built when
 # DocumentDB is not provisioned. Issue #955.
@@ -298,8 +359,11 @@ data "archive_file" "documentdb_rotation" {
   count = local.is_aws_documentdb ? 1 : 0
 
   type        = "zip"
-  source_dir  = "${path.module}/lambda/rotate-documentdb"
+  source_dir  = local.documentdb_rotation_build_dir
   output_path = "${path.module}/.terraform/lambda/rotate-documentdb.zip"
+
+  # Deferred to apply so the build directory is populated first.
+  depends_on = [null_resource.build_documentdb_rotation]
 }
 
 #
@@ -307,8 +371,11 @@ data "archive_file" "documentdb_rotation" {
 #
 data "archive_file" "rds_rotation" {
   type        = "zip"
-  source_dir  = "${path.module}/lambda/rotate-rds"
+  source_dir  = local.rds_rotation_build_dir
   output_path = "${path.module}/.terraform/lambda/rotate-rds.zip"
+
+  # Deferred to apply so the build directory is populated first.
+  depends_on = [null_resource.build_rds_rotation]
 }
 
 #


### PR DESCRIPTION
## Summary

Follow-up to #1612. That PR pinned `urllib3>=2.7.0` in the rotation Lambdas' `requirements.txt`, but **AWS Lambda does not install `requirements.txt`**: `archive_file` in `terraform/aws-ecs/secret-rotation.tf` zips the source dir, and at runtime the function uses the AWS-managed `python3.13` runtime's bundled SDK. So the pin documented intent but had **no runtime effect** — the deployed Lambda kept using the runtime's `urllib3`, which is affected by CVE-2025-66471/66418 and CVE-2026-21441/44431.

This adds a **package-time build step** that installs a patched `urllib3` into each Lambda's deployment package, so it ships in `/var/task` and takes precedence over the runtime copy on `sys.path` — which is what actually remediates the advisories.

## Approach: build step (not committed vendored source)

- A `null_resource` + `local-exec` builds each package into `.terraform/lambda-build/<lambda>/` (copies `index.py`, then `pip install "urllib3>=2.7.0" --no-deps --target`), and `archive_file` zips that build dir (`depends_on` the build so it runs first).
- **Only `urllib3` is installed** — it is the sole vulnerable component, is pure-Python with no deps (~130 KB), and shadows the runtime copy for botocore's `import urllib3`. `boto3`/`botocore` continue to come from the runtime; their floors in `requirements.txt` document the expected minimum.
- **No third-party source is committed to the repo.** This keeps library internals out of code scanning (an earlier vendored-source revision tripped CodeQL on urllib3's own `ssl_.py`), consistent with the repo's existing "do not scan vendored internals" stance.

## Build-time cost

`pip install urllib3 --no-deps` at `terraform apply` is ~1-2s and adds ~130 KB to the zip. Requires `python3` + `pip` on the apply host (already expected for the Lambda build flow).

## Verification

- Ran the exact build the `local-exec` performs: the resulting zip contains `urllib3/` (84 entries) + `index.py`, ~364 KB.
- Vendored `urllib3.__version__ == 2.7.0`, resolving from the package dir when it is first on `sys.path` (mimicking `/var/task` precedence).
- `index.py` compiles for both Lambdas (imports `boto3`/`botocore` from the runtime, unaffected).
- `terraform fmt -check` passes on the changed file.
- Post-deploy acceptance: a rotation invocation (or `python -c "import urllib3; print(urllib3.__version__)"` in the function) reports `2.7.0`.

Relates to #1612.
