### PR TITLE
fix(1532): keep empty inputSchema arrays as [] (lua fix + OpenResty cjson runtime)

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -5400,11 +5400,19 @@ class RegistryClient:
         action = "enable" if enable else "disable"
         logger.info(f"Toggling virtual server {api_path}: {action}")
 
+        # The API exposes a single POST .../toggle endpoint that takes the
+        # desired state in the JSON body ({"enabled": true|false}); there are
+        # no separate /enable and /disable paths.
         response = self._make_request(
-            method="POST", endpoint=f"/api/virtual-servers{api_path}/{action}"
+            method="POST",
+            endpoint=f"/api/virtual-servers{api_path}/toggle",
+            data={"enabled": enable},
         )
 
+        # The toggle endpoint returns only {"path", "is_enabled"}; supply a
+        # human-readable message so VirtualServerToggleResponse validates.
         result = response.json()
+        result.setdefault("message", f"Virtual server {action}d successfully")
         logger.info(f"Virtual server {action}d: {result.get('is_enabled')}")
         return VirtualServerToggleResponse(**result)
 

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -57,6 +57,23 @@ COPY cli/examples/ /app/cli/examples/
 # deps already installed above by `uv sync --locked`).
 RUN . .venv/bin/activate && uv pip install --no-deps -e .
 
+# ===== OPENRESTY LUA-CJSON BUILD STAGE =====
+# The virtual_router.lua aggregation path relies on cjson.empty_array_mt to emit
+# empty JSON-Schema arrays (e.g. "required": []) as [] rather than {} (issue
+# #1532). That metatable is an OpenResty lua-cjson extension; Debian's lua-cjson
+# 2.1.0 lacks it (empty_array_mt == nil), so the tag would be a no-op and empty
+# arrays would serialize as {}. Build OpenResty's lua-cjson against the same
+# LuaJIT the nginx lua module (nginx-extras) uses, so `require "cjson"` at
+# runtime resolves to a cjson that honors empty_array_mt.
+FROM python:3.14.7-slim AS cjson-builder
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git build-essential libluajit-5.1-dev \
+ && git clone --depth 1 https://github.com/openresty/lua-cjson /tmp/lua-cjson \
+ && make -C /tmp/lua-cjson LUA_INCLUDE_DIR=/usr/include/luajit-2.1 \
+ && make -C /tmp/lua-cjson install LUA_CMODULE_DIR=/usr/local/lib/lua/5.1
+
+
 # ===== FINAL RUNTIME STAGE =====
 FROM python:3.14.7-slim AS runtime
 
@@ -85,13 +102,19 @@ ARG BUILD_VERSION="1.0.0"
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     nginx \
     nginx-extras \
