### PR TITLE
feat(egress): implement Keycloak RFC 8693 token-exchange for OBO

### DIFF
--- a/auth_server/egress_obo.py
+++ b/auth_server/egress_obo.py
@@ -111,29 +111,99 @@ def _keycloak_exchange_body(
     target_audience: str,
     scopes: list[str],
 ) -> dict[str, str]:
-    """Build the Keycloak RFC 8693 token-exchange request body.
+    """Build the Keycloak RFC 8693 token-exchange (OBO) request body.
 
-    Phase 4 (follow-on). Keycloak uses ``subject_token``/``audience`` (the bare
-    target client id), NOT Entra's ``assertion``/``scope=api://.../.default``.
+    Keycloak's standard token exchange authenticates the gateway's own client
+    via ``client_id``/``client_secret`` form fields, carries the caller's
+    ingress access token as ``subject_token`` (typed as an access_token), and
+    names the target as ``audience`` — the bare target client id, not an
+    https URL and not Entra's ``assertion``/``scope=api://.../.default``
+    convention.
+
+    ``requested_token_type`` is pinned rather than left to the server default,
+    because that default differs by Keycloak generation: legacy exchange
+    (<= 26.1) defaults to ``refresh_token`` and would mint a refresh token this
+    code reads past and discards on every request, while standard exchange
+    (26.2+) defaults to ``access_token``. RFC 8693 §2.1 makes the parameter
+    OPTIONAL with a server-chosen default, which is exactly why relying on it
+    is an interop hazard.
+
+    ``scope`` is sent only when explicit scopes are requested; omitting it
+    makes Keycloak apply the **requesting** client's default client scopes —
+    the gateway's own client, not the audience client.
     """
-    raise OboUnsupportedIdpError(
-        "Keycloak OBO token-exchange (RFC 8693) is not yet implemented; "
-        "Entra (jwt-bearer) ships first. Tracked as Phase 4."
-    )
+    body: dict[str, str] = {
+        "grant_type": _RFC8693_TOKEN_EXCHANGE_GRANT,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "subject_token": subject_token,
+        "subject_token_type": _RFC8693_ACCESS_TOKEN_TYPE,
+        "requested_token_type": _RFC8693_ACCESS_TOKEN_TYPE,
+        "audience": target_audience,
+    }
+    if scopes:
+        body["scope"] = " ".join(scopes)
+    return body
 
 
-def _map_token_error(status_code: int, payload: dict) -> OboExchangeError:
-    """Map an IdP token-endpoint error response to a typed exception."""
+def _map_token_error(status_code: int, payload: dict, kind: str = "") -> OboExchangeError:
+    """Map an IdP token-endpoint error response to a typed exception.
+
+    ``kind`` is the IdP family (``entra``/``keycloak``). It exists so a
+    provider-specific remediation hint never reaches an operator running the
+    other IdP: the codes overlap but their causes and fixes do not. Codes whose
+    meaning is provider-independent stay in the shared branches below.
+    """
     err = (payload.get("error") or "").strip()
     if err == "interaction_required":
         return OboConsentRequired("IdP requires consent")
-    if err == "invalid_grant":
+    if err in ("invalid_grant", "invalid_token"):
         # invalid_grant spans both user-fixable (expired/no-permission) and
-        # config (gateway not granted access) cases; surface as re-auth with the
-        # IdP detail so the agent/user sees the actual reason.
+        # config (gateway not granted access) cases; re-auth is the safer of the
+        # two, since retrying with a fresh token is cheap and a config problem
+        # simply fails again. The IdP's error_description is logged, not
+        # returned: it is operator diagnostics, not something the calling agent
+        # can act on.
+        # Keycloak never answers invalid_grant for token-exchange: legacy
+        # exchange reports an expired or unusable subject_token as
+        # invalid_token, which is the same user-fixable situation.
         return OboReauthRequired("IdP rejected the user assertion")
+    if err == "unsupported_grant_type":
+        # The token-exchange grant is not enabled on the server at all — on
+        # Keycloak <= 26.1 that means KC_FEATURES lacks token-exchange.
+        return OboConfigError(
+            f"IdP does not support the token-exchange grant "
+            f"(unsupported_grant_type, status={status_code})"
+        )
+    if err == "access_denied" and kind == "keycloak":
+        # Keycloak answers access_denied when the exchange is not permitted,
+        # and what "permitted" means depends on the server generation, so name
+        # both rather than asserting one: legacy exchange (<= 26.1) wants the
+        # token-exchange permission on the TARGET client, while standard
+        # exchange (26.2+) wants the gateway's own client inside the subject
+        # token's audience. Both are operator-actionable configuration.
+        #
+        # Deliberately NOT shared with Entra: Entra returns access_denied for
+        # denied consent and for conditional-access blocks, which are a
+        # different fix and, for CA, not operator configuration at all.
+        # Reclassifying it there would also move an already-released code path
+        # from the exchange_failed audit bucket into config_error.
+        return OboConfigError(
+            f"Keycloak denied the exchange (access_denied, status={status_code}): "
+            "grant the target client's token-exchange permission (legacy exchange), "
+            "or place the gateway client inside the subject token's audience "
+            "(standard exchange, Keycloak 26.2+)"
+        )
     if err in ("invalid_client", "invalid_scope", "unauthorized_client"):
         return OboConfigError(f"IdP rejected exchange configuration ({err})")
+    # invalid_request is deliberately NOT classified. Keycloak standard exchange
+    # (26.2+) answers it for at least three unrelated situations: an expired
+    # subject_token, the client's standard-token-exchange toggle being off, and
+    # a requested audience that cannot be placed in the token. Two are operator
+    # config and one is user re-auth, and the code alone cannot tell them apart
+    # — only error_description can, which is why it is logged at the call site.
+    # Guessing here would be worse than the generic error: classifying an
+    # expired token as config would stop the caller retrying with a fresh one.
     return OboExchangeError(
         f"IdP token exchange failed (status={status_code}, error={err or 'unknown'})"
     )
@@ -170,7 +240,23 @@ async def obo_exchange(
     token_url = getattr(idp_provider, "token_url", "") or ""
     if not token_url or not client_id or not client_secret:
         raise OboConfigError("gateway IdP credentials/token_url not configured for OBO exchange")
+    if not target_audience.strip():
+        # Registration enforces a non-empty audience, but this is the last hop
+        # before the gateway's client_secret and the user's raw JWT leave the
+        # process, and a check that can be reached with the value missing is
+        # equivalent to no check. Entra would send scope="/.default" and
+        # Keycloak a blank audience field; neither should ever be attempted.
+        raise OboConfigError("obo target_audience missing")
 
+    # CREDENTIALED_OAUTH_PROFILE enforces TLS (require_https=True): self-hosted
+    # IdPs (Keycloak is the default self-managed IdP) are supported over https
+    # only. EGRESS_OAUTH_TRUSTED_IDP_HOSTS (#1707) relaxes the public-address
+    # requirement for the named IdP hosts, not the TLS requirement, so the
+    # shipped in-cluster http://keycloak:8080 default cannot serve OBO as-is.
+    # An internal CA works via the process trust store (SSL_CERT_FILE); there
+    # is no per-hop CA-bundle setting. In-cluster non-TLS OBO is deliberately
+    # out of scope pending an explicit, operator-gated design (see
+    # docs/design/egress-auth-design.md).
     try:
         validate_url(
             token_url,
@@ -233,12 +319,29 @@ async def obo_exchange(
             payload = resp.json()
         except ValueError:
             payload = {}
+        # error_description is the only way to tell apart the situations that
+        # share an error code (notably invalid_request on standard exchange).
+        # It carries IdP configuration text, never a token or a secret, and is
+        # truncated so a verbose IdP cannot flood the log.
+        description = str(payload.get("error_description") or "")[:200]
         logger.warning(
-            f"obo_exchange: IdP token exchange failed status={resp.status_code} error={payload.get('error') or 'unknown'}",
+            "obo_exchange: IdP token exchange failed status=%s error=%s description=%s",
+            resp.status_code,
+            payload.get("error") or "unknown",
+            description or "-",
         )
-        raise _map_token_error(resp.status_code, payload)
+        raise _map_token_error(resp.status_code, payload, kind)
 
-    access_token = resp.json().get("access_token")
+    try:
+        success_payload = resp.json()
+    except ValueError as exc:
+        # The error path already tolerates a non-JSON body; the success path
+        # must too, or a 200 with a broken body escapes as an unhandled
+        # exception and the caller returns 500 instead of a typed JSON-RPC
+        # failure.
+        raise OboExchangeError("IdP returned 200 with a non-JSON body") from exc
+
+    access_token = success_payload.get("access_token")
     if not access_token:
         raise OboExchangeError("IdP returned 200 but no access_token")
     return access_token

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -2,7 +2,7 @@
 
 How the MCP Gateway lets a user reach an authentication-protected ("auth-based") third-party MCP server — GitHub, Slack, Atlassian, etc. — **as themselves**, without the coding assistant ever handling the third-party token.
 
-- Status of the modes: **`none` (no egress auth), `vault-oauth` (3LO), `token-exchange` (OBO), and `vault-pat` (PAT) are implemented today** (OBO via Microsoft Entra `jwt-bearer`; Keycloak RFC 8693 is the next phase); a **custom-header** egress mode is designed but not yet built (placeholder below).
+- Status of the modes: **`none` (no egress auth), `vault-oauth` (3LO), `token-exchange` (OBO), and `vault-pat` (PAT) are implemented today** (OBO via Microsoft Entra `jwt-bearer` and Keycloak RFC 8693 token exchange); a **custom-header** egress mode is designed but not yet built (placeholder below).
 - Authoritative implementation references: `registry/egress_auth/`, `registry/secrets/`, `registry/api/egress_auth_routes.py`, `auth_server/server.py` (`mcp_proxy`, `_vend_egress_token`, `_forward_headers`).
 
 ---
@@ -236,7 +236,7 @@ Wire the chosen value on the **registry** container across your deployment surfa
 |------|-------------|----------------------------------------|--------|
 | **`none` (no egress auth)** | No | The server needs no upstream credential. All client auth headers are stripped on egress; nothing is injected. The default for every server. | **Implemented** (`egress_auth_mode = "none"`) |
 | **`vault-oauth` (3LO)** | Yes | User completes provider OAuth (3LO) out of band; the gateway vaults the per-user token and injects it. This document's main flow. | **Implemented** (`egress_auth_mode = "oauth_user"`) |
-| **`token-exchange` (OBO)** | No | For same-trust-domain backends, the gateway exchanges the user's ingress token for a backend-audience token (Entra `jwt-bearer` / Keycloak RFC 8693). `sub` preserved; nothing stored. | **Implemented** (`egress_auth_mode = "obo_exchange"`; Entra `jwt-bearer` today, Keycloak RFC 8693 next) |
+| **`token-exchange` (OBO)** | No | For same-trust-domain backends, the gateway exchanges the user's ingress token for a backend-audience token (Entra `jwt-bearer` / Keycloak RFC 8693). `sub` preserved; nothing stored. | **Implemented** (`egress_auth_mode = "obo_exchange"`; Entra `jwt-bearer` and Keycloak RFC 8693) |
 | **`vault-pat` (PAT)** | Yes | A per-user static Personal Access Token / API key is stored in the vault (bounded TTL) and injected into the same header the server's backend auth uses. No OAuth dance. Admin seed-on-behalf supported. | **Implemented** (`egress_auth_mode = "pat"`) |
 | **custom-header** | Yes | A per-user credential the operator specifies by header **name + value**, stored in the vault and injected verbatim on egress. For backends with a bespoke/out-of-band auth scheme. Generalizes `vault-pat`. | **Placeholder — not implemented (planned with PAT)** |
 
@@ -254,7 +254,16 @@ The flow described throughout this document. `egress_auth_mode = "oauth_user"` o
 
 `egress_auth_mode = "obo_exchange"`. When the gateway IdP and the backend share a trust domain (e.g. M365 in the same Entra tenant), the gateway exchanges the user's verified ingress token for a token scoped to the backend's audience and injects that. `sub` is carried cryptographically across the exchange; **no vault, no refresh loop, nothing stored per user.** It fails closed: the ingress token is stripped and, on exchange failure, an error is returned — the ingress token is never relayed and there is no app-only (client-credentials) fallback that would drop the user identity. Its reach is limited to same-trust-domain backends — public SaaS (GitHub/Slack) does not federate with the gateway IdP, so those use `vault-oauth` instead.
 
-Provider support: **Microsoft Entra `jwt-bearer`** (the ingress token is the assertion, requesting the backend app audience) is implemented today. **Keycloak RFC 8693 token exchange** (ingress token as the subject token, backend as the audience) is the next phase and currently raises a not-implemented error. The exchange reuses the auth-server's configured IdP token endpoint and client credentials, runs on the async egress path, and logs no token material. Implementation: `auth_server/egress_obo.py` (`obo_exchange`) and the `mcp_proxy` egress hop in `auth_server/server.py`.
+Provider support: **Microsoft Entra `jwt-bearer`** (the ingress token is the assertion, requesting the backend app audience) and **Keycloak RFC 8693 token exchange** (the ingress token is the subject token, the backend client is the audience) are both implemented. The exchange reuses the auth-server's configured IdP token endpoint and client credentials, runs on the async egress path, and logs no token material. Implementation: `auth_server/egress_obo.py` (`obo_exchange`) and the `mcp_proxy` egress hop in `auth_server/server.py`.
+
+#### Keycloak (self-hosted) as the OBO identity provider
+
+Keycloak is supported for OBO via RFC 8693 token exchange: the gateway posts `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with the user's ingress token as `subject_token` (`subject_token_type=…:access_token`), the target MCP server's **bare Keycloak client id** as `audience`, its own `client_id`/`client_secret`, a pinned `requested_token_type=…:access_token`, and `scope` only when the server entry configures explicit scopes (see `_keycloak_exchange_body` in `auth_server/egress_obo.py` for the rationale). The Keycloak side must permit the gateway client to exchange to the target audience; an `access_denied` answer is surfaced as a configuration error naming both the legacy and the standard-exchange grant.
+
+Prerequisites for a **self-hosted / in-cluster** Keycloak:
+
+- **Name the Keycloak host in `EGRESS_OAUTH_TRUSTED_IDP_HOSTS` on the auth-server.** The token POST carries the gateway's client secret and the user's token, so it goes through the credentialed-OAuth SSRF profile (`CREDENTIALED_OAUTH_PROFILE`), which allows only public token endpoints by default and deliberately does not inherit `SSRF_ALLOWED_HOSTS` / `SSRF_ALLOWED_CIDRS`. A private-address Keycloak is rejected with `IdP token endpoint blocked by security policy` until its exact hostname is listed. See `EGRESS_OAUTH_TRUSTED_IDP_HOSTS` in [the parameter reference](../unified-parameter-reference.md).
+- **TLS is required.** `CREDENTIALED_OAUTH_PROFILE` sets `require_https=True`; trusted-host naming relaxes the public-address requirement, not TLS. The shipped in-cluster default (`KEYCLOAK_URL=http://keycloak:8080`) therefore cannot serve OBO until Keycloak is fronted with `https://`. An internal CA works, but there is no application-level CA-bundle setting for this hop today (`KEYCLOAK_CA_BUNDLE` is consumed by nginx only): the auth-server's httpx client verifies against the certifi store, so the internal CA must be added via the process environment (`SSL_CERT_FILE`). In-cluster **non-TLS** OBO is intentionally unsupported; an explicit, operator-gated override is a possible future extension, out of scope for the current implementation.
 
 ### `vault-pat` (PAT) — implemented
 

--- a/tests/auth_server/unit/test_egress_obo.py
+++ b/tests/auth_server/unit/test_egress_obo.py
@@ -3,8 +3,8 @@
 Covers:
 - Entra jwt-bearer request body shape (grant_type, assertion, scope, on_behalf_of).
 - .default scope synthesis vs explicit scopes.
+- Keycloak RFC 8693 request body shape (subject_token, audience, client auth).
 - IdP error-code -> typed exception mapping.
-- Keycloak path raises (Phase 4 stub).
 - No caching: two calls hit the token endpoint twice.
 - Missing gateway credentials -> config error.
 """
