### PR TITLE
test(nginx): cover absolute_redirect off in front-door server blocks

### DIFF
--- a/tests/unit/core/test_nginx_absolute_redirect.py
+++ b/tests/unit/core/test_nginx_absolute_redirect.py
@@ -1,0 +1,71 @@
+"""The front-door nginx templates must not emit absolute redirects.
+
+Issue #1606: the #1501 fix made generated location blocks trailing-slash
+terminated, so a request to a registered MCP server *without* the trailing
+slash now hits nginx's automatic "add the slash" 301. With ``absolute_redirect``
+at its nginx default (on), that Location is rebuilt from the listener that
+served the request -- ``http://`` and the internal container port 8080/8443 --
+which is not routable from outside the cluster, and TLS terminates upstream
+anyway. MCP clients follow the redirect and hang until they time out.
+
+``absolute_redirect off`` makes nginx send a relative Location, so the client
+stays on the origin it dialed. It has to be set in every server block: the
+internal port is baked into the redirect by whichever listener answered.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DOCKER_DIR = Path(__file__).resolve().parents[3] / "docker"
+_TEMPLATES = (
+    "nginx_rev_proxy_http_and_https.conf",
+    "nginx_rev_proxy_http_only.conf",
+)
+
+
+def _server_blocks(text: str) -> list[str]:
+    """Split a config into its top-level ``server { ... }`` blocks.
+
+    Top-level only: the templates nest ``location``/``if`` blocks several levels
+    deep, so this brace-counts from each ``server {`` at column 0 rather than
+    trying to match with a regex.
+    """
+    blocks = []
+    for match in re.finditer(r"^server \{", text, re.MULTILINE):
+        depth = 0
+        for index in range(match.start(), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(text[match.start() : index + 1])
+                    break
+    return blocks
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_every_server_block_disables_absolute_redirect(template: str) -> None:
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    blocks = _server_blocks(text)
+    assert blocks, f"no server blocks found in {template}"
+
+    for block in blocks:
+        listen = re.search(r"^\s*listen ([^;]+);", block, re.MULTILINE)
+        listen_desc = listen.group(1) if listen else "unknown"
+        assert re.search(r"^\s*absolute_redirect off;", block, re.MULTILINE), (
+            f"{template}: server block listening on {listen_desc!r} does not set "
+            "'absolute_redirect off', so nginx's automatic trailing-slash 301 "
+            "would leak the internal scheme and port to MCP clients (#1606)"
+        )
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_absolute_redirect_is_never_re_enabled(template: str) -> None:
+    """A later ``absolute_redirect on`` would silently undo this per-scope."""
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    assert not re.search(r"^\s*absolute_redirect\s+on;", text, re.MULTILINE)


### PR DESCRIPTION
## Summary

Adds regression coverage for the relative-nginx-redirect fix that shipped in #1635 (which closed #1606) but **without any tests**. `main` currently has the fix and nothing guarding it against a future regression; this closes that gap.

## Credit

The test is authored by @rahul188 (git authorship preserved on the commit), originally submitted in #1620. That PR also re-applied the `absolute_redirect off;` config change that #1635 had already merged, so it could not be merged as-is — merging the duplicated directive would fail `nginx -t` (`"absolute_redirect" directive is duplicate`). This PR salvages the valuable half — the tests — and drops the redundant config edits. Thanks to @rahul188 for the coverage, and to @zsxh1990 whose #1610 the original fix adopted.

## What it tests

`tests/unit/core/test_nginx_absolute_redirect.py`, 4 tests (parametrized over both templates):

- `test_every_server_block_disables_absolute_redirect` — brace-counts the top-level `server { }` blocks in `nginx_rev_proxy_http_and_https.conf` and `nginx_rev_proxy_http_only.conf` and asserts each sets `absolute_redirect off`. Reports the offending block's `listen` line, so a future server block added without it fails with a message naming which one.
- `test_absolute_redirect_is_never_re_enabled` — guards against a later `absolute_redirect on` silently undoing the fix in a narrower scope.

## Verification

All 4 pass unmodified against current `main` (which already carries #1635's config). Closes the test-coverage gap left by #1635.

Relates to #1606, #1620, #1635.