### PR TITLE
feat(egress): add operator_credential mode to inject the shared backend credential

### DIFF
--- a/api/registry_client.py
+++ b/api/registry_client.py
@@ -3886,7 +3886,7 @@ class RegistryClient:
 
         return response.json()
 
-    # Egress Auth Methods (per-user egress credential vault)
+    # Egress Auth Methods
 
     def configure_egress_auth(
         self,
@@ -3903,7 +3903,7 @@ class RegistryClient:
         custom_token_auth_style: str | None = None,
         custom_resource: str | None = None,
     ) -> dict[str, Any]:
-        """Configure per-user egress auth on a server (admin only).
+        """Configure gateway-managed egress auth on a server (admin only).
 
         Wraps POST /api/servers/{path}/egress-auth. Sets the egress auth mode
         and the mode-specific parameters. For ``pat`` mode, pass ``mode="pat"``
@@ -3911,7 +3911,8 @@ class RegistryClient:
 
         Args:
             server_path: Server path (e.g., "/github" or "github").
-            mode: Egress auth mode (none, oauth_user, obo_exchange, pat).
+            mode: Egress auth mode (none, operator_credential, oauth_user,
+                obo_exchange, pat).
             provider: Provider slug/name. Required for oauth_user and pat.
             client_id: OAuth client id (oauth_user only).
             client_secret: OAuth client secret (oauth_user only, write-only).

--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -6725,11 +6725,11 @@ Examples:
     )
     server_connect_config_parser.add_argument("--json", action="store_true", help="Output raw JSON")
 
