### PR TITLE
fix(helm): stack-owned keycloak-internal Service so nginx survives Keycloak pod rolls

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -429,12 +429,6 @@
         "filename": "charts/mcp-gateway-registry-stack/tests/ingress_topology_test.yaml",
         "hashed_secret": "331bd1c1ebbac84bfdb8ba2548dccc6f9be7e6b6",
         "is_verified": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "charts/mcp-gateway-registry-stack/tests/ingress_topology_test.yaml",
-        "hashed_secret": "f9679097ee060a0d9703dd613d0ff46fe87768b4",
-        "is_verified": false
       }
     ],
     "charts/mcp-gateway-registry-stack/tests/mongodb_password_test.yaml": [
@@ -1412,5 +1406,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T16:17:14Z"
+  "generated_at": "2026-08-21T18:16:50Z"
 }

--- a/charts/README.md
+++ b/charts/README.md
@@ -66,9 +66,12 @@ keycloak:
   create: true
 
 # For external Keycloak
+global:
+  authProvider:
+    keycloak:
+      internalUrl: https://your-keycloak.com  # required when create=false
 keycloak:
   create: false
-  externalUrl: https://your-keycloak.com
 
 # For Entra ID
 keycloak:

--- a/charts/auth-server/templates/_helpers.tpl
+++ b/charts/auth-server/templates/_helpers.tpl
@@ -71,3 +71,28 @@ Call as: {{- include "auth-server.validateExtraEnv" . -}}
   {{- $_ := set $seen $e.name $i -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+In-cluster Keycloak HTTP URL, targeting the stack-owned ClusterIP
+Service "<release>-kc-int" (stack chart,
+templates/keycloak-internal-service.yaml). See
+registry.keycloakInternalUrl for the full rationale: nginx pins
+proxy_pass IPs at start, so the URL must be a stable ClusterIP name;
+port 8080 must stay explicit so Keycloak keeps deriving issuers with a
+port (auth-server's exact-match issuer allowlist and startswith()
+discovery rewrite depend on it); the short hostname resolves through
+the pod's namespace search path; no truncation is needed because Helm
+caps release names at 53 chars (53 + 7-char suffix < 63).
+global.authProvider.keycloak.internalUrl is the one canonical
+override, for external Keycloak and standalone installs. The default
+must render the same string as the registry, keycloak-configure, and
+stack copies of this helper.
+*/}}
+{{- define "auth-server.keycloakInternalUrl" -}}
+{{- $override := dig "authProvider" "keycloak" "internalUrl" "" (.Values.global | default dict) -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- printf "http://%s-kc-int:8080" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/auth-server/templates/deployment.yaml
+++ b/charts/auth-server/templates/deployment.yaml
@@ -29,6 +29,14 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.app.name }}
         app.kubernetes.io/component: {{ .Values.app.name }}
+      annotations:
+        # envFrom-sourced env is snapshotted at pod start, so a helm upgrade
+        # that changes the internal Keycloak URL (e.g. headless -> ClusterIP)
+        # updates the Secret but leaves running pods on the stale URL until
+        # an unrelated restart. Pinning the helper output here rolls the
+        # pods exactly when the chart's URL definition changes and never
+        # otherwise.
+        checksum/keycloak-internal-url: {{ include "auth-server.keycloakInternalUrl" . | sha256sum }}
     spec:
       serviceAccountName: {{ include "auth-server.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}

--- a/charts/auth-server/templates/secret.yaml
+++ b/charts/auth-server/templates/secret.yaml
@@ -42,7 +42,7 @@ clients fail to validate (401 on every /validate call).
 */ -}}
 {{- $authServerExternalUrl := "" }}
 {{- $keycloakExternalUrl := "" }}
