### PR TITLE
fix(auth): strip ingress proxy-context headers on the egress hop

### DIFF
--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6299,13 +6299,30 @@ async def _read_bounded(
 # servers that need an upstream credential use the egress vault.
 _INTERNAL_INGRESS_RELAY_SERVERS: frozenset[str] = frozenset({"airegistry-tools"})
 
+# Proxy-context headers describe the client -> Gateway hop (scheme, host, port,
+# path prefix as seen by nginx/an ingress LB) and must not be copied onto the
+# separate Gateway -> upstream MCP server hop; an upstream that trusts them can
+# see a stale scheme and issue a redirect loop. X-Forwarded-For is deliberately
+# excluded: some deployments rely on it to see the real client IP upstream.
+_PROXY_CONTEXT_HEADERS: frozenset[str] = frozenset(
+    {
+        "forwarded",
+        "x-forwarded-host",
+        "x-forwarded-port",
+        "x-forwarded-proto",
+        "x-forwarded-prefix",
+        "x-original-uri",
+        "x-original-url",
+    }
+)
+
 
 def _forward_headers(
     incoming: dict[str, str],
     relay_authorization: bool = False,
 ) -> dict[str, str]:
     """Copy incoming request headers to the upstream, stripping hop-by-hop and
-    proxy-hint headers so httpx can set them correctly for the connection.
+    proxy-context headers so httpx can set them correctly for the connection.
 
     Ingress-auth policy (issue #1266): Cookie is ALWAYS stripped (never
     forwarded to any upstream). Authorization and X-Authorization are also
@@ -6322,6 +6339,8 @@ def _forward_headers(
             continue
         if lower == "x-upstream-url":
             # Never leak this internal routing header to the upstream.
+            continue
+        if lower in _PROXY_CONTEXT_HEADERS:
             continue
         if lower in ("x-body", "x-body-uninspectable"):
             # Gateway-internal body-capture headers set by capture_body.lua for

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -5031,6 +5031,57 @@ class TestForwardHeadersIngressStrip:
         assert "authorization" not in {k.lower() for k in out}
 
 
+class TestForwardHeadersProxyContextStrip:
+    """Ingress proxy-context headers (issue #1625) describe the client -> Gateway
+    hop and must not leak onto the separate Gateway -> upstream MCP server hop,
+    or an upstream that trusts them can see a stale scheme and redirect-loop.
+    """
+
+    def _forward(self, incoming):
+        from auth_server.server import _forward_headers
+
+        return _forward_headers(incoming)
+
+    def test_strips_each_proxy_context_header(self):
+        for name in (
+            "X-Forwarded-Proto",
+            "X-Forwarded-Host",
+            "X-Forwarded-Port",
+            "X-Forwarded-Prefix",
+            "Forwarded",
+            "X-Original-URI",
+            "X-Original-URL",
+        ):
+            out = self._forward({name: "x", "Accept": "y"})
+            assert name.lower() not in {k.lower() for k in out}, name
+            assert out.get("Accept") == "y"
+
+    def test_case_insensitive(self):
+        out = self._forward({"x-forwarded-proto": "http", "x-original-url": "u"})
+        assert "x-forwarded-proto" not in {k.lower() for k in out}
+        assert "x-original-url" not in {k.lower() for k in out}
+
+    def test_stale_ingress_scheme_does_not_reach_the_egress_hop(self):
+        """The issue's own repro: an HTTPS ingress request that arrives carrying
+        a stale X-Forwarded-Proto: http must not forward it to an HTTPS upstream."""
+        out = self._forward(
+            {
+                "X-Forwarded-Proto": "http",
+                "X-Forwarded-Host": "gateway.example.com",
+                "X-Forwarded-Prefix": "/my-server",
+                "Mcp-Session-Id": "vs-abc",
+                "Accept": "application/json",
+            }
+        )
+        assert set(k.lower() for k in out) == {"mcp-session-id", "accept"}
+
+    def test_x_forwarded_for_is_not_stripped(self):
+        """X-Forwarded-For is a client-IP hint, not routing/scheme context, and
+        the issue explicitly asks that it stay untouched (compatibility)."""
+        out = self._forward({"X-Forwarded-For": "203.0.113.5"})
+        assert out.get("X-Forwarded-For") == "203.0.113.5"
+
+
 class TestInternalRelayDecision:
     """The mcp_proxy relay decision keys on the verified `server` claim (first
     path segment), matches the hardcoded internal set exactly, and normalizes


### PR DESCRIPTION
`_forward_headers()` copies the incoming request's headers onto the outbound
call to the upstream MCP server, stripping hop-by-hop headers and client
auth. It never stripped proxy-context headers: `X-Forwarded-Proto`,
`X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Prefix`, `Forwarded`,
`X-Original-URI`, `X-Original-URL`. Those describe the client to Gateway
hop, and the Gateway to upstream hop is a separate connection with its own
scheme and host. When TLS terminates in front of the Gateway, the request
can arrive carrying a stale `X-Forwarded-Proto: http` even though the
Gateway's own outbound call to the upstream is HTTPS. An upstream ingress
that trusts that header sees an HTTP request on an HTTPS connection and
answers with an HTTP-to-HTTPS redirect, which loops through the Gateway
indefinitely.

## Fix

Added `_PROXY_CONTEXT_HEADERS` and strip it in `_forward_headers`, next to
the existing hop-by-hop and auth-header stripping. `X-Forwarded-For` is
left untouched, since some deployments rely on it to see the real client
IP on the upstream side.

## Verification

- New regression tests in `TestForwardHeadersProxyContextStrip` fail
  against the pre-fix `_forward_headers` (each proxy-context header leaks
  through) and pass after the fix, including the issue's own repro shape
  (`X-Forwarded-Proto: http` with an HTTPS-configured upstream) and a
  check that `X-Forwarded-For` is still forwarded.
- Full `tests/auth_server/` suite (755 tests) passes.
- `ruff check`, `ruff format --check`, and the repo's `pre-commit` hooks
  (bandit, mypy, detect-secrets) pass on the changed files.
- Not verified: an end-to-end run against a real TLS-terminating ingress
  in front of both the Gateway and the upstream; the fix and tests are at
  the header-forwarding unit level where the leak originates.

Fixes #1625
