### PR TITLE
fix(keycloak): pass KEYCLOAK_EXTERNAL_URL to the prebuilt registry, warn when it cannot work

### DIFF
--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -1,7 +1,9 @@
 """Factory for creating authentication provider instances."""
 
+import ipaddress
 import logging
 import os
+from urllib.parse import urlparse
 
 from .auth0 import Auth0Provider
 from .base import AuthProvider
@@ -17,6 +19,99 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Hostnames that only ever mean "this machine". Kept separate from the
+# misconfiguration check because loopback is the shipped default for local
+# development and genuinely works for a client on the same host.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", "ip6-localhost"})
+
+
+def _host_is_loopback(host: str) -> bool:
+    """Whether `host` refers to the local machine."""
+    if host.lower() in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _unroutable_host_reason(host: str) -> str | None:
+    """Return why `host` is unreachable from outside the deployment, or None.
+
+    Loopback is deliberately NOT reported here: it is the shipped default for
+    local development and is usable by a client on the same host, so the caller
+    reports it separately at a lower level rather than as a misconfiguration.
+
+    Args:
+        host: Hostname or IP literal taken from a configured URL.
+
+    Returns:
+        A human-readable reason, or None if the host looks externally routable.
+    """
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Not an IP literal. A name with no dot is a container/service DNS name
+        # (e.g. "keycloak"), which resolves only inside the deployment network.
+        if host.lower() in _LOOPBACK_HOSTNAMES or "." in host:
+            return None
+        return (
+            f"'{host}' is a single-label hostname, which normally means a container "
+            f"or service DNS name that resolves only inside the deployment network"
+        )
+
+    if ip.is_loopback:
+        return None
+    if ip.is_private or ip.is_link_local or ip.is_reserved:
+        return f"'{host}' is a private or non-routable address"
+    return None
+
+
+def _check_keycloak_external_url(external_url: str, *, configured: bool) -> None:
+    """Log a startup diagnostic when the advertised Keycloak URL cannot work.
+
+    Both the registry and the auth server publish this value in their OAuth
+    discovery documents (`.well-known/oauth-authorization-server`). A value that
+    resolves only inside the container network produces a well-formed metadata
+    document that no external MCP client can act on. Nothing fails server-side,
+    and the client sees a generic OAuth error, so the misconfiguration is close
+    to invisible without this line.
+
+    Args:
+        external_url: The URL that will be advertised to external clients.
+        configured: Whether KEYCLOAK_EXTERNAL_URL was actually set, as opposed
+            to having fallen back to the internal KEYCLOAK_URL.
+    """
+    if not configured:
+        logger.warning(
+            f"KEYCLOAK_EXTERNAL_URL is not set, so OAuth discovery metadata will advertise "
+            f"the internal URL '{external_url}'. External MCP clients cannot reach it. Set "
+            f"KEYCLOAK_EXTERNAL_URL to the address clients use to reach this deployment."
+        )
+        return
+
+    host = urlparse(external_url).hostname
+    if not host:
+        logger.warning(
+            f"KEYCLOAK_EXTERNAL_URL '{external_url}' has no host component, so the OAuth "
+            f"discovery metadata built from it will not be usable by external clients."
+        )
+        return
+
+    reason = _unroutable_host_reason(host)
+    if reason:
+        logger.warning(
+            f"KEYCLOAK_EXTERNAL_URL '{external_url}' is advertised in OAuth discovery "
+            f"metadata, but {reason}. External MCP clients will fail discovery."
+        )
+    elif _host_is_loopback(host):
+        logger.info(
+            f"KEYCLOAK_EXTERNAL_URL '{external_url}' is a loopback address, so OAuth "
+            f"discovery only works for clients on this host. Set it to the deployment's "
+            f"externally reachable address to admit remote clients."
+        )
 
 
 def _parse_allowed_audiences(env_var: str) -> list[str]:
@@ -106,6 +201,10 @@ def _create_keycloak_provider() -> KeycloakProvider:
 
     logger.info(
         f"Initializing Keycloak provider for realm '{realm}' at {keycloak_url} (external: {keycloak_external_url})"
+    )
+    _check_keycloak_external_url(
+        keycloak_external_url,
+        configured="KEYCLOAK_EXTERNAL_URL" in os.environ,
     )
 
     return KeycloakProvider(

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -148,6 +148,10 @@ services:
       - AUTH_PROVIDER=${AUTH_PROVIDER:-cognito}
       - KEYCLOAK_ENABLED=${KEYCLOAK_ENABLED:-false}
       - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080}