-    # Egress Auth Commands (per-user egress credential vault)
+    # Egress Auth Commands
 
     # Configure egress auth command
     egress_configure_parser = subparsers.add_parser(
-        "egress-configure", help="Configure per-user egress auth on a server (admin only)"
+        "egress-configure", help="Configure gateway-managed egress auth on a server (admin only)"
     )
     egress_configure_parser.add_argument(
         "--path", required=True, help="Server path (e.g., /github)"
@@ -6737,7 +6737,7 @@ Examples:
     egress_configure_parser.add_argument(
         "--mode",
         required=True,
-        choices=["none", "oauth_user", "obo_exchange", "pat"],
+        choices=["none", "operator_credential", "oauth_user", "obo_exchange", "pat"],
         help="Egress auth mode",
     )
     egress_configure_parser.add_argument(

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -7094,14 +7094,12 @@ async def mcp_proxy(
     # We drop the foreign header on this path (see the 401 handling below).
     egress_token_injected = False
 
-    # Per-user egress credential vault. When the feature is on, ask the
-    # registry to vend this user's third-party token for the resolved server. The
-    # registry re-verifies the signed proxy token, enforces per-user/upstream
-    # authz, and returns consent_required for non-oauth_user servers.
-    # On a real vend we strip the user's own gateway credentials/identity
-    # before injecting the vaulted token. On a consent-required miss for an
-    # egress-configured server we DO NOT forward unauthenticated -- we ask the
-    # user to connect via MCP URL-mode elicitation (see _egress_consent_response).
+    # Gateway-managed egress auth. The registry re-verifies the signed proxy
+    # token, binds the request to the registered upstream, and returns either a
+    # shared operator credential, a per-user credential, or an OBO directive.
+    # On a credential hit we strip gateway credentials/identity before injecting
+    # the upstream credential. A per-user miss triggers consent rather than an
+    # unauthenticated forward (see _egress_consent_response).
     if settings.egress_auth_enabled:
         internal_proxy_token = request.headers.get("X-Internal-Token", "")
         if internal_proxy_token:
@@ -7245,12 +7243,11 @@ async def mcp_proxy(
                 # (same cross-resource-PRM protection as the vaulted-token path).
                 egress_token_injected = True
             elif vend and vend.get("access_token"):
-                # Token is vaulted (consent done): strip the user's gateway
-                # credentials/identity and inject the vaulted upstream token.
-                # oauth_user/obo use "Authorization: Bearer"; a pat server may
-                # override the header name + value prefix (e.g. GitLab
-                # "PRIVATE-TOKEN: <t>" bare, or "X-API-Key: <t>"). Defaults
-                # reproduce "Authorization: Bearer <t>".
+                # Strip the caller's gateway credentials/identity and inject the
+                # gateway-managed upstream credential. oauth_user uses
+                # "Authorization: Bearer"; PAT and operator_credential may
+                # inherit another Backend Authentication header (e.g.
+                # "PRIVATE-TOKEN: <t>" or "X-API-Key: <t>").
                 inject_header = vend.get("pat_header_name") or "Authorization"
                 inject_prefix = (
                     vend["pat_value_prefix"]

--- a/cli/examples/internal-bearer-mcp-server.json
+++ b/cli/examples/internal-bearer-mcp-server.json
@@ -1,0 +1,11 @@
+{
+  "server_name": "Internal MCP (shared backend credential)",
+  "description": "Template for an in-cluster or trusted MCP server that authenticates with a static bearer token. Register this file, store the token with server-update-credential (do not put secrets in this JSON), then POST egress-auth with egress_auth_mode=operator_credential. The gateway injects the Backend Authentication credential on the user proxy hop after authorizing the caller. Clients never receive the token. Do not use this mode for hosted third-party MCP servers that should call as the user (GitHub, Slack, Datadog MCP use oauth_user or pat).",
+  "path": "/internal-mcp",
+  "proxy_pass_url": "https://mcp.internal.example.com/mcp",
+  "tags": ["internal", "egress-operator-credential"],
+  "auth_scheme": "bearer",
+  "supported_transports": ["streamable-http"],
+  "status": "active",
+  "visibility": "private"
+}

--- a/docs/design/egress-auth-design.md
+++ b/docs/design/egress-auth-design.md
@@ -2,7 +2,7 @@
 
 How the MCP Gateway lets a user reach an authentication-protected ("auth-based") third-party MCP server — GitHub, Slack, Atlassian, etc. — **as themselves**, without the coding assistant ever handling the third-party token.
 
-- Status of the modes: **`none` (no egress auth), `vault-oauth` (3LO), `token-exchange` (OBO), and `vault-pat` (PAT) are implemented today** (OBO via Microsoft Entra `jwt-bearer`; Keycloak RFC 8693 is the next phase); a **custom-header** egress mode is designed but not yet built (placeholder below).
+- Status of the modes: **`none` (no egress auth), `operator-credential` (shared registered credential), `vault-oauth` (3LO), `token-exchange` (OBO), and `vault-pat` (PAT) are implemented today** (OBO via Microsoft Entra `jwt-bearer`; Keycloak RFC 8693 is the next phase); a **custom-header** per-user mode is designed but not yet built (placeholder below).
 - Authoritative implementation references: `registry/egress_auth/`, `registry/secrets/`, `registry/api/egress_auth_routes.py`, `auth_server/server.py` (`mcp_proxy`, `_vend_egress_token`, `_forward_headers`).
 
 ---
@@ -230,11 +230,12 @@ Wire the chosen value on the **registry** container across your deployment surfa
 
 ## The egress modes
 
-`egress_auth_mode` on the server entry selects how the gateway obtains the outbound credential. Today the **no-auth**, **vault-OAuth (3LO)**, **token-exchange (OBO)**, and **vault-PAT** paths are implemented; the **custom-header** mode is designed and reserved.
+`egress_auth_mode` on the server entry selects how the gateway obtains the outbound credential. Today the **no-auth**, **shared operator credential**, **vault-OAuth (3LO)**, **token-exchange (OBO)**, and **vault-PAT** paths are implemented; the **custom-header** per-user mode is designed and reserved.
 
 | Mode | Vault used? | How the egress credential is obtained | Status |
 |------|-------------|----------------------------------------|--------|
 | **`none` (no egress auth)** | No | The server needs no upstream credential. All client auth headers are stripped on egress; nothing is injected. The default for every server. | **Implemented** (`egress_auth_mode = "none"`) |
+| **`operator-credential` (shared service account)** | No per-user vault | The gateway decrypts the server's registered Backend Authentication credential after caller authorization and registered-upstream binding, then injects it for every authorized caller. | **Implemented** (`egress_auth_mode = "operator_credential"`) |
 | **`vault-oauth` (3LO)** | Yes | User completes provider OAuth (3LO) out of band; the gateway vaults the per-user token and injects it. This document's main flow. | **Implemented** (`egress_auth_mode = "oauth_user"`) |
 | **`token-exchange` (OBO)** | No | For same-trust-domain backends, the gateway exchanges the user's ingress token for a backend-audience token (Entra `jwt-bearer` / Keycloak RFC 8693). `sub` preserved; nothing stored. | **Implemented** (`egress_auth_mode = "obo_exchange"`; Entra `jwt-bearer` today, Keycloak RFC 8693 next) |
 | **`vault-pat` (PAT)** | Yes | A per-user static Personal Access Token / API key is stored in the vault (bounded TTL) and injected into the same header the server's backend auth uses. No OAuth dance. Admin seed-on-behalf supported. | **Implemented** (`egress_auth_mode = "pat"`) |
@@ -245,6 +246,10 @@ Wire the chosen value on the **registry** container across your deployment surfa
 ### `none` (no egress auth) — implemented
 
 The default. The server needs no upstream credential (or it is a public endpoint). On egress the client's ingress auth headers are stripped (`_forward_headers`) and nothing is injected. Most registered servers are `none`.
+
+### `operator-credential` (shared service account) — implemented
+
+Set `egress_auth_mode = "operator_credential"` after registering a bearer token or API key under Backend Authentication. The registry re-verifies the signed proxy token and confirms its upstream host is registered for that server before decrypting the credential. The auth server strips ingress credentials and injects the operator credential using the configured Backend Authentication header. This mode is server-scoped rather than user-scoped, so it supports authorized human, M2M, and network-trusted callers without distributing the upstream service credential to clients. Operator walkthrough: [FAQ: How do I inject a shared Backend Authentication credential on egress?](../faq/configuring-operator-credential-egress.md).
 
 ### `vault-oauth` (3LO) — implemented
 

--- a/docs/egress-credential-vault.md
+++ b/docs/egress-credential-vault.md
@@ -491,15 +491,54 @@ curl -X POST "https://mcpgateway.example.com/api/servers/github-mcp/mcp/egress-a
       }'
 ```
 
-- `egress_auth_mode`: `none` (default, feature off for this server),
-  `oauth_user` (per-user 3LO OAuth), `obo_exchange` (on-behalf-of token
-  exchange, nothing vaulted), or `pat` (per-user static PAT / API key vaulted
-  with a bounded TTL). See [egress modes](design/egress-auth-design.md#the-egress-modes).
+- `egress_auth_mode`: `none` (default, no gateway-managed upstream
+  credential), `operator_credential` (the registered Backend Authentication
+  credential is shared by every gateway-authorized caller), `oauth_user`
+  (per-user 3LO OAuth), `obo_exchange` (on-behalf-of token exchange, nothing
+  vaulted), or `pat` (per-user static PAT / API key vaulted with a bounded
+  TTL). See [egress modes](design/egress-auth-design.md#the-egress-modes).
 - `client_secret` is **write-only** — it is Fernet-encrypted with the gateway
   `SECRET_KEY` at rest and never returned by the `GET` endpoint. Rotating
   `SECRET_KEY` invalidates stored secrets.
 - The `GET` response includes the `callback_url` to register in the provider's
   OAuth app.
+
+For a service account shared by authorized callers, first configure Backend
+Authentication on the server as `bearer` or `api_key` with the service
+credential, then select the explicit operator mode. Storing the Backend
+Authentication credential alone is **not** enough for user tool calls through
+the gateway; health checks already inject it, but the proxy hop only injects
+it when this mode is set.
+
+```json
+{
+  "egress_auth_mode": "operator_credential"
+}
+```
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  egress-configure --path /internal-mcp --mode operator_credential
+```
+
+The registry decrypts that credential only after re-verifying the internal
+proxy token and binding its upstream URL to the registered server. The auth
+server then strips client gateway credentials and injects the operator
+credential into the Backend Authentication header. Clients never receive it
+or configure a server-auth placeholder. This mode is server-scoped, so it
+works for per-user and non-per-user callers that are authorized to use the
+server.
+
+Do not enable this mode for a hosted third-party MCP that should call as the
+user (GitHub, Slack, Datadog MCP): those stay on `oauth_user` or `pat`. See the
+[operator-credential FAQ](faq/configuring-operator-credential-egress.md).
+
+Deploy the registry and auth-server code to every replica before changing a
+server to `operator_credential`. Older registry replicas do not recognize
+this new mode and cannot vend its credential; configuring it during a
+mixed-version rollout causes intermittent tokenless upstream requests until
+the rollout finishes.
 
 For a custom OIDC provider:
 

--- a/docs/faq/configuring-operator-credential-egress.md
+++ b/docs/faq/configuring-operator-credential-egress.md
@@ -1,0 +1,89 @@
+# How do I inject a shared Backend Authentication credential on egress?
+
+This FAQ covers `egress_auth_mode=operator_credential`: the gateway injects the server's registered **Backend Authentication** credential on the user proxy hop, after the caller is authorized. Every authorized caller shares one upstream identity. The credential never appears in client Connect configs.
+
+For the mode table and security model, see [egress modes](../design/egress-auth-design.md#the-egress-modes) and [Per-User Egress Credential Vault](../egress-credential-vault.md).
+
+## When to use this mode
+
+Use it for a trusted internal or in-cluster MCP server where:
+
+- the upstream expects a static bearer token or API key
+- the gateway is the access-control boundary (scopes / groups at `/validate`)
+- you do **not** need the upstream to see a distinct per-user identity
+
+Do **not** use it for hosted third-party MCP servers that should call as the user. GitHub, Slack, Atlassian, and [Datadog MCP](configuring-datadog-mcp-server.md) stay on `oauth_user` or `pat`.
+
+Storing Backend Authentication alone is **not** enough for user tool calls. Health checks and registry tool-listing already decrypt that credential. The `/mcp-proxy/...` hop does not, until this mode is set. That is deliberate: a shared identity on the data path is an operator choice, not an inference from `auth_scheme=bearer`.
+
+## What you need
+
+- `EGRESS_AUTH_ENABLED=true` on the registry and auth-server (same flag as 3LO / PAT / OBO). There is no second deployment flag.
+- Registry admin access.
+- The server registered with Backend Authentication `bearer` or `api_key` **and** a stored encrypted credential.
+- Every registry and auth-server replica on a build that knows `operator_credential` **before** you flip the mode. Mixed-version rollouts vend nothing on old replicas.
+
+## Step 1: Register the server with Backend Authentication
+
+A template is in [`cli/examples/internal-bearer-mcp-server.json`](../../cli/examples/internal-bearer-mcp-server.json). Edit `proxy_pass_url`, then register. Put the real token in `--auth-credential` (or the UI), never in the JSON file:
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  register --config cli/examples/internal-bearer-mcp-server.json
+
+uv run python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  server-update-credential --path /internal-mcp \
+  --auth-scheme bearer --credential '<service-token>'
+```
+
+For a non-standard header (GitLab `PRIVATE-TOKEN`, Datadog `DD-API-KEY` on an internal wrapper, and so on) use `auth_scheme=api_key` and `--auth-header-name`. Operator mode inherits that header at vend time; there is no separate egress header field.
+
+## Step 2: Enable operator credential egress
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  egress-configure --path /internal-mcp --mode operator_credential
+```
+
+There is no `--provider`, `--client-id`, or `--client-secret`. The equivalent REST body:
+
+```json
+{
+  "egress_auth_mode": "operator_credential"
+}
+```
+
+In the UI: **Edit** the server, confirm Backend Authentication is set, then **Egress Auth → Mode → Shared backend credential**.
+
+`400` here means Backend Authentication is `none` or the credential was never stored. Fix that first; do not retry egress-configure.
+
+## Step 3: Enable the server and check Connect config
+
+```bash
+uv run python api/registry_management.py \
+  --registry-url https://mcpgateway.example.com --token-file .token \
+  toggle --path /internal-mcp --enabled true
+```
+
+Open **Connect**. The generated IDE config must **not** contain a server `Authorization` / API-key placeholder. The client authenticates to the gateway only; the gateway injects the upstream credential.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Health checks work, user tool calls get upstream `401` | Backend Authentication is set, egress mode is still `none` | Step 2 |
+| `400` `operator_credential requires Backend Authentication scheme 'bearer' or 'api_key'` | `auth_scheme` is `none` | Set bearer or api_key and store a credential |
+| `400` `requires a stored Backend Authentication credential` | Scheme set, credential never written | `server-update-credential` or the UI credential field |
+| `503` `operator credential unavailable` | Stale mode, decrypt failure, or scheme flipped back to `none` | Re-store the credential; fail-closed on purpose |
+| Intermittent tokenless upstream requests | Mixed-version rollout | Finish deploying registry + auth-server, then set the mode |
+| Connect config still has `Authorization: Bearer YOUR_TOKEN` | Egress mode not saved, or dashboard cache | Re-open Connect after egress-configure; `egress_auth_mode` must not be `none` |
+| Want per-user Datadog / GitHub identity | Wrong mode | Use `oauth_user` or `pat`, not `operator_credential` |
+
+## Related documentation
+
+- [How do I register MCP servers that require authentication?](registering-auth-protected-servers.md) — Backend Authentication for health checks
+- [How does an admin seed per-user egress PATs?](seeding-per-user-egress-pats-as-admin.md) — per-user static tokens instead of a shared credential
+- [How do I configure the Datadog MCP server with per-user egress OAuth?](configuring-datadog-mcp-server.md) — hosted Datadog MCP is 3LO, not this mode

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -60,3 +60,4 @@ Common questions and answers about the MCP Gateway Registry.
 - [How do I generate an MCP access token that lasts longer than 8 hours?](generate-token-longer-than-8-hours.md)
 - [How do I pass an M2M token from Entra to the registration gate?](oauth2-token-for-registration-gate.md)
 - [How does an admin seed per-user egress PATs for a `pat` server?](seeding-per-user-egress-pats-as-admin.md)
+- [How do I inject a shared Backend Authentication credential on egress?](configuring-operator-credential-egress.md)

--- a/docs/faq/registering-auth-protected-servers.md
+++ b/docs/faq/registering-auth-protected-servers.md
@@ -51,9 +51,10 @@ Once registered with credentials, the registry automatically:
 
 1. **Health checks** -- Injects the decrypted credential when checking if the server is reachable
 2. **Tool discovery** -- Uses the credential to call the MCP `tools/list` method on the backend server
-3. **Request proxying** -- When clients connect through the gateway, the credential is injected into proxied requests
 
-This means tool discovery works the same way for protected servers as it does for public ones -- no additional configuration is needed beyond providing the credential at registration time.
+Those two paths are registry-internal. They do **not** by themselves inject the credential on the user tool-call hop (`/mcp-proxy/...`). For that, set `egress_auth_mode` to `operator_credential` after Backend Authentication is stored. See [How do I inject a shared Backend Authentication credential on egress?](configuring-operator-credential-egress.md).
+
+Health checks and tool discovery work the same way for protected servers as for public ones once the credential is registered. User tool calls through the gateway need the explicit egress mode.
 
 ## Manually Providing Tools
 
@@ -112,7 +113,7 @@ curl -X PATCH https://registry.example.com/api/servers/my-protected-server/auth-
 
 - Credentials are **encrypted at rest** using the `SECRET_KEY` configured in your deployment
 - Credentials are **never returned** in API responses or displayed in the UI
-- Credentials are **decrypted only in memory** when needed for health checks, tool discovery, or request proxying
+- Credentials are **decrypted only in memory** when needed for health checks, tool discovery, or (when `egress_auth_mode` is `operator_credential`) the gateway proxy hop
 
 ## Getting a JWT Token
 

--- a/frontend/src/components/ServerConfigModal.tsx
+++ b/frontend/src/components/ServerConfigModal.tsx
@@ -10,6 +10,7 @@ import { isSafeUrl } from '../utils/safeUrl';
 import {
   initiateConsent,
   disconnect as disconnectEgress,
+  isGatewayManagedEgress,
   type EgressCardState,
 } from '../utils/egressAuth';
 
@@ -245,17 +246,13 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
   // Per-server override for the trailing '/mcp' transport segment on the gateway
   // URL. null = auto-detect from proxy_pass_url.
   const [appendMcpPath, setAppendMcpPath] = useState<boolean | null>(null);
-  // Per-user egress credential vault mode ('none' | 'oauth_user'). When
-  // 'oauth_user' the gateway injects the user's vaulted upstream token on
-  // egress, so the Connect config must emit NO server Authorization/API-key
-  // header (the client sends none; a placeholder would be forwarded verbatim
-  // and break the connection).
-  const [egressAuthMode, setEgressAuthMode] = useState<string>('none');
+  // Gateway-managed egress mode. Any non-'none' value (including an unknown
+  // future mode) means the gateway supplies the upstream credential, so Connect
+  // configs must not ask clients for a second server Authorization/API-key.
+  const [egressAuthMode, setEgressAuthMode] = useState<unknown>('none');
 
   const useOAuthLogin = !!oauthClientId && !isRegistryOnly;
-  // True when the gateway supplies the upstream credential itself (egress 3LO),
-  // so the client must not send any server-auth header.
-  const egressManaged = egressAuthMode === 'oauth_user';
+  const egressManaged = isGatewayManagedEgress(egressAuthMode);
 
   // Fetch JWT token when modal opens (only in gateway mode, and only for remote servers).
   // Local stdio servers don't go through the gateway — no token needed.
@@ -503,7 +500,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     // token is omitted - the IDE obtains it through the OAuth/PKCE flow.
     // The server-auth header is dropped (default includeServerAuth) in two
     // cases, for every IDE that emits it: (1) OAuth-login mode, and (2)
-    // egress-managed servers (egress_auth_mode == 'oauth_user'). In both the
+    // egress-managed servers (any non-'none' egress_auth_mode). In both the
     // gateway injects the upstream credential itself, so the client must NOT
     // send a server Authorization/API-key header (the [YOUR_SERVER_AUTH_TOKEN]
     // placeholder would be forwarded as-is and break the connection). IDEs that

--- a/frontend/src/components/__tests__/ServerConfigModal.test.tsx
+++ b/frontend/src/components/__tests__/ServerConfigModal.test.tsx
@@ -256,6 +256,32 @@ describe('ServerConfigModal IDE OAuth login (oauth_client_id)', () => {
     expect(serverConfig.auth).toBeUndefined();
   });
 
+  test('Cursor: shared backend credential omits server token placeholder', async () => {
+    connectConfig = { custom_headers: [], egress_auth_mode: 'operator_credential' };
+
+    renderModal({ auth_scheme: 'bearer' } as Partial<Server>);
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.headers['X-Authorization']).toContain('Bearer');
+    });
+    const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+    expect(serverConfig.headers.Authorization).toBeUndefined();
+  });
+
+  test('Cursor: unknown egress mode omits server token placeholder', async () => {
+    connectConfig = { custom_headers: [], egress_auth_mode: 'future_mode' };
+
+    renderModal({ auth_scheme: 'bearer' } as Partial<Server>);
+
+    await waitFor(() => {
+      const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+      expect(serverConfig.headers['X-Authorization']).toContain('Bearer');
+    });
+    const serverConfig = getDisplayedConfig().mcpServers['test-server'];
+    expect(serverConfig.headers.Authorization).toBeUndefined();
+  });
+
   test('registry-only deployment never enables OAuth login', async () => {
     mockUseRegistryConfig.mockReturnValue(registryOnlyConfig());
     connectConfig = { custom_headers: [], oauth_client_id: 'mcp-gateway' };

--- a/frontend/src/components/entities/forms/ServerEditModal.tsx
+++ b/frontend/src/components/entities/forms/ServerEditModal.tsx
@@ -12,6 +12,10 @@ import {
   LABEL,
 } from '../../formFields';
 import Button from '../../Button';
+import {
+  normalizeEgressAuthMode,
+  type EgressAuthMode,
+} from '../../../utils/egressAuth';
 
 /**
  * Shape of the server edit form state. Owned by the Dashboard (kept as state
@@ -34,8 +38,8 @@ export interface ServerEditForm {
   deployment: 'remote' | 'local';
   local_runtime: LocalRuntimeFormData;
   custom_headers: Array<{ name: string; value: string }>;
-  // Egress auth to the upstream (admin config). 'none' | 'oauth_user' | 'obo_exchange' | 'pat'.
-  egress_auth_mode: 'none' | 'oauth_user' | 'obo_exchange' | 'pat';
+  // Egress auth to the upstream (admin config).
+  egress_auth_mode: EgressAuthMode;
   // oauth_user (3LO vault) fields:
   egress_provider: string;
   egress_client_id: string;
@@ -228,6 +232,8 @@ const ServerEditModal: React.FC<ServerEditModalProps> = ({
               </h4>
               <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
                 How the gateway authenticates to this upstream on the user&apos;s behalf.
+                <strong> Shared backend credential</strong> injects the credential configured
+                in Backend Authentication for every caller authorized to use this server.
                 <strong> Per-user OAuth (3LO)</strong> has each user connect a third-party
                 account (GitHub, Slack, …) whose token the gateway injects.
                 <strong> OBO exchange</strong> re-audiences the user&apos;s gateway token to an
@@ -241,17 +247,25 @@ const ServerEditModal: React.FC<ServerEditModalProps> = ({
                     onChange={(e) =>
                       setForm((prev) => ({
                         ...prev,
-                        egress_auth_mode: e.target.value as ServerEditForm['egress_auth_mode'],
+                        egress_auth_mode: normalizeEgressAuthMode(e.target.value),
                       }))
                     }
                     className={FIELD}
                   >
                     <option value="none">Disabled</option>
+                    <option value="operator_credential">Shared backend credential</option>
                     <option value="oauth_user">Per-user OAuth (3LO)</option>
                     <option value="obo_exchange">OBO exchange (same IdP)</option>
                     <option value="pat">Per-user PAT / API key</option>
                   </select>
                 </div>
+                {form.egress_auth_mode === 'operator_credential' && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    The gateway injects the Backend Authentication credential
+                    above after authorizing each caller. Clients receive
+                    neither the credential nor a server-auth placeholder.
+                  </p>
+                )}
                 {form.egress_auth_mode === 'obo_exchange' && (
                   <div>
                     <label className={LABEL}>Target Audience</label>

--- a/frontend/src/components/entities/forms/__tests__/ServerEditModal.test.tsx
+++ b/frontend/src/components/entities/forms/__tests__/ServerEditModal.test.tsx
@@ -161,6 +161,20 @@ describe('ServerEditModal', () => {
     expect(screen.queryByText('Client ID')).not.toBeInTheDocument();
   });
 
+  it('describes shared backend credential injection in operator mode', () => {
+    render(
+      <Harness
+        initial={{ ...baseForm, egress_auth_mode: 'operator_credential' }}
+        egressEnabled
+      />
+    );
+    expect(
+      screen.getByText(/Clients receive neither the credential nor a server-auth placeholder/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Provider')).not.toBeInTheDocument();
+    expect(screen.queryByText('Target Audience')).not.toBeInTheDocument();
+  });
+
   it('shows token auth style and resource fields for a custom provider', () => {
     render(
       <Harness

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -71,7 +71,13 @@ import type {
 } from '../types/customEntity';
 import axios from 'axios';
 import { getBaseURL } from '../utils/basePath';
-import { isEgressAuthEnabled, loadEgressCardState, type EgressCardState } from '../utils/egressAuth';
+import {
+  buildEgressAuthConfigPayload,
+  isEgressAuthEnabled,
+  loadEgressCardState,
+  normalizeEgressAuthMode,
+  type EgressCardState,
+} from '../utils/egressAuth';
 import { EgressConnectProvider } from '../contexts/EgressConnectContext';
 import {
   buildLocalRuntimeForm,
@@ -306,7 +312,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
     },
     custom_headers: [] as Array<{ name: string; value: string }>,
     // Egress auth to the upstream (admin config).
-    egress_auth_mode: 'none' as 'none' | 'oauth_user' | 'obo_exchange' | 'pat',
+    egress_auth_mode: 'none',
     egress_provider: '',
     egress_client_id: '',
     egress_client_secret: '',  // write-only; blank on edit keeps the stored one
@@ -1295,7 +1301,7 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
         deployment,
         local_runtime: buildLocalRuntimeForm(localRuntimeRaw),
         custom_headers: (serverDetails.custom_header_names || []).map((name: string) => ({ name, value: '' })),
-        egress_auth_mode: (serverDetails.egress_auth_mode || 'none') as 'none' | 'oauth_user' | 'obo_exchange' | 'pat',
+        egress_auth_mode: normalizeEgressAuthMode(serverDetails.egress_auth_mode),
         egress_provider: serverDetails.egress_oauth?.provider || '',
         egress_client_id: serverDetails.egress_oauth?.client_id || '',
         egress_client_secret: '',  // never round-trip the secret
@@ -1518,56 +1524,12 @@ const Dashboard: React.FC<DashboardProps> = ({ activeFilter = 'all', setActiveFi
           const csrf = await axios.get('/api/auth/csrf-token');
           const csrfHeaders: Record<string, string> = {};
           if (csrf.data?.csrf_token) csrfHeaders['X-CSRF-Token'] = csrf.data.csrf_token;
-          const mode = editForm.egress_auth_mode;
-          const scopesList = editForm.egress_scopes
-            .split(/[,\s]+/)
-            .map(s => s.trim())
-            .filter(Boolean);
-          if (mode === 'obo_exchange') {
-            await axios.post(
-              `/api/servers${editingServer.path}/egress-auth`,
-              {
-                egress_auth_mode: 'obo_exchange',
-                target_audience: editForm.egress_target_audience.trim(),
-                scopes: scopesList,
-              },
-              { headers: csrfHeaders }
-            );
-          } else if (mode === 'oauth_user') {
-            await axios.post(
-              `/api/servers${editingServer.path}/egress-auth`,
-              {
-                egress_auth_mode: 'oauth_user',
-                egress_provider: editForm.egress_provider.trim(),
-                client_id: editForm.egress_client_id.trim(),
-                // Blank secret on edit keeps the stored one (backend semantics).
-                client_secret: editForm.egress_client_secret || undefined,
-                scopes: scopesList,
-                custom_authorize_url: editForm.egress_custom_authorize_url || undefined,
-                custom_token_url: editForm.egress_custom_token_url || undefined,
-                custom_token_auth_style: editForm.egress_custom_token_auth_style || undefined,
-                custom_resource: editForm.egress_custom_resource || undefined,
-              },
-              { headers: csrfHeaders }
-            );
-          } else if (mode === 'pat') {
-            await axios.post(
-              `/api/servers${editingServer.path}/egress-auth`,
-              {
-                egress_auth_mode: 'pat',
-                egress_provider: editForm.egress_provider.trim(),
-                // The inject header is inherited from Backend Authentication at
-                // vend time, so it is not sent here.
-              },
-              { headers: csrfHeaders }
-            );
-          } else {
-            await axios.post(
-              `/api/servers${editingServer.path}/egress-auth`,
-              { egress_auth_mode: 'none' },
-              { headers: csrfHeaders }
-            );
-          }
+          const egressPayload = buildEgressAuthConfigPayload(editForm);
+          await axios.post(
+            `/api/servers${editingServer.path}/egress-auth`,
+            egressPayload,
+            { headers: csrfHeaders }
+          );
         } catch (egressErr: any) {
           // Surface but don't lose the successful server edit.
           const d = egressErr.response?.data?.detail;

--- a/frontend/src/utils/__tests__/egressAuth.test.ts
+++ b/frontend/src/utils/__tests__/egressAuth.test.ts
@@ -1,0 +1,78 @@
+import {
+  buildEgressAuthConfigPayload,
+  isGatewayManagedEgress,
+  normalizeEgressAuthMode,
+  type EgressAuthConfigForm,
+} from '../egressAuth';
+
+const baseForm: EgressAuthConfigForm = {
+  egress_auth_mode: 'none',
+  egress_provider: ' github ',
+  egress_client_id: ' client-id ',
+  egress_client_secret: '',
+  egress_scopes: 'read, write',
+  egress_custom_authorize_url: '',
+  egress_custom_token_url: '',
+  egress_custom_token_auth_style: '',
+  egress_custom_resource: '',
+  egress_target_audience: ' api://backend ',
+};
+
+describe('egress auth config helpers', () => {
+  test('normalizes unknown modes to none', () => {
+    expect(normalizeEgressAuthMode('operator_credential')).toBe('operator_credential');
+    expect(normalizeEgressAuthMode('unknown')).toBe('none');
+    expect(normalizeEgressAuthMode(null)).toBe('none');
+  });
+
+  test('treats only explicit none as unmanaged egress', () => {
+    expect(isGatewayManagedEgress('none')).toBe(false);
+    expect(isGatewayManagedEgress('')).toBe(false);
+    expect(isGatewayManagedEgress(null)).toBe(false);
+    expect(isGatewayManagedEgress(undefined)).toBe(false);
+    expect(isGatewayManagedEgress('operator_credential')).toBe(true);
+    expect(isGatewayManagedEgress('oauth_user')).toBe(true);
+    expect(isGatewayManagedEgress('future_mode')).toBe(true);
+  });
+
+  test('builds the minimal operator credential payload', () => {
+    expect(
+      buildEgressAuthConfigPayload({
+        ...baseForm,
+        egress_auth_mode: 'operator_credential',
+      })
+    ).toEqual({ egress_auth_mode: 'operator_credential' });
+  });
+
+  test('builds the OBO payload and normalizes scopes', () => {
+    expect(
+      buildEgressAuthConfigPayload({
+        ...baseForm,
+        egress_auth_mode: 'obo_exchange',
+      })
+    ).toEqual({
+      egress_auth_mode: 'obo_exchange',
+      target_audience: 'api://backend',
+      scopes: ['read', 'write'],
+    });
+  });
+
+  test('builds the OAuth payload without an empty secret', () => {
+    expect(
+      buildEgressAuthConfigPayload({
+        ...baseForm,
+        egress_auth_mode: 'oauth_user',
+      })
+    ).toEqual({
+      egress_auth_mode: 'oauth_user',
+      egress_provider: 'github',
+      client_id: 'client-id',
+      client_secret: undefined,
+      scopes: ['read', 'write'],
+      custom_authorize_url: undefined,
+      custom_token_url: undefined,
+      custom_token_auth_style: undefined,
+      custom_resource: undefined,
+    });
+  });
+});

--- a/frontend/src/utils/egressAuth.ts
+++ b/frontend/src/utils/egressAuth.ts
@@ -7,6 +7,94 @@
  */
 import axios from 'axios';
 
+export type EgressAuthMode =
+  | 'none'
+  | 'operator_credential'
+  | 'oauth_user'
+  | 'obo_exchange'
+  | 'pat';
+
+export interface EgressAuthConfigForm {
+  egress_auth_mode: EgressAuthMode;
+  egress_provider: string;
+  egress_client_id: string;
+  egress_client_secret: string;
+  egress_scopes: string;
+  egress_custom_authorize_url: string;
+  egress_custom_token_url: string;
+  egress_custom_token_auth_style: string;
+  egress_custom_resource: string;
+  egress_target_audience: string;
+}
+
+type EgressAuthConfigPayload = {
+  egress_auth_mode: EgressAuthMode;
+  [key: string]: string | string[] | undefined;
+};
+
+const EGRESS_AUTH_MODES = new Set<EgressAuthMode>([
+  'none',
+  'operator_credential',
+  'oauth_user',
+  'obo_exchange',
+  'pat',
+]);
+
+export function normalizeEgressAuthMode(value: unknown): EgressAuthMode {
+  return typeof value === 'string' && EGRESS_AUTH_MODES.has(value as EgressAuthMode)
+    ? (value as EgressAuthMode)
+    : 'none';
+}
+
+export function isGatewayManagedEgress(value: unknown): boolean {
+  // Connect configs must fail closed: only explicit none/empty is unmanaged.
+  // An unrecognized future mode still injects upstream, so never emit a
+  // client server-auth placeholder for it.
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const mode = value.trim();
+  return mode !== '' && mode !== 'none';
+}
+
+export function buildEgressAuthConfigPayload(
+  form: EgressAuthConfigForm
+): EgressAuthConfigPayload {
+  const mode = form.egress_auth_mode;
+  const scopes = form.egress_scopes
+    .split(/[,\s]+/)
+    .map(scope => scope.trim())
+    .filter(Boolean);
+
+  if (mode === 'operator_credential' || mode === 'none') {
+    return { egress_auth_mode: mode };
+  }
+  if (mode === 'obo_exchange') {
+    return {
+      egress_auth_mode: mode,
+      target_audience: form.egress_target_audience.trim(),
+      scopes,
+    };
+  }
+  if (mode === 'pat') {
+    return {
+      egress_auth_mode: mode,
+      egress_provider: form.egress_provider.trim(),
+    };
+  }
+  return {
+    egress_auth_mode: mode,
+    egress_provider: form.egress_provider.trim(),
+    client_id: form.egress_client_id.trim(),
+    client_secret: form.egress_client_secret || undefined,
+    scopes,
+    custom_authorize_url: form.egress_custom_authorize_url || undefined,
+    custom_token_url: form.egress_custom_token_url || undefined,
+    custom_token_auth_style: form.egress_custom_token_auth_style || undefined,
+    custom_resource: form.egress_custom_resource || undefined,
+  };
+}
+
 export interface EgressConnection {
   provider: string;
   server_path: string;

--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -12,11 +12,15 @@ Security model for POST /internal/egress-token:
 - The forwarded X-Internal-Token (the mcp-proxy token /validate minted) is
   RE-VERIFIED here; sub + auth_method are taken from the verified claims,
   never from the request body.
-- Non-per-user auth_method is rejected so a static-key/federation caller
-  can never address a per-user vault bucket.
+- Non-per-user auth_method is rejected before any per-user vault lookup.
+  ``operator_credential`` is the explicit exception: it is server-scoped,
+  not user-scoped, and is still protected by the verified proxy token,
+  gateway authorization, and registered-upstream binding.
 - claims["upstream_url"] is cross-checked against the server's registered
   proxy_pass_url union so a forged X-Resolved-Upstream (minted via a
   direct /validate call) cannot vend a token to an attacker-controlled host.
+- The requested server path must match claims["server"], preventing a token for
+  one server from selecting another server that shares the same upstream host.
 """
 
 import logging
@@ -39,7 +43,13 @@ from registry.core.config import settings
 from registry.core.schemas import _is_gateway_own_audience
 from registry.egress_auth.factory import get_egress_auth_service
 from registry.egress_auth.providers import list_provider_names, resolve_provider
-from registry.egress_auth.schemas import StoredToken
+from registry.egress_auth.schemas import (
+    EGRESS_MODES_REQUIRING_OAUTH_CONFIG,
+    EgressAuthMode,
+    StoredToken,
+    parse_egress_auth_mode,
+    validate_operator_credential_backend,
+)
 from registry.egress_auth.service import (
     EgressAuthError,
     EgressAuthService,
@@ -50,7 +60,7 @@ from registry.repositories.factory import get_server_repository
 from registry.secrets.factory import get_secret_store
 from registry.secrets.interfaces import SecretStoreError
 from registry.services.server_service import server_service
-from registry.utils.credential_encryption import encrypt_credential
+from registry.utils.credential_encryption import decrypt_credential, encrypt_credential
 from registry.utils.url_guard import (
     CREDENTIALED_OAUTH_PROFILE,
     PROXY_PROFILE,
@@ -71,20 +81,18 @@ _PAT_MAX_TTL_SECONDS: int = 30 * 24 * 3600
 _TTL_UNIT_SECONDS: dict[str, int] = {"minutes": 60, "hours": 3600, "days": 86400}
 
 
-def _derive_pat_inject_header(server: dict) -> tuple[str, str]:
-    """Derive the (header_name, value_prefix) the PAT is injected with.
+def _derive_backend_inject_header(server: dict) -> tuple[str, str]:
+    """Derive the (header_name, value_prefix) for a backend-shaped credential.
 
-    The PAT is injected into the SAME header the server's Backend Authentication
-    uses -- it is the same upstream, so the header contract is one thing. This
-    mirrors the registry's own health-check / tool-listing inject in
-    ``registry/core/mcp_client.py``:
+    PAT and operator-credential modes inject into the SAME header configured by
+    Backend Authentication. This mirrors the registry's health-check/tool-list
+    client in ``registry/core/mcp_client.py``:
 
-      - ``bearer``  -> ``<auth_header_name or "Authorization">: Bearer <PAT>``
-      - ``api_key`` -> ``<auth_header_name or "X-API-Key">: <PAT>`` (bare, no prefix)
-      - anything else (``none``/unset) -> ``Authorization: Bearer <PAT>`` (safe default)
+      - ``bearer``  -> ``<auth_header_name or "Authorization">: Bearer <credential>``
+      - ``api_key`` -> ``<auth_header_name or "X-API-Key">: <credential>`` (bare)
+      - anything else -> ``Authorization: Bearer <credential>`` (PAT fallback only)
 
-    So an operator configures the header ONCE, in Backend Authentication, and
-    ``pat`` egress inherits it; there is no separate egress header config.
+    The operator configures the header once; egress modes inherit it.
 
     Args:
         server: The server dict (carries ``auth_scheme`` / ``auth_header_name``).
@@ -293,12 +301,15 @@ class EgressTokenResponse(BaseModel):
         description="Provider key (github/google/entra/...) for the human-readable "
         "elicitation message.",
     )
-    # obo_exchange directive (returned instead of a token; the exchange runs in
-    # auth_server, which holds the gateway's IdP creds and the raw ingress JWT).
+    # Mode signal for the mcp_proxy hop. obo_exchange returns a directive
+    # instead of a token (the exchange runs in auth_server, which holds the
+    # gateway's IdP creds and the raw ingress JWT).
     mode: str | None = Field(
         default=None,
-        description="Egress mode for this server: 'obo_exchange' when the caller "
-        "should perform a same-IdP OBO token exchange instead of a vault vend.",
+        description="Egress mode signal: 'obo_exchange' (perform a same-IdP OBO "
+        "token exchange instead of a vault vend), 'pat' (terminal PAT miss; "
+        "prompt the user to submit a token), or 'operator_credential' (hit "
+        "carrying the shared backend credential).",
     )
     obo_target_audience: str | None = Field(
         default=None,
@@ -308,17 +319,77 @@ class EgressTokenResponse(BaseModel):
         default=None,
         description="obo_exchange: audience-scoped scopes for the exchange request.",
     )
-    # pat: the header the vended PAT is injected into and its value prefix,
-    # derived at vend time from the server's Backend Auth scheme, so mcp_proxy
-    # can build "<pat_header_name>: <pat_value_prefix><PAT>" instead of the
-    # hard-coded "Authorization: Bearer". Only set on a pat hit.
+    # Credential injection shape, derived at vend time from the server's Backend
+    # Authentication scheme. The field names predate operator_credential and are
+    # retained for wire compatibility.
     pat_header_name: str | None = Field(
         default=None,
-        description="pat: HTTP header to inject the PAT into (e.g. Authorization, PRIVATE-TOKEN).",
+        description="HTTP header for a PAT or operator credential.",
     )
     pat_value_prefix: str | None = Field(
         default=None,
-        description="pat: value prefix before the PAT (e.g. 'Bearer ' or '' for a bare token).",
+        description="Value prefix before a PAT or operator credential.",
+    )
+
+
+def _vend_operator_credential(
+    server: dict,
+    server_path: str,
+) -> EgressTokenResponse:
+    """Decrypt and shape a validated server's shared operator credential.
+
+    Config drift (auth_scheme flipped off bearer/api_key after the mode was
+    set, credential deleted, or ciphertext undecryptable) answers 503, NOT a
+    4xx: the auth-server maps 5xx to its fail-closed retry signal
+    (``EgressVendUnavailable``), while any other non-200 makes its vend call
+    return None and ``mcp_proxy`` degrade to a tokenless forward -- a
+    misleading upstream 401. Both write paths validate this config up front
+    (``configure_egress_auth`` and ``ServerInfo._validate_egress_auth``), so
+    drift is the only way here.
+
+    Args:
+        server: The server dict (Backend Authentication fields + ciphertext).
+        server_path: Slash-prefixed server path, for log context.
+
+    Returns:
+        A vend hit carrying the decrypted credential and its inject header.
+
+    Raises:
+        HTTPException: 503 when the Backend Authentication config is invalid
+            or the stored credential cannot be decrypted.
+    """
+    try:
+        validate_operator_credential_backend(
+            server.get("auth_scheme", "none"),
+            server.get("auth_credential_encrypted"),
+        )
+    except ValueError:
+        logger.error(
+            "operator credential unavailable for %s; invalid Backend Authentication config",
+            server_path,
+        )
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="operator credential unavailable",
+        ) from None
+
+    credential = decrypt_credential(server["auth_credential_encrypted"])
+    if not credential:
+        logger.error(
+            "operator credential unavailable for %s; credential undecryptable",
+            server_path,
+        )
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="operator credential unavailable",
+        )
+
+    header_name, value_prefix = _derive_backend_inject_header(server)
+    return EgressTokenResponse(
+        access_token=credential,
+        mode=EgressAuthMode.OPERATOR_CREDENTIAL.value,
+        pat_header_name=header_name,
+        pat_value_prefix=value_prefix,
     )
 
 
@@ -379,28 +450,46 @@ async def vend_egress_token(
     auth_method = claims.get("auth_method") or ""
     token_upstream = claims.get("upstream_url") or ""
 
-    # Only real per-user principals may vend.
-    if not is_per_user_auth_method(auth_method):
-        logger.info("egress vend: non-per-user auth_method %r -> consent", auth_method)
-        return EgressTokenResponse(consent_required=True)
-
     # Normalize the server path: mcp_proxy passes the first path segment without a
     # leading slash ("github"), but server entries, the vault key, and the consent
     # state all use the slash-prefixed path ("/github"). Without this, the lookup
     # misses and consent loops forever. Use the canonical form everywhere below.
     server_path = body.server_path if body.server_path.startswith("/") else "/" + body.server_path
 
+    # The body-selected server must be the same server /validate authorized into
+    # the signed proxy token. Upstream binding alone is insufficient because two
+    # registered servers may share one upstream host. Bind before repository
+    # lookup and before any credential/vault access.
+    claim_server = str(claims.get("server") or "").strip("/")
+    if not claim_server or f"/{claim_server}" != server_path:
+        logger.warning(
+            "egress vend REFUSED: token server %r does not match %s",
+            claim_server,
+            server_path,
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail="proxy token is not bound to the requested server",
+        )
+
     server = await get_server_repository().get(server_path)
     if server is None:
         return EgressTokenResponse(consent_required=True)
 
     # Per-server enablement: a misconfigured/half-deleted server never vends.
-    egress_mode = server.get("egress_auth_mode")
-    if egress_mode not in ("oauth_user", "obo_exchange", "pat") or not server.get("egress_oauth"):
+    try:
+        egress_mode = parse_egress_auth_mode(server.get("egress_auth_mode", "none"))
+    except ValueError:
+        return EgressTokenResponse(consent_required=True)
+    if egress_mode is EgressAuthMode.NONE:
+        return EgressTokenResponse(consent_required=True)
+
+    egress_oauth = server.get("egress_oauth")
+    if egress_mode in EGRESS_MODES_REQUIRING_OAUTH_CONFIG and not egress_oauth:
         return EgressTokenResponse(consent_required=True)
 
     # The bound upstream MUST match a registered upstream for this server. This
-    # cross-check applies to BOTH egress modes: an OBO directive must only be
+    # cross-check applies to every egress mode: an OBO directive must only be
     # handed out for a legitimately-bound upstream, same as a vault vend.
     legal = _registered_upstreams(server)
     if _base_url(token_upstream) not in legal:
@@ -414,14 +503,22 @@ async def vend_egress_token(
             status.HTTP_403_FORBIDDEN, detail="upstream not registered for this server"
         )
 
-    egress_oauth = server["egress_oauth"]
+    if egress_mode is EgressAuthMode.OPERATOR_CREDENTIAL:
+        # Decryption happens only after the verified server and upstream binds.
+        return _vend_operator_credential(server, server_path)
+
+    # Every remaining mode addresses a per-user vault bucket or carries a
+    # delegated user assertion. Static/federation callers must never enter them.
+    if not is_per_user_auth_method(auth_method):
+        logger.info("egress vend: non-per-user auth_method %r -> consent", auth_method)
+        return EgressTokenResponse(consent_required=True)
 
     # pat: vend the stored per-user PAT. This branch runs BEFORE oauth_user so a
     # pat server is never routed through svc.get_valid_token (which resolves an
     # OAuth provider and rejects a token stored with client_id=None). A miss
     # (never submitted OR expired) is TERMINAL: set mode="pat" so auth_server
     # emits the PAT-missing message; NO authorize_url/connect_url (not interactive).
-    if egress_mode == "pat":
+    if egress_mode is EgressAuthMode.PAT:
         provider = egress_oauth.get("provider")
         token = await get_egress_auth_service().get_pat(
             auth_method=auth_method,
@@ -433,7 +530,7 @@ async def vend_egress_token(
             # The PAT is injected into the SAME header the server's Backend
             # Authentication uses (same upstream, one header contract). Derived
             # from auth_scheme/auth_header_name; no separate egress header config.
-            header_name, value_prefix = _derive_pat_inject_header(server)
+            header_name, value_prefix = _derive_backend_inject_header(server)
             return EgressTokenResponse(
                 access_token=token,
                 pat_header_name=header_name,
@@ -445,12 +542,19 @@ async def vend_egress_token(
     # token exchange runs in auth_server (which holds the gateway's own IdP
     # credentials and the raw ingress JWT); the registry never sees the JWT and
     # holds no per-user token for this mode. Stateless -- no vault lookup.
-    if egress_mode == "obo_exchange":
+    if egress_mode is EgressAuthMode.OBO_EXCHANGE:
         return EgressTokenResponse(
             mode="obo_exchange",
             obo_target_audience=egress_oauth.get("target_audience"),
             obo_scopes=egress_oauth.get("scopes") or [],
         )
+
+    # Explicit terminal dispatch: only oauth_user may enter the vault flow
+    # below. A future enum mode not handled above fails closed to consent
+    # instead of silently riding the oauth_user path.
+    if egress_mode is not EgressAuthMode.OAUTH_USER:
+        logger.warning("egress vend: unhandled egress mode %r -> consent", egress_mode.value)
+        return EgressTokenResponse(consent_required=True)
 
     svc = get_egress_auth_service()
     try:
@@ -527,7 +631,7 @@ async def vend_egress_token(
 class EgressConfigRequest(BaseModel):
     """Configure egress auth on a server (admin/registrant)."""
 
-    egress_auth_mode: str = "oauth_user"  # "none" | "oauth_user" | "obo_exchange" | "pat"
+    egress_auth_mode: str = "oauth_user"
     egress_provider: str = ""
     client_id: str = ""
     client_secret: str | None = None  # write-only; encrypted, never echoed
@@ -572,10 +676,10 @@ async def configure_egress_auth(
     user_context: Annotated[dict, Depends(nginx_proxied_auth)],
     _csrf: Annotated[None, Depends(verify_csrf_token_flexible)] = None,
 ):
-    """Configure (or disable) per-user egress OAuth on a server. Admin only.
+    """Configure or disable gateway-managed egress auth on a server. Admin only.
 
-    The client_secret is Fernet-encrypted and never returned. Returns the
-    callback URL the operator must register in the provider's OAuth app.
+    OAuth client secrets and Backend Authentication credentials remain encrypted
+    and are never returned. Returns the non-secret configuration view.
     """
     _feature_enabled_or_404()
     _require_admin(user_context)
@@ -587,10 +691,25 @@ async def configure_egress_auth(
     if not server:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="server not found")
 
-    if body.egress_auth_mode == "none":
-        server["egress_auth_mode"] = "none"
+    try:
+        mode = parse_egress_auth_mode(body.egress_auth_mode)
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    if mode is EgressAuthMode.NONE:
+        server["egress_auth_mode"] = mode.value
         server["egress_oauth"] = None
-    elif body.egress_auth_mode == "oauth_user":
+    elif mode is EgressAuthMode.OPERATOR_CREDENTIAL:
+        try:
+            validate_operator_credential_backend(
+                server.get("auth_scheme", "none"),
+                server.get("auth_credential_encrypted"),
+            )
+        except ValueError as exc:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+        server["egress_auth_mode"] = mode.value
+        server["egress_oauth"] = None
+    elif mode is EgressAuthMode.OAUTH_USER:
         if body.egress_provider not in list_provider_names():
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST,
@@ -682,9 +801,9 @@ async def configure_egress_auth(
                 eo["client_secret_encrypted"] = prior
             if not eo["client_secret_encrypted"]:
                 raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="client_secret required")
-        server["egress_auth_mode"] = "oauth_user"
+        server["egress_auth_mode"] = mode.value
         server["egress_oauth"] = eo
-    elif body.egress_auth_mode == "obo_exchange":
+    elif mode is EgressAuthMode.OBO_EXCHANGE:
         target = (body.target_audience or "").strip()
         if not target:
             raise HTTPException(
@@ -698,13 +817,13 @@ async def configure_egress_auth(
             )
         # Same-IdP exchange: no per-server provider/client_id/secret. Only the
         # target audience and (optional) audience-scoped scopes are stored.
-        server["egress_auth_mode"] = "obo_exchange"
+        server["egress_auth_mode"] = mode.value
         server["egress_oauth"] = {
             "target_audience": target,
             "scopes": body.scopes,
         }
-    elif body.egress_auth_mode == "pat":
-        # pat needs only a provider slug as the vault-namespace/display key. No
+    elif mode is EgressAuthMode.PAT:
+        # PAT needs only a provider slug as the vault-namespace/display key. No
         # SSRF check, no client_secret, no resolve_provider (there is no OAuth
         # endpoint). The provider is slug-constrained because it becomes a
         # vault-key segment.
@@ -715,12 +834,13 @@ async def configure_egress_auth(
                 detail="pat mode requires a provider slug matching ^[a-z0-9_-]{1,64}$ "
                 "(namespace/display key)",
             )
-        # The PAT inject header is NOT configured here: it is inherited from the
-        # server's Backend Authentication (auth_scheme/auth_header_name) at vend
-        # time (see _derive_pat_inject_header), since it is the same upstream.
-        server["egress_auth_mode"] = "pat"
+        # The PAT inject header is NOT configured here: it is inherited at vend
+        # time from the server's Backend Authentication settings
+        # (auth_scheme/auth_header_name, see _derive_backend_inject_header),
+        # since it is the same upstream.
+        server["egress_auth_mode"] = mode.value
         server["egress_oauth"] = {"provider": provider, "scopes": body.scopes or []}
-    else:
+    else:  # pragma: no cover - parse_egress_auth_mode exhausts EgressAuthMode
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail="invalid egress_auth_mode")
 
     if not await server_service.update_server(server_path, server):

--- a/registry/core/schemas.py
+++ b/registry/core/schemas.py
@@ -6,6 +6,11 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from registry.constants import DeploymentType, LocalRuntimeType, TransportType
+from registry.egress_auth.schemas import (
+    EgressAuthMode,
+    parse_egress_auth_mode,
+    validate_operator_credential_backend,
+)
 from registry.schemas.agent_models import AgentProvider
 from registry.schemas.registry_card import LifecycleStatus
 
@@ -676,12 +681,12 @@ class ServerInfo(BaseModel):
         description="ISO timestamp of last custom-headers update.",
     )
 
-    # Per-user egress credential vault (third-party OBO). Default 'none' keeps
-    # today's behavior; the registration write path is not yet implemented.
     egress_auth_mode: str = Field(
         default="none",
-        description="Egress auth to the upstream: 'none', 'oauth_user' (3LO vault), "
-        "or 'obo_exchange' (same-IdP OBO).",
+        description="Egress auth to the upstream: 'none' (strip ingress auth, "
+        "inject nothing), 'operator_credential' (shared registered backend "
+        "credential), 'oauth_user' (3LO vault), 'obo_exchange' (same-IdP OBO), "
+        "or 'pat' (per-user static token).",
     )
     egress_oauth: EgressOAuthConfig | None = Field(
         default=None,
@@ -791,6 +796,8 @@ class ServerInfo(BaseModel):
     def _validate_egress_auth(self) -> "ServerInfo":
         """Enforce per-mode egress config invariants.
 
+        - operator_credential: requires a bearer/API-key Backend Authentication
+          credential and no per-user egress_oauth config.
         - oauth_user: requires egress_oauth with a provider (3LO needs a provider).
         - obo_exchange: requires egress_oauth.target_audience, and that audience
           MUST (a) differ from the gateway's own IdP client id / app ID URI (Entra
@@ -801,21 +808,24 @@ class ServerInfo(BaseModel):
           exfiltrated to the server's upstream. Both are rejected at registration
           rather than at the first live request.
         """
-        mode = self.egress_auth_mode
-        if mode not in ("none", "oauth_user", "obo_exchange", "pat"):
-            raise ValueError(
-                f"invalid egress_auth_mode {mode!r}; expected 'none', 'oauth_user', "
-                "'obo_exchange', or 'pat'"
+        mode = parse_egress_auth_mode(self.egress_auth_mode)
+        if mode is EgressAuthMode.NONE:
+            return self
+        if mode is EgressAuthMode.OPERATOR_CREDENTIAL:
+            validate_operator_credential_backend(
+                self.auth_scheme,
+                self.auth_credential_encrypted,
             )
-        if mode == "none":
+            if self.egress_oauth is not None:
+                raise ValueError("egress_auth_mode='operator_credential' must not set egress_oauth")
             return self
         if self.egress_oauth is None:
-            raise ValueError(f"egress_auth_mode={mode!r} requires egress_oauth config")
-        if mode == "oauth_user":
+            raise ValueError(f"egress_auth_mode={mode.value!r} requires egress_oauth config")
+        if mode is EgressAuthMode.OAUTH_USER:
             if not self.egress_oauth.provider:
                 raise ValueError("egress_auth_mode='oauth_user' requires egress_oauth.provider")
             return self
-        if mode == "pat":
+        if mode is EgressAuthMode.PAT:
             # pat needs a provider only as a vault-namespace/display key; no OAuth
             # endpoints, client_id, or secret are required.
             if not self.egress_oauth.provider:

--- a/registry/egress_auth/schemas.py
+++ b/registry/egress_auth/schemas.py
@@ -19,19 +19,67 @@ from pydantic import BaseModel, Field
 
 
 class EgressAuthMode(str, Enum):
-    """How the gateway authenticates to the upstream MCP server on egress.
-
-    ``operator_credential`` is intentionally NOT included in this feature: it
-    would require net-new decrypt-and-inject logic in ``mcp_proxy`` (the #542
-    credential is not wired on the egress hop today), so shipping the enum
-    value without that implementation would silently behave as ``none``. It is
-    deferred to a follow-on that lands the injection code and tests.
-    """
+    """How the gateway authenticates to the upstream MCP server on egress."""
 
     NONE = "none"  # no egress auth
+    OPERATOR_CREDENTIAL = "operator_credential"  # shared registered backend credential
     OAUTH_USER = "oauth_user"  # per-user 3LO token from the vault
     OBO_EXCHANGE = "obo_exchange"  # same-IdP OBO token exchange; stateless, no vault
     PAT = "pat"  # per-user static PAT/API-key from the vault
+
+
+EGRESS_MODES_REQUIRING_OAUTH_CONFIG: frozenset[EgressAuthMode] = frozenset(
+    {
+        EgressAuthMode.OAUTH_USER,
+        EgressAuthMode.OBO_EXCHANGE,
+        EgressAuthMode.PAT,
+    }
+)
+
+
+def parse_egress_auth_mode(
+    value: str,
+) -> EgressAuthMode:
+    """Parse an egress mode with a stable, actionable validation error.
+
+    Args:
+        value: The raw ``egress_auth_mode`` value.
+
+    Returns:
+        The matching ``EgressAuthMode`` member.
+
+    Raises:
+        ValueError: If ``value`` is not a recognized egress mode; the message
+            lists the accepted values.
+    """
+    try:
+        return EgressAuthMode(value)
+    except ValueError as exc:
+        expected = ", ".join(repr(mode.value) for mode in EgressAuthMode)
+        raise ValueError(f"invalid egress_auth_mode {value!r}; expected {expected}") from exc
+
+
+def validate_operator_credential_backend(
+    auth_scheme: str,
+    encrypted_credential: str | None,
+) -> None:
+    """Validate the Backend Authentication fields used by operator mode.
+
+    Args:
+        auth_scheme: The server's Backend Authentication scheme.
+        encrypted_credential: The stored encrypted credential, if any.
+
+    Raises:
+        ValueError: If the scheme is not ``bearer``/``api_key`` or no
+            encrypted credential is stored.
+    """
+    if auth_scheme not in ("bearer", "api_key"):
+        raise ValueError(
+            "egress_auth_mode='operator_credential' requires Backend "
+            "Authentication scheme 'bearer' or 'api_key'"
+        )
+    if not encrypted_credential:
+        raise ValueError("operator_credential requires a stored Backend Authentication credential")
 
 
 class TokenEndpointAuthStyle(str, Enum):

--- a/tests/unit/core/test_server_egress_auth_validation.py
+++ b/tests/unit/core/test_server_egress_auth_validation.py
@@ -2,6 +2,7 @@
 
 Covers ServerInfo._validate_egress_auth (@model_validator):
 - mode=none: no egress_oauth required.
+- mode=operator_credential: requires encrypted bearer/API-key Backend Authentication.
 - mode=oauth_user: requires egress_oauth.provider (3LO).
 - mode=obo_exchange: requires target_audience; rejects same-app audience.
 - invalid mode string rejected.
@@ -35,6 +36,39 @@ class TestServerEgressAuthValidation:
     def test_invalid_mode_rejected(self):
         with pytest.raises(ValidationError, match="invalid egress_auth_mode"):
             _server(egress_auth_mode="bogus")
+
+    def test_operator_credential_with_encrypted_bearer_accepted(self):
+        s = _server(
+            egress_auth_mode="operator_credential",
+            auth_scheme="bearer",
+            auth_credential_encrypted="encrypted-token",
+        )
+        assert s.egress_auth_mode == "operator_credential"
+        assert s.egress_oauth is None
+
+    def test_operator_credential_requires_backend_auth_scheme(self):
+        with pytest.raises(ValidationError, match="requires Backend Authentication scheme"):
+            _server(
+                egress_auth_mode="operator_credential",
+                auth_scheme="none",
+                auth_credential_encrypted="encrypted-token",
+            )
+
+    def test_operator_credential_requires_encrypted_credential(self):
+        with pytest.raises(ValidationError, match="requires a stored Backend"):
+            _server(
+                egress_auth_mode="operator_credential",
+                auth_scheme="bearer",
+            )
+
+    def test_operator_credential_rejects_per_user_config(self):
+        with pytest.raises(ValidationError, match="must not set egress_oauth"):
+            _server(
+                egress_auth_mode="operator_credential",
+                auth_scheme="api_key",
+                auth_credential_encrypted="encrypted-key",
+                egress_oauth=EgressOAuthConfig(provider="github"),
+            )
 
     def test_oauth_user_requires_provider(self):
         with pytest.raises(ValidationError, match="requires egress_oauth.provider"):

--- a/tests/unit/egress_auth/test_configure_egress_url_validation.py
+++ b/tests/unit/egress_auth/test_configure_egress_url_validation.py
@@ -275,6 +275,83 @@ class TestConfigureOperatorCredential:
 
 
 @pytest.mark.unit
+class TestConfigureModeDispatch:
+    """Mode parsing and the non-oauth_user branches of the configure route."""
+
+    def test_unknown_server_is_404(self, make_client, monkeypatch):
+        client = make_client()
+
+        async def _missing(path, include_credentials=False):
+            return None
+
+        monkeypatch.setattr(client._svc, "get_server_info", _missing)
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "none"},
+        )
+        assert resp.status_code == 404
+        assert client._svc.updated_with is None
+
+    def test_invalid_mode_is_400(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "not-a-real-mode"},
+        )
+        assert resp.status_code == 400
+        assert client._svc.updated_with is None
+
+    def test_none_resets_mode_and_clears_oauth_config(self, make_client):
+        client = make_client(
+            server={
+                "path": "/gh",
+                "egress_auth_mode": "oauth_user",
+                "egress_oauth": {"provider": "github", "client_id": "Iv1.x"},
+            }
+        )
+        resp = client.post("/servers/gh/egress-auth", json={"egress_auth_mode": "none"})
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_auth_mode"] == "none"
+        assert client._svc.updated_with["egress_oauth"] is None
+
+    def test_update_failure_is_500(self, make_client, monkeypatch):
+        client = make_client()
+
+        async def _fail(path, server):
+            return False
+
+        monkeypatch.setattr(client._svc, "update_server", _fail)
+        resp = client.post("/servers/gh/egress-auth", json={"egress_auth_mode": "none"})
+        assert resp.status_code == 500
+
+    def test_obo_requires_target_audience(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "obo_exchange", "target_audience": "   "},
+        )
+        assert resp.status_code == 400
+        assert "target_audience" in resp.json()["detail"]
+        assert client._svc.updated_with is None
+
+    def test_obo_stores_target_and_scopes(self, make_client):
+        client = make_client()
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={
+                "egress_auth_mode": "obo_exchange",
+                "target_audience": "api://backend-api",
+                "scopes": ["read"],
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_auth_mode"] == "obo_exchange"
+        eo = client._svc.updated_with["egress_oauth"]
+        assert eo["target_audience"] == "api://backend-api"
+        assert eo["scopes"] == ["read"]
+
+
+@pytest.mark.unit
 class TestConfigurePublicClient:
     """token_endpoint_auth_method=none (custom provider): a public client has
     no secret by design -- the configure route must accept a secretless config,

--- a/tests/unit/egress_auth/test_configure_egress_url_validation.py
+++ b/tests/unit/egress_auth/test_configure_egress_url_validation.py
@@ -229,6 +229,52 @@ class TestConfigureEgressUrlValidation:
 
 
 @pytest.mark.unit
+class TestConfigureOperatorCredential:
+    def test_accepts_stored_bearer_backend_credential(self, make_client):
+        client = make_client(
+            server={
+                "path": "/gh",
+                "auth_scheme": "bearer",
+                "auth_credential_encrypted": "enc:service-token",
+                "egress_oauth": {"provider": "github"},
+            }
+        )
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "operator_credential"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert client._svc.updated_with["egress_auth_mode"] == "operator_credential"
+        assert client._svc.updated_with["egress_oauth"] is None
+
+    def test_rejects_missing_backend_credential(self, make_client):
+        client = make_client(server={"path": "/gh", "auth_scheme": "bearer", "egress_oauth": None})
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "operator_credential"},
+        )
+        assert resp.status_code == 400
+        assert "stored Backend Authentication credential" in resp.json()["detail"]
+        assert client._svc.updated_with is None
+
+    def test_rejects_none_backend_auth_scheme(self, make_client):
+        client = make_client(
+            server={
+                "path": "/gh",
+                "auth_scheme": "none",
+                "auth_credential_encrypted": "enc:unused",
+                "egress_oauth": None,
+            }
+        )
+        resp = client.post(
+            "/servers/gh/egress-auth",
+            json={"egress_auth_mode": "operator_credential"},
+        )
+        assert resp.status_code == 400
+        assert "requires Backend Authentication scheme" in resp.json()["detail"]
+
+
+@pytest.mark.unit
 class TestConfigurePublicClient:
     """token_endpoint_auth_method=none (custom provider): a public client has
     no secret by design -- the configure route must accept a secretless config,

--- a/tests/unit/egress_auth/test_internal_egress_token_route.py
+++ b/tests/unit/egress_auth/test_internal_egress_token_route.py
@@ -75,6 +75,7 @@ def _claims(**over):
     base = {
         "sub": "alice",
         "auth_method": "oauth2",
+        "server": "github-mcp",
         "upstream_url": "https://api.githubcopilot.com/mcp",
     }
     base.update(over)
@@ -124,6 +125,115 @@ class TestInternalEgressTokenRoute:
         assert r.json()["consent_required"] is True
         assert r.json()["access_token"] is None
         assert not client._svc.called
+
+    def test_operator_credential_vends_to_non_per_user_caller(self, make_client, monkeypatch):
+        # This explicit server-scoped mode is the exception to per-user vault
+        # gating: any gateway-authorized caller may use the shared credential.
+        monkeypatch.setattr(routes, "decrypt_credential", lambda value: "dd-service-token")
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="bearer",
+            auth_credential_encrypted="ciphertext",
+        )
+        client = make_client(_claims(auth_method="network-trusted"), server)
+        r = _post(client)
+        assert r.status_code == 200
+        body = r.json()
+        assert body["access_token"] == "dd-service-token"
+        assert body["mode"] == "operator_credential"
+        assert body["pat_header_name"] == "Authorization"
+        assert body["pat_value_prefix"] == "Bearer "
+        assert not client._svc.called
+
+    def test_operator_credential_uses_backend_api_key_header(self, make_client, monkeypatch):
+        monkeypatch.setattr(routes, "decrypt_credential", lambda value: "shared-api-key")
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="api_key",
+            auth_header_name="DD-API-KEY",
+            auth_credential_encrypted="ciphertext",
+        )
+        body = _post(make_client(_claims(), server)).json()
+        assert body["pat_header_name"] == "DD-API-KEY"
+        assert body["pat_value_prefix"] == ""
+
+    def test_operator_credential_decrypt_failure_is_retryable_503(self, make_client, monkeypatch):
+        monkeypatch.setattr(routes, "decrypt_credential", lambda value: None)
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="bearer",
+            auth_credential_encrypted="bad-ciphertext",
+        )
+        r = _post(make_client(_claims(), server))
+        assert r.status_code == 503
+        assert r.json()["detail"] == "operator credential unavailable"
+
+    def test_operator_credential_rejects_token_bound_to_different_server(
+        self, make_client, monkeypatch
+    ):
+        decrypt_called = False
+
+        def _decrypt(value):
+            nonlocal decrypt_called
+            decrypt_called = True
+            return "must-not-vend"
+
+        monkeypatch.setattr(routes, "decrypt_credential", _decrypt)
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="bearer",
+            auth_credential_encrypted="ciphertext",
+        )
+        client = make_client(_claims(server="other-server"), server)
+        r = _post(client)
+        assert r.status_code == 403
+        assert "not bound to the requested server" in r.json()["detail"]
+        assert not decrypt_called
+
+    def test_operator_credential_stale_mode_with_disabled_backend_auth_fails_closed(
+        self, make_client, monkeypatch
+    ):
+        decrypt_called = False
+
+        def _decrypt(value):
+            nonlocal decrypt_called
+            decrypt_called = True
+            return "must-not-vend"
+
+        monkeypatch.setattr(routes, "decrypt_credential", _decrypt)
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="none",
+            auth_credential_encrypted="stale-ciphertext",
+        )
+        r = _post(make_client(_claims(), server))
+        assert r.status_code == 503
+        assert r.json()["detail"] == "operator credential unavailable"
+        assert not decrypt_called
+
+    def test_operator_credential_upstream_mismatch_prevents_decrypt(self, make_client, monkeypatch):
+        decrypt_called = False
+
+        def _decrypt(value):
+            nonlocal decrypt_called
+            decrypt_called = True
+            return "must-not-vend"
+
+        monkeypatch.setattr(routes, "decrypt_credential", _decrypt)
+        server = _server(
+            egress_auth_mode="operator_credential",
+            egress_oauth=None,
+            auth_scheme="bearer",
+            auth_credential_encrypted="ciphertext",
+        )
+        client = make_client(_claims(upstream_url="https://attacker.example/mcp"), server)
+        assert _post(client).status_code == 403
+        assert not decrypt_called
 
     def test_server_not_oauth_user_consent(self, make_client):
         client = make_client(_claims(), _server(egress_auth_mode="none", egress_oauth=None))

