### PR TITLE
fix(keycloak): make the container healthcheck runnable inside the image

### DIFF
--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -788,11 +788,23 @@ services:
       - ./keycloak/import:/opt/keycloak/data/import
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      # The Keycloak image deliberately ships without curl (upstream removes HTTP
+      # clients to cut attack surface), so a curl-based check can never succeed
+      # and leaves the container permanently unhealthy. Use bash's /dev/tcp
+      # redirection, which is what the Keycloak health guide documents for
+      # HEALTHCHECK. Since Keycloak 25 the health endpoints are served on the
+      # management port (9000), not on the main HTTP port.
+      test:
+        - CMD
+        - /bin/bash
+        - -c
+        - "{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000"
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      # First boot runs the Keycloak DB schema migration; a short start_period
+      # reports the container unhealthy during an otherwise normal startup.
+      start_period: 120s
 
   pingfederate:
     image: pingidentity/pingfederate:13.0.2

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -676,6 +676,9 @@ services:
       # Logging
       KC_LOG_LEVEL: INFO
 
+      # Health endpoints (required for /health/ready on the management port)
+      KC_HEALTH_ENABLED: 'true'
+
     # start-dev serves plain HTTP with a bootstrap admin account, so the
     # published port is bound to loopback: the browser reaches it via
     # http://localhost:8080 on the same host, and in-cluster services use the
@@ -697,11 +700,23 @@ services:
       - ./keycloak/import:/opt/keycloak/data/import
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      # The Keycloak image deliberately ships without curl (upstream removes HTTP
+      # clients to cut attack surface), so a curl-based check can never succeed
+      # and leaves the container permanently unhealthy. Use bash's /dev/tcp
+      # redirection, which is what the Keycloak health guide documents for
+      # HEALTHCHECK. Since Keycloak 25 the health endpoints are served on the
+      # management port (9000), not on the main HTTP port.
+      test:
+        - CMD
+        - /bin/bash
+        - -c
+        - "{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000"
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      # First boot runs the Keycloak DB schema migration; a short start_period
+      # reports the container unhealthy during an otherwise normal startup.
+      start_period: 120s
 
   pingfederate:
     image: pingidentity/pingfederate:13.0.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1029,6 +1029,9 @@ services:
       # Logging
       KC_LOG_LEVEL: INFO
 
+      # Health endpoints (required for /health/ready on the management port)
+      KC_HEALTH_ENABLED: 'true'
+
     # start-dev serves plain HTTP with a bootstrap admin account, so the
     # published port is bound to loopback: the browser reaches it via
     # http://localhost:8080 on the same host, and in-cluster services use the
@@ -1051,11 +1054,23 @@ services:
       - ./keycloak/import:/opt/keycloak/data/import
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      # The Keycloak image deliberately ships without curl (upstream removes HTTP
+      # clients to cut attack surface), so a curl-based check can never succeed
+      # and leaves the container permanently unhealthy. Use bash's /dev/tcp
+      # redirection, which is what the Keycloak health guide documents for
+      # HEALTHCHECK. Since Keycloak 25 the health endpoints are served on the
+      # management port (9000), not on the main HTTP port.
+      test:
+        - CMD
+        - /bin/bash
+        - -c
+        - "{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000"
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      # First boot runs the Keycloak DB schema migration; a short start_period
+      # reports the container unhealthy during an otherwise normal startup.
+      start_period: 120s
 
   pingfederate:
     # Pinned to a specific version rather than :latest so the image is

--- a/docker/keycloak/Dockerfile
+++ b/docker/keycloak/Dockerfile
@@ -16,9 +16,15 @@ COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
 WORKDIR /opt/keycloak
 
-# Health check for keycloak ready endpoint
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:8080/health/ready || exit 1
+# Health check for the keycloak ready endpoint.
+# The Keycloak base image ships without curl (upstream removes HTTP clients to
+# cut attack surface), so a curl-based check can never succeed and leaves the
+# container permanently unhealthy. bash's /dev/tcp redirection is what the
+# Keycloak health guide documents for HEALTHCHECK. Since Keycloak 25 the health
+# endpoints are served on the management port (9000), not on the main HTTP port.
+# start-period covers the DB schema migration on first boot.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD ["/bin/bash", "-c", "{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000"]
 
 # Switch to keycloak user (provided by base image, UID 1000)
 USER keycloak