+      # Externally reachable Keycloak URL. The registry serves the OAuth
+      # discovery documents, so without this it advertises the internal
+      # Docker DNS name and no external MCP client can complete the flow.
+      - KEYCLOAK_EXTERNAL_URL=${KEYCLOAK_EXTERNAL_URL:-http://localhost:8080}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-mcp-gateway}
       - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-mcp-gateway-web}
       - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}

--- a/tests/auth_server/unit/providers/test_keycloak.py
+++ b/tests/auth_server/unit/providers/test_keycloak.py
@@ -894,3 +894,91 @@ class TestKeycloakAuthorizationServerMetadata:
         assert (
             provider.authorization_server_issuer() == "https://auth.example.com/realms/test-realm"
         )
+
+
+# =============================================================================
+# KEYCLOAK_EXTERNAL_URL STARTUP DIAGNOSTIC
+# =============================================================================
+
+
+class TestKeycloakExternalUrlDiagnostic:
+    """The factory must say so at startup when the advertised URL cannot work.
+
+    The registry and the auth server publish KEYCLOAK_EXTERNAL_URL in their OAuth
+    discovery documents. A value that resolves only inside the container network
+    yields a well-formed metadata document that no external MCP client can act
+    on: nothing fails server-side and the client reports a generic OAuth error,
+    so without a startup line the misconfiguration is effectively invisible.
+    """
+
+    def _create(self, monkeypatch, external_url: str | None):
+        """Build a Keycloak provider through the factory with a patched env."""
+        from auth_server.providers import factory
+
+        monkeypatch.setenv("KEYCLOAK_URL", "http://keycloak:8080")
+        monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "test-client")
+        monkeypatch.setenv("KEYCLOAK_CLIENT_SECRET", "test-secret")
+        if external_url is None:
+            monkeypatch.delenv("KEYCLOAK_EXTERNAL_URL", raising=False)
+        else:
+            monkeypatch.setenv("KEYCLOAK_EXTERNAL_URL", external_url)
+        return factory._create_keycloak_provider()
+
+    def test_unset_external_url_warns(self, monkeypatch, caplog):
+        """An unset variable silently advertises the internal URL, so warn."""
+        with caplog.at_level(logging.WARNING, logger="auth_server.providers.factory"):
+            provider = self._create(monkeypatch, None)
+
+        assert provider.keycloak_external_url == "http://keycloak:8080"
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("KEYCLOAK_EXTERNAL_URL is not set" in m for m in warnings), warnings
+
+    @pytest.mark.parametrize(
+        "external_url",
+        [
+            "http://keycloak:8080",  # container DNS name, the reported case
+            "http://10.0.1.5:8080",  # RFC 1918
+            "http://192.168.1.10:8080",  # RFC 1918
+            "http://169.254.10.10:8080",  # link-local
+            "http://203.0.113.10:8080",  # RFC 5737 documentation range
+        ],
+    )
+    def test_unroutable_external_url_warns(self, monkeypatch, caplog, external_url):
+        """A set-but-unroutable value is the same outage with a different cause."""
+        with caplog.at_level(logging.WARNING, logger="auth_server.providers.factory"):
+            self._create(monkeypatch, external_url)
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("fail discovery" in m for m in warnings), warnings
+
+    @pytest.mark.parametrize(
+        "external_url",
+        [
+            "https://gateway.example.com",
+            "https://gateway.example.com:8443",
+            "http://93.184.216.34:8080",  # globally routable literal
+        ],
+    )
+    def test_routable_external_url_is_silent(self, monkeypatch, caplog, external_url):
+        """A correctly configured deployment must not emit a warning every boot."""
+        with caplog.at_level(logging.WARNING, logger="auth_server.providers.factory"):
+            self._create(monkeypatch, external_url)
+
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert not warnings, warnings
+
+    @pytest.mark.parametrize(
+        "external_url",
+        ["http://localhost:8080", "http://127.0.0.1:8080"],
+    )
+    def test_loopback_external_url_is_not_a_warning(self, monkeypatch, caplog, external_url):
+        """Loopback is the shipped default for local dev, so it must not warn.
+
+        It is still worth an INFO line, because it does exclude remote clients.
+        """
+        with caplog.at_level(logging.INFO, logger="auth_server.providers.factory"):
+            self._create(monkeypatch, external_url)
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
+        assert any("only works for clients on this host" in m for m in infos), infos