--- a/tests/unit/egress_auth/test_internal_egress_token_route.py
+++ b/tests/unit/egress_auth/test_internal_egress_token_route.py
@@ -235,6 +235,31 @@ class TestInternalEgressTokenRoute:
         assert _post(client).status_code == 403
         assert not decrypt_called
 
+    def test_invalid_stored_mode_fails_closed_to_consent(self, make_client):
+        # The model validator rejects a bad mode on write, but an old or
+        # hand-edited document bypasses it; the vend path must degrade to
+        # consent rather than vend or 500.
+        server = _server(egress_auth_mode="not-a-real-mode", egress_oauth=None)
+        client = make_client(_claims(), server)
+        r = _post(client)
+        assert r.status_code == 200
+        assert r.json()["consent_required"] is True
+        assert r.json()["access_token"] is None
+        assert not client._svc.called
+
+    def test_obo_mode_returns_exchange_directive(self, make_client):
+        server = _server(
+            egress_auth_mode="obo_exchange",
+            egress_oauth={"target_audience": "api://backend", "scopes": ["read"]},
+        )
+        r = _post(make_client(_claims(), server))
+        assert r.status_code == 200
+        body = r.json()
+        assert body["mode"] == "obo_exchange"
+        assert body["obo_target_audience"] == "api://backend"
+        assert body["obo_scopes"] == ["read"]
+        assert body["access_token"] is None
+
     def test_server_not_oauth_user_consent(self, make_client):
         client = make_client(_claims(), _server(egress_auth_mode="none", egress_oauth=None))
         r = _post(client)

