### PR TITLE
chore(ruff): enforce F821 (undefined name) instead of ignoring it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,10 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "W", "F", "I", "B", "C4", "UP"]
-ignore = ["E501", "B008", "B904", "B019", "C401", "B007", "E402", "F841", "F823", "E722", "F811", "W293", "W291", "F821"]
+# F821 (undefined name) is intentionally NOT ignored: it catches type names used
+# in annotations but never imported, which break typing.get_type_hints(), mypy,
+# and IDE navigation even when they do not crash at runtime (see #1654).
+ignore = ["E501", "B008", "B904", "B019", "C401", "B007", "E402", "F841", "F823", "E722", "F811", "W293", "W291"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/unit/services/test_webhook_service.py
+++ b/tests/unit/services/test_webhook_service.py
@@ -6,6 +6,7 @@ import json
 import logging
 from unittest.mock import (
     AsyncMock,
+    MagicMock,
     patch,
 )
 


### PR DESCRIPTION
Follow-up to #1654.

## Why

#1654 fixed four `F821` (undefined name) violations — type names used in annotations but never imported. Those slipped through because **`F821` is in the ruff `ignore` list** (`pyproject.toml`), so the existing ruff run never flagged them. Undefined names in annotations break `typing.get_type_hints()`, mypy, and IDE navigation even when they don't crash at runtime.

## Change

- Remove `F821` from `[tool.ruff.lint] ignore` so the existing ruff invocation (the `ruff` pre-commit hook and the Code Quality CI job) enforces it. No new tool or job — it rides the ruff run that already exists.
- Fix the one remaining repo-wide `F821`: `MagicMock` was used but not imported in `tests/unit/services/test_webhook_service.py` (added it to the existing `unittest.mock` import).

## Verification

- `ruff check --select F821 .`: 0 errors (was 1 after #1654 merged).
- `ruff check .` with F821 now enforced via `pyproject.toml`: clean.
- `tests/unit/services/test_webhook_service.py`: 18 passed.

No runtime or config-parameter changes.