### PR TITLE
fix(nginx): add proxy_http_version 1.1 to /validate block + forward i…

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -304,6 +304,7 @@ server {
         internal;
 
         proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/validate;
+        proxy_http_version 1.1;
 
         # Pass original request info
         proxy_set_header X-Original-URI $request_uri;
@@ -1132,6 +1133,7 @@ server {
         internal;
 
         proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/validate;
+        proxy_http_version 1.1;
 
         # Pass original request info
         proxy_set_header X-Original-URI $request_uri;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -526,6 +526,7 @@ server {
         internal;
 
         proxy_pass http://{{AUTH_SERVER_HOST}}:{{AUTH_SERVER_PORT}}/validate;
+        proxy_http_version 1.1;
 
         # Pass original request info
         proxy_set_header X-Original-URI $request_uri;


### PR DESCRIPTION
…dentity headers in virtual server backends

Two fixes for ECS Service Connect deployments:

1. /validate auth subrequest missing proxy_http_version 1.1 ECS Service Connect uses HTTP/1.1 keepalive connections between the envoy sidecar and the upstream container. Without proxy_http_version 1.1 on the /validate location, nginx defaults to HTTP/1.0 which closes the connection after each subrequest. Under load this exhausts the connection pool and causes intermittent 502s on auth validation.

2. Virtual server _vs_backend_* locations do not forward caller identity (same fix from PR #1650, rebased onto 1.29.0)
   - virtual_router.lua: set X-User/X-Username via ngx.req.set_header
   - nginx_service.py: proxy_set_header X-User/X-Username using $http_x_*

Both fixes tested on ECS Fargate with Cognito auth and Service Connect.

*Issue #, if available:*
Closes #1643  (proxy_http_version), relates to #1650 (identity headers)

*Description of changes:*
Adds proxy_http_version 1.1 to the /validate auth subrequest location (fixes intermittent 502s on ECS Service Connect) and rebases the virtual server identity header fix from #1650 onto 1.29.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