--- a/tests/unit/egress_auth/test_pat_ttl.py
+++ b/tests/unit/egress_auth/test_pat_ttl.py
@@ -8,40 +8,40 @@ import pytest
 
 from registry.api.egress_auth_routes import (
     _PAT_MAX_TTL_SECONDS,
-    _derive_pat_inject_header,
+    _derive_backend_inject_header,
     _resolve_pat_ttl_seconds,
 )
 
 
-class TestDerivePatInjectHeader:
-    """The pat inject header inherits from the server's Backend Auth scheme."""
+class TestDeriveBackendInjectHeader:
+    """The egress inject header inherits the server's Backend Auth scheme."""
 
     def test_bearer_scheme_uses_authorization_bearer(self):
         server = {"auth_scheme": "bearer"}
-        assert _derive_pat_inject_header(server) == ("Authorization", "Bearer ")
+        assert _derive_backend_inject_header(server) == ("Authorization", "Bearer ")
 
     def test_bearer_scheme_honors_custom_header_name(self):
         server = {"auth_scheme": "bearer", "auth_header_name": "X-Auth"}
-        assert _derive_pat_inject_header(server) == ("X-Auth", "Bearer ")
+        assert _derive_backend_inject_header(server) == ("X-Auth", "Bearer ")
 
     def test_api_key_scheme_uses_bare_token(self):
         # api_key: bare token, no prefix, into the configured header.
         server = {"auth_scheme": "api_key", "auth_header_name": "PRIVATE-TOKEN"}
