### PR TITLE
fix(servers): reject a half-filled provider pair with 400 instead of 500

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -1142,6 +1142,57 @@ def _normalize_server_path(path: str) -> str:
     return path
 
 
+def _build_provider_entry(
+    provider_organization: str | None,
+    provider_url: str | None,
+) -> dict[str, Any] | None:
+    """Build the nested provider object from the two provider form fields.
+
+    The pair is optional as a whole but meaningless half-filled: per the A2A
+    specification, and per ``AgentProvider``'s own required fields, a provider
+    that is present must carry both an organization and a URL.
+
+    A blank or whitespace-only field counts as absent. An HTML form submits an
+    empty string for a field the user left alone, so treating ``""`` as a value
+    would store a provider with an empty organization -- valid to Pydantic,
+    useless to a reader.
+
+    Args:
+        provider_organization: Raw ``provider_organization`` form field.
+        provider_url: Raw ``provider_url`` form field.
+
+    Returns:
+        The serialized provider object, or None when neither field was supplied
+        so the caller omits ``provider`` entirely.
+
+    Raises:
+        HTTPException: 400 naming the missing field when exactly one is given.
+            Building ``AgentProvider`` with a None field raises a Pydantic
+            ValidationError that no handler catches, which surfaces as a 500
+            with nothing to indicate which field was at fault (issue #1651).
+    """
+    from ..schemas.agent_models import AgentProvider
+
+    organization = (provider_organization or "").strip() or None
+    url = (provider_url or "").strip() or None
+
+    if organization is None and url is None:
+        return None
+
+    if organization is None or url is None:
+        missing = "provider_organization" if organization is None else "provider_url"
+        supplied = "provider_url" if organization is None else "provider_organization"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"'{missing}' is required when '{supplied}' is supplied. "
+                f"Provider organization and URL must be given together, or both left empty."
+            ),
+        )
+
+    return AgentProvider(organization=organization, url=url).model_dump()
+
+
 def _to_dt(value: Any) -> datetime | None:
     """Coerce a stored timestamp value into a datetime.
 
@@ -1579,14 +1630,11 @@ async def register_service(
     if effective_status:
         server_entry["status"] = effective_status
 
-    # Add provider information (stored as nested AgentProvider object)
-    if provider_organization or provider_url:
-        from ..schemas.agent_models import AgentProvider
-
-        server_entry["provider"] = AgentProvider(
-            organization=provider_organization,
-            url=provider_url,
-        ).model_dump()
+    # Add provider information (stored as nested AgentProvider object).
+    # A half-filled pair is rejected with a 400 naming the missing field.
+    provider_entry = _build_provider_entry(provider_organization, provider_url)
+    if provider_entry is not None:
+        server_entry["provider"] = provider_entry
 
     # Add source timestamps
     if source_created_at:
@@ -4118,14 +4166,11 @@ async def register_service_api(
     if effective_status:
         server_entry["status"] = effective_status
 
-    # Add provider information
-    if provider_organization or provider_url:
-        from ..schemas.agent_models import AgentProvider
-
-        server_entry["provider"] = AgentProvider(
-            organization=provider_organization,
-            url=provider_url,
-        ).model_dump()
+    # Add provider information. A half-filled pair is rejected with a 400
+    # naming the missing field.
+    provider_entry = _build_provider_entry(provider_organization, provider_url)
+    if provider_entry is not None:
+        server_entry["provider"] = provider_entry
 
     # Add source timestamps
     if source_created_at:

--- a/tests/unit/api/test_provider_pair_validation.py
+++ b/tests/unit/api/test_provider_pair_validation.py
@@ -1,0 +1,112 @@
+"""Unit tests for _build_provider_entry in server_routes.py.
+
+Provider organization and URL are only meaningful as a pair. Before issue #1651
+the two form handlers guarded on ``or``, so a half-filled pair entered the branch
+and constructed ``AgentProvider`` with one field set to None. ``AgentProvider``
+requires both, so Pydantic raised a ValidationError that no handler caught, and
+the caller got a 500 with nothing indicating which field was at fault.
+
+These tests pin the three outcomes: both absent is valid and yields no provider,
+exactly one is a 400 naming the missing field, and both present builds the entry.
+"""
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from registry.api.server_routes import _build_provider_entry
+
+
+class TestBuildProviderEntry:
+    """Tests for the shared provider-pair helper."""
+
+    # -- Neither field supplied: the pair is optional as a whole ------------
+
+    def test_both_none_returns_none(self):
+        """Omitting the provider entirely stays valid."""
+        assert _build_provider_entry(None, None) is None
+
+    def test_both_empty_strings_return_none(self):
+        """An HTML form submits "" for a field the user left alone."""
+        assert _build_provider_entry("", "") is None
+
+    def test_both_whitespace_return_none(self):
+        """Whitespace-only is the same as blank, not a value."""
+        assert _build_provider_entry("   ", "\t\n ") is None
+
+    # -- Exactly one field supplied: 400, never a 500 -----------------------
+
+    def test_organization_without_url_is_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _build_provider_entry("Example Org", None)
+        assert exc_info.value.status_code == 400
+        assert "provider_url" in exc_info.value.detail
+
+    def test_url_without_organization_is_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _build_provider_entry(None, "https://example.com")
+        assert exc_info.value.status_code == 400
+        assert "provider_organization" in exc_info.value.detail
+
+    def test_organization_with_blank_url_is_400(self):
+        """The form case: the field is submitted but left empty."""
+        with pytest.raises(HTTPException) as exc_info:
+            _build_provider_entry("Example Org", "  ")
+        assert exc_info.value.status_code == 400
+        assert "provider_url" in exc_info.value.detail
+
+    def test_blank_organization_with_url_is_400(self):
+        with pytest.raises(HTTPException) as exc_info:
+            _build_provider_entry("", "https://example.com")
+        assert exc_info.value.status_code == 400
+        assert "provider_organization" in exc_info.value.detail
+
+    @pytest.mark.parametrize(
+        ("organization", "url"),
+        [
+            ("Example Org", None),
+            (None, "https://example.com"),
+            ("Example Org", ""),
+            ("", "https://example.com"),
+        ],
+    )
+    def test_half_filled_pair_never_raises_validation_error(self, organization, url):
+        """The regression: a half-filled pair must not reach Pydantic.
+
+        An uncaught ValidationError is what produced the unhandled 500. Asserting
+        the exception type (not just the status code) pins the fix at the layer
+        it belongs to, so a future refactor cannot reintroduce the 500 while
+        still returning 400 on some other path.
+        """
+        with pytest.raises(HTTPException):
+            _build_provider_entry(organization, url)
+
+        with pytest.raises(HTTPException):  # i.e. not ValidationError
+            try:
+                _build_provider_entry(organization, url)
+            except ValidationError as exc:  # pragma: no cover - fails the test
+                pytest.fail(f"half-filled pair reached Pydantic: {exc}")
+
+    def test_error_message_names_both_fields(self):
+        """The message must say what to supply, not just that something is wrong."""
+        with pytest.raises(HTTPException) as exc_info:
+            _build_provider_entry("Example Org", None)
+        detail = exc_info.value.detail
+        assert "provider_url" in detail
+        assert "provider_organization" in detail
+
+    # -- Both fields supplied: build the entry ------------------------------
+
+    def test_both_supplied_builds_entry(self):
+        result = _build_provider_entry("Example Org", "https://example.com")
+        assert result == {"organization": "Example Org", "url": "https://example.com"}
+
+    def test_values_are_stripped(self):
+        """Leading/trailing whitespace from a form field is not part of the value."""
+        result = _build_provider_entry("  Example Org  ", "  https://example.com  ")
+        assert result == {"organization": "Example Org", "url": "https://example.com"}
+
+    def test_result_is_a_plain_dict(self):
+        """Callers assign the result straight into the server document."""
+        result = _build_provider_entry("Example Org", "https://example.com")
+        assert isinstance(result, dict)


### PR DESCRIPTION
Fixes #1651

## What was wrong

`provider_organization` and `provider_url` are only meaningful as a pair. Both form handlers guarded on `or`, so a half-filled pair entered the branch and constructed `AgentProvider` with one field set to None. `AgentProvider` requires both — per the A2A specification, quoted in the model's own docstring — so Pydantic raised a `ValidationError` that no handler catches, and the caller got a 500 with nothing indicating which field was at fault.

While fixing it I found the pair has a second, quieter failure mode. **An HTML form submits an empty string for a field the user left alone, not None.** And `AgentProvider(organization="", url="https://example.com")` passes Pydantic without complaint, because `str` has no minimum length. So the same half-filled pair produces one of two wrong outcomes depending on whether the frontend omits the empty field or submits it blank:

| Submitted | Before |
|---|---|
| `organization` set, `url` omitted | unhandled 500 |
| `organization` set, `url` empty string | provider stored with an empty URL |

Both call sites named in the issue are affected — `register_service` and the server update handler.

## The fix

A single `_build_provider_entry` helper replaces the inline construction at both call sites. `None`, empty and whitespace-only are treated alike as absent:

| Input | Result |
|---|---|
| neither field | no provider; the pair stays optional as a whole |
| exactly one field | **400** naming the missing field |
| both fields | provider built, values stripped |

The issue suggested expressing the constraint on the request model rather than in each handler. That does not apply directly here: both handlers take `Annotated[str | None, Form()]` parameters, not a model. A shared helper achieves the same goal — one rule instead of three — and keeps the 400 at the layer that can name the field.

The issue also noted that changing `or` to `and` would fix the 500 while silently discarding a half-filled pair. This does not do that: a half-filled pair is rejected, not dropped.

## The JSON API path was never broken

`PUT /servers/{path}` (`server_routes.py:6146`) takes a Pydantic body with `provider: AgentProvider`, so FastAPI validates it and returns 422 for a half-filled pair. No change needed there, and none made.

## Verification

New tests in `tests/unit/api/test_provider_pair_validation.py` — 15 cases across all three outcomes, including the four half-filled permutations, whitespace handling, and stripping.

One test deliberately asserts the **exception type**, not just the status code: a half-filled pair must raise `HTTPException` and never reach Pydantic. An uncaught `ValidationError` is what produced the 500, so pinning the type stops a future refactor from reintroducing it while still returning 400 on some other path.

## A sibling for maintainers to decide on

Per the repo's own standing rule about grepping a fixed pattern repo-wide, two further places build `AgentProvider` from a possibly half-filled pair:

- `registry/api/agent_routes.py:999`
- `registry/services/agent_batch_item_processor.py:158`

Both do `request.provider.get("organization", "")`. No 500 there — the empty-string default sidesteps it — but they persist a provider with an empty organization, which contradicts the A2A requirement that `AgentProvider`'s docstring cites.

**I left them untouched.** Rejecting those with a 400 would be a behaviour change in the agent API, and existing clients may rely on the current leniency. That is a maintainer call, not mine. Happy to apply the same helper there in this PR or a follow-up, whichever you prefer.