--- a/tests/unit/test_compose_keycloak_external_url.py
+++ b/tests/unit/test_compose_keycloak_external_url.py
@@ -1,0 +1,114 @@
+"""Compose parity check for KEYCLOAK_EXTERNAL_URL.
+
+Both the registry and the auth server build OAuth discovery documents
+(`.well-known/oauth-authorization-server`) from KEYCLOAK_EXTERNAL_URL. When the
+variable is absent from a service's environment, `_create_keycloak_provider`
+falls back to KEYCLOAK_URL, so that service advertises the internal Docker DNS
+name. The response is a valid metadata document, nothing errors server-side, and
+external MCP clients fail OAuth discovery with a generic error.
+
+The variable has gone missing from a service before (issue #1649, and #1378 for
+the Podman stack), so this asserts the invariant across every compose file and
+every service that serves discovery metadata.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.unit]
+
+COMPOSE_FILES = [
+    "docker-compose.yml",
+    "docker-compose.prebuilt.yml",
+    "docker-compose.podman.yml",
+]
+
+# Services running an application that serves OAuth discovery metadata.
+DISCOVERY_SERVICES = ["registry", "auth-server"]
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    """Repository root directory."""
+    return Path(__file__).parent.parent.parent
+
+
+def _service_environment(compose_path: Path, service: str) -> dict[str, str]:
+    """Return a service's environment as a mapping.
+
+    Compose accepts both the ``KEY: value`` mapping form and the ``- KEY=value``
+    list form; normalise to a dict so assertions work against either.
+    """
+    data = yaml.safe_load(compose_path.read_text())
+    env = data["services"][service].get("environment", {}) or {}
+    if isinstance(env, dict):
+        return {str(k): str(v) for k, v in env.items()}
+    normalised: dict[str, str] = {}
+    for entry in env:
+        key, _, value = str(entry).partition("=")
+        normalised[key] = value
+    return normalised
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+@pytest.mark.parametrize("service", DISCOVERY_SERVICES)
+def test_discovery_service_receives_keycloak_external_url(
+    repo_root: Path,
+    compose_filename: str,
+    service: str,
+):
+    """Every service serving OAuth metadata must receive KEYCLOAK_EXTERNAL_URL.
+
+    Without it the service advertises the internal KEYCLOAK_URL, which no
+    external client can resolve, and the failure is silent server-side.
+    """
+    env = _service_environment(repo_root / compose_filename, service)
+
+    assert "KEYCLOAK_EXTERNAL_URL" in env, (
+        f"{compose_filename}: service '{service}' serves OAuth discovery metadata but does "
+        f"not receive KEYCLOAK_EXTERNAL_URL, so it will advertise the internal "
+        f"KEYCLOAK_URL that external MCP clients cannot reach."
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+@pytest.mark.parametrize("service", DISCOVERY_SERVICES)
+def test_keycloak_external_url_is_operator_overridable(
+    repo_root: Path,
+    compose_filename: str,
+    service: str,
+):
+    """The value must interpolate ``${KEYCLOAK_EXTERNAL_URL}`` from the operator's .env.
+
+    Hard-coding it would silently ignore the setting an operator puts in .env,
+    which is the same outage with a harder-to-find cause.
+    """
+    env = _service_environment(repo_root / compose_filename, service)
+    value = env["KEYCLOAK_EXTERNAL_URL"]
+
+    assert value.startswith("${KEYCLOAK_EXTERNAL_URL"), (
+        f"{compose_filename}: service '{service}' sets KEYCLOAK_EXTERNAL_URL to "
+        f"'{value}' instead of interpolating the operator's value from .env."
+    )
+
+
+@pytest.mark.parametrize("compose_filename", COMPOSE_FILES)
+@pytest.mark.parametrize("service", DISCOVERY_SERVICES)
+def test_internal_and_external_urls_are_both_present(
+    repo_root: Path,
+    compose_filename: str,
+    service: str,
+):
+    """KEYCLOAK_URL must remain alongside it: the two serve different traffic.
+
+    KEYCLOAK_URL is the container-to-container hop; KEYCLOAK_EXTERNAL_URL is what
+    leaves the deployment. Replacing one with the other breaks the opposite half.
+    """
+    env = _service_environment(repo_root / compose_filename, service)
+
+    assert "KEYCLOAK_URL" in env, (
+        f"{compose_filename}: service '{service}' is missing KEYCLOAK_URL, which is the "
+        f"URL used for container-to-container traffic."
+    )


### PR DESCRIPTION
Refs #1649

## Correction to the issue first

I filed #1649, and part of it was wrong. `docker-compose.yml` already passes `KEYCLOAK_EXTERNAL_URL` to the registry service, and has since d8543fe ("fix: Add KEYCLOAK_EXTERNAL_URL to registry service", #681, March 2026). The Podman stack and the Helm chart (via `oauthProviderSecretName`) carry it too.

Our deployment was built from a `docker-compose.yml` carried over from a 1.0.x release and never re-synced, so it predates that fix. The symptom was real, the diagnosis of *our* environment was not. Apologies for the noise.

The report's nginx observation is also not a bug: `registry/core/nginx_service.py` builds the Keycloak upstream from `KEYCLOAK_URL`, but that hop is container-to-container and must stay internal. The issue itself said as much.

Two things do remain, and this PR addresses them.

## 1. `docker-compose.prebuilt.yml` still omits it

The registry service there does not receive `KEYCLOAK_EXTERNAL_URL`. That is the quick-start path with prebuilt images, so it is the file a new operator is most likely to run.

Both the registry and the auth server build OAuth discovery documents from this value. Without it, `_create_keycloak_provider` falls back to `KEYCLOAK_URL`:

```python
# auth_server/providers/factory.py
keycloak_external_url = os.environ.get("KEYCLOAK_EXTERNAL_URL", keycloak_url)
```

so the service advertises the internal Docker DNS name. The response is a well-formed metadata document, nothing errors server-side, and external MCP clients fail discovery with a generic OAuth error.

Added the variable, plus a compose parity test covering every discovery-serving service in every compose file, so a third instance cannot land silently. There have now been two (#1378 for Podman, this one for prebuilt).

## 2. The fallback is silent, and a parity test cannot catch every case

A compose parity test does not help the case we actually hit: an operator running a compose file carried over from an older release. Nothing in the repo can assert on a file that is not in the repo. The only place that can catch it is the process that reads the value at startup.

So `_create_keycloak_provider` now says what is wrong instead of leaving it to be inferred from a client-side error:

| Configured value | Level |
|---|---|
| `KEYCLOAK_EXTERNAL_URL` unset | WARNING |
| single-label host (`keycloak`, i.e. container DNS) | WARNING |
| private, link-local or reserved address | WARNING |
| loopback (`localhost`, `127.0.0.1`) | INFO |
| globally routable | silent |

**Loopback is deliberately INFO, not WARNING.** It is the shipped default for local development and genuinely works for a client on the same host. Warning on it would fire on every default deployment and train operators to ignore the line, which is exactly the failure mode this is meant to prevent.

One detail worth flagging for reviewers: RFC 5737 documentation ranges (`203.0.113.0/24` and friends) are `is_private` on Python 3.12.4+, so they warn as well. That is correct behaviour, and the tests pin it so a future reader does not "fix" it back. I only found this because a fixture I had written as a routable example failed.

No behaviour changes beyond logging. The fallback itself is untouched, including its exact semantics for an empty-string value.

## Verification

New tests:

- `tests/auth_server/unit/providers/test_keycloak.py::TestKeycloakExternalUrlDiagnostic` — 11 cases across unset, unroutable, routable and loopback values.
- `tests/unit/test_compose_keycloak_external_url.py` — 18 cases asserting every discovery-serving service in every compose file receives the variable, that it interpolates from `.env` rather than being hard-coded, and that `KEYCLOAK_URL` remains alongside it.

Run locally with `--noconftest` (the full conftest pulls the whole registry dependency tree, which this environment does not have):

- `test_keycloak.py`: 33 passed, 8 errors.
- Same file on a clean tree: 22 passed, **the same 8 errors**. They are pre-existing fixtures unavailable under `--noconftest`, not regressions.
- `test_compose_keycloak_external_url.py`: 18 passed.

`pre-commit run --files <changed files>` passes with `SKIP=pytest-fast`, matching `.github/workflows/pre-commit.yaml`. Bandit and MyPy both run against `factory.py` and pass.