### PR TITLE
fix(nginx): remove duplicate absolute_redirect directive (breaks nginx -t)

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -165,8 +165,6 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
-    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
-    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};
@@ -1093,8 +1091,6 @@ server {
 
 # Keep the HTTPS server for clients that prefer it
 server {
-    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
-    absolute_redirect off;
     listen 8443 ssl;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -166,8 +166,6 @@ map $host $rl_retry {
 {{VERSION_MAP}}
 # First server block now directly handles HTTP requests instead of redirecting
 server {
-    # Use relative redirects to avoid leaking internal scheme/port behind TLS-terminating proxies
-    absolute_redirect off;
     listen 8080;
     # {{ADDITIONAL_SERVER_NAMES}} is replaced with custom domains/IPs for gateway access
     server_name localhost {{ADDITIONAL_SERVER_NAMES}};


### PR DESCRIPTION
## Problem — `main` is currently broken

#1620 merged `absolute_redirect off;` into each front-door `server` block, but #1635 had **already** added it to those same blocks (closing #1606). The result is **two identical `absolute_redirect off;` directives per block**:

- `docker/nginx_rev_proxy_http_and_https.conf`: `:8080` block and `:8443` ssl block (2 each)
- `docker/nginx_rev_proxy_http_only.conf`: `:8080` block

nginx rejects a duplicated simple flag directive at parse time:

```
nginx: [emerg] "absolute_redirect" directive is duplicate
```

so the gateway container **fails to start** on current `main`.

### Why nothing caught it

- The test added in #1620 (`test_nginx_absolute_redirect.py`) asserts each block *disables* `absolute_redirect` — a duplicate still satisfies that, so the test passes.
- CI has no `nginx -t` step (no nginx binary in the unit-test env), which #1620 explicitly flagged as a gap.

## Fix

Remove the terse earlier copy and keep the single, fully-commented directive per block. Net: one `absolute_redirect off;` per front-door server block, behavior identical to the intended #1635/#1620 outcome.

## Verification

- `grep -c` confirms one directive per block (http_only: 1; http_and_https: 2, one per listener).
- `tests/unit/core/test_nginx_absolute_redirect.py`: 4 passed.
- Recommend a container `nginx -t` smoke test before merge to close the CI gap for good.

Fixes the regression from #1620. Relates to #1606, #1635.