-    lua-cjson \
     curl \
     procps \
     openssl \
     ca-certificates \
     logrotate \
     && rm -rf /var/lib/apt/lists/*
+
+# Ship OpenResty's lua-cjson (built in the cjson-builder stage) instead of the
+# Debian lua-cjson package. This is the cjson `require "cjson"` resolves to at
+# runtime and provides cjson.empty_array_mt, which the virtual router needs to
+# serialize empty JSON-Schema arrays as [] not {} (issue #1532). See the
+# lua_package_cpath in the generated nginx configs, which pins this location.
+COPY --from=cjson-builder /usr/local/lib/lua/5.1/cjson.so /usr/local/lib/lua/5.1/cjson.so
 
 WORKDIR /app
 

--- a/docker/Dockerfile.registry
+++ b/docker/Dockerfile.registry
@@ -68,10 +68,21 @@ RUN . .venv/bin/activate && uv pip install --no-deps -e .
 FROM python:3.14.7-slim AS cjson-builder
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git build-essential libluajit-5.1-dev \
+      git build-essential libluajit-5.1-dev lua5.1 \
  && git clone --depth 1 https://github.com/openresty/lua-cjson /tmp/lua-cjson \
  && make -C /tmp/lua-cjson LUA_INCLUDE_DIR=/usr/include/luajit-2.1 \
- && make -C /tmp/lua-cjson install LUA_CMODULE_DIR=/usr/local/lib/lua/5.1
+ && make -C /tmp/lua-cjson install LUA_CMODULE_DIR=/usr/local/lib/lua/5.1 \
+ # Guardrail: fail the build if the cjson we are about to ship lacks
+ # empty_array_mt, and confirm an empty array-tagged table encodes as [].
+ # This is the exact property virtual_router.lua depends on (issue #1532);
+ # asserting it here means a future base-image or source change that regresses
+ # cjson breaks the image build instead of silently shipping the old bug.
+ && lua5.1 -e "package.cpath='/usr/local/lib/lua/5.1/?.so;'..package.cpath; \
+      local c=require('cjson'); \
+      assert(c.empty_array_mt, 'FATAL: shipped lua-cjson lacks empty_array_mt'); \
+      local t=setmetatable({}, c.empty_array_mt); \
+      assert(c.encode({required=t})=='{\"required\":[]}', 'FATAL: empty array did not encode as []'); \
+      print('cjson empty_array_mt guardrail: OK')"
 
 
 # ===== FINAL RUNTIME STAGE =====

--- a/docker/auth-entrypoint.sh
+++ b/docker/auth-entrypoint.sh
@@ -48,7 +48,7 @@ if [ -n "$MONGODB_CONNECTION_STRING" ] || [ -n "$DOCUMENTDB_HOST" ]; then
     source /app/.venv/bin/activate
     python3 -c "
 import pymongo, os, re, time
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, quote_plus
 
 override = os.getenv('MONGODB_CONNECTION_STRING', '')
 if override:
@@ -66,7 +66,10 @@ else:
     ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
     auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
     if user and pwd:
-        uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+        # Escape credentials per RFC 3986 so passwords with reserved
+        # characters (e.g. after a Secrets Manager rotation) do not break
+        # the connection URI. Mirrors scripts/_mongo_conn_args.py.
+        uri = f'mongodb://{quote_plus(user)}:{quote_plus(pwd)}@{host}:{port}/?authMechanism={auth}&authSource=admin'
     else:
         uri = f'mongodb://{host}:{port}/'
     tls_options = {}

--- a/docker/lua/virtual_router.lua
+++ b/docker/lua/virtual_router.lua
@@ -120,11 +120,48 @@ local function _forward_identity_headers()
 end
 
 
+-- JSON Schema keywords whose value must serialize as an array.
+local SCHEMA_ARRAY_KEYS = {
+    required = true, enum = true, allOf = true, anyOf = true,
+    oneOf = true, examples = true, prefixItems = true,
+}
+
+-- Keywords holding a map of caller-chosen names to subschemas. A member named
+-- "required" there is a property name, not the keyword, so descend into the
+-- members without matching their names against SCHEMA_ARRAY_KEYS.
+local SCHEMA_MAP_KEYS = {
+    properties = true, patternProperties = true,
+    definitions = true, ["$defs"] = true,
+}
+
+-- cjson decodes an empty JSON array to a bare table, which re-encodes as {}.
+-- Tag those tables so the keywords above survive the round trip as [].
+local function _tag_empty_schema_arrays(node, depth)
+    if type(node) ~= "table" or depth > 16 then
+        return
+    end
+    for key, value in pairs(node) do
+        if type(value) == "table" then
+            if SCHEMA_MAP_KEYS[key] then
+                for _, subschema in pairs(value) do
+                    _tag_empty_schema_arrays(subschema, depth + 1)
+                end
+            elseif SCHEMA_ARRAY_KEYS[key] and next(value) == nil then
+                setmetatable(value, empty_array_mt)
+            else
+                _tag_empty_schema_arrays(value, depth + 1)
+            end
+        end
+    end
+end
+
+
 -- Ensure inputSchema has "type": "object" as required by MCP spec
 local function _ensure_mcp_schema(schema)
     if not schema or type(schema) ~= "table" then
         return { type = "object", properties = {} }
     end
+    _tag_empty_schema_arrays(schema, 0)
     if schema.type == "object" then
         return schema
     end

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -67,6 +67,11 @@ map $uri $mcp_gateway_register_key {
     "~*/api/internal/register/?$"        $binary_remote_addr;
 }
 
