### PR TITLE
fix(lua): fail-closed caller-identity headers on virtual server path (follow-up to #1627)

### DIFF
--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -87,6 +87,39 @@ local function _auth_user_id()
 end
 
 
+-- Forward the validated caller identity to backend subrequests, fail-closed.
+--
+-- auth_request_set variables ($auth_user, $auth_username) are scoped to the
+-- parent request and do NOT propagate into ngx.location.capture subrequests
+-- via proxy_set_header, so we copy them onto request headers here; the
+-- _vs_backend_* locations then forward them to the upstream MCP server via
+-- $http_x_user/$http_x_username, enabling backends to enforce write-gates and
+-- record audit attribution.
+--
+-- SECURITY: $http_x_user is a CLIENT-controllable request header. The backend
+-- value must be the gateway-validated identity or nothing -- never a value the
+-- caller supplied. When auth_user is empty (e.g. an M2M / client-credentials
+-- token that authenticates with a client_id but no user), we must CLEAR any
+-- inbound X-User rather than leave it intact, otherwise a caller could spoof
+-- X-User to the backend. This mirrors the direct-server path, which forwards
+-- `proxy_set_header X-User $auth_user;` unconditionally so a client header can
+-- never survive. Always overwrite or clear; never pass through.
+local function _forward_identity_headers()
+    local auth_user = ngx.var.auth_user
+    local auth_username = ngx.var.auth_username
+    if auth_user and auth_user ~= "" then
+        ngx.req.set_header("X-User", auth_user)
+    else
+        ngx.req.clear_header("X-User")
+    end
+    if auth_username and auth_username ~= "" then
+        ngx.req.set_header("X-Username", auth_username)
+    else
+        ngx.req.clear_header("X-Username")
+    end
+end
+
+
 -- Ensure inputSchema has "type": "object" as required by MCP spec
 local function _ensure_mcp_schema(schema)
     if not schema or type(schema) ~= "table" then
@@ -962,20 +995,9 @@ function _M.route()
     -- all ngx.location.capture subrequests to backends inherit it.
     ngx.req.set_header("Accept", "application/json, text/event-stream")
 
-    -- Forward the validated caller identity to backend subrequests.
-    -- auth_request_set variables ($auth_user, $auth_username) are scoped to the
-    -- parent request and do NOT propagate into ngx.location.capture subrequests
-    -- via proxy_set_header. Setting them as request headers here ensures the
-    -- _vs_backend_* locations pass them through to the upstream MCP server,
-    -- enabling backends to enforce write-gates and record audit attribution.
-    local auth_user = ngx.var.auth_user
-    local auth_username = ngx.var.auth_username
-    if auth_user and auth_user ~= "" then
-        ngx.req.set_header("X-User", auth_user)
-    end
-    if auth_username and auth_username ~= "" then
-        ngx.req.set_header("X-Username", auth_username)
-    end
+    -- Forward the validated caller identity to backend subrequests (fail-closed:
+    -- always the gateway-validated value or cleared, never a client-supplied one).
+    _forward_identity_headers()
 
     local request_method = ngx.var.request_method
 
@@ -1214,6 +1236,7 @@ if _G._VR_TEST then
     _M._fetch_backend_tools_list = _fetch_backend_tools_list
     _M._append_mapping_tools_for_backend = _append_mapping_tools_for_backend
     _M._handle_tools_list = _handle_tools_list
+    _M._forward_identity_headers = _forward_identity_headers
     return _M
 end
 

--- a/tests/lua/test_virtual_router.lua
+++ b/tests/lua/test_virtual_router.lua
@@ -49,7 +49,13 @@ _G.ngx = {
     location = {
         capture = function(loc, _opts) return capture_responses[loc] end,
     },
-    req = { set_header = function() end },
+    -- Stateful request-header mock so tests can seed a client-supplied header
+    -- and observe whether set_header overwrote it or clear_header removed it.
+    req = {
+        _headers = {},
+        set_header = function(k, v) _G.ngx.req._headers[k] = v end,
+        clear_header = function(k) _G.ngx.req._headers[k] = nil end,
+    },
     log = function() end,
     ERR = 4,
     WARN = 5,
@@ -150,6 +156,49 @@ do
 
     M._handle_tools_list("1", mapping, "", nil, "srv2")
     check(dict._store["tools_enriched:srv2"] ~= nil, "fully-discovered result IS cached")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _forward_identity_headers overwrites a spoofed client X-User")
+do
+    -- Client tries to spoof identity; a validated user is present.
+    ngx.req._headers = { ["X-User"] = "attacker", ["X-Username"] = "attacker" }
+    ngx.var.auth_user = "alice"
+    ngx.var.auth_username = "alice@corp"
+    M._forward_identity_headers()
+    check(ngx.req._headers["X-User"] == "alice",
+        "validated auth_user overwrites the client-supplied X-User")
+    check(ngx.req._headers["X-Username"] == "alice@corp",
+        "validated auth_username overwrites the client-supplied X-Username")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _forward_identity_headers CLEARS a spoofed X-User when auth_user is empty")
+do
+    -- M2M / client-credentials token: authenticates but carries no user, so
+    -- nginx auth_request_set yields "" for $auth_user. A client-supplied X-User
+    -- must NOT survive to the backend (this is the fail-open bug from #1627).
+    ngx.req._headers = { ["X-User"] = "attacker", ["X-Username"] = "attacker" }
+    ngx.var.auth_user = ""
+    ngx.var.auth_username = ""
+    M._forward_identity_headers()
+    check(ngx.req._headers["X-User"] == nil,
+        "empty auth_user clears the client-supplied X-User (no spoof passthrough)")
+    check(ngx.req._headers["X-Username"] == nil,
+        "empty auth_username clears the client-supplied X-Username")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: _forward_identity_headers CLEARS a spoofed X-User when auth_user is nil")
+do
+    ngx.req._headers = { ["X-User"] = "attacker", ["X-Username"] = "attacker" }
+    ngx.var.auth_user = nil
+    ngx.var.auth_username = nil
+    M._forward_identity_headers()
+    check(ngx.req._headers["X-User"] == nil,
+        "nil auth_user clears the client-supplied X-User")
+    check(ngx.req._headers["X-Username"] == nil,
+        "nil auth_username clears the client-supplied X-Username")
 end
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #1627, addressing the fail-open identity-forwarding raised in review. #1627 added caller-identity forwarding (`X-User`/`X-Username`) to virtual-server backends — important functionality — but did so **fail-open**. This PR makes it fail-closed.

## The problem

The `_vs_backend` location forwards identity from `$http_x_user` — a **client-controllable request header** — and `virtual_router.lua` only overwrote it when `auth_user` was non-empty:

```lua
if auth_user and auth_user ~= "" then
    ngx.req.set_header("X-User", auth_user)
end   -- no else: client-supplied X-User survives when auth_user is empty
```

When `$auth_user` is empty, a caller can send `X-User: victim` and have it forwarded to the backend, forging the identity the backend uses for write-gates and audit attribution. The direct-server path is not vulnerable because it forwards `proxy_set_header X-User $auth_user;` unconditionally, so a client header is never read.

## Exploitability is IdP-dependent (important scoping)

The vulnerable code is IdP-agnostic, but whether it can actually be **triggered** depends on whether a *valid* token can produce an empty `X-User`. `$auth_user` is whatever the auth-server put in `X-User` when validating the token, and that comes from the token's resolved `username`:

- **Cognito — EXPLOITABLE.** A machine-to-machine (`client_credentials`) token carries no username claim, so the auth-server returns `valid: true` with `username = ""` (`auth_server/server.py` ~L2529; see also the auth-server's own note that "a Cognito M2M token does not [carry username]"). That yields an empty `X-User` → the fail-open branch runs → a spoofed `X-User` reaches the backend.
- **Keycloak — NOT exploitable.** `username = preferred_username or sub` (`auth_server/providers/keycloak.py` ~L179); a service-account/M2M token has `preferred_username = service-account-*` and `sub` is always present, so `X-User` is never empty and the Lua always overwrites a spoofed value.

Empirically confirmed against a live **Keycloak** stack: minted a real M2M token and validated it directly — the auth-server always emits a non-empty `X-User`, so the spoof is neutralized even before this fix on Keycloak. The exploit is specific to **Cognito** deployments (and any future provider / config / `/validate` success path that can return an empty username).

Because the platform is explicitly **IdP-agnostic**, "exploitable on Cognito, defense-in-depth on Keycloak" still warrants the fail-closed fix.

## The fix

Extract the logic into `_forward_identity_headers()` and make it **fail closed** — always set the header from the gateway-validated value, or **clear** it when there is no validated user, so a client-supplied value can never pass through regardless of IdP:

```lua
if auth_user and auth_user ~= "" then ngx.req.set_header("X-User", auth_user)
else ngx.req.clear_header("X-User") end
-- same for X-Username
```

## Tests

New cases in `tests/lua/test_virtual_router.lua` (runs in the existing `lua-test.yml` CI lane):

- validated `auth_user` **overwrites** a spoofed client `X-User`;
- empty `auth_user` **clears** a spoofed `X-User` (red against #1627, green with this fix);
- nil `auth_user` clears too.

Verified locally with the CI toolchain:
- `luajit -bl docker/lua/virtual_router.lua` — parses clean.
- `luajit tests/lua/test_virtual_router.lua` — all 19 checks pass.
- `tests/unit/test_virtual_server_nginx.py` — 30 passed (config generator unchanged).

## Remaining follow-ups (tracked, not in this PR)

- **End-to-end spoofing test** in `tests/e2e/` on a **Cognito** stack (or a Keycloak client deliberately configured to omit `preferred_username`/`sub`), since a stock Keycloak stack cannot produce the empty-`X-User` precondition. Send a userless token + `X-User: victim`, assert the backend never receives `victim`.
- **Identity-header parity pass** for `X-Client-Id` / `X-Scopes` / `X-Groups` so the virtual path stays aligned with the direct path.

Relates to #1627, #1626.
