### PR TITLE
docs(egress): how to choose custom_token_auth_style + Datadog MCP public-client FAQ

### DIFF
--- a/cli/examples/datadog-mcp-server.json
+++ b/cli/examples/datadog-mcp-server.json
@@ -1,0 +1,14 @@
+{
+  "server_name": "Datadog MCP",
+  "description": "Datadog's hosted MCP server (Bits AI): query metrics, logs, traces, monitors, incidents, and dashboards. Uses per-user egress OAuth (3LO) against a PUBLIC PKCE client: Datadog's authorization server advertises token_endpoint_auth_methods_supported=[\"none\"], so there is no client_secret to configure -- the client_id is minted by its Dynamic Client Registration endpoint (https://app.datadoghq.com/api/v2/oauth2/register) and PKCE S256 is the proof of possession (pkce_required=true). Configure egress OAuth separately after registration via POST /servers/datadog/egress-auth with egress_provider=custom and custom_token_auth_style=none (see the example body in the registry docs: docs/egress-credential-vault.md). URLs below are the US1 site; on other sites substitute the regional domain (datadoghq.eu, us3/us5.datadoghq.com, ap1.datadoghq.com, ddog-gov.com). Set append_mcp_path=false: proxy_pass_url already ends in the /mcp transport segment.",
+  "path": "/datadog",
+  "proxy_pass_url": "https://mcp.datadoghq.com/v1/mcp",
+  "tags": ["datadog", "observability", "monitoring", "logs", "traces", "egress-oauth", "public-client", "pkce"],
+  "auth_scheme": "none",
+  "supported_transports": ["streamable-http"],
+  "append_mcp_path": false,
+  "status": "active",
+  "provider_organization": "Datadog",
+  "provider_url": "https://docs.datadoghq.com/bits_ai/mcp_server/",
+  "visibility": "public"
+}