-{{- $keycloakUrl := printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace}}
+{{- $keycloakUrl := include "auth-server.keycloakInternalUrl" . }}
 {{- /*
 auth-server has no public ingress of its own; all browser-facing
 traffic arrives via the registry pod's nginx which strips any path

--- a/charts/auth-server/tests/checksum_annotation_test.yaml
+++ b/charts/auth-server/tests/checksum_annotation_test.yaml
@@ -1,0 +1,18 @@
+suite: keycloak internal URL checksum rolls pods on change
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # envFrom-sourced env is snapshotted at pod start; this annotation is what
+  # makes a helm upgrade that changes the internal Keycloak URL definition
+  # (e.g. the headless -> stack-owned ClusterIP fix) actually roll the pods.
+  # The expected value is sha256("http://test-kc-int:8080") — if the
+  # keycloakInternalUrl helper changes, update this hash alongside the
+  # URL assertions in keycloak_service_test.yaml.
+  - it: pins the keycloakInternalUrl output into the pod template
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/keycloak-internal-url"]
+          value: 6f04647ff2f831586d70fbe1db77f870d8baa49802d457c1c23ee6ff5751128a  # pragma: allowlist secret

--- a/charts/auth-server/tests/keycloak_service_test.yaml
+++ b/charts/auth-server/tests/keycloak_service_test.yaml
@@ -1,0 +1,87 @@
+suite: stable Keycloak service URL
+templates:
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # Stack-owned "<release>-kc-int" ClusterIP Service (stable VIP,
+  # survives pod rolls; name and 8080 port fixed in the stack template,
+  # not in replaceable values) — NOT the headless Service (pod IP that
+  # nginx pins until restart) and NOT a default :80 port (clients omit
+  # default ports from Host, breaking issuer/discovery matching). Must
+  # match the same assertion in the registry, keycloak-configure, and
+  # stack suites.
+  - it: uses the stack-owned internal Service on port 8080
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+
+  # External Keycloak and standalone installs point at their own
+  # Keycloak via the one canonical override, shared with the stack.
+  - it: honors the global internalUrl override
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+          keycloak:
+            internalUrl: http://my-own-keycloak.example:8080
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://my-own-keycloak.example:8080
+          decodeBase64: true
+
+  # At the 53-char release-name maximum the full release name is kept
+  # (53 + 7-char "-kc-int" = 60 <= 63), so long releases sharing a
+  # prefix still get distinct hostnames. Must stay in lockstep with the
+  # stack's keycloakInternalHost helper.
+  - it: keeps the full release name at the maximum length
+    release:
+      name: release-with-a-shared-forty-five-char-prefix-alpha-01
+      namespace: default
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://release-with-a-shared-forty-five-char-prefix-alpha-01-kc-int:8080
+          decodeBase64: true

--- a/charts/auth-server/values.yaml
+++ b/charts/auth-server/values.yaml
@@ -126,7 +126,10 @@ app:
 authProvider:
   # Provider type: "keycloak", "entra", "okta", "auth0", "cognito", or "pingfederate"
   type: keycloak
-# Keycloak integration (used when authProvider.type = "keycloak")
+# Keycloak integration (used when authProvider.type = "keycloak").
+# The in-cluster Keycloak base URL for KEYCLOAK_URL comes from
+# global.authProvider.keycloak.internalUrl (shared with the umbrella
+# stack); empty targets the stack's "<release>-kc-int" Service.
 keycloak:
   enabled: true
   realm: mcp-gateway

--- a/charts/keycloak-configure/templates/_helpers.tpl
+++ b/charts/keycloak-configure/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+In-cluster Keycloak HTTP URL for KEYCLOAK_URL / KEYCLOAK_ADMIN_URL,
+targeting the stack-owned ClusterIP Service "<release>-kc-int" (stack
+chart, templates/keycloak-internal-service.yaml). See
+registry.keycloakInternalUrl for the full rationale: nginx pins
+proxy_pass IPs at start, so the URL must be a stable ClusterIP name;
+port 8080 must stay explicit so Keycloak keeps deriving issuers with a
+port; the short hostname resolves through the pod's namespace search
+path; no truncation is needed because Helm caps release names at 53
+chars (53 + 7-char suffix < 63).
+global.authProvider.keycloak.internalUrl is the one canonical
+override, for external Keycloak and standalone installs. The default
+must render the same string as the registry, auth-server, and stack
+copies of this helper.
+*/}}
+{{- define "keycloak-configure.keycloakInternalUrl" -}}
+{{- $override := dig "authProvider" "keycloak" "internalUrl" "" (.Values.global | default dict) -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- printf "http://%s-kc-int:8080" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/keycloak-configure/templates/secret.yaml
+++ b/charts/keycloak-configure/templates/secret.yaml
@@ -3,7 +3,7 @@
 {{- $domain := .Values.global.domain | default "localhost" }}
 {{- $protocol := ternary "https" "http" .Values.global.ingress.tls }}
 {{- $registryPath := .Values.global.ingress.paths.registry | default "/registry" }}
-{{- $keycloakUrl := printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace }}
+{{- $keycloakUrl := include "keycloak-configure.keycloakInternalUrl" . }}
 {{- $authServerExternalUrl := "" }}
 {{- $registryUrl := "" }}
 {{- /*

--- a/charts/keycloak-configure/tests/keycloak_service_test.yaml
+++ b/charts/keycloak-configure/tests/keycloak_service_test.yaml
@@ -1,0 +1,78 @@
+suite: stable Keycloak service URL
+templates:
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # Stack-owned "<release>-kc-int" ClusterIP Service (stable VIP,
+  # survives pod rolls; name and 8080 port fixed in the stack template,
+  # not in replaceable values) — NOT the headless Service (pod IP that
+  # nginx pins until restart) and NOT a default :80 port (clients omit
+  # default ports from Host, breaking issuer/discovery matching). Must
+  # match the same assertion in the registry, auth-server, and stack
+  # suites.
+  - it: uses the stack-owned internal Service on port 8080
+    set:
+      global:
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+      - equal:
+          path: data.KEYCLOAK_ADMIN_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+
+  # External Keycloak and standalone installs point at their own
+  # Keycloak via the one canonical override, shared with the stack.
+  - it: honors the global internalUrl override
+    set:
+      global:
+        authProvider:
+          keycloak:
+            internalUrl: http://my-own-keycloak.example:8080
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://my-own-keycloak.example:8080
+          decodeBase64: true
+      - equal:
+          path: data.KEYCLOAK_ADMIN_URL
+          value: http://my-own-keycloak.example:8080
+          decodeBase64: true
+
+  # At the 53-char release-name maximum the full release name is kept
+  # (53 + 7-char "-kc-int" = 60 <= 63), so long releases sharing a
+  # prefix still get distinct hostnames. Must stay in lockstep with the
+  # stack's keycloakInternalHost helper.
+  - it: keeps the full release name at the maximum length
+    release:
+      name: release-with-a-shared-forty-five-char-prefix-alpha-01
+      namespace: default
+    set:
+      global:
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: false
+          paths:
+            registry: /registry
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://release-with-a-shared-forty-five-char-prefix-alpha-01-kc-int:8080
+          decodeBase64: true

--- a/charts/keycloak-configure/values.yaml
+++ b/charts/keycloak-configure/values.yaml
@@ -1,4 +1,7 @@
-# Keycloak configuration
+# Keycloak configuration.
+# The in-cluster Keycloak base URL for KEYCLOAK_URL / KEYCLOAK_ADMIN_URL
+# comes from global.authProvider.keycloak.internalUrl (shared with the
+# umbrella stack); empty targets the stack's "<release>-kc-int" Service.
 keycloak:
   adminUser: user
   realm: mcp-gateway

--- a/charts/mcp-gateway-registry-stack/README.md
+++ b/charts/mcp-gateway-registry-stack/README.md
@@ -92,15 +92,22 @@ keycloak-configure:
 global:
   authProvider:
     type: keycloak
+    keycloak:
+      realm: mcp-gateway
+      # REQUIRED when keycloak.create=false: base URL of your Keycloak,
+      # reachable from inside the cluster. Without it the chart fails to
+      # render — there is no in-cluster Keycloak Service to default to.
+      internalUrl: https://your-keycloak.example.com
 
 keycloak:
   create: false  # Don't deploy Keycloak
-  externalUrl: https://your-keycloak.example.com
-  realm: mcp-gateway
 
 keycloak-configure:
   enabled: true  # Still configure the external Keycloak
 ```
+
+The configure Job reads the Keycloak admin password from the Secret `<release>-keycloak` (key `admin-password`).
+The bundled Keycloak generates that Secret; with an external instance, create it yourself with the admin password for the account in `keycloak-configure.keycloak.adminUser` — or set `keycloak-configure.enabled=false` and configure the realm manually.
 
 **Optional: Keycloak M2M authentication:**
 

--- a/charts/mcp-gateway-registry-stack/templates/_helpers.tpl
+++ b/charts/mcp-gateway-registry-stack/templates/_helpers.tpl
@@ -75,3 +75,81 @@ Selector labels
 app.kubernetes.io/name: {{ include "mcp-gateway-registry-stack.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Name of the stack-owned internal Keycloak Service
+(templates/keycloak-internal-service.yaml). A release-scoped constant:
+deliberately NOT derived from bitnami common.names.fullname, so
+keycloak.nameOverride / keycloak.fullnameOverride cannot move the
+endpoint out from under the URL. Shared by the Service's metadata.name
+and keycloakInternalUrl below so the two cannot drift.
+
+No truncation: Helm caps release names at 53 chars, so with the 7-char
+"-kc-int" suffix the name never exceeds the 63-char DNS label limit.
+Keeping the full release name keeps the Service name unique per
+release — any truncation would map two long releases sharing a prefix
+onto the same name. The subchart helpers replicate this printf; the
+long-release-name tests in each chart's keycloak_service_test.yaml pin
+both properties.
+*/}}
+{{- define "mcp-gateway-registry-stack.keycloakInternalHost" -}}
+{{- printf "%s-kc-int" .Release.Name -}}
+{{- end -}}
+
+{{/*
+Fail-closed guards for the stack-owned keycloak-internal Service. The
+Service finds Keycloak pods with a fixed label selector in the release
+namespace; two supported Bitnami overrides would silently leave it with
+zero endpoints behind healthy-looking manifests, so both are rejected
+at render time: overriding a selector label via keycloak.podLabels /
+keycloak.commonLabels, and moving the pods with keycloak.namespaceOverride.
+*/}}
+{{- define "mcp-gateway-registry-stack.validateKeycloakInternal" -}}
+{{- $kc := index .Values "keycloak" | default dict -}}
+{{- if and $kc.namespaceOverride (ne $kc.namespaceOverride .Release.Namespace) -}}
+{{- fail (printf "keycloak.namespaceOverride=%q: the keycloak-internal Service lives in the release namespace %q and cannot select pods in another namespace" $kc.namespaceOverride .Release.Namespace) -}}
+{{- end -}}
+{{- range $key := list "app.kubernetes.io/instance" "app.kubernetes.io/component" "app.kubernetes.io/part-of" -}}
+{{- range $src := list "podLabels" "commonLabels" -}}
+{{- if hasKey (index $kc $src | default dict) $key -}}
+{{- fail (printf "keycloak.%s[%q]: reserved label — the keycloak-internal Service selects Keycloak pods by it, and overriding it would leave the Service with no endpoints" $src $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+In-cluster Keycloak HTTP URL for the shared oauth-provider Secret.
+
+See registry.keycloakInternalUrl for the full rationale (nginx pins
+proxy_pass IPs at start, so the URL must be a stable ClusterIP name;
+port 8080 must stay explicit so Keycloak keeps deriving issuers with a
+port). The hostname is short (no namespace / cluster-domain suffix):
+every consumer runs in the release namespace and the resolver search
+path expands it, which keeps the URL independent of namespace and
+cluster-domain settings.
+
+Resolution order:
+  1. global.authProvider.keycloak.internalUrl — the one canonical
+     override, seen identically by this chart and by the subcharts'
+     copies of this helper. REQUIRED when keycloak.create=false: with
+     an external Keycloak the keycloak-internal Service is not
+     rendered, so the default URL would point at nothing; fail closed
+     rather than write a dead URL into the shared Secret. (The Secret
+     template only resolves this helper when the auth provider is
+     keycloak, so Entra/Okta/... installs with keycloak.create=false
+     are unaffected.)
+  2. The stack-owned Service above (keycloak.create=true).
+keycloak_service_test.yaml in each chart pins the four helper copies
+to the same output.
+*/}}
+{{- define "mcp-gateway-registry-stack.keycloakInternalUrl" -}}
+{{- $override := dig "authProvider" "keycloak" "internalUrl" "" (.Values.global | default dict) -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else if .Values.keycloak.create -}}
+{{- printf "http://%s:8080" (include "mcp-gateway-registry-stack.keycloakInternalHost" .) -}}
+{{- else -}}
+{{- fail "keycloak.create=false (external Keycloak) requires global.authProvider.keycloak.internalUrl: the stack-owned keycloak-internal Service only exists for the bundled Keycloak, so the default in-cluster URL would point at nothing" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/mcp-gateway-registry-stack/templates/keycloak-internal-service.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/keycloak-internal-service.yaml
@@ -1,0 +1,65 @@
+{{/*
+Stack-owned stable ClusterIP Service in front of the Bitnami Keycloak
+pods. Every internal consumer (registry nginx proxy_pass, auth-server
+issuer validation, keycloak-configure Job) targets it via the
+*.keycloakInternalUrl helpers.
+
+Why not one of the Bitnami-rendered Services:
+  - the headless Service resolves to pod IPs, which registry nginx pins
+    at startup, so /realms/ 503s after a Keycloak pod roll until the
+    registry restarts;
+  - the Bitnami ClusterIP Service's name follows common.names.fullname
+    (keycloak.nameOverride / fullnameOverride) and its port list is
+    plain user values (service.ports.http, service.extraPorts), so a
+    URL derived from those chart internals silently breaks under
+    overrides or `helm upgrade --reuse-values`.
+Owning the Service here puts both the name and the port under this
+chart's control: this template and the URL helpers are the only two
+owners, locked together by the keycloakInternalHost helper and the
+keycloak_service_test.yaml suites.
+
+Rendered only for the bundled Keycloak (keycloak.create=true).
+External-Keycloak installs must set
+global.authProvider.keycloak.internalUrl instead — the URL helper
+fails the render if they don't.
+
+Port 8080 (-> container port "http") keeps an explicit port in the
+Host header. Keycloak derives issuer/discovery URLs from Host, and a
+portless issuer would break auth-server's exact-match issuer allowlist
+and startswith() discovery rewrite. The hostname still differs from
+the pre-fix headless URL, so tokens minted against the old internal
+issuer are invalidated at cutover; deployments that pin the issuer via
+KC_HOSTNAME are unaffected.
+
+The selector deliberately avoids app.kubernetes.io/name (it follows
+keycloak.nameOverride). instance/component/part-of are invariant: the
+Bitnami statefulset hardcodes component and part-of on its pods, and
+instance is always the release name. keycloak_service_test.yaml renders
+the vendored statefulset and asserts these labels, so a Bitnami bump
+that renames them fails CI instead of leaving this Service without
+endpoints. Overrides that would break the selector at deploy time
+(keycloak.podLabels/commonLabels on the selector keys,
+keycloak.namespaceOverride) are rejected by validateKeycloakInternal.
+*/}}
+{{- if .Values.keycloak.create }}
+{{- include "mcp-gateway-registry-stack.validateKeycloakInternal" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-gateway-registry-stack.keycloakInternalHost" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "mcp-gateway-registry-stack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-internal
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: keycloak
+    app.kubernetes.io/part-of: keycloak
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+{{- end }}

--- a/charts/mcp-gateway-registry-stack/templates/oauth-provider-secret.yaml
+++ b/charts/mcp-gateway-registry-stack/templates/oauth-provider-secret.yaml
@@ -11,7 +11,14 @@ Contains the auth provider type and identity provider credentials
 {{- $routingMode := .Values.global.ingress.routingMode | default "subdomain" }}
 {{- $domain := .Values.global.domain | default "localhost" }}
 {{- $protocol := ternary "https" "http" .Values.global.ingress.tls }}
-{{- $keycloakUrl := printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace }}
+{{- /* Resolved only for the keycloak provider: the helper fails closed
+when keycloak.create=false and global.authProvider.keycloak.internalUrl
+is unset, and that guard must not trip Entra/Okta/... installs, which
+also run with keycloak.create=false and never emit KEYCLOAK_URL. */ -}}
+{{- $keycloakUrl := "" }}
+{{- if eq $authProviderType "keycloak" }}
+  {{- $keycloakUrl = include "mcp-gateway-registry-stack.keycloakInternalUrl" . }}
+{{- end }}
 {{- /*
 KEYCLOAK_EXTERNAL_URL is the host Keycloak emits in `iss` claims and
 discovery documents. It MUST match what the Keycloak pod actually puts

--- a/charts/mcp-gateway-registry-stack/tests/ingress_topology_test.yaml
+++ b/charts/mcp-gateway-registry-stack/tests/ingress_topology_test.yaml
@@ -67,10 +67,12 @@ tests:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation
 
-  # Internal KEYCLOAK_URL must be bare (no /keycloak suffix) in both
-  # routing modes — the registry pod's nginx handles browser-side path
-  # rewriting, and Keycloak serves from its own root.
-  - it: internal KEYCLOAK_URL has no path suffix in subdomain mode
+  # Internal KEYCLOAK_URL must use the stack-owned "<release>-kc-int"
+  # ClusterIP Service (NOT the headless Service, whose pod-IP A record
+  # nginx pins until restart, 503ing /realms/ after a Keycloak pod
+  # replacement) and remain bare (no /keycloak suffix) in both routing
+  # modes. See keycloak_service_test.yaml for the Service half.
+  - it: internal KEYCLOAK_URL uses the internal Service with no path suffix in subdomain mode
     templates:
       - templates/oauth-provider-secret.yaml
     set:
@@ -82,10 +84,10 @@ tests:
     asserts:
       - equal:
           path: data.KEYCLOAK_URL
-          # base64 of http://test-keycloak-headless.default.svc.cluster.local:8080
-          value: aHR0cDovL3Rlc3Qta2V5Y2xvYWstaGVhZGxlc3MuZGVmYXVsdC5zdmMuY2x1c3Rlci5sb2NhbDo4MDgw
+          value: http://test-kc-int:8080
+          decodeBase64: true
 
-  - it: internal KEYCLOAK_URL has no path suffix in path mode
+  - it: internal KEYCLOAK_URL uses the internal Service with no path suffix in path mode
     templates:
       - templates/oauth-provider-secret.yaml
     set:
@@ -97,7 +99,8 @@ tests:
     asserts:
       - equal:
           path: data.KEYCLOAK_URL
-          value: aHR0cDovL3Rlc3Qta2V5Y2xvYWstaGVhZGxlc3MuZGVmYXVsdC5zdmMuY2x1c3Rlci5sb2NhbDo4MDgw
+          value: http://test-kc-int:8080
+          decodeBase64: true
 
   # KEYCLOAK_EXTERNAL_URL is the BARE host (no /keycloak suffix). Keycloak
   # emits issuer claims and discovery-doc `issuer` fields without the

--- a/charts/mcp-gateway-registry-stack/tests/keycloak_service_test.yaml
+++ b/charts/mcp-gateway-registry-stack/tests/keycloak_service_test.yaml
@@ -1,0 +1,292 @@
+suite: stack-owned internal Keycloak Service matches KEYCLOAK_URL
+templates:
+  - templates/keycloak-internal-service.yaml
+  - templates/oauth-provider-secret.yaml
+  - charts/keycloak/templates/statefulset.yaml
+  # statefulset.yaml includes this sibling for its checksum annotation;
+  # helm-unittest only resolves includes for templates listed here.
+  - charts/keycloak/templates/configmap-env-vars.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # The stack owns both sides of the internal Keycloak endpoint: the
+  # "<release>-kc-int" Service (name and 8080 port fixed in
+  # templates/keycloak-internal-service.yaml, not in replaceable user
+  # values) and the KEYCLOAK_URL that targets it (both render through
+  # the keycloakInternalHost helper, so they cannot drift). These tests
+  # pin that contract and its immunity to Bitnami keycloak.* overrides.
+  - it: renders a release-scoped ClusterIP Service on 8080
+    templates:
+      - templates/keycloak-internal-service.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-kc-int
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports
+          value:
+            - name: http
+              port: 8080
+              protocol: TCP
+              targetPort: http
+
+  # The selector may only use labels the Bitnami statefulset hardcodes
+  # on its pods (instance/component/part-of) — never
+  # app.kubernetes.io/name, which follows keycloak.nameOverride.
+  - it: selects Keycloak pods by override-immune labels
+    templates:
+      - templates/keycloak-internal-service.yaml
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: test
+            app.kubernetes.io/component: keycloak
+            app.kubernetes.io/part-of: keycloak
+
+  - it: ships a KEYCLOAK_URL that targets that Service and port
+    templates:
+      - templates/oauth-provider-secret.yaml
+    set:
+      global:
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: true
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+
+  # Bitnami overrides rename the subchart's own Services and replace
+  # their port lists — the failure mode that ruled out deriving the URL
+  # from the Bitnami Service. The stack-owned endpoint must not move.
+  - it: keeps Service name and port under keycloak overrides
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        fullnameOverride: my-kc
+        nameOverride: kc
+        service:
+          ports:
+            http: 8181
+          extraPorts:
+            - name: custom
+              port: 9999
+              protocol: TCP
+              targetPort: http
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-kc-int
+      - equal:
+          path: spec.ports
+          value:
+            - name: http
+              port: 8080
+              protocol: TCP
+              targetPort: http
+
+  - it: keeps KEYCLOAK_URL under keycloak overrides
+    templates:
+      - templates/oauth-provider-secret.yaml
+    set:
+      keycloak:
+        fullnameOverride: my-kc
+        nameOverride: kc
+      global:
+        domain: example.com
+        ingress:
+          routingMode: subdomain
+          tls: true
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+
+  - it: is not rendered when keycloak.create is false
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        create: false
+      # Required for external Keycloak (and the suite renders the shared
+      # Secret too, which enforces that) — the Service must stay absent
+      # regardless.
+      global:
+        authProvider:
+          keycloak:
+            internalUrl: http://keycloak.corp.example:8080
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # External Keycloak (keycloak.create=false): the Service above is not
+  # rendered, so a default KEYCLOAK_URL would be dead on arrival. The
+  # helper fails closed unless the one canonical override,
+  # global.authProvider.keycloak.internalUrl, supplies the real URL.
+  - it: fails external Keycloak without the internalUrl override
+    templates:
+      - templates/oauth-provider-secret.yaml
+    set:
+      keycloak:
+        create: false
+    asserts:
+      - failedTemplate:
+          errorPattern: requires global.authProvider.keycloak.internalUrl
+
+  - it: uses the internalUrl override for external Keycloak
+    templates:
+      - templates/oauth-provider-secret.yaml
+    set:
+      keycloak:
+        create: false
+      global:
+        authProvider:
+          keycloak:
+            internalUrl: http://keycloak.corp.example:8080
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://keycloak.corp.example:8080
+          decodeBase64: true
+
+  # Non-keycloak providers also run with keycloak.create=false but never
+  # emit KEYCLOAK_URL — the fail-closed guard must not fire for them.
+  - it: does not require the override for non-keycloak providers
+    templates:
+      - templates/oauth-provider-secret.yaml
+    set:
+      keycloak:
+        create: false
+      global:
+        authProvider:
+          type: entra
+    asserts:
+      - notExists:
+          path: data.KEYCLOAK_URL
+      - equal:
+          path: data.AUTH_PROVIDER
+          value: entra
+          decodeBase64: true
+
+  # Name uniqueness at the 53-char release-name maximum: the full
+  # release name is kept (53 + 7-char "-kc-int" suffix = 60 <= 63), so
+  # two releases sharing a 45-char prefix still get distinct Services.
+  # Any truncation of the release portion would collapse these two
+  # names into one.
+  - it: keeps the full release name at maximum length (alpha)
+    templates:
+      - templates/keycloak-internal-service.yaml
+    release:
+      name: release-with-a-shared-forty-five-char-prefix-alpha-01
+      namespace: default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: release-with-a-shared-forty-five-char-prefix-alpha-01-kc-int
+
+  - it: keeps the full release name at maximum length (bravo)
+    templates:
+      - templates/keycloak-internal-service.yaml
+    release:
+      name: release-with-a-shared-forty-five-char-prefix-bravo-02
+      namespace: default
+    asserts:
+      - equal:
+          path: metadata.name
+          value: release-with-a-shared-forty-five-char-prefix-bravo-02-kc-int
+
+  # Supported Bitnami overrides that would silently leave the Service
+  # with zero endpoints must fail the render instead (validateKeycloakInternal).
+  - it: rejects selector-label overrides via podLabels
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        podLabels:
+          app.kubernetes.io/instance: hijacked
+    asserts:
+      - failedTemplate:
+          errorPattern: reserved label
+
+  - it: rejects selector-label overrides via commonLabels
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        commonLabels:
+          app.kubernetes.io/component: hijacked
+    asserts:
+      - failedTemplate:
+          errorPattern: reserved label
+
+  - it: rejects keycloak.namespaceOverride pointing elsewhere
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        namespaceOverride: other-ns
+    asserts:
+      - failedTemplate:
+          errorPattern: cannot select pods in another namespace
+
+  - it: accepts benign podLabels without touching the selector
+    templates:
+      - templates/keycloak-internal-service.yaml
+    set:
+      keycloak:
+        podLabels:
+          team: platform
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/instance: test
+            app.kubernetes.io/component: keycloak
+            app.kubernetes.io/part-of: keycloak
+
+  # Contract with the vendored Bitnami chart: the keycloak-internal
+  # Service selects pods purely by instance/component/part-of, so those
+  # labels must keep appearing on the statefulset's pod template. This
+  # renders the vendored subchart, so a `helm dep update` that bumps
+  # Bitnami and renames these labels fails here in CI instead of
+  # shipping a Service with no endpoints.
+  - it: Bitnami pod labels still match the Service selector
+    templates:
+      - charts/keycloak/templates/statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: test
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: keycloak
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/part-of"]
+          value: keycloak
+
+  - it: Bitnami pod labels keep matching under name overrides
+    templates:
+      - charts/keycloak/templates/statefulset.yaml
+    set:
+      keycloak:
+        fullnameOverride: my-kc
+        nameOverride: kc
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: test
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: keycloak
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/part-of"]
+          value: keycloak

--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -48,6 +48,13 @@ global:
       adminUsername: &keycloakAdmin "user"
       realm: &keycloakRealm "mcp-gateway"
       # Don't set password here - let Keycloak chart generate it
+      # In-cluster Keycloak base URL for KEYCLOAK_URL, used by the shared
+      # oauth-provider Secret and (via Helm globals) by every subchart.
+      # Leave empty with the bundled Keycloak: it targets the stack-owned
+      # "<release>-kc-int" Service. REQUIRED when keycloak.create=false —
+      # that Service is only rendered for the bundled Keycloak, so the
+      # chart refuses to render a default URL that would point at nothing.
+      internalUrl: ""
     entra:
       adminGroupId: # UUID of Entra admin group
   # Common ingress settings. Only the registry exposes a public ingress.
@@ -226,6 +233,11 @@ keycloak:
       value: edge
     - name: KC_PROXY_HEADERS
       value: xforwarded
+  # NOTE: internal consumers do NOT use the Bitnami-rendered Services.
+  # KEYCLOAK_URL targets the stack-owned "<release>-kc-int" ClusterIP
+  # Service (templates/keycloak-internal-service.yaml), whose name and
+  # 8080 port are fixed in the template rather than in replaceable
+  # values, so service.* overrides here cannot break it.
   ingress:
     enabled: false
   nodeSelector: {}

--- a/charts/registry/templates/_helpers.tpl
+++ b/charts/registry/templates/_helpers.tpl
@@ -77,3 +77,50 @@ Call as: {{- include "registry.validateExtraEnv" . -}}
   {{- $_ := set $seen $e.name $i -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+In-cluster Keycloak HTTP URL.
+
+Nginx proxy_pass interpolates KEYCLOAK_URL as a literal hostname and
+resolves it once at start. The Bitnami headless Service's A record is
+the pod IP, so a Keycloak roll 503s /realms/ until the registry
+restarts. The URL therefore targets the stack-owned ClusterIP Service
+"<release>-kc-int" (stack chart,
+templates/keycloak-internal-service.yaml): a stable VIP whose name and
+8080 port are fixed by the stack chart itself, unlike the Bitnami
+Services whose name follows nameOverride/fullnameOverride and whose
+port list is replaceable user values.
+
+The short in-namespace hostname is deliberate: every consumer runs in
+the release namespace, the resolver search path expands it, and it
+keeps the URL independent of namespace and cluster-domain settings.
+No truncation: Helm caps release names at 53 chars, so with the
+7-char "-kc-int" suffix the name never exceeds the 63-char DNS label
+limit, and keeping the full release name keeps it unique per release.
+
+Port 8080 MUST stay explicit: HTTP clients omit default ports from the
+Host header, Keycloak derives issuer/discovery URLs from Host, and a
+portless issuer breaks auth-server's exact-match issuer allowlist and
+startswith() discovery rewrite. Note the hostname does differ from the
+old headless URL, so tokens minted against the previous internal
+issuer are invalidated when this fix lands; deployments that pin the
+issuer via KC_HOSTNAME are unaffected.
+
+global.authProvider.keycloak.internalUrl is the one canonical
+override, shared with the stack chart (Helm propagates globals to
+subcharts): the stack requires it for external Keycloak
+(keycloak.create=false), and standalone installs of this chart use it
+to point at their own Keycloak. The default assumes the stack
+topology (same release name and namespace as the stack that owns the
+Service). The stack and sibling charts render the same URL from their
+own copies of this helper; each chart's keycloak_service_test.yaml
+pins the string.
+*/}}
+{{- define "registry.keycloakInternalUrl" -}}
+{{- $override := dig "authProvider" "keycloak" "internalUrl" "" (.Values.global | default dict) -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- printf "http://%s-kc-int:8080" .Release.Name -}}
+{{- end -}}
+{{- end -}}

--- a/charts/registry/templates/deployment.yaml
+++ b/charts/registry/templates/deployment.yaml
@@ -24,6 +24,14 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.app.name }}
         app.kubernetes.io/component: {{ .Values.app.name }}
+      annotations:
+        # envFrom-sourced env is snapshotted at pod start, so a helm upgrade
+        # that changes the internal Keycloak URL (e.g. headless -> ClusterIP)
+        # updates the Secret but leaves running pods (and their nginx
+        # proxy_pass) on the stale URL until an unrelated restart. Pinning
+        # the helper output here rolls the pods exactly when the chart's
+        # URL definition changes and never otherwise.
+        checksum/keycloak-internal-url: {{ include "registry.keycloakInternalUrl" . | sha256sum }}
     spec:
       # Run as the chart's ServiceAccount so attached roles apply (e.g. OpenBao
       # kubernetes-auth for the egress vault).

--- a/charts/registry/templates/secret.yaml
+++ b/charts/registry/templates/secret.yaml
@@ -44,7 +44,7 @@
 {{- $registryPath := .Values.global.ingress.paths.registry | default "/registry" }}
 {{- $authServerExternalUrl := "" }}
 {{- $registryExternalUrl := "" }}
-{{- $keycloakUrl := printf "http://%s-keycloak-headless.%s.svc.cluster.local:8080" .Release.Name .Release.Namespace}}
+{{- $keycloakUrl := include "registry.keycloakInternalUrl" . }}
 {{- $rootPath := "" }}
 {{- $gatewayAdditionalServerNames := $domain}}
 {{- /*

--- a/charts/registry/tests/checksum_annotation_test.yaml
+++ b/charts/registry/tests/checksum_annotation_test.yaml
@@ -1,0 +1,19 @@
+suite: keycloak internal URL checksum rolls pods on change
+templates:
+  - deployment.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # envFrom-sourced env is snapshotted at pod start; this annotation is what
+  # makes a helm upgrade that changes the internal Keycloak URL definition
+  # (e.g. the headless -> stack-owned ClusterIP fix) actually roll the pods
+  # so nginx drops its pinned upstream IP. The expected value is
+  # sha256("http://test-kc-int:8080") — if the keycloakInternalUrl helper
+  # changes, update this hash alongside the URL assertions in
+  # keycloak_service_test.yaml.
+  - it: pins the keycloakInternalUrl output into the pod template
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/keycloak-internal-url"]
+          value: 6f04647ff2f831586d70fbe1db77f870d8baa49802d457c1c23ee6ff5751128a  # pragma: allowlist secret

--- a/charts/registry/tests/keycloak_service_test.yaml
+++ b/charts/registry/tests/keycloak_service_test.yaml
@@ -1,0 +1,69 @@
+suite: stable Keycloak service URL
+templates:
+  - secret.yaml
+release:
+  name: test
+  namespace: default
+tests:
+  # Stack-owned "<release>-kc-int" ClusterIP Service (stable VIP,
+  # survives pod rolls; name and 8080 port fixed in the stack template,
+  # not in replaceable values) — NOT the headless Service (pod IP that
+  # nginx pins until restart) and NOT a default :80 port (clients omit
+  # default ports from Host, breaking issuer/discovery matching). Must
+  # match the same assertion in the auth-server, keycloak-configure,
+  # and stack suites.
+  - it: uses the stack-owned internal Service on port 8080
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://test-kc-int:8080
+          decodeBase64: true
+
+  # External Keycloak and standalone installs point at their own
+  # Keycloak via the one canonical override, shared with the stack.
+  - it: honors the global internalUrl override
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+          keycloak:
+            internalUrl: http://my-own-keycloak.example:8080
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://my-own-keycloak.example:8080
+          decodeBase64: true
+
+  # At the 53-char release-name maximum the full release name is kept
+  # (53 + 7-char "-kc-int" = 60 <= 63), so long releases sharing a
+  # prefix still get distinct hostnames. Must stay in lockstep with the
+  # stack's keycloakInternalHost helper.
+  - it: keeps the full release name at the maximum length
+    release:
+      name: release-with-a-shared-forty-five-char-prefix-alpha-01
+      namespace: default
+    set:
+      app:
+        secretKey: "test-key-not-for-prod"  # pragma: allowlist secret
+      egressAuth:
+        markerSecret: "test-marker-not-for-prod"  # pragma: allowlist secret
+      global:
+        authProvider:
+          type: keycloak
+    asserts:
+      - equal:
+          path: data.KEYCLOAK_URL
+          value: http://release-with-a-shared-forty-five-char-prefix-alpha-01-kc-int:8080
+          decodeBase64: true

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -28,6 +28,10 @@ global:
     keycloak:
       adminUsername: user
       realm: mcp-gateway
+      # In-cluster Keycloak base URL for KEYCLOAK_URL. Empty targets the
+      # umbrella stack's "<release>-kc-int" Service; set it when
+      # installing this chart standalone against your own Keycloak.
+      internalUrl: ""
 # Per-service image configuration
 # Any field left empty falls back to the corresponding global.image.* value.
 image:

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -294,7 +294,7 @@ that server's Connect dialog:
 
 | Parameter | Docker (`.env`) | Terraform (`.tfvars`) | Helm (`values.yaml`) | Purpose |
 |-----------|-----------------|-----------------------|----------------------|---------|
-| Internal URL | `KEYCLOAK_URL` | — (templated) | `auth-server.keycloak.externalUrl` + Helm service DNS | Inside container network. |
+| Internal URL | `KEYCLOAK_URL` | — (templated) | — (templated to the stack-owned `<release>-kc-int` ClusterIP Service); override `global.authProvider.keycloak.internalUrl`, required for external Keycloak (`keycloak.create=false`) | Inside container network. Stable VIP so the registry nginx `proxy_pass` survives Keycloak pod rolls. |
 | External URL | `KEYCLOAK_EXTERNAL_URL` | — (from `keycloak_domain` / `base_domain`) | — (templated from `global.domain`) | Browser-reachable URL. |
 | Admin URL | `KEYCLOAK_ADMIN_URL` | — | — | Used by setup scripts. |
 | Realm | `KEYCLOAK_REALM` | — | `global.authProvider.keycloak.realm` / `auth-server.keycloak.realm` | e.g. `mcp-gateway`. |


### PR DESCRIPTION
The charts set `KEYCLOAK_URL` to the Bitnami Keycloak headless Service. The registry pod's nginx interpolates it into a literal `proxy_pass` and resolves the hostname once at startup — and a headless Service's A record is the Keycloak pod IP itself. When the pod is replaced (upgrade, node roll, OOM), nginx keeps proxying to the dead IP: every `/realms/*` request (login, OIDC discovery, token mint) returns 503 until the registry pod is manually restarted. `KEYCLOAK_URL` is consumed via `envFrom`, snapshotted at pod start, so even a corrected Secret needs a pod roll to take effect.

### Reproduction (defaults, bundled Keycloak)
1. `helm install` the stack chart with defaults.
2. `kubectl delete pod <release>-keycloak-0`; wait for the replacement to become ready.
3. `curl <registry>/realms/<realm>/.well-known/openid-configuration` → 503, indefinitely.
4. `kubectl rollout restart` the registry deployment → 200 again.

## Fix
A stack-owned ClusterIP Service (`<release>-kc-int`, port 8080) in front of the Keycloak pods — a stable virtual IP that kube-proxy retargets to the current pod on replacement. All four `keycloakInternalUrl` helpers (stack, registry, auth-server, keycloak-configure) render that same release-scoped constant, and a `checksum/keycloak-internal-url` pod annotation on registry and auth-server rolls exactly the pods that consume the URL via `envFrom` when it changes.

## Design notes
- **Stack-owned rather than derived from the Bitnami Service:** the Bitnami Service name follows `nameOverride`/`fullnameOverride` and its port list is replaceable user values, so a derived URL can be silently broken by overrides or `helm upgrade --reuse-values`. Owning the Service fixes name and port where no values override can reach.
- **Port 8080 stays explicit:** HTTP clients omit default ports from the Host header, Keycloak derives issuer/discovery URLs from Host, and a portless issuer breaks auth-server's exact-match issuer allowlist and discovery rewrite.
- **No truncation:** Helm caps release names at 53 chars and 53 + 7 fits the 63-char DNS label, so the name is unique per release by construction. Max-length tests pin this, including two 53-char names sharing a prefix.
- **Fail closed:** configurations that would leave the Service with no endpoints (`keycloak.podLabels`/`commonLabels` overriding a selector label, `keycloak.namespaceOverride`) are rejected at render time.
- **Verified on a live EKS cluster**: deleted the bundled Keycloak pod; its IP changed when the StatefulSet replaced it, and the same registry pod — no restart, nginx untouched — served `/realms/<realm>/.well-known/openid-configuration` with 200 as soon as the replacement was ready.

