### PR TITLE
fix(lua): keep empty inputSchema arrays as [] in virtual tools/list

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -120,11 +120,48 @@ local function _forward_identity_headers()
 end
 
 
+-- JSON Schema keywords whose value must serialize as an array.
+local SCHEMA_ARRAY_KEYS = {
+    required = true, enum = true, allOf = true, anyOf = true,
+    oneOf = true, examples = true, prefixItems = true,
+}
+
+-- Keywords holding a map of caller-chosen names to subschemas. A member named
+-- "required" there is a property name, not the keyword, so descend into the
+-- members without matching their names against SCHEMA_ARRAY_KEYS.
+local SCHEMA_MAP_KEYS = {
+    properties = true, patternProperties = true,
+    definitions = true, ["$defs"] = true,
+}
+
+-- cjson decodes an empty JSON array to a bare table, which re-encodes as {}.
+-- Tag those tables so the keywords above survive the round trip as [].
+local function _tag_empty_schema_arrays(node, depth)
+    if type(node) ~= "table" or depth > 16 then
+        return
+    end
+    for key, value in pairs(node) do
+        if type(value) == "table" then
+            if SCHEMA_MAP_KEYS[key] then
+                for _, subschema in pairs(value) do
+                    _tag_empty_schema_arrays(subschema, depth + 1)
+                end
+            elseif SCHEMA_ARRAY_KEYS[key] and next(value) == nil then
+                setmetatable(value, empty_array_mt)
+            else
+                _tag_empty_schema_arrays(value, depth + 1)
+            end
+        end
+    end
+end
+
+
 -- Ensure inputSchema has "type": "object" as required by MCP spec
 local function _ensure_mcp_schema(schema)
     if not schema or type(schema) ~= "table" then
         return { type = "object", properties = {} }
     end
+    _tag_empty_schema_arrays(schema, 0)
     if schema.type == "object" then
         return schema
     end

--- a/tests/lua/test_virtual_router.lua
+++ b/tests/lua/test_virtual_router.lua
@@ -202,6 +202,61 @@ do
 end
 
 -- ---------------------------------------------------------------------------
+print("test: _handle_tools_list keeps empty schema arrays as [] (issue #1532)")
+do
+    dict._store["tools_enriched:srv3"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "no_arg", original_name = "no_arg", backend_location = "/ok" },
+        { name = "one_arg", original_name = "one_arg", backend_location = "/ok" },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200, body = cjson.encode({ result = { tools = {
+        { name = "no_arg", inputSchema = {
+            type = "object", properties = {},
+            required = setmetatable({}, cjson.empty_array_mt) } },
+        { name = "one_arg", inputSchema = {
+            type = "object",
+            properties = { q = { type = "string",
+                                 enum = setmetatable({}, cjson.empty_array_mt) } },
+            required = { "q" } } },
+    } } }) }
+
+    local body = M._handle_tools_list("1", mapping, "", nil, "srv3")
+    check(body:find('"required":[]', 1, true) ~= nil,
+        "empty required serializes as [] not {}")
+    check(body:find('"required":["q"]', 1, true) ~= nil,
+        "non-empty required is still an array")
+    check(body:find('"properties":{}', 1, true) ~= nil,
+        "empty properties stays an object")
+    check(body:find('"enum":[]', 1, true) ~= nil,
+        "empty enum nested under properties serializes as []")
+
+    -- The cached path decodes and re-encodes, so it must hold the same shape.
+    local cached_body = M._handle_tools_list("1", mapping, "", nil, "srv3")
+    check(dict._store["tools_enriched:srv3"] ~= nil, "result was cached")
+    check(cached_body:find('"required":[]', 1, true) ~= nil,
+        "empty required is still [] when served from cache")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: a property named like a schema keyword stays an object")
+do
+    dict._store["tools_enriched:srv4"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "odd", original_name = "odd", backend_location = "/ok" },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200, body = cjson.encode({ result = { tools = {
+        { name = "odd", inputSchema = {
+            type = "object", properties = { required = { type = "object" } } } },
+    } } }) }
+
+    local body = M._handle_tools_list("1", mapping, "", nil, "srv4")
+    check(body:find('"required":[]', 1, true) == nil,
+        "a property called 'required' is not coerced into an array")
+end
+
+-- ---------------------------------------------------------------------------
 if failures > 0 then
     print(string.format("\n%d check(s) FAILED", failures))
     os.exit(1)


### PR DESCRIPTION
`lua-cjson` cannot distinguish an empty array from an empty object: both decode to a bare Lua table, and that table re-encodes as `{}`. The virtual router decodes each backend's `tools/list` response and re-encodes it, once into the enriched shared-dict cache and once into the JSON-RPC result, so a backend advertising `"required": []` reaches the client as `"required": {}`.

That also accounts for the two asymmetries in the report: a non-empty `required` carries integer keys and re-encodes as an array, and the per-server proxy path is a byte pass-through with no cjson round trip, so only the virtual aggregation path corrupts the schema.

### Why the change is not in `nginx_service.py`

The report points at `_ensure_mcp_compliant_schema` and the persisted `tool_list`. Python's `json` module round-trips `[]` as `[]`, and that helper feeds the mapping file, which the Lua router reads only when every backend `tools/list` fetch has failed. In a deployment with a reachable backend that branch never runs, so a change there would not reach the reported symptom. Normalising in Lua covers the mapping-file branch as well.

### Fix

`_ensure_mcp_schema` is the single point every `tools/list` schema crosses on all three paths: live enrichment, the per-backend mapping fallback, and the scope filter that rebuilds the response on every request, cache hit or miss. It now walks the schema and marks empty array-valued keywords with `cjson.empty_array_mt`.

Object-valued keywords are left alone, since `{}` is correct for `properties` and `additionalProperties`. Members of `properties` are not matched against the keyword list, so a tool parameter that happens to be named `required` keeps its object form.

### Verification

- New checks in `tests/lua/test_virtual_router.lua`, driven through `_handle_tools_list`: 3 fail on `main` and pass here (empty `required` on the live path, the same value served from cache, and a nested empty `enum`).
- The full Lua suite passes, including guard checks that a non-empty `required`, an empty `properties` and a property named `required` are all unchanged.
- Run in `openresty/openresty:alpine` with the same luajit invocation as `lua-test.yml`, plus that workflow's syntax check and `pre-commit` over both changed files.
- Not verified end to end: I did not stand up nginx, MongoDB and a live backend. The checks drive the aggregation path with `ngx.location.capture` mocked, so they pin the encoding behaviour rather than the deployment.

Fixes #1532