@@ -49,6 +49,19 @@ class _FakeResponse:
 
     def json(self):
         return self._payload
+
+
+class _FakeNonJsonResponse:
+    """A response whose body is not JSON — what a misbehaving proxy in front of
+    the IdP returns. The error path already tolerates this; the success path
+    must too."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.text = "<html>gateway timeout</html>"
+
+    def json(self):
+        raise ValueError("not json")
 
 
 def _patch_post(monkeypatch, response, capture: dict):
@@ -158,13 +171,176 @@ class TestErrorMapping:
         with pytest.raises(OboConfigError):
             await obo_exchange(_FakeEntraProvider(), subject_token="j", target_audience="api://srv")
 
+    @pytest.mark.asyncio
+    async def test_entra_access_denied_stays_generic(self, monkeypatch):
+        """access_denied must NOT be reclassified on the Entra path.
+
+        The Keycloak remediation hint would be wrong there (Entra returns this
+        for denied consent and for conditional-access blocks — a different fix,
+        and for CA not operator configuration at all), and moving an already
+        released code path out of the exchange_failed audit bucket would break
+        any alerting keyed on it. This test exists to keep that boundary.
+        """
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeResponse(403, {"error": "access_denied"}), cap)
+        with pytest.raises(OboExchangeError) as excinfo:
+            await obo_exchange(_FakeEntraProvider(), subject_token="j", target_audience="api://srv")
+        assert not isinstance(excinfo.value, OboConfigError)
+        assert "Keycloak" not in str(excinfo.value)
+
+
+@pytest.mark.unit
+class TestKeycloakExchangeBody:
+    @pytest.mark.asyncio
+    async def test_token_exchange_body_shape(self, monkeypatch):
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeResponse(200, {"access_token": "obo-tok"}), cap)
+
+        token = await obo_exchange(
+            _FakeKeycloakProvider(),
+            subject_token="ingress-jwt",
+            target_audience="finance-mcp-server",
+            scopes=[],
+        )
+
+        assert token == "obo-tok"
+        # The credential and the user's JWT must go to the CONFIGURED endpoint and
+        # nowhere else; without this a regression that redirected the POST would
+        # pass every other assertion in this file.
+        assert cap["url"] == _FakeKeycloakProvider().token_url
+        body = cap["data"]
+        assert body["grant_type"] == "urn:ietf:params:oauth:grant-type:token-exchange"
+        assert body["subject_token"] == "ingress-jwt"
+        assert body["subject_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+        # Pinned, not left to the server default: legacy Keycloak defaults to
+        # refresh_token and would mint a credential this code discards.
+        assert body["requested_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+        # Keycloak takes the bare target client id as audience, never an https URL
+        # and never Entra's assertion/requested_token_use convention.
+        assert body["audience"] == "finance-mcp-server"
+        assert body["client_id"] == "gw-client"
+        assert body["client_secret"] == "gw-secret"
+        assert "assertion" not in body
+        assert "requested_token_use" not in body
+        # No explicit scopes -> omit the field entirely so Keycloak applies
+        # the target client's defaults.
+        assert "scope" not in body
+
+    @pytest.mark.asyncio
+    async def test_explicit_scopes_joined_into_scope(self, monkeypatch):
+        """Scopes are space-joined into `scope` when explicitly requested.
+
+        The inputs deliberately mirror what registration actually accepts:
+        ServerInfo._validate_egress_auth binds every scope's resource prefix to
+        target_audience, so bare OIDC names like "profile" are rejected before
+        they could ever reach this builder. Asserting on those would be green
+        and meaningless.
+        """
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeResponse(200, {"access_token": "t"}), cap)
+
+        await obo_exchange(
+            _FakeKeycloakProvider(),
+            subject_token="j",
+            target_audience="srv-client",
+            scopes=["srv-client/read", "srv-client/write"],
+        )
+        assert cap["data"]["scope"] == "srv-client/read srv-client/write"
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_maps_to_reauth(self, monkeypatch):
+        """An expired subject_token must surface as re-auth, not a generic failure.
+
+        Keycloak never answers invalid_grant for token-exchange — legacy
+        exchange reports an unusable subject_token as invalid_token — so
+        mapping only invalid_grant would leave the single most likely runtime
+        failure (the ingress JWT expiring mid-flight) in the generic bucket.
+        """
+        cap: dict = {}
+        _patch_post(
+            monkeypatch,
+            _FakeResponse(400, {"error": "invalid_token", "error_description": "Invalid token"}),
+            cap,
+        )
+        with pytest.raises(OboReauthRequired):
+            await obo_exchange(
+                _FakeKeycloakProvider(), subject_token="j", target_audience="srv-client"
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_request_stays_generic(self, monkeypatch):
+        """invalid_request must NOT be classified — the code is overloaded.
+
+        Keycloak standard exchange answers it for an expired subject_token, for
+        the client's exchange toggle being off, and for an unplaceable audience.
+        Two are operator config and one is user re-auth; guessing config would
+        stop the caller retrying with a fresh token. error_description is the
+        only discriminator and it is logged, not classified on.
+        """
+        cap: dict = {}
+        _patch_post(
+            monkeypatch,
+            _FakeResponse(400, {"error": "invalid_request", "error_description": "Invalid token"}),
+            cap,
+        )
+        with pytest.raises(OboExchangeError) as excinfo:
+            await obo_exchange(
+                _FakeKeycloakProvider(), subject_token="j", target_audience="srv-client"
+            )
+        assert not isinstance(excinfo.value, OboConfigError | OboReauthRequired)
+
+    @pytest.mark.asyncio
+    async def test_unsupported_grant_type_maps_to_config(self, monkeypatch):
+        """Keycloak without the token-exchange feature enabled."""
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeResponse(400, {"error": "unsupported_grant_type"}), cap)
+        with pytest.raises(OboConfigError, match="token-exchange grant"):
+            await obo_exchange(
+                _FakeKeycloakProvider(), subject_token="j", target_audience="srv-client"
+            )
+
+    @pytest.mark.asyncio
+    async def test_access_denied_maps_to_config(self, monkeypatch):
+        """Keycloak answers access_denied when the target client has not granted
+        the token-exchange permission — the common first-run failure. It must
+        surface as an actionable configuration error, not a generic exchange
+        failure."""
+        cap: dict = {}
+        _patch_post(
+            monkeypatch,
+            _FakeResponse(
+                403,
+                {"error": "access_denied", "error_description": "Client not allowed to exchange"},
+            ),
+            cap,
+        )
+        with pytest.raises(OboConfigError, match="token-exchange permission"):
+            await obo_exchange(
+                _FakeKeycloakProvider(), subject_token="j", target_audience="srv-client"
+            )
+
 
 @pytest.mark.unit
 class TestUnsupportedAndConfig:
     @pytest.mark.asyncio
-    async def test_keycloak_raises_not_implemented(self, monkeypatch):
-        # Keycloak path is a Phase 4 stub; it must raise cleanly, not silently pass.
-        with pytest.raises(OboUnsupportedIdpError, match="Keycloak"):
+    async def test_blank_target_audience_is_config_error(self, monkeypatch):
+        """No credential leaves the process without a target to exchange for."""
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeResponse(200, {"access_token": "t"}), cap)
+        with pytest.raises(OboConfigError, match="target_audience"):
+            await obo_exchange(_FakeKeycloakProvider(), subject_token="j", target_audience="   ")
+        assert cap["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_non_json_success_body_is_typed_error(self, monkeypatch):
+        """A 200 with a broken body must stay inside the OboExchangeError family.
+
+        Otherwise the ValueError escapes the caller's `except OboExchangeError`
+        and the user gets a 500 instead of a JSON-RPC failure.
+        """
+        cap: dict = {}
+        _patch_post(monkeypatch, _FakeNonJsonResponse(200), cap)
+        with pytest.raises(OboExchangeError, match="non-JSON"):
             await obo_exchange(
                 _FakeKeycloakProvider(), subject_token="j", target_audience="srv-client"
             )


### PR DESCRIPTION
Refs #1461 (see *Not covered* below — this does not close it on its own)

## What

Implements the Keycloak half of egress OBO token exchange (Phase 4 follow-up to #1269): replaces the `not yet implemented` stub in `_keycloak_exchange_body` with a real RFC 8693 standard-token-exchange request.

- `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`
- `subject_token` + `subject_token_type=urn:ietf:params:oauth:token-type:access_token`
- `requested_token_type` **pinned** to `access_token` rather than left to the server default — see *Version semantics*
- `audience` = the bare target client id (registration-time validation already constrains audience shape upstream)
- the gateway's own `client_id` / `client_secret` as form fields
- `scope` sent only when explicit scopes are requested; omitting it makes Keycloak apply the **requesting** client's default client scopes — the gateway's own, not the audience client's

### Error mapping

`_map_token_error` now takes the IdP family so a provider-specific remediation hint cannot reach an operator running the other IdP:

| code | mapping | note |
|---|---|---|
| `invalid_grant`, `invalid_token` | `OboReauthRequired` | Keycloak never answers `invalid_grant` for token-exchange; legacy exchange reports an unusable `subject_token` as `invalid_token`, so the most likely runtime failure — the ingress JWT expiring mid-flight — was landing in the generic bucket |
| `unsupported_grant_type` | `OboConfigError` | the feature is not enabled on the server |
| `access_denied` | `OboConfigError` — **Keycloak only** | names both authorization models rather than asserting one; see *Version semantics*. Deliberately not applied to Entra, which returns this for denied consent and for conditional-access blocks, and where reclassifying would move an already-released path out of the `exchange_failed` audit bucket |
| `invalid_client`, `invalid_scope`, `unauthorized_client` | `OboConfigError` | unchanged |
| `invalid_request` | **deliberately unclassified** | standard exchange answers it for an expired `subject_token`, for the client's exchange toggle being off, and for an unplaceable audience — two config, one re-auth. The code alone cannot separate them, and calling an expired token a config problem would stop the caller retrying with a fresh one. `error_description` is the only discriminator, so it is now logged |

The IdP's `error_description` is now logged (truncated; it carries configuration text, never a token) — without it the overloaded codes above are undiagnosable.

Also in this PR: a blank `target_audience` is rejected before any credential leaves the process, and `resp.json()` on the success path is wrapped so a 200 with a broken body stays an `OboExchangeError` instead of escaping as a 500.

## Version semantics

This matters more than it looks, because the repo ships three Keycloak majors across four surfaces:

| surface | Keycloak | `KC_FEATURES` |
|---|---|---|
| `docker-compose*.yml`, `terraform/aws-ecs` | 25.0 | `token-exchange,admin-api` |
| `infra/` (CDK) | 26.2.4 | `token-exchange` |
| `charts/` (Helm) | 26.3.3 | *(absent)* |

Legacy exchange (≤ 26.1) and standard exchange (26.2+) differ in ways this code path touches directly:

- **default `requested_token_type`** — legacy `refresh_token`, standard `access_token`. Unpinned, the legacy path made Keycloak mint a refresh token on every per-request exchange that the code reads past and discards. Now pinned.
- **what `access_denied` means** — legacy: the *target* client lacks the token-exchange permission. Standard: the *gateway's own* client is outside the subject token's audience. The message names both.
- **on 26.2+ both are enabled** (`token-exchange` is the v1 key; v2 is on by default and takes precedence), so the same request is served by different implementations depending on the client's Standard-token-exchange toggle.

The live verification was done on Keycloak 25 — i.e. **legacy** exchange. The standard-exchange path is reasoned from the docs and source, not exercised.

## Tests

26 unit tests, all passing. Beyond body shape and error mapping:

- the POST target URL is asserted — previously it was captured and never checked, so a regression redirecting the gateway's `client_secret` and the user's JWT to another endpoint would have passed every assertion in the file;
- scope inputs use shapes that survive `ServerInfo._validate_egress_auth`, which binds each scope's resource prefix to `target_audience` — bare OIDC names like `profile` are rejected at registration and asserting on them proves nothing;
- an Entra `access_denied` test pins that the new branch does **not** reclassify that path.

## Design question — resolved by #1707

`obo_exchange` routes the token POST through `guarded_async_client` with `CREDENTIALED_OAUTH_PROFILE` (HTTPS-only, deliberately empty allowlist), so an in-cluster IdP on a private address — including the shipped compose default `KEYCLOAK_URL=http://keycloak:8080` — was blocked before the body was ever built. The question this section originally raised (trust the configured IdP `token_url`, or add an opt-in allowlist knob) has since been answered upstream: #1707 added `EGRESS_OAUTH_TRUSTED_IDP_HOSTS`, an operator-named allowlist of exact IdP hostnames, and 7d2f85b6 propagates it to the auth-server, which is the process that performs the exchange.

This PR keeps the guard untouched and documents the two prerequisites that remain for a self-hosted Keycloak: the IdP host must be listed in `EGRESS_OAUTH_TRUSTED_IDP_HOSTS`, and TLS stays required (`require_https=True` on the profile; an internal CA works through the process trust store, there is no per-hop CA-bundle setting). In-cluster non-TLS OBO remains out of scope for now, per review.

## Not covered by this PR

Listed so the tracking issue is not closed by mistake:

1. **No integration test** proving the exchanged token is delegated with the subject's `sub` preserved. #1269's checklist asks for that, plus a negative test for an audience the IdP does not own and a regression test that `client_credentials` never appears on the OBO path. None ship here.
2. **Design doc updated here; the operator doc is not.** `docs/design/egress-auth-design.md` now states that Keycloak RFC 8693 is implemented (status line, mode table, provider paragraph) and gains a "Keycloak (self-hosted) as the OBO identity provider" subsection with the request shape and the `EGRESS_OAUTH_TRUSTED_IDP_HOSTS` / TLS prerequisites. `docs/obo-token-exchange.md` still has no Keycloak setup section, no `KEYCLOAK_*` row in the env table, and a failure-triage table of `AADSTS*` codes only; the ops notes below belong there — follow-up.
3. **`extra_audiences` is a no-op on Keycloak.** `auth_server/server.py` computes per-server OBO audiences and passes them to `validate_token`, and `_server_advertises_per_server_prm()` returns true for OBO on *any* provider — but `KeycloakProvider.validate_token(**kwargs)` swallows the argument and its allowlist is hardcoded. Harmless while Keycloak ignores RFC 8707 `resource`, but an operator who adds an audience mapper for the advertised per-server resource gets a fail-closed `Invalid audience` with no knob. Not touched here; happy to fix in a follow-up if you want it separate.
4. **`egress_oauth.scopes` is effectively unusable on Keycloak.** `_obo_scope_mismatches_target` requires a scope's resource prefix to equal `target_audience`, which is an Entra convention; every scope a Keycloak operator would want (`profile`, `email`, …) is rejected at registration, and the shapes that survive are not Keycloak client-scope names. The happy path (empty scopes → target's defaults) works, and the UI exposes no scopes field, so this is latent rather than breaking.
5. **The Helm chart never enables token exchange** (`KC_FEATURES` appears in no chart), so that surface needs a manual step.

## Ops notes (for `docs/obo-token-exchange.md`)

- legacy exchange (Keycloak ≤ 26.1) needs the target client's token-exchange permission via fine-grained admin permissions, otherwise the token endpoint answers `access_denied — Client not allowed to exchange`;
- standard exchange (26.2+) instead needs the gateway's own client inside the subject token's `aud`;
- the exchange uses the gateway IdP provider's `client_id` — the **web** client, not `m2m_client_id` — so whichever permission applies must be granted there;
- the subject token's `iss` must match the token endpoint's host, which matters when the gateway and the caller reach the IdP through different front doors.