--- a/terraform/aws-ecs/keycloak-ecs.tf
+++ b/terraform/aws-ecs/keycloak-ecs.tf
@@ -328,11 +328,16 @@ resource "aws_ecs_task_definition" "keycloak" {
       readonlyRootFilesystem = false
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -f http://localhost:9000/health/ready || exit 1"]
+        # The Keycloak image ships without curl (upstream removes HTTP clients to
+        # cut attack surface), so a curl-based check can never succeed and the task
+        # never reports healthy. bash's /dev/tcp redirection is the check documented
+        # by the Keycloak health guide.
+        command     = ["CMD", "/bin/bash", "-c", "{ printf 'HEAD /health/ready HTTP/1.0\\r\\n\\r\\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000"]
         interval    = 30
         timeout     = 5
         retries     = 3
-        startPeriod = 90
+        # Covers the Keycloak DB schema migration on first boot.
+        startPeriod = 120
       }
     }
   ])

--- a/tests/security/test_container_security.py
+++ b/tests/security/test_container_security.py
@@ -250,6 +250,116 @@ def test_docker_compose_registry_port_mapping(repo_root: Path):
 
 
 # ---------------------------------------------------------------------------
+# Keycloak healthcheck: must be runnable inside the Keycloak image
+# ---------------------------------------------------------------------------
+
+
+def _keycloak_healthcheck_command(compose_path: Path) -> str:
+    """Return the keycloak service healthcheck command as a single string.
+
+    Both the exec form (``["CMD", ...]``) and the shell form (``CMD-SHELL``)
+    are flattened to one string so callers can assert on its content without
+    caring which form the file happens to use.
+    """
+    data = yaml.safe_load(compose_path.read_text())
+    keycloak = data["services"]["keycloak"]
+    test = keycloak["healthcheck"]["test"]
+    return test if isinstance(test, str) else " ".join(test)
+
+
+def _keycloak_environment(compose_path: Path) -> dict[str, str]:
+    """Return the keycloak service environment as a mapping.
+
+    Compose accepts both the ``KEY: value`` mapping form and the ``- KEY=value``
+    list form; normalise to a dict so assertions work against either.
+    """
+    data = yaml.safe_load(compose_path.read_text())
+    env = data["services"]["keycloak"].get("environment", {})
+    if isinstance(env, dict):
+        return {str(k): str(v) for k, v in env.items()}
+    normalised = {}
+    for entry in env:
+        key, _, value = str(entry).partition("=")
+        normalised[key] = value
+    return normalised
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_keycloak_healthcheck_does_not_use_curl(repo_root: Path, compose_filename: str):
+    """The keycloak healthcheck must not invoke curl.
+
+    The Keycloak image deliberately ships without curl (upstream removes HTTP
+    clients to cut attack surface), so a curl-based check can never succeed and
+    the container reports unhealthy forever. That is worse than having no check
+    at all: it trains operators to ignore health status and removes the signal
+    for a real Keycloak outage. Upstream documents a bash /dev/tcp check instead.
+    """
+    command = _keycloak_healthcheck_command(repo_root / compose_filename)
+    assert "curl" not in command, (
+        f"{compose_filename}: keycloak healthcheck invokes curl, which is not present "
+        f"in the Keycloak image; the container can never become healthy. "
+        f"Use the bash /dev/tcp check documented in the Keycloak health guide."
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_keycloak_healthcheck_targets_management_port(repo_root: Path, compose_filename: str):
+    """The keycloak healthcheck must probe /health/ready on the management port.
+
+    Since Keycloak 25 the health endpoints moved off the main HTTP port and are
+    served on the management port (9000) by default, so a check against 8080
+    returns 404 even once a working HTTP client is used.
+    """
+    command = _keycloak_healthcheck_command(repo_root / compose_filename)
+    assert "/health/ready" in command, (
+        f"{compose_filename}: keycloak healthcheck does not probe /health/ready"
+    )
+    assert "9000" in command, (
+        f"{compose_filename}: keycloak healthcheck must target the management port 9000; "
+        f"since Keycloak 25 the health endpoints are not served on the main HTTP port."
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+def test_keycloak_health_endpoints_enabled(repo_root: Path, compose_filename: str):
+    """KC_HEALTH_ENABLED must be set, or /health/ready is not served at all.
+
+    Without it the healthcheck fails for a second, independent reason, which is
+    easy to miss once the curl problem is fixed.
+    """
+    env = _keycloak_environment(repo_root / compose_filename)
+    assert env.get("KC_HEALTH_ENABLED", "").lower() == "true", (
+        f"{compose_filename}: keycloak is missing KC_HEALTH_ENABLED=true, so the "
+        f"health endpoints are not exposed and the healthcheck cannot pass."
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["docker/keycloak/Dockerfile", "terraform/aws-ecs/keycloak-ecs.tf"],
+)
+def test_keycloak_healthcheck_does_not_use_curl_outside_compose(repo_root: Path, path: str):
+    """The same invariant for the built image and the ECS task definition.
+
+    Both run the same Keycloak image, so a curl-based check is equally broken
+    there; keeping them in one test stops the fix from being applied to the
+    compose files only.
+    """
+    content = (repo_root / path).read_text()
+    healthcheck_lines = [
+        line
+        for line in content.splitlines()
+        if "health/ready" in line and not line.lstrip().startswith("#")
+    ]
+    assert healthcheck_lines, f"{path}: no /health/ready healthcheck found -- has it moved?"
+    for line in healthcheck_lines:
+        assert "curl" not in line, (
+            f"{path}: healthcheck invokes curl, which is not present in the Keycloak image: "
+            f"{line.strip()}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # SA-5: compose port-exposure hardening (loopback-by-default binds)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1650

## What was wrong

The `keycloak` healthcheck invoked `curl`, which the Keycloak image deliberately does not ship — upstream removes HTTP clients from the image to cut attack surface, and [documents this explicitly](https://www.keycloak.org/observability/health). The check could never succeed, so the container reported `unhealthy` forever while Keycloak itself worked fine.

While fixing it I found two further faults stacked underneath, so adding `curl` to the image would not have been sufficient:

1. **Wrong port.** Since Keycloak 25 the health endpoints [moved off the main HTTP port to the management port `9000`](https://www.keycloak.org/2024/06/keycloak-2500-released). The repo runs `quay.io/keycloak/keycloak:25.0` everywhere, so `http://localhost:8080/health/ready` returns 404 even with a working HTTP client.
2. **Health endpoints not enabled.** `KC_HEALTH_ENABLED` was absent from `docker-compose.yml` and `docker-compose.prebuilt.yml`, so `/health/ready` was not served at all in those deployments. Only `docker-compose.podman.yml` had it set.

The same broken check was present in four places beyond the compose file named in the issue, all running the same image:

| File | curl | Port | `KC_HEALTH_ENABLED` |
|---|---|---|---|
| `docker-compose.yml` | yes | 8080 | missing |
| `docker-compose.prebuilt.yml` | yes | 8080 | missing |
| `docker-compose.podman.yml` | yes | 8080 | present |
| `docker/keycloak/Dockerfile` | yes | 8080 | present (build time) |
| `terraform/aws-ecs/keycloak-ecs.tf` | yes | 9000 | present |

They are fixed together, since fixing only the compose file would leave the built image and the ECS task definition equally broken.

## The fix

The check now uses the bash `/dev/tcp` redirection that the Keycloak health guide documents for `HEALTHCHECK`, so it needs no additional packages in the image:

```
{ printf 'HEAD /health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.[01] 200'; } 0<>/dev/tcp/localhost/9000
```

`KC_HEALTH_ENABLED=true` is set where it was missing, and `start_period` goes from 60s to 120s so the DB schema migration on first boot no longer reports the container unhealthy during a normal startup, as the issue requested.

**One deliberate deviation from the upstream snippet:** upstream matches literally on `HTTP/1.0 200`. Testing against a stub endpoint showed the server answering an HTTP/1.0 request with `HTTP/1.1 200 OK`, which that grep would miss. The pattern is widened to `HTTP/1.[01] 200`, which is a strict superset of the documented match.

## Verification

The command was exercised in bash against a local HTTP endpoint (port remapped, as 9000 was reserved on the test host):

| Endpoint state | Exit code |
|---|---|
| 200 on `/health/ready` | 0 |
| 503 | 1 |
| nothing listening | 1 |

Regression tests added to `tests/security/test_container_security.py`, asserting the invariant across every surface: no `curl`, the management port, `/health/ready`, and `KC_HEALTH_ENABLED`. They also cover the Dockerfile and the Terraform task definition, so the fix cannot be re-applied to the compose files alone.

- With the fix: 78 passed (16 selected by `-k keycloak`).
- Against the pre-fix tree, with the tests kept and only the source changes stashed: **10 of the 11 new tests fail.** The one that passes is `KC_HEALTH_ENABLED` on the podman compose file, which already had it.

`pre-commit run --files <changed files>` passes with `SKIP=pytest-fast`, matching what `.github/workflows/pre-commit.yaml` does in CI.

## Why this is worth fixing despite being cosmetic

Quoting the issue, because it is the actual argument: a container that is always unhealthy trains operators to ignore health status and removes the signal for the case where Keycloak really is broken. It also costs time on first deployment, since an unhealthy identity provider is the first thing anyone investigates when OAuth does not work.

## Not included

`keycloak/README.md` and `docs/keycloak-agent-m2m.md` still tell operators to `curl localhost:8080/health/ready` from the host. That returns 404 on Keycloak 25 and did so before this change too. Fixing it properly needs a maintainer decision — publish the management port, or document a `docker compose exec` command instead — so it is left out of this PR rather than guessed at. Happy to follow up in a separate PR once you say which you prefer.