### PR TITLE
fix(ecs): grant registry exec role read on embeddings-idp-secret

### DIFF
--- a/terraform/aws-ecs/modules/mcp-gateway/iam.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/iam.tf
@@ -19,6 +19,7 @@ resource "aws_iam_policy" "ecs_secrets_access" {
             aws_secretsmanager_secret.keycloak_client_secret.arn,
             aws_secretsmanager_secret.keycloak_m2m_client_secret.arn,
             aws_secretsmanager_secret.embeddings_api_key.arn,
+            aws_secretsmanager_secret.embeddings_idp_client_secret.arn,
             aws_secretsmanager_secret.keycloak_admin_password.arn
           ],
           var.documentdb_credentials_secret_arn != "" ? [var.documentdb_credentials_secret_arn] : [],


### PR DESCRIPTION
## Problem

On main, `terraform/aws-ecs` creates `aws_secretsmanager_secret.embeddings_idp_client_secret` and the **registry task definition mounts it** (`EMBEDDINGS_AUTH_MODE=idp`), but that secret's ARN is **missing from the `ecs_secrets_access` execution-role policy** (`modules/mcp-gateway/iam.tf`).

Result: whenever the embeddings-idp secret exists, every registry task fails at init with:

```
ResourceInitializationError: unable to pull secrets ... AccessDeniedException:
role mcp-gateway-v2-registry-... is not authorized to perform
secretsmanager:GetSecretValue on ...:secret:mcp-gateway-v2-embeddings-idp-secret-...
```

so the registry service crash-loops at **0/N running** (observed live on the deployed stack).

## Fix

Add `aws_secretsmanager_secret.embeddings_idp_client_secret.arn` to the execution-role
secrets policy (unconditional, alongside `embeddings_api_key`). One line.

## Notes

- Independent of the go-validate fast-path work; this is a standalone main bug. The same
  fix already exists on the `feat/go-validate-fastpath-sidecar` branch (cherry-picked here) but was never merged to main.
- `terraform validate` passes.
- Plan to `terraform apply` from this branch against the live stack to confirm registry
  recovers, **before** merging.