-        assert _derive_pat_inject_header(server) == ("PRIVATE-TOKEN", "")
+        assert _derive_backend_inject_header(server) == ("PRIVATE-TOKEN", "")
 
     def test_api_key_scheme_defaults_header_name(self):
         server = {"auth_scheme": "api_key"}
-        assert _derive_pat_inject_header(server) == ("X-API-Key", "")
+        assert _derive_backend_inject_header(server) == ("X-API-Key", "")
 
     def test_none_scheme_defaults_to_authorization_bearer(self):
         # Fail-safe: Backend Auth "none" still yields a usable default.
-        assert _derive_pat_inject_header({"auth_scheme": "none"}) == (
+        assert _derive_backend_inject_header({"auth_scheme": "none"}) == (
             "Authorization",
             "Bearer ",
         )
 
     def test_missing_scheme_defaults_to_authorization_bearer(self):
-        assert _derive_pat_inject_header({}) == ("Authorization", "Bearer ")
+        assert _derive_backend_inject_header({}) == ("Authorization", "Bearer ")
 
 
 @pytest.mark.unit

--- a/tests/unit/egress_auth/test_pat_vend.py
+++ b/tests/unit/egress_auth/test_pat_vend.py
@@ -79,6 +79,7 @@ def _claims(**over):
     base = {
         "sub": "alice",
         "auth_method": "oauth2",
+        "server": "github",
         "upstream_url": "https://api.githubcopilot.com/mcp",
     }
     base.update(over)


### PR DESCRIPTION
If you register an MCP server that uses a static bearer token or API key (Backend Authentication), health checks pass, but user tool calls don't. The proxy hop strips the caller's gateway auth and injects nothing. 

This was reported in #1598, where the patch was declined in favor of an explicit egress mode. This PR builds that mode. Credit to @hochbit for the original patch and for surfacing the gap.

This PR adds one new egress mode: `operator_credential`. An admin sets it on a server, and from then on the gateway injects that server's stored Backend Authentication credential for every caller it authorizes. It works with both `bearer` and `api_key` schemes and reuses the configured header name, exactly like PAT mode.

It's strictly opt-in: `auth_scheme=bearer` alone changes nothing, an admin has to set the mode per server, and the deployment needs `EGRESS_AUTH_ENABLED=true`. Clients never see the credential. Connect configs stop emitting the server-auth placeholder.