### PR TITLE
docs+hardening: metadata field projection follow-up (#1277)

### DIFF
--- a/docs/custom-metadata.md
+++ b/docs/custom-metadata.md
@@ -118,3 +118,5 @@ curl "https://registry.example.com/api/search?q=us-east-1 deployed"
 - [Service Management Guide](service-management.md)
 - [A2A Agent Guide](a2a.md)
 - [Semantic Search](design/hybrid-search-architecture.md)
+- [Metadata Field Projection](metadata-field-projection.md) — return only selected metadata fields on list and search responses
+- [FAQ: return only the metadata fields I need when listing or searching](faq/metadata-field-projection-search-listing.md)

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -12,6 +12,7 @@ Common questions and answers about the MCP Gateway Registry.
 - [How do I discover available MCP tools for my AI agent?](discovering-mcp-tools.md)
 - [How do I handle tool discovery when I don't know what tools are available?](agent-autonomous-tool-discovery.md)
 - [What filtering options are available for agents in the registry?](filtering-agents-by-tags-and-fields.md)
+- [How do I return only the metadata fields I need when listing or searching?](metadata-field-projection-search-listing.md)
 
 ## Connecting and Integration
 

--- a/docs/faq/metadata-field-projection-search-listing.md
+++ b/docs/faq/metadata-field-projection-search-listing.md
@@ -1,0 +1,86 @@
+# How do I return only the metadata fields I need when listing or searching?
+
+When you list or search servers, agents, or skills, the response includes each asset's full `metadata` subdocument. If that metadata holds large or deeply nested objects you don't need, add the `metadata_fields` parameter to project only the paths you care about. This shrinks the payload without changing any other field in the response.
+
+Omit the parameter and responses are unchanged, so this is a safe, opt-in addition to any existing integration.
+
+## The quick version
+
+Pass a comma-separated list of dot-notation paths:
+
+```bash
+# List: only the "owner" and the nested config.region metadata fields
+curl "http://localhost/api/servers?metadata_fields=owner,config.region" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+"metadata": { "owner": "team-platform", "config": { "region": "us-east-1" } }
+```
+
+Everything outside `metadata` (name, description, tags, endpoint, etc.) is always returned in full.
+
+## Which endpoints support it?
+
+Listing and single-GET for all three asset types, plus semantic search:
+
+| Where | How to pass it |
+|-------|----------------|
+| `GET /api/servers`, `GET /api/servers/{path}` | query param |
+| `GET /api/agents`, `GET /api/agents/{path}` | query param |
+| `GET /api/skills`, `GET /api/skills/{path}` | query param |
+| `POST /api/search/semantic` | `metadata_fields` field in the JSON body |
+
+## Search example
+
+```bash
+curl -X POST "http://localhost/api/search/semantic" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"query": "deployment tools", "metadata_fields": "owner,config.region"}'
+```
+
+Each returned asset's `metadata` is projected to the requested paths. An asset whose metadata does not contain a requested path simply returns `{}` (or `null` if it has no metadata at all) for that field — never an error.
+
+## Two ways to pass multiple fields
+
+Comma-separated and repeated query params are equivalent, and you can mix them:
+
+```
+?metadata_fields=owner,config.region
+?metadata_fields=owner&metadata_fields=config.region
+?metadata_fields=owner,config.region&metadata_fields=limits.rps
+```
+
+## From the CLI
+
+```bash
+registry_management.py list        --metadata-fields "owner,config.region" --json
+registry_management.py agent-list  --metadata-fields "team" --json
+registry_management.py skill-list  --metadata-fields "owner" --json
+registry_management.py server-search --query "tools" --metadata-fields "owner"
+```
+
+## A few behaviors worth knowing
+
+- **Nested paths** use dots: `config.region` returns `{"config": {"region": ...}}`.
+- **Ancestor wins:** if you request both `config` and `config.region`, you get the full `config` subtree (the ancestor already includes the descendant).
+- **Missing paths are dropped silently**, not errored — so you can request a superset of fields across a heterogeneous result set.
+- **Backward compatible:** leaving `metadata_fields` off returns full metadata exactly as before.
+
+## What gets rejected (HTTP 422)
+
+Input is validated at the API boundary and fails closed with a descriptive message:
+
+| Rule | Example that is rejected |
+|------|--------------------------|
+| At most 20 paths | 21 comma-separated fields |
+| At most 5 levels deep | `a.b.c.d.e.f` |
+| Segment at most 64 characters | a single 65-char segment |
+| No `$`-prefixed segment | `$set.injection` |
+| No empty segment | `config..region` |
+| Allowed characters only (letters incl. accented/non-Latin, digits, `_`, `-`) | `owner name`, `re@gion`, `own$er` |
+
+## See also
+
+- [Metadata Field Projection](../metadata-field-projection.md) — full reference, including the database-level projection and performance notes.
+- [Custom Metadata](../custom-metadata.md) — how to attach metadata to assets in the first place.

--- a/docs/metadata-field-projection.md
+++ b/docs/metadata-field-projection.md
@@ -105,6 +105,7 @@ Invalid input returns HTTP 422 with a descriptive error message.
 | Segment length | 64 characters | A single segment exceeding 64 chars |
 | No `$` prefix | Any segment | `?metadata_fields=$set.injection` |
 | No empty segments | Between dots | `?metadata_fields=config..region` |
+| Allowed characters only | Letters (incl. accented/non-Latin), digits, `_`, `-` | `?metadata_fields=owner name` or `re@gion` |
 
 ## Performance
 

--- a/docs/release-notes/1.30.0.md
+++ b/docs/release-notes/1.30.0.md
@@ -1,0 +1,54 @@
+# Release 1.30.0 - Metadata Field Projection
+
+**August 2026**
+
+---
+
+## Upgrading from 1.29.0
+
+This release adds an opt-in read-API capability and introduces **no breaking changes**. Existing list, single-GET, and semantic-search responses are unchanged unless a caller explicitly passes the new `metadata_fields` parameter.
+
+- **No action needed** for existing integrations.
+- **No new environment variables** and **no configuration changes** — the feature is a per-request API/CLI parameter, not a deployment setting.
+
+---
+
+## What's New
+
+### Metadata Field Projection (#1637, closes #1277)
+
+Read and search endpoints now accept an optional `metadata_fields` parameter that returns only the requested dot-notation paths from an asset's `metadata` subdocument. This lets API consumers shrink response payloads when metadata holds large or deeply nested objects they do not need, without affecting any other field in the response.
+
+- **Supported surfaces:** `GET /api/servers`, `GET /api/agents`, `GET /api/skills` and their single-asset variants (query parameter), plus `POST /api/search/semantic` (request-body field).
+- **Two input forms:** comma-separated (`?metadata_fields=owner,config.region`) and repeated query params (`?metadata_fields=owner&metadata_fields=config.region`), which may be mixed.
+- **CLI:** `--metadata-fields` on `list`, `agent-list`, `skill-list`, and `server-search`; `metadata_fields` on the client library's `semantic_search()` and `list_skills()`.
+- **Database-level projection:** the server list path projects the `metadata` subdocument inside MongoDB via an aggregation `$set` stage (avoiding transfer of large blobs), with a transparent Python fallback that is provably equivalent to the canonical projection.
+- **Backward compatible:** omitting `metadata_fields` returns full metadata exactly as before.
+
+Example:
+
+```bash
+curl "http://localhost/api/servers?metadata_fields=owner,config.region" \
+  -H "Authorization: Bearer $TOKEN"
+# -> "metadata": {"owner": "team-platform", "config": {"region": "us-east-1"}}
+```
+
+**Validation (fail-closed, HTTP 422):** at most 20 paths, at most 5 levels deep, segments at most 64 characters, no `$`-prefixed segments, no empty segments, and a positive character allowlist (letters — including accented/non-Latin — digits, `_`, and `-`). Invalid input is rejected at the API boundary with a descriptive message, and the projection cannot inject a MongoDB operator into the aggregation pipeline.
+
+See the [Metadata Field Projection reference](metadata-field-projection.md) and the [FAQ](faq/metadata-field-projection-search-listing.md) for full details and examples.
+
+### Documentation
+
+- New reference page and FAQ for metadata field projection; cross-linked from the Custom Metadata guide (#1277).
+
+---
+
+## Contributors
+
+- Metadata field projection: @cj-taylor (#1637)
+
+---
+
+## Support
+
+For questions or issues, please open a GitHub issue in the [mcp-gateway-registry](https://github.com/agentic-community/mcp-gateway-registry) repository.

--- a/registry/utils/metadata.py
+++ b/registry/utils/metadata.py
@@ -1,6 +1,12 @@
-"""Shared metadata utilities for keyword search and field projection."""
+"""Shared utilities for ``metadata_fields`` projection on the read/search APIs.
+
+Provides the parse/validate, ancestor-dedup normalization, the canonical Python
+projection (the "oracle"), and the MongoDB ``$set`` aggregation-stage builder used
+to project the ``metadata`` subdocument on servers, agents, and skills (Issue #1277).
+"""
 
 import logging
+import re
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -11,6 +17,15 @@ logger = logging.getLogger(__name__)
 MAX_METADATA_PATHS: int = 20
 MAX_PATH_DEPTH: int = 5
 MAX_SEGMENT_LENGTH: int = 64
+
+# Positive allowlist for a single dot-path segment: word characters (Unicode
+# letters of any script -- so accented/non-Latin metadata keys like ``café`` are
+# preserved -- plus digits and '_') and '-'. This is defense-in-depth on top of
+# the explicit empty/'$'-prefix checks -- it rejects any other character (spaces,
+# a mid-segment '$', '/', braces, operators, etc.) before a segment is
+# interpolated into a ``$metadata.<path>`` field reference or used as a ``$set``
+# object key.
+_VALID_SEGMENT: re.Pattern[str] = re.compile(r"[\w-]+")
 
 
 def parse_metadata_fields(
@@ -50,6 +65,11 @@ def parse_metadata_fields(
             if len(segment) > MAX_SEGMENT_LENGTH:
                 raise ValueError(
                     f"Path segment too long (max {MAX_SEGMENT_LENGTH} chars): '{segment}'"
+                )
+            if not _VALID_SEGMENT.fullmatch(segment):
+                raise ValueError(
+                    "Invalid path segment (allowed characters: letters, digits, "
+                    f"'_', '-'): '{segment}'"
                 )
         validated.append(path)
 
@@ -234,7 +254,7 @@ def parse_and_validate_metadata_fields(
         return parsed
     except ValueError as e:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid metadata_fields: {e}",
         ) from e
 

--- a/tests/unit/utils/test_metadata_projection.py
+++ b/tests/unit/utils/test_metadata_projection.py
@@ -74,6 +74,24 @@ class TestParseMetadataFields:
         with pytest.raises(ValueError, match="Path segment too long"):
             parse_metadata_fields(long_segment)
 
+    def test_mid_segment_dollar_raises(self) -> None:
+        # A '$' that is not the leading char passes the prefix check but is
+        # caught by the positive allowlist.
+        with pytest.raises(ValueError, match="allowed characters"):
+            parse_metadata_fields("own$er")
+
+    def test_space_in_segment_raises(self) -> None:
+        with pytest.raises(ValueError, match="allowed characters"):
+            parse_metadata_fields("owner name")
+
+    def test_special_char_in_segment_raises(self) -> None:
+        with pytest.raises(ValueError, match="allowed characters"):
+            parse_metadata_fields("config.re@gion")
+
+    def test_underscore_hyphen_digits_allowed(self) -> None:
+        result = parse_metadata_fields("owner_id,region-1,config.v2")
+        assert result == ["owner_id", "region-1", "config.v2"]
+
     def test_max_segment_length_ok(self) -> None:
         segment = "x" * 64
         result = parse_metadata_fields(segment)


### PR DESCRIPTION
Follow-up to #1637 (metadata field projection, closes #1277). Picks up the review's optional "nice-to-have" items and adds documentation. **No change to the feature's happy-path behavior.**

## Hardening (code)

`registry/utils/metadata.py`:

- **Positive character allowlist for path segments** — word characters (Unicode letters of any script, so accented / non-Latin metadata keys like `café` / `région` keep working, plus digits and `_`) and `-`. Defense-in-depth on top of the existing empty / `$`-prefix checks: it rejects spaces, a mid-segment `$`, braces, operators, and any other character before a segment is interpolated into a `$metadata.<path>` reference or used as a `$set` key.
- **`HTTP_422_UNPROCESSABLE_CONTENT`** at the projection validation raise site (clears the deprecated `ENTITY` alias). Scoped to this feature's raise site only — the many pre-existing `ENTITY` usages elsewhere are left untouched.
- **Tighter module docstring** describing field projection specifically.
- New unit tests for the allowlist (mid-`$`, space, special char, and the allowed `_`/`-`/digits case). The existing Unicode-field-name test still passes.

## Documentation

- **New FAQ:** `docs/faq/metadata-field-projection-search-listing.md` (task-oriented: "how do I return only the fields I need when listing/searching?"), registered in the FAQ index.
- **What's New:** `docs/release-notes/1.30.0.md`.
- **Reference doc:** the character allowlist added to the validation table in `docs/metadata-field-projection.md`.
- **Cross-links** from `docs/custom-metadata.md` to the feature reference and FAQ.

## Verification

- `tests/unit/utils/test_metadata_projection.py` + `tests/unit/api/test_server_routes.py`: 214 passed, 5 skipped.
- `ruff check` / `ruff format --check`: clean.
- `mypy` (v1.15.0, pre-commit args): no issues.

No configuration parameters changed (no unified-parameter-reference update needed).

Relates to #1277, #1637.