### PR TITLE
fix(nginx): serve ROOT_PATH-prefixed static assets and favicon in path mode

### DIFF
--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -251,13 +251,13 @@ server {
 {{VIRTUAL_SERVER_BLOCKS}}
 
     # Serve static files directly from nginx (more efficient than proxying)
-    location /static/ {
+    location {{ROOT_PATH}}/static/ {
         alias /app/frontend/build/static/;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location = /favicon.ico {
+    location = {{ROOT_PATH}}/favicon.ico {
         alias /app/frontend/build/favicon.ico;
         expires 1y;
         add_header Cache-Control "public, immutable";
@@ -1910,13 +1910,13 @@ server {
 {{VIRTUAL_SERVER_BLOCKS}}
 
     # Serve static files directly from nginx (more efficient than proxying)
-    location /static/ {
+    location {{ROOT_PATH}}/static/ {
         alias /app/frontend/build/static/;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location = /favicon.ico {
+    location = {{ROOT_PATH}}/favicon.ico {
         alias /app/frontend/build/favicon.ico;
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -473,13 +473,13 @@ server {
 {{VIRTUAL_SERVER_BLOCKS}}
 
     # Serve static files directly from nginx (more efficient than proxying)
-    location /static/ {
+    location {{ROOT_PATH}}/static/ {
         alias /app/frontend/build/static/;
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    location = /favicon.ico {
+    location = {{ROOT_PATH}}/favicon.ico {
         alias /app/frontend/build/favicon.ico;
         expires 1y;
         add_header Cache-Control "public, immutable";

--- a/registry/main.py
+++ b/registry/main.py
@@ -1416,11 +1416,8 @@ async def serve_rum_js():
 if FRONTEND_BUILD_PATH.exists():
     # Build the cached HTML at import time
     _CACHED_INDEX_HTML = _build_cached_index_html()
-    # Mount static files - path depends on ROOT_PATH
-    # When ROOT_PATH is set, FastAPI automatically handles the prefix for routes,
-    # but we need to explicitly mount static files at the root level
-    # The <base> tag in HTML will make browsers request /registry/static/*
-    # which FastAPI will handle correctly with root_path
+    # Mount static files at the unprefixed path; nginx's own ROOT_PATH-prefixed
+    # static location handles the prefixed request and never reaches this app.
     app.mount("/static", StaticFiles(directory=FRONTEND_BUILD_PATH / "static"), name="static")
 
     # Serve React app for all other routes (SPA)

--- a/tests/unit/core/test_nginx_static_root_path.py
+++ b/tests/unit/core/test_nginx_static_root_path.py
@@ -1,0 +1,84 @@
+"""Static/favicon nginx locations must be ROOT_PATH-prefixed like other routes.
+
+Issue #1660: in path-based routing mode (ROOT_PATH set, e.g. ``/registry``),
+the frontend's rewritten HTML requests assets at ``{ROOT_PATH}/static/...``
+and ``{ROOT_PATH}/favicon.ico``. The nginx locations serving those assets
+directly via ``alias`` were bare ``/static/`` and ``/favicon.ico``, so a
+ROOT_PATH-prefixed request never matched them; it fell through to the
+catch-all ``location /``, which proxies the unstripped path to the FastAPI
+backend and gets back the SPA's cached index.html instead of the real asset.
+Every other backend route in these templates already uses a
+``{{ROOT_PATH}}``-prefixed location for exactly this reason.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_DOCKER_DIR = Path(__file__).resolve().parents[3] / "docker"
+_TEMPLATES = (
+    "nginx_rev_proxy_http_and_https.conf",
+    "nginx_rev_proxy_http_only.conf",
+)
+
+
+def _server_blocks(text: str) -> list[str]:
+    """Split a config into its top-level ``server { ... }`` blocks."""
+    blocks = []
+    for match in re.finditer(r"^server \{", text, re.MULTILINE):
+        depth = 0
+        for index in range(match.start(), len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(text[match.start() : index + 1])
+                    break
+    return blocks
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_every_server_block_prefixes_static_location(template: str) -> None:
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    blocks = _server_blocks(text)
+    assert blocks, f"no server blocks found in {template}"
+
+    for block in blocks:
+        listen = re.search(r"^\s*listen ([^;]+);", block, re.MULTILINE)
+        listen_desc = listen.group(1) if listen else "unknown"
+        assert re.search(r"^\s*location \{\{ROOT_PATH\}\}/static/ \{", block, re.MULTILINE), (
+            f"{template}: server block listening on {listen_desc!r} does not "
+            "prefix its /static/ location with {{ROOT_PATH}}, so a path-mode "
+            "request for a static asset falls through to the SPA fallback (#1660)"
+        )
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_every_server_block_prefixes_favicon_location(template: str) -> None:
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    blocks = _server_blocks(text)
+    assert blocks, f"no server blocks found in {template}"
+
+    for block in blocks:
+        listen = re.search(r"^\s*listen ([^;]+);", block, re.MULTILINE)
+        listen_desc = listen.group(1) if listen else "unknown"
+        assert re.search(
+            r"^\s*location = \{\{ROOT_PATH\}\}/favicon\.ico \{", block, re.MULTILINE
+        ), (
+            f"{template}: server block listening on {listen_desc!r} does not "
+            "prefix its /favicon.ico location with {{ROOT_PATH}}, so a path-mode "
+            "request for it falls through to the SPA fallback (#1660)"
+        )
+
+
+@pytest.mark.parametrize("template", _TEMPLATES)
+def test_bare_static_and_favicon_locations_are_gone(template: str) -> None:
+    """A later edit re-introducing the unprefixed form would silently regress this."""
+    text = (_DOCKER_DIR / template).read_text(encoding="utf-8")
+
+    assert not re.search(r"^\s*location /static/ \{", text, re.MULTILINE)
+    assert not re.search(r"^\s*location = /favicon\.ico \{", text, re.MULTILINE)


### PR DESCRIPTION
In path-based routing mode (`ROOT_PATH` set, e.g. `/registry`), the frontend's cached `index.html` rewrites its asset references to `{ROOT_PATH}/static/...` and `{ROOT_PATH}/favicon.ico`. The nginx locations serving those assets directly via `alias` were bare `/static/` and `/favicon.ico`, so a prefixed request never matched them. It fell through to the catch-all `location /`, which proxies the unstripped path to FastAPI; FastAPI's own `/static` mount only matches an unprefixed path either, so the request lands on the SPA fallback and gets back `index.html` (`text/html`) instead of the real JS/CSS asset. Every other backend route in these templates already uses a `{{ROOT_PATH}}`-prefixed location for exactly this reason (e.g. `location {{ROOT_PATH}}/api/`); the static/favicon block was the one left over from before path-mode routing was added. The reporter's proposed Ingress fix does not address this: the ALB `/registry` rule is `pathType: Prefix` and already routes `/registry/static/*` to the service, so the request reaches nginx correctly and fails there.

Fix: prefix both locations with `{{ROOT_PATH}}`, in both nginx templates (`_and_https` and `_only`). `{{ROOT_PATH}}` renders to an empty string when `ROOT_PATH` is unset, so root-mode deployments are unaffected. Left the FastAPI `/static` mount as-is; nginx now serves the asset directly via `alias` for both prefixed and unprefixed requests, so the mount is never reached in either mode. Updated the comment above it, which described the stale (incorrect) routing.

Fixes #1660

## Verification

- New regression test (`tests/unit/core/test_nginx_static_root_path.py`) parses both nginx templates and asserts every `server` block prefixes its static/favicon location: 6/6 cases fail on `main`, 6/6 pass on this branch, run in a clean `python:3.14-slim` container.
- The nginx-template and virtual-server unit suites (`tests/unit/core/`, `tests/unit/test_agent_nginx.py`, `tests/unit/test_virtual_server_nginx.py`, 215 tests) pass unchanged on this branch.
- `ruff check`, `ruff format --check` and `bandit` clean on the changed files.
- Not verified: a live nginx process serving the rendered template, and the full test suite with the MongoDB-backed coverage run CI uses. The location-block prefix match is static, deterministic text matching with no dynamic logic, and the change is scoped to nginx config plus a comment, so the parsed-template test above covers the actual mechanism.