--- a/docs/egress-credential-vault.md
+++ b/docs/egress-credential-vault.md
@@ -526,22 +526,27 @@ For a custom OIDC provider:
 - `custom_token_auth_style: "none"` is [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
   `token_endpoint_auth_method=none`: a **public client** with no client secret at
   all, as minted by an MCP resource server's Dynamic Client Registration endpoint
-  (for example **Datadog's MCP server**, whose DCR endpoint only issues public
-  clients). The gateway sends `client_id` plus the PKCE `S256` verifier on the
-  code exchange and refresh grants and never sends a `client_secret`; `client_id`
-  becomes required and no secret is stored (a previously stored secret is dropped
-  on the switch). PKCE remains mandatory. Example (Datadog MCP, US1, via `custom`):
+  (for example **Datadog's MCP server**, whose authorization server advertises
+  `token_endpoint_auth_methods_supported: ["none"]` and `pkce_required: true`, so
+  it issues public clients only). The gateway sends `client_id` plus the PKCE
+  `S256` verifier on the code exchange and refresh grants and never sends a
+  `client_secret`; `client_id` becomes required and no secret is stored (a
+  previously stored secret is dropped on the switch). PKCE remains mandatory.
+  Example (Datadog MCP, US1, via `custom`) — for the end-to-end walkthrough,
+  including the redirect-URL allow-list step that must be done inside Datadog,
+  see the
+  [FAQ: How do I configure the Datadog MCP server with per-user egress OAuth?](faq/configuring-datadog-mcp-server.md):
 
 ```jsonc
 {
   "egress_auth_mode": "oauth_user",
   "egress_provider": "custom",
   "client_id": "<client_id returned by Datadog DCR>",
-  "scopes": [],
+  "scopes": ["mcp_all"],
   "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
   "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
   "custom_token_auth_style": "none",
-  "custom_resource": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+  "custom_resource": "https://mcp.datadoghq.com"
 }
 ```
 - `custom_resource` (optional) is an [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
@@ -568,6 +573,67 @@ For a custom OIDC provider:
   "custom_resource": "https://mcp.atlassian.com/v1/mcp/authv2"
 }
 ```
+
+<a id="choosing-token-auth-style"></a>
+### Choosing `custom_token_auth_style`
+
+Do not guess this value: the provider publishes it. Work through the steps in
+order and stop at the first one that answers.
+
+**1. Is `egress_provider` a built-in?** (`github`, `google`, `atlassian`,
+`microsoft`, `slack`) Then there is nothing to set. `resolve_provider()` returns
+the built-in provider row verbatim and never reads `custom_token_auth_style`, so
+the field is ignored on those servers. Every built-in is confidential.
+
+**2. For `custom`, read the provider's authorization-server metadata**
+([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)). Start from the MCP server's
+protected-resource metadata and follow it to the authorization server:
+
+```bash
+# 1) the MCP server names its authorization server(s)
+curl -s https://<mcp-host>/.well-known/oauth-protected-resource
+
+# 2) the authorization server declares how clients authenticate
+curl -s https://<as-host>/.well-known/oauth-authorization-server
+# (some providers publish it at .../.well-known/openid-configuration instead)
+```
+
+Map `token_endpoint_auth_methods_supported` straight onto the setting:
+
+| Published value | Set `custom_token_auth_style` to |
+|---|---|
+| `["none"]` | `none` — public client; the PKCE verifier replaces the secret |
+| contains `client_secret_post` | `post_body` (the default) |
+| `client_secret_basic` only | `basic_header` |
+
+**3. Nothing published?** Then the app client's own configuration decides. The
+common case is **Amazon Cognito**, which does not serve discovery on its
+`*.auth.<region>.amazoncognito.com` domain: an app client **with** a secret must
+send it as HTTP Basic (`basic_header`), while a **public** app client with no
+secret sends only `client_id` (`none`). Cognito does not accept
+`client_secret_post` for confidential clients.
+
+**4. Already working?** An `active` entry for the server in
+`GET /api/egress-auth/connections` is proof that the current style is correct.
+Leave it alone.
+
+Guessing wrong is safe and loud: the provider rejects the token request with
+`invalid_client`, the gateway surfaces an `OAuthEngineError`, and no token is
+stored. When probing by hand, `invalid_grant` means client authentication
+**succeeded** (only the code or refresh token was bad), whereas `invalid_client`
+means the style is wrong.
+
+Verified examples of each value:
+
+| Upstream | Style | Evidence |
+|---|---|---|
+| Datadog MCP (`mcp.datadoghq.com`) | `none` | AS metadata publishes `token_endpoint_auth_methods_supported: ["none"]` with `pkce_required: true` |
+| Slack MCP (`mcp.slack.com`) | `post_body` | AS metadata publishes `["client_secret_post"]` |
+| Cognito app client that has a secret | `basic_header` | no discovery document; Cognito requires HTTP Basic for confidential clients |
+
+A public client also changes what the **admin form** asks for: once the style is
+`none` the Client Secret field disappears, `client_id` becomes required, and any
+previously stored secret is dropped on save.
 
 ---
 

--- a/docs/faq/configuring-datadog-mcp-server.md
+++ b/docs/faq/configuring-datadog-mcp-server.md
@@ -1,0 +1,204 @@
+# How do I configure the Datadog MCP server with per-user egress OAuth?
+
+This FAQ walks through registering [Datadog's MCP server](https://docs.datadoghq.com/mcp_server/) behind the gateway and wiring it to the **per-user egress credential vault**, so each user connects their own Datadog account once and the gateway injects that user's token on egress. Nobody stores a Datadog credential on their laptop.
+
+Datadog is the reference example of a **public OAuth client**: its authorization server issues clients that have *no* `client_secret` at all. That path requires `custom_token_auth_style: "none"` (added in 1.30.0). The same steps apply to any MCP server whose authorization server advertises `token_endpoint_auth_methods_supported: ["none"]`.
+
+## Why Datadog needs the public-client path
+
+Ask Datadog's authorization server directly:
+
+```bash
+curl -s https://mcp.datadoghq.com/.well-known/oauth-authorization-server
+```
+
+```json
+{
+  "issuer": "https://mcp.datadoghq.com/v1/mcp",
+  "authorization_endpoint": "https://app.datadoghq.com/oauth2/v1/authorize",
+  "token_endpoint": "https://app.datadoghq.com/api/v2/oauth2/token",
+  "registration_endpoint": "https://app.datadoghq.com/api/v2/oauth2/register",
+  "scopes_supported": ["mcp_all"],
+  "code_challenge_methods_supported": ["S256"],
+  "pkce_required": true,
+  "token_endpoint_auth_methods_supported": ["none"]
+}
+```
+
+Three facts drive the whole configuration:
+
+- `token_endpoint_auth_methods_supported` is **exactly** `["none"]` — there is no confidential option, so a `client_secret` cannot be supplied even if you wanted to. Set `custom_token_auth_style: "none"`.
+- `pkce_required: true` with `S256` — PKCE is the proof of possession that replaces the secret. The gateway always sends it for `custom` providers, so there is nothing to enable.
+- The protected-resource metadata (`https://mcp.datadoghq.com/.well-known/oauth-protected-resource`) declares `"resource": "https://mcp.datadoghq.com"`. That bare origin — **not** the endpoint URL — is the [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707) `custom_resource` value.
+
+## What you need before you start
+
+- A running MCP Gateway Registry with the vault enabled (`EGRESS_AUTH_ENABLED=true`) and a public callback base URL (`EGRESS_OAUTH_CALLBACK_BASE_URL`). See [Per-User Egress Credential Vault](../egress-credential-vault.md).
+- Registry admin access (the egress configure endpoint is admin-only).
+- **Datadog organization admin** access — one step must be done in the Datadog UI (Step 3), and it cannot be worked around.
+- A Datadog account on a supported site. Datadog's MCP server is not available on GovCloud (`app.ddog-gov.com`, `us2.ddog-gov.com`).
+
+Throughout, the gateway's callback URL is:
+
+```text
+{EGRESS_OAUTH_CALLBACK_BASE_URL}/oauth2/egress/callback
+```
+
+The exact value your deployment uses is returned by `GET /api/servers/{path}/egress-auth` as `callback_url` — read it from there rather than assembling it by hand. Examples below use `https://mcpgateway.example.com/oauth2/egress/callback`.
+
+## Step 1: Register the MCP server
+
+A ready-made registration file ships in the repo:
+
+```bash
+python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  register --config cli/examples/datadog-mcp-server.json
+```
+
+> **Argument order matters.** Global flags (`--registry-url`, `--token-file`) come *before* the subcommand. Putting them after `register` fails with `unrecognized arguments`.
+
+Two fields in that file are worth understanding:
+
+- `proxy_pass_url` is `https://mcp.datadoghq.com/v1/mcp` — the current endpoint named by Datadog's protected-resource metadata.
+- `append_mcp_path` is `false`, because that URL already ends in the `/mcp` transport segment.
+
+## Step 2: Get a `client_id`
+
+Datadog exposes a [Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591) endpoint that accepts anonymous registration:
+
+```bash
+curl -sX POST https://app.datadoghq.com/api/v2/oauth2/register \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "client_name": "MCP Gateway & Registry (egress vault)",
+    "redirect_uris": ["https://mcpgateway.example.com/oauth2/egress/callback"],
+    "token_endpoint_auth_method": "none",
+    "grant_types": ["authorization_code", "refresh_token"],
+    "response_types": ["code"]
+  }'
+```
+
+The response contains a `client_id` and **no** `client_secret` — that is the point.
+
+> **Expect a constant `client_id`.** At the time of writing this endpoint returns the *same* `client_id` regardless of the metadata posted, and merely echoes your `redirect_uris` back. It is a fixed public client behind a DCR-shaped facade, not a per-registration credential. Two consequences: the `client_id` is not a secret and needs no rotation, and the `redirect_uris` you post here are **not** what gets allow-listed — that is Step 3.
+
+## Step 3: Allow-list the gateway callback in Datadog
+
+This is the step that is easy to miss, and skipping it fails late: the user logs into Datadog, approves consent, and only then is the redirect rejected, so the gateway never receives an authorization code.
+
+In the Datadog UI:
+
+1. Go to **Organization Settings → Preferences** (<https://app.datadoghq.com/organization-settings/preferences>).
+2. Find **MCP OAuth Redirect URLs**.
+3. Add your gateway callback, e.g. `https://mcpgateway.example.com/oauth2/egress/callback`.
+
+While you are there, confirm two related settings:
+
+- **Role permissions** — *Organization Settings → Roles* → the role needs **MCP Read** (and **MCP Write** if you want write tools). Without these, consent succeeds but every tool call fails on permissions.
+- **IP allowlist** — if your org enables [IP allowlisting](https://docs.datadoghq.com/account_management/org_settings/ip_allowlist/), remember that requests now originate from the **gateway's** egress IP, not the user's laptop. That is the intended effect of the vault, but the gateway's address must be allowed.
+
+## Step 4: Configure egress auth on the server
+
+```bash
+python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  egress-configure --path /datadog --mode oauth_user --provider custom \
+  --client-id "<client_id from Step 2>" \
+  --scopes mcp_all \
+  --custom-authorize-url https://app.datadoghq.com/oauth2/v1/authorize \
+  --custom-token-url     https://app.datadoghq.com/api/v2/oauth2/token \
+  --custom-token-auth-style none \
+  --custom-resource      https://mcp.datadoghq.com
+```
+
+Note there is **no** `--client-secret`. Passing one is not an error, but it is ignored and not stored: a public client has no request field to put it in.
+
+The equivalent REST call:
+
+```bash
+curl -X POST https://mcpgateway.example.com/api/servers/datadog/egress-auth \
+  -H "Authorization: Bearer $ADMIN_TOKEN" -H 'Content-Type: application/json' \
+  -d '{
+    "egress_auth_mode": "oauth_user",
+    "egress_provider": "custom",
+    "client_id": "<client_id from Step 2>",
+    "scopes": ["mcp_all"],
+    "custom_authorize_url": "https://app.datadoghq.com/oauth2/v1/authorize",
+    "custom_token_url": "https://app.datadoghq.com/api/v2/oauth2/token",
+    "custom_token_auth_style": "none",
+    "custom_resource": "https://mcp.datadoghq.com"
+  }'
+```
+
+Or in the UI: edit the server, set **Egress Auth → Mode** to *Per-user OAuth (3LO)*, **Provider** to *Custom OIDC*, then set **Token Endpoint Authentication** to *None — public client (PKCE only)*. The Client Secret field disappears when you do, which is the confirmation that the public-client path is active. Fill **Resource (RFC 8707, optional)** with `https://mcp.datadoghq.com`.
+
+Verify what was stored:
+
+```bash
+python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  egress-config-get --path /datadog
+```
+
+`custom_token_auth_style` must echo back as `"none"`. If it comes back `null` or `post_body`, the setting did not persist and consent will fail with `invalid_client`.
+
+## Step 5: Enable the server
+
+Registration does not enable a server — the gateway will not route to it until you toggle it on:
+
+```bash
+python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  toggle --path /datadog --enabled true
+```
+
+## Step 6: Connect your account and verify
+
+Each user connects once:
+
+1. Open the registry UI. The Datadog card now shows the **Link account** (3LO connect) affordance, because the server has per-user egress the current user can reach.
+2. Click it, complete the Datadog login and consent, and you are returned to the gateway.
+3. Confirm the vaulted connection:
+
+```bash
+curl -s https://mcpgateway.example.com/api/egress-auth/connections \
+  -H "Authorization: Bearer $USER_TOKEN"
+```
+
+```json
+[{ "server_path": "/datadog", "provider": "custom", "status": "active", "expires_at": "..." }]
+```
+
+`status: "active"` means the code exchange succeeded with `client_id` + PKCE and no secret — the public-client flow end to end. Tool calls now carry that user's Datadog token.
+
+> If you configured the server from the CLI while the dashboard was already open, the connect icon will not appear until you reload the page: the dashboard fetches egress eligibility once and only re-fetches after a connect or disconnect.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `400 'none' is not a valid TokenEndpointAuthStyle` | Registry predates 1.30.0 | Upgrade; the public-client style did not exist before |
+| `400 client_id required when custom_token_auth_style is 'none'` | No `client_id` sent | A public client is identified only by `client_id`; supply it |
+| `400 client_secret required` | `custom_token_auth_style` was not applied (still `post_body`) | Re-check `egress-config-get`; the style must be `none` |
+| Consent completes, then the redirect is rejected | Callback not allow-listed in Datadog | Step 3 — *Organization Settings → Preferences → MCP OAuth Redirect URLs* |
+| Token exchange fails with `invalid_client` | Wrong auth style for this provider | See [Choosing `custom_token_auth_style`](../egress-credential-vault.md#choosing-token-auth-style) |
+| Connect icon missing on the server card | Stale dashboard, or the user has no access to `/datadog` | Reload; then check `GET /api/egress-auth/available-servers` as that user |
+| Consent works but tools return permission errors | Role lacks **MCP Read** / **MCP Write** | Step 3, *Organization Settings → Roles* |
+| `num_tools: 0` and no health status | No user has consented yet | Datadog returns `401` to anonymous callers, so discovery stays empty until the first connection |
+
+## Other Datadog sites
+
+The values above are for **US1** (`app.datadoghq.com`). On other sites substitute the regional domain in the authorize URL, token URL, `proxy_pass_url`, and `custom_resource` — for example `app.datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, `ap1.datadoghq.com`. Confirm by fetching the metadata for your site:
+
+```bash
+curl -s https://mcp.<your-datadog-site>/.well-known/oauth-authorization-server
+```
+
+## Related documentation
+
+- [Per-User Egress Credential Vault](../egress-credential-vault.md) — the full design, API surface, and secret-store setup
+- [Choosing `custom_token_auth_style`](../egress-credential-vault.md#choosing-token-auth-style) — the general decision procedure for any provider
+- [How do I use a 3LO (per-user OAuth) AgentCore Gateway with the registry?](agentcore-3lo-per-user-oauth.md) — the same flow against a confidential Cognito client
+- [How do I register commonly used third-party MCP servers like GitHub, Slack, and Atlassian?](registering-third-party-mcp-servers.md)
+- [Datadog MCP Server documentation](https://docs.datadoghq.com/mcp_server/)

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -17,6 +17,7 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [How do I get my AI coding assistant to work with this registry?](connect-ai-coding-assistant.md)
 - [How do I register commonly used third-party MCP servers like GitHub, Slack, and Atlassian?](registering-third-party-mcp-servers.md)
+- [How do I configure the Datadog MCP server with per-user egress OAuth (public client + PKCE)?](configuring-datadog-mcp-server.md)
 - [How do I connect my agent to multiple MCP servers through the gateway?](connecting-multiple-mcp-servers.md)
 - [How do I test my agent's integration with the MCP Gateway locally?](local-testing-agent-integration.md)
 


### PR DESCRIPTION
Follow-up to #1613 (public OAuth clients with `token_endpoint_auth_method=none`). Docs and an example only — **no code changes**.

#1613 added the capability but left two gaps for operators: nothing explains *how you decide* which auth style a given provider needs, and the worked Datadog example did not match what Datadog currently publishes.

## What this adds

### 1. `docs/egress-credential-vault.md` — new "Choosing `custom_token_auth_style`" section

A decision procedure instead of a guess, stopping at the first step that answers:

1. **Built-in provider?** Nothing to set — `resolve_provider()` returns the built-in row verbatim and never reads the field.
2. **`custom`?** Read `token_endpoint_auth_methods_supported` from the provider's authorization-server metadata ([RFC 8414](https://www.rfc-editor.org/rfc/rfc8414)), reached from the MCP server's protected-resource metadata. `["none"]` → `none`; contains `client_secret_post` → `post_body`; `client_secret_basic` only → `basic_header`.
3. **No discovery document?** The app client's own config decides. Amazon Cognito is the common case: a client **with** a secret must use HTTP Basic (`basic_header`); a **public** client uses `none`. Cognito does not accept `client_secret_post` for confidential clients.
4. **Already working?** An `active` entry in `GET /api/egress-auth/connections` is proof the current style is right — leave it.

Plus the failure semantics: a wrong style is rejected as `invalid_client` with nothing stored, and when probing by hand `invalid_grant` means client auth *succeeded* (only the code/refresh token was bad). Includes a table of verified values for Datadog MCP (`none`), Slack MCP (`post_body`), and Cognito-with-secret (`basic_header`).

### 2. Corrected the Datadog example against live metadata

| Field | Was | Now | Source |
|---|---|---|---|
| `custom_resource` | `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp` | `https://mcp.datadoghq.com` | its protected-resource metadata declares `"resource"` as the bare origin |
| `scopes` | `[]` | `["mcp_all"]` | `scopes_supported` |
| endpoint | `/api/unstable/mcp-server/mcp` | `/v1/mcp` | the authorization server named by the PRM |

Also cites the advertised `token_endpoint_auth_methods_supported: ["none"]` and `pkce_required: true`, which is *why* this provider needs the public-client path at all.

### 3. `docs/faq/configuring-datadog-mcp-server.md` — new end-to-end FAQ

Registration → DCR `client_id` → Datadog-side allow-list → egress config → enable → consent → verify, with CLI, REST, and UI forms. Things it makes explicit because they cost real debugging time:

- **The step that fails late:** the gateway callback must be allow-listed in Datadog under **Organization Settings → Preferences → MCP OAuth Redirect URLs**. Skip it and the user logs in, approves, and *then* the redirect is rejected — the gateway never sees a code.
- Datadog's DCR endpoint returns a **constant** `client_id` for any metadata posted and echoes `redirect_uris` back **without** registering them, so the `client_id` is neither secret nor per-deployment.
- **MCP Read / MCP Write** role permissions, and the IP-allowlist implication now that egress originates from the gateway rather than the user's laptop.
- CLI global flags (`--registry-url`, `--token-file`) must precede the subcommand.
- Troubleshooting table mapping each real error to its cause, including `400 client_secret required` (style did not persist) and a missing connect icon (stale dashboard vs. no access).

### 4. `cli/examples/datadog-mcp-server.json`

Registration file using `https://mcp.datadoghq.com/v1/mcp` with `append_mcp_path=false` (the URL already carries the `/mcp` segment). Validated against `ServerInfo`.

## Verification

- Every URL, scope, and resource value was taken from Datadog's live metadata (`/.well-known/oauth-protected-resource` and `/.well-known/oauth-authorization-server`), not from prior docs.
- The full flow was exercised on a running deployment: register → `egress-configure --custom-token-auth-style none` → 3LO consent → `GET /api/egress-auth/connections` reports `status: active`, with no `client_secret` anywhere in the token exchange.
- Example JSON validates against `registry.core.schemas.ServerInfo`; hook-equivalent checks (JSON validity, trailing whitespace, EOF newline) pass; all relative doc links and the new `#choosing-token-auth-style` anchor resolve.

## Not included

Deliberately left for separate PRs so this one stays docs-only:

- **Engine-level PKCE enforcement for `NONE` style.** `exchange_code` adds `code_verifier` only `if cfg.use_pkce and pkce_verifier`; with style `none` and no verifier the token request would carry neither a secret nor a verifier. Unreachable today (verifier is always minted for `custom`, and the state blob is signed + encrypted), but the confidential mirror rule *is* enforced in the same function, so the asymmetry is worth closing. ~3 lines plus a test.
- Moving the `client_id`-required rule into `ServerInfo._validate_egress_auth` so the generic register/update path shares it.
- Invalidating vaulted per-user tokens when a server's egress client identity changes.