### PR TITLE
fix: import missing annotation types flagged by ruff F821

### DIFF
--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -272,6 +272,8 @@ from registry_client import (
     RatingInfoResponse,
     RatingResponse,
     RegistryClient,
+    RescanResponse,
+    SecurityScanResult,
     ServerUpdateResponse,
     Skill,
     SkillRegistrationRequest,

--- a/cli/agentcore/registration.py
+++ b/cli/agentcore/registration.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import sys
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import requests
@@ -38,6 +38,9 @@ from api.registry_client import (
     InternalServiceRegistration,
     RegistryClient,
 )
+
+if TYPE_CHECKING:
+    from .discovery import AgentCoreScanner
 
 logger = logging.getLogger(__name__)
 

--- a/cli/agentcore/sync.py
+++ b/cli/agentcore/sync.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from .models import (
     DEFAULT_MANIFEST_PATH,
@@ -29,6 +30,9 @@ from .security import (
     require_secure_registry_url,
     validate_account_ids,
 )
+
+if TYPE_CHECKING:
+    import boto3
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Four type names are used in annotations but never imported (ruff F821). None of them crash at runtime today (`from __future__ import annotations` / local-variable annotations are lazy), but they break `typing.get_type_hints()`, mypy, and IDE navigation:

1. **`api/registry_management.py`** — `SecurityScanResult` (line ~1822) and `RescanResponse` (line ~1874) annotate the results of `client.get_security_scan()` / `client.rescan_server()`. Both classes are defined and exported by `registry_client`; added them to the existing import list.

2. **`cli/agentcore/registration.py`** — `AgentCoreScanner` (the `SyncOrchestrator` constructor's `scanner` param) is defined in `cli/agentcore/discovery.py` but never imported. Added under `if TYPE_CHECKING:` (annotation-only usage, avoids any import-cycle risk).

3. **`cli/agentcore/sync.py`** — `boto3` is referenced in the `-> boto3.Session` return annotation of `_assume_role_session()` but only imported lazily inside a different function. Added `if TYPE_CHECKING: import boto3`.

## Testing
`python -m py_compile` passes on all three files; `ruff check --select F821` on these paths goes from 4 errors to clean. No runtime behavior change (all additions are import-list entries or TYPE_CHECKING-guarded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)