### PR TITLE
fix(keycloak): emit the KEYCLOAK_EXTERNAL_URL diagnostic once, not per request

### DIFF
--- a/auth_server/providers/factory.py
+++ b/auth_server/providers/factory.py
@@ -26,6 +26,20 @@ logger = logging.getLogger(__name__)
 # development and genuinely works for a client on the same host.
 _LOOPBACK_HOSTNAMES = frozenset({"localhost", "localhost.localdomain", "ip6-localhost"})
 
+# The KEYCLOAK_EXTERNAL_URL diagnostic is emitted from the provider factory, which
+# `get_auth_provider()` invokes on every OAuth-discovery request (`.well-known/*`),
+# not just at startup. Those endpoints are public and crawled anonymously, so
+# without de-duplication the same line repeats on every hit. Remember which
+# (url, configured) states have already been reported so each is logged at most
+# once per process; a genuinely new configuration still logs. Reset in tests via
+# ``_reset_external_url_diagnostic()``.
+_reported_external_urls: set[tuple[str, bool]] = set()
+
+
+def _reset_external_url_diagnostic() -> None:
+    """Clear the per-process de-dup state (test helper)."""
+    _reported_external_urls.clear()
+
 
 def _host_is_loopback(host: str) -> bool:
     """Whether `host` refers to the local machine."""
@@ -84,6 +98,13 @@ def _check_keycloak_external_url(external_url: str, *, configured: bool) -> None
         configured: Whether KEYCLOAK_EXTERNAL_URL was actually set, as opposed
             to having fallen back to the internal KEYCLOAK_URL.
     """
+    # The factory runs per OAuth-discovery request, so log each distinct state
+    # once instead of on every anonymous `.well-known` hit.
+    key = (external_url, configured)
+    if key in _reported_external_urls:
+        return
+    _reported_external_urls.add(key)
+
     if not configured:
         logger.warning(
             f"KEYCLOAK_EXTERNAL_URL is not set, so OAuth discovery metadata will advertise "

--- a/tests/auth_server/unit/providers/test_keycloak.py
+++ b/tests/auth_server/unit/providers/test_keycloak.py
@@ -911,6 +911,16 @@ class TestKeycloakExternalUrlDiagnostic:
     so without a startup line the misconfiguration is effectively invisible.
     """
 
+    @pytest.fixture(autouse=True)
+    def _reset_diagnostic_dedup(self):
+        """The diagnostic logs each (url, configured) state once per process; clear
+        that de-dup state before every test so cases stay independent."""
+        from auth_server.providers import factory
+
+        factory._reset_external_url_diagnostic()
+        yield
+        factory._reset_external_url_diagnostic()
+
     def _create(self, monkeypatch, external_url: str | None):
         """Build a Keycloak provider through the factory with a patched env."""
         from auth_server.providers import factory
@@ -982,3 +992,33 @@ class TestKeycloakExternalUrlDiagnostic:
         assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
         infos = [r.message for r in caplog.records if r.levelno == logging.INFO]
         assert any("only works for clients on this host" in m for m in infos), infos
+
+    def test_diagnostic_logs_once_per_config(self, monkeypatch, caplog):
+        """The factory runs per OAuth-discovery request; the warning must not repeat.
+
+        `.well-known` endpoints are public and crawled anonymously, so a warning
+        on every hit is noise. The same misconfiguration should log exactly once.
+        """
+        with caplog.at_level(logging.WARNING, logger="auth_server.providers.factory"):
+            for _ in range(5):
+                self._create(monkeypatch, "http://keycloak:8080")
+
+        warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "fail discovery" in r.message
+        ]
+        assert len(warnings) == 1, warnings
+
+    def test_distinct_configs_each_log(self, monkeypatch, caplog):
+        """A genuinely new (url, configured) state still logs, even after another."""
+        with caplog.at_level(logging.WARNING, logger="auth_server.providers.factory"):
+            self._create(monkeypatch, "http://keycloak:8080")  # single-label WARNING
+            self._create(monkeypatch, "http://10.0.1.5:8080")  # private-address WARNING
+
+        warnings = [
+            r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "fail discovery" in r.message
+        ]
+        assert len(warnings) == 2, warnings


### PR DESCRIPTION
Follow-up to #1657.

## Why

The `KEYCLOAK_EXTERNAL_URL` startup diagnostic added in #1657 is logged from `_create_keycloak_provider()`, and `get_auth_provider()` is **not cached** — it is invoked on **every OAuth-discovery request** (the `.well-known/oauth-authorization-server` and `oauth-protected-resource` routes served by both the registry and the auth-server, via `registry/api/wellknown_routes.py`). Those endpoints are public and crawled anonymously, so a misconfigured deployment logged the same `WARNING` on **every hit** rather than once.

Confirmed live during testing of #1657: two discovery requests produced two identical WARNING lines.

## Fix

De-duplicate at the diagnostic itself (no change to provider lifecycle or auth behavior): remember which `(external_url, configured)` states have been reported and emit each at most once per process. A genuinely new configuration still logs, so a value that changes at runtime is not swallowed.

- `auth_server/providers/factory.py`: module-level `_reported_external_urls` set + an early-return guard in `_check_keycloak_external_url`, plus a `_reset_external_url_diagnostic()` test helper.
- `tests/auth_server/unit/providers/test_keycloak.py`:
  - `test_diagnostic_logs_once_per_config` — 5 repeated calls with the same misconfig log exactly one warning.
  - `test_distinct_configs_each_log` — two different unroutable URLs each still log.
  - autouse fixture resets the de-dup state between cases so the existing 11 tests stay independent.

## Verification

`pytest tests/auth_server/unit/providers/test_keycloak.py::TestKeycloakExternalUrlDiagnostic`: **13 passed** (11 existing + 2 new). Ruff check + format clean.

No behavior change beyond logging frequency; the misconfiguration is still surfaced.