+# Resolve `require "cjson"` to OpenResty's lua-cjson (built into the registry
+# image at this path), which provides cjson.empty_array_mt. virtual_router.lua
+# needs it to serialize empty JSON-Schema arrays as [] not {} (issue #1532).
+lua_package_cpath "/usr/local/lib/lua/5.1/?.so;;";
+
 # Lua shared dictionary for metrics collection (10MB)
 lua_shared_dict metrics_buffer 10m;
 

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -67,6 +67,11 @@ map $uri $mcp_gateway_register_key {
     "~*/api/internal/register/?$"        $binary_remote_addr;
 }
 
+# Resolve `require "cjson"` to OpenResty's lua-cjson (built into the registry
+# image at this path), which provides cjson.empty_array_mt. virtual_router.lua
+# needs it to serialize empty JSON-Schema arrays as [] not {} (issue #1532).
+lua_package_cpath "/usr/local/lib/lua/5.1/?.so;;";
+
 # Lua shared dictionary for metrics collection (10MB)
 lua_shared_dict metrics_buffer 10m;
 

--- a/docker/registry-entrypoint.sh
+++ b/docker/registry-entrypoint.sh
@@ -40,7 +40,7 @@ if [ -n "$MONGODB_CONNECTION_STRING" ] || [ -n "$DOCUMENTDB_HOST" ]; then
     source /app/.venv/bin/activate
     python3 -c "
 import pymongo, os, re, time
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, quote_plus
 
 override = os.getenv('MONGODB_CONNECTION_STRING', '')
 if override:
@@ -59,7 +59,10 @@ else:
     ca_file = os.getenv('DOCUMENTDB_TLS_CA_FILE', '/app/certs/global-bundle.pem')
     auth = 'SCRAM-SHA-256' if backend == 'mongodb-ce' else 'SCRAM-SHA-1'
     if user and pwd:
-        uri = f'mongodb://{user}:{pwd}@{host}:{port}/?authMechanism={auth}&authSource=admin'
+        # Escape credentials per RFC 3986 so passwords with reserved
+        # characters (e.g. after a Secrets Manager rotation) do not break
+        # the connection URI. Mirrors scripts/_mongo_conn_args.py.
+        uri = f'mongodb://{quote_plus(user)}:{quote_plus(pwd)}@{host}:{port}/?authMechanism={auth}&authSource=admin'
     else:
         uri = f'mongodb://{host}:{port}/'
     tls_options = {}

--- a/registry/utils/mongodb_connection.py
+++ b/registry/utils/mongodb_connection.py
@@ -6,6 +6,7 @@ synchronous MongoDBLogHandler.
 """
 
 from typing import Any
+from urllib.parse import quote_plus
 
 
 def build_connection_string() -> str:
@@ -31,8 +32,10 @@ def build_connection_string() -> str:
         credentials = session.get_credentials()
         if not credentials:
             raise ValueError("AWS credentials not found for DocumentDB IAM auth")
+        # Escape credentials per RFC 3986: AWS secret keys can contain
+        # reserved characters such as "/" and "+".
         return (
-            f"mongodb://{credentials.access_key}:{credentials.secret_key}@"
+            f"mongodb://{quote_plus(credentials.access_key)}:{quote_plus(credentials.secret_key)}@"
             f"{settings.documentdb_host}:{settings.documentdb_port}/"
             f"{settings.documentdb_database}?"
             f"authSource=$external&authMechanism=MONGODB-AWS"
@@ -46,8 +49,11 @@ def build_connection_string() -> str:
             auth_mechanism = "SCRAM-SHA-1"
         else:
             auth_mechanism = "SCRAM-SHA-256"
+        # Escape credentials per RFC 3986 so passwords with reserved
+        # characters (e.g. after a Secrets Manager rotation) do not break
+        # the connection URI.
         return (
-            f"mongodb://{settings.documentdb_username}:{settings.documentdb_password}@"
+            f"mongodb://{quote_plus(settings.documentdb_username)}:{quote_plus(settings.documentdb_password)}@"
             f"{settings.documentdb_host}:{settings.documentdb_port}/"
             f"{settings.documentdb_database}?authMechanism={auth_mechanism}&authSource=admin"
         )

--- a/tests/integration/test_virtual_empty_schema_e2e.py
+++ b/tests/integration/test_virtual_empty_schema_e2e.py
@@ -1,0 +1,138 @@
+"""End-to-end check that empty inputSchema arrays survive as ``[]`` (issue #1532).
+
+This is a live-stack test, not an in-process one. The empty-array serialization
+bug lived in the nginx + lua virtual router, which the FastAPI-app integration
+tests cannot exercise, and it only reproduced on the shipped runtime (Debian
+nginx + Debian lua-cjson, where ``cjson.empty_array_mt`` is nil). So this test
+drives a real gateway over HTTP.
+
+It skips unless a gateway URL and bearer token are provided, so it is a no-op in
+the standard unit/integration CI. Point it at a running stack to exercise it:
+
+    export MCP_GATEWAY_E2E_URL=http://localhost
+    export MCP_GATEWAY_E2E_TOKEN="$(python3 -c \
+      "import json;print(json.load(open('.token'))['tokens']['access_token'])")"
+    uv run pytest tests/integration/test_virtual_empty_schema_e2e.py -v
+
+The durable, always-on guardrail for the same property is the build-time
+assertion in ``docker/Dockerfile.registry`` (the image build fails if the shipped
+cjson lacks ``empty_array_mt``); this test adds an HTTP-level confirmation when a
+stack is available.
+"""
+
+import json
+import os
+import uuid
+
+import httpx
+import pytest
+
+_GATEWAY_URL = os.environ.get("MCP_GATEWAY_E2E_URL")
+_TOKEN = os.environ.get("MCP_GATEWAY_E2E_TOKEN")
+
+pytestmark = pytest.mark.skipif(
+    not (_GATEWAY_URL and _TOKEN),
+    reason="Set MCP_GATEWAY_E2E_URL and MCP_GATEWAY_E2E_TOKEN to run the live E2E.",
+)
+
+_MCP_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {_TOKEN}"}
+
+
+def _parse_mcp_body(text: str) -> dict:
+    """Return the JSON object from a plain or SSE-framed MCP response body."""
+    data_lines = [line[len("data:") :].strip() for line in text.splitlines() if line.startswith("data:")]
+    return json.loads(data_lines[-1] if data_lines else text)
+
+
+def _find_backend_with_empty_required(client: httpx.Client) -> tuple[str, str] | None:
+    """Find a (server_path, tool_name) whose tool advertises ``required: []``."""
+    resp = client.get("/api/servers", params={"limit": 200}, headers=_auth_headers())
+    resp.raise_for_status()
+    for server in resp.json().get("servers", []):
+        for tool in server.get("tool_list", []):
+            schema = tool.get("schema") or tool.get("inputSchema") or {}
+            if isinstance(schema.get("required"), list) and not schema["required"]:
+                return server["path"], tool["name"]
+    return None
+
+
+def test_empty_required_serializes_as_array_through_virtual_server() -> None:
+    base = _GATEWAY_URL.rstrip("/")
+    vs_path = f"/virtual/e2e-empty-required-{uuid.uuid4().hex[:8]}"
+
+    with httpx.Client(base_url=base, timeout=30.0) as client:
+        backend = _find_backend_with_empty_required(client)
+        if backend is None:
+            pytest.skip("No registered backend advertises a tool with required: [].")
+        backend_path, tool_name = backend
+
+        create_body = {
+            "path": vs_path,
+            "server_name": "E2E empty-required (issue 1532)",
+            "description": "Transient VS asserting empty required stays [].",
+            "tool_mappings": [{"tool_name": tool_name, "backend_server_path": backend_path}],
+            "required_scopes": [],
+            "tool_scope_overrides": [],
+            "tags": ["e2e", "issue-1532"],
+            "supported_transports": ["streamable-http"],
+            "is_enabled": True,
+        }
+
+        try:
+            created = client.post("/api/virtual-servers", json=create_body, headers=_auth_headers())
+            assert created.status_code == 201, created.text
+
+            toggled = client.post(
+                f"/api/virtual-servers{vs_path}/toggle",
+                json={"enabled": True},
+                headers=_auth_headers(),
+            )
+            assert toggled.status_code == 200, toggled.text
+
+            mcp_url = f"{base}{vs_path}/mcp"
+            init = client.post(
+                mcp_url,
+                headers={**_auth_headers(), **_MCP_HEADERS},
+                content=json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2025-06-18",
+                            "capabilities": {},
+                            "clientInfo": {"name": "e2e-1532", "version": "1.0"},
+                        },
+                    }
+                ),
+            )
+            session_id = init.headers.get("Mcp-Session-Id")
+            assert session_id, f"no Mcp-Session-Id from initialize: {init.text}"
+
+            listed = client.post(
+                mcp_url,
+                headers={**_auth_headers(), **_MCP_HEADERS, "Mcp-Session-Id": session_id},
+                content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+            )
+            body_text = listed.text
+            body = _parse_mcp_body(body_text)
+
+            tools = body.get("result", {}).get("tools", [])
+            assert tools, f"no tools returned: {body_text}"
+
+            target = next((t for t in tools if t.get("name") == tool_name), tools[0])
+            required = target.get("inputSchema", {}).get("required")
+
+            # The fix: empty required must be a JSON array, not an object.
+            assert required == [], f"expected required == [], got {required!r} in {body_text}"
+            assert '"required":[]' in body_text.replace(" ", "")
+            assert '"required":{}' not in body_text.replace(" ", "")
+        finally:
+            client.delete(f"/api/virtual-servers{vs_path}", headers=_auth_headers())

--- a/tests/integration/test_virtual_empty_schema_e2e.py
+++ b/tests/integration/test_virtual_empty_schema_e2e.py
@@ -47,7 +47,9 @@ def _auth_headers() -> dict[str, str]:
 
 def _parse_mcp_body(text: str) -> dict:
     """Return the JSON object from a plain or SSE-framed MCP response body."""
-    data_lines = [line[len("data:") :].strip() for line in text.splitlines() if line.startswith("data:")]
+    data_lines = [
+        line[len("data:") :].strip() for line in text.splitlines() if line.startswith("data:")
+    ]
     return json.loads(data_lines[-1] if data_lines else text)
 
 
@@ -119,7 +121,9 @@ def test_empty_required_serializes_as_array_through_virtual_server() -> None:
             listed = client.post(
                 mcp_url,
                 headers={**_auth_headers(), **_MCP_HEADERS, "Mcp-Session-Id": session_id},
-                content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+                content=json.dumps(
+                    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+                ),
             )
             body_text = listed.text
             body = _parse_mcp_body(body_text)

--- a/tests/integration/test_virtual_empty_schema_e2e.py
+++ b/tests/integration/test_virtual_empty_schema_e2e.py
@@ -22,10 +22,17 @@ stack is available.
 
 import json
 import os
+import time
 import uuid
 
 import httpx
 import pytest
+
+# Enabling a virtual server makes the registry regenerate the nginx config, write
+# the mapping file, and reload nginx asynchronously; the MCP endpoint is not
+# routable until that finishes. Poll for readiness rather than racing the reload.
+_READY_TIMEOUT_S = 30.0
+_READY_POLL_S = 1.0
 
 _GATEWAY_URL = os.environ.get("MCP_GATEWAY_E2E_URL")
 _TOKEN = os.environ.get("MCP_GATEWAY_E2E_TOKEN")
@@ -51,6 +58,65 @@ def _parse_mcp_body(text: str) -> dict:
         line[len("data:") :].strip() for line in text.splitlines() if line.startswith("data:")
     ]
     return json.loads(data_lines[-1] if data_lines else text)
+
+
+_INIT_BODY = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "e2e-1532", "version": "1.0"},
+        },
+    }
+)
+
+
+def _initialize_with_retry(client: httpx.Client, mcp_url: str) -> str:
+    """Wait for the enabled virtual server to be routable and return a session id.
+
+    Retries ``initialize`` until it yields an ``Mcp-Session-Id`` (or the timeout
+    elapses), so the test does not race the post-enable nginx reload / mapping
+    write. Raises with the last response on timeout.
+    """
+    deadline = time.monotonic() + _READY_TIMEOUT_S
+    last = "no attempt made"
+    while time.monotonic() < deadline:
+        resp = client.post(mcp_url, headers={**_auth_headers(), **_MCP_HEADERS}, content=_INIT_BODY)
+        session_id = resp.headers.get("Mcp-Session-Id")
+        if session_id:
+            return session_id
+        last = f"HTTP {resp.status_code}: {resp.text[:200]}"
+        time.sleep(_READY_POLL_S)
+    raise AssertionError(f"virtual server not ready within {_READY_TIMEOUT_S}s (last: {last})")
+
+
+def _tools_list_with_retry(
+    client: httpx.Client, mcp_url: str, session_id: str
+) -> tuple[str, list[dict]]:
+    """Retry ``tools/list`` until the backend enrichment yields tools.
+
+    A just-enabled virtual server may return an empty aggregation on the first
+    call while backend discovery completes; poll until tools are present.
+    """
+    deadline = time.monotonic() + _READY_TIMEOUT_S
+    body_text = ""
+    while time.monotonic() < deadline:
+        resp = client.post(
+            mcp_url,
+            headers={**_auth_headers(), **_MCP_HEADERS, "Mcp-Session-Id": session_id},
+            content=json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+        )
+        body_text = resp.text
+        tools = _parse_mcp_body(body_text).get("result", {}).get("tools", [])
+        if tools:
+            return body_text, tools
+        time.sleep(_READY_POLL_S)
+    raise AssertionError(
+        f"no tools from virtual server within {_READY_TIMEOUT_S}s (last: {body_text[:200]})"
+    )
 
 
 def _find_backend_with_empty_required(client: httpx.Client) -> tuple[str, str] | None:
@@ -99,37 +165,10 @@ def test_empty_required_serializes_as_array_through_virtual_server() -> None:
             assert toggled.status_code == 200, toggled.text
 
             mcp_url = f"{base}{vs_path}/mcp"
-            init = client.post(
-                mcp_url,
-                headers={**_auth_headers(), **_MCP_HEADERS},
-                content=json.dumps(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "initialize",
-                        "params": {
-                            "protocolVersion": "2025-06-18",
-                            "capabilities": {},
-                            "clientInfo": {"name": "e2e-1532", "version": "1.0"},
-                        },
-                    }
-                ),
-            )
-            session_id = init.headers.get("Mcp-Session-Id")
-            assert session_id, f"no Mcp-Session-Id from initialize: {init.text}"
-
-            listed = client.post(
-                mcp_url,
-                headers={**_auth_headers(), **_MCP_HEADERS, "Mcp-Session-Id": session_id},
-                content=json.dumps(
-                    {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
-                ),
-            )
-            body_text = listed.text
-            body = _parse_mcp_body(body_text)
-
-            tools = body.get("result", {}).get("tools", [])
-            assert tools, f"no tools returned: {body_text}"
+            # Wait for the enable -> nginx reload to settle before driving MCP,
+            # then wait for backend enrichment to produce tools.
+            session_id = _initialize_with_retry(client, mcp_url)
+            body_text, tools = _tools_list_with_retry(client, mcp_url, session_id)
 
             target = next((t for t in tools if t.get("name") == tool_name), tools[0])
             required = target.get("inputSchema", {}).get("required")

--- a/tests/lua/test_virtual_router.lua
+++ b/tests/lua/test_virtual_router.lua
@@ -202,6 +202,61 @@ do
 end
 
 -- ---------------------------------------------------------------------------
+print("test: _handle_tools_list keeps empty schema arrays as [] (issue #1532)")
+do
+    dict._store["tools_enriched:srv3"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "no_arg", original_name = "no_arg", backend_location = "/ok" },
+        { name = "one_arg", original_name = "one_arg", backend_location = "/ok" },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200, body = cjson.encode({ result = { tools = {
+        { name = "no_arg", inputSchema = {
+            type = "object", properties = {},
+            required = setmetatable({}, cjson.empty_array_mt) } },
+        { name = "one_arg", inputSchema = {
+            type = "object",
+            properties = { q = { type = "string",
+                                 enum = setmetatable({}, cjson.empty_array_mt) } },
+            required = { "q" } } },
+    } } }) }
+
+    local body = M._handle_tools_list("1", mapping, "", nil, "srv3")
+    check(body:find('"required":[]', 1, true) ~= nil,
+        "empty required serializes as [] not {}")
+    check(body:find('"required":["q"]', 1, true) ~= nil,
+        "non-empty required is still an array")
+    check(body:find('"properties":{}', 1, true) ~= nil,
+        "empty properties stays an object")
+    check(body:find('"enum":[]', 1, true) ~= nil,
+        "empty enum nested under properties serializes as []")
+
+    -- The cached path decodes and re-encodes, so it must hold the same shape.
+    local cached_body = M._handle_tools_list("1", mapping, "", nil, "srv3")
+    check(dict._store["tools_enriched:srv3"] ~= nil, "result was cached")
+    check(cached_body:find('"required":[]', 1, true) ~= nil,
+        "empty required is still [] when served from cache")
+end
+
+-- ---------------------------------------------------------------------------
+print("test: a property named like a schema keyword stays an object")
+do
+    dict._store["tools_enriched:srv4"] = nil
+    local mapping = { required_scopes = nil, tools = {
+        { name = "odd", original_name = "odd", backend_location = "/ok" },
+    } }
+    capture_responses = {}
+    capture_responses["/ok"] = { status = 200, body = cjson.encode({ result = { tools = {
+        { name = "odd", inputSchema = {
+            type = "object", properties = { required = { type = "object" } } } },
+    } } }) }
+
+    local body = M._handle_tools_list("1", mapping, "", nil, "srv4")
+    check(body:find('"required":[]', 1, true) == nil,
+        "a property called 'required' is not coerced into an array")
+end
+
+-- ---------------------------------------------------------------------------
 if failures > 0 then
     print(string.format("\n%d check(s) FAILED", failures))
     os.exit(1)

--- a/tests/lua/test_virtual_router.lua
+++ b/tests/lua/test_virtual_router.lua
@@ -18,6 +18,14 @@ _G._VR_TEST = true
 
 local cjson = require("cjson")
 
+-- Environment guard (issue #1532): the empty-array fix relies on
+-- cjson.empty_array_mt, an OpenResty lua-cjson extension. If this suite is ever
+-- run against a cjson without it (e.g. Debian lua-cjson 2.1.0, which is what the
+-- registry image used to ship), the schema-array assertions below would give a
+-- false sense of safety. Fail loudly instead of passing on the wrong runtime.
+assert(cjson.empty_array_mt,
+    "cjson.empty_array_mt is missing -- these tests require OpenResty's lua-cjson")
+
 local failures = 0
 local function check(cond, msg)
     if cond then


### PR DESCRIPTION
Closes #1532. Supersedes #1646 (its Lua commit is cherry-picked here with @ebarkhordar's authorship preserved).

## Background

An MCP backend that advertises `"required": []` on a tool reached clients through a virtual server as `"required": {}`. lua-cjson cannot distinguish an empty array from an empty object (both decode to a bare Lua table that re-encodes as `{}`), and the virtual router does a decode/re-encode round trip on the `tools/list` aggregation path. The direct per-server proxy path is a byte passthrough, so only the virtual path corrupted the schema.

## Why one PR

The complete fix has two interdependent halves; neither works alone:

1. **Lua** (`docker/lua/virtual_router.lua`, from #1646): `_tag_empty_schema_arrays` tags empty array-valued JSON-Schema keywords (`required`, `enum`, `allOf`, ...) with `cjson.empty_array_mt` so they survive the round trip as `[]`. Map-valued keywords (`properties`, `$defs`, ...) are descended into without matching member names, so a property literally named `required` stays an object.
2. **Runtime** (this PR): `cjson.empty_array_mt` is an OpenResty lua-cjson extension. The registry image shipped Debian `lua-cjson` 2.1.0, where it is `nil`, so `setmetatable(value, empty_array_mt)` was a no-op and the empty array still serialized as `{}` in production. CI passed only because `lua-test.yml` runs in `openresty/openresty:alpine`, which has the extension.

Verified end to end: created a virtual server over a backend advertising `required: []`, ran `initialize` + `tools/list` through the virtual endpoint. On the old image it returned `"required": {}`; after this change it returns `"required": []`, and empty objects like `"properties": {}` correctly stay `{}`.

## Changes

- `docker/Dockerfile.registry`: add a `cjson-builder` stage that builds OpenResty's lua-cjson against the nginx-lua LuaJIT, drop the Debian `lua-cjson` package, and `COPY` the built `cjson.so` into the runtime image. A build-time assertion fails the image build if the shipped cjson lacks `empty_array_mt` (or if an empty array-tagged table does not encode as `[]`).
- `docker/nginx_rev_proxy_http_and_https.conf`, `docker/nginx_rev_proxy_http_only.conf`: pin `lua_package_cpath` so `require "cjson"` resolves to the OpenResty build.
- `docker/lua/virtual_router.lua` + `tests/lua/test_virtual_router.lua` (from #1646): the fix and its unit tests, plus a guard that fails the suite if run against a cjson without `empty_array_mt`.
- `tests/integration/test_virtual_empty_schema_e2e.py`: live-stack E2E asserting `required` serializes as `[]` through a virtual server. Skips unless `MCP_GATEWAY_E2E_URL` / `MCP_GATEWAY_E2E_TOKEN` are set.

## Scope note

Switching to OpenResty's cjson helps beyond this issue: `_as_json_array` already relies on `empty_array_mt`, so on the Debian runtime any empty array the virtual router emits (empty `tools`/`resources`/`prompts` lists, not just schema fields) had the same problem. This change corrects that whole class of serialization and aligns the shipped runtime with what CI already tests.

The registry image is shared across Docker Compose, ECS (Terraform), and EKS (Helm), so this one image change covers all three deployment surfaces.

## Testing

- Full Lua suite passes in `openresty/openresty:alpine` (incl. the schema-array cases and the new env guard).
- Rebuilt the registry image with the runtime change and re-ran the E2E on a live stack: `tools/list` returns `"required": []`; `"properties": {}` stays `{}`; no lua/cjson errors; metrics lua unaffected.
- New integration test collects and skips cleanly with no live stack; `ruff` clean.

No configuration parameters changed.
