### PR TITLE
fix(keycloak): rewrite every internal URL in the discovery document

### DIFF
--- a/auth_server/providers/keycloak.py
+++ b/auth_server/providers/keycloak.py
@@ -21,6 +21,11 @@ JWT_AUDIENCE = os.environ.get("JWT_AUDIENCE", "mcp-registry")
 # raises if it is missing rather than silently using a known-bad value.
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
+# Characters that can legally follow an origin in a URL. Used to anchor the
+# internal-URL rewrite at a boundary so an internal base of
+# "http://keycloak:8080" cannot also match "http://keycloak:80801".
+_URL_BOUNDARY_CHARS: frozenset[str] = frozenset({"/", "?", "#"})
+
 
 logging.basicConfig(
     level=logging.INFO,
@@ -464,34 +469,76 @@ class KeycloakProvider(AuthProvider):
             logger.error(f"Failed to get M2M token: {e}")
             raise ValueError(f"M2M token generation failed: {e}")
 
+    def _rewrite_internal_url(self, value: str) -> str:
+        """Rewrite one string onto the external host if it is an internal URL.
+
+        The internal URL is only replaced at a real URL boundary. A bare
+        ``startswith`` would let an internal base of ``http://keycloak:8080``
+        also match ``http://keycloak:80801``, i.e. a different port on the same
+        host, and silently rewrite it.
+
+        Args:
+            value: Any string from the discovery document.
+
+        Returns:
+            The rewritten URL, or the input unchanged when it is not an internal
+            Keycloak URL.
+        """
+        if not value.startswith(self.keycloak_url):
+            return value
+        tail = value[len(self.keycloak_url) :]
+        if tail and tail[0] not in _URL_BOUNDARY_CHARS:
+            return value
+        return f"{self.keycloak_external_url}{tail}"
+
+    def _rewrite_internal_urls(self, node: Any) -> Any:
+        """Recursively rewrite every internal Keycloak URL in a JSON structure.
+
+        Returns new containers rather than mutating in place. That matters:
+        ``_get_openid_configuration`` is ``lru_cache``d, so mutating a nested
+        dict would poison the cache for every later caller.
+
+        Args:
+            node: Any JSON value from the discovery document.
+
+        Returns:
+            A structurally equal value with internal URLs rewritten.
+        """
+        if isinstance(node, str):
+            return self._rewrite_internal_url(node)
+        if isinstance(node, dict):
+            return {key: self._rewrite_internal_urls(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [self._rewrite_internal_urls(value) for value in node]
+        return node
+
     def authorization_server_metadata(self) -> dict[str, Any]:
         """Return Keycloak's RFC 8414 metadata, with internal hostnames rewritten.
 
         Keycloak's OpenID configuration is RFC 8414-shaped already. We fetch it
-        from the internal cluster URL but rewrite any browser-facing endpoints
-        onto the external URL so a discovery client lands on the correct host.
+        from the internal cluster URL but rewrite every endpoint onto the
+        external URL so a discovery client lands on the correct host.
+
+        The rewrite walks the whole document rather than a list of known field
+        names. An allowlist silently left behind every field it did not
+        enumerate -- ``check_session_iframe``, ``pushed_authorization_request_
+        endpoint``, ``backchannel_authentication_endpoint`` and the entire
+        nested ``mtls_endpoint_aliases`` object -- so a client using PAR, CIBA,
+        mTLS client auth or OIDC session management was handed an unreachable
+        internal URL while the primary endpoints looked correct (issue #1649).
+        It also meant every field Keycloak adds in a future release starts out
+        broken by default. Walking the document inverts that: a field is
+        rewritten because it points at the internal host, not because someone
+        remembered to list it.
         """
         config = self._get_openid_configuration()
         if self.keycloak_url == self.keycloak_external_url:
             return dict(config)
 
-        rewritten: dict[str, Any] = dict(config)
-        for field in (
-            "issuer",
-            "authorization_endpoint",
-            "token_endpoint",
-            "userinfo_endpoint",
-            "jwks_uri",
-            "end_session_endpoint",
-            "introspection_endpoint",
-            "registration_endpoint",
-            "revocation_endpoint",
-            "device_authorization_endpoint",
-        ):
-            value = rewritten.get(field)
-            if isinstance(value, str) and value.startswith(self.keycloak_url):
-                rewritten[field] = value.replace(self.keycloak_url, self.keycloak_external_url, 1)
-        return rewritten
+        rewritten = self._rewrite_internal_urls(config)
+        # _rewrite_internal_urls returns a dict for a dict input; assert the
+        # shape for mypy and for a malformed upstream document.
+        return rewritten if isinstance(rewritten, dict) else dict(config)
 
     @lru_cache(maxsize=1)
     def _get_openid_configuration(self) -> dict[str, Any]:

--- a/tests/auth_server/unit/providers/test_keycloak.py
+++ b/tests/auth_server/unit/providers/test_keycloak.py
@@ -896,6 +896,188 @@ class TestKeycloakAuthorizationServerMetadata:
         )
 
 
+class TestKeycloakMetadataRewritesEveryUrl:
+    """No internal URL may survive anywhere in the discovery document.
+
+    The rewrite used to enumerate ten field names, so everything it did not list
+    kept the internal Docker URL: ``check_session_iframe``, ``pushed_authorization_
+    request_endpoint``, ``backchannel_authentication_endpoint`` and the whole
+    nested ``mtls_endpoint_aliases`` object. The primary endpoints looked
+    correct, so a client using PAR, CIBA, mTLS client auth or OIDC session
+    management failed in a way that is hard to attribute (issue #1649).
+    """
+
+    INTERNAL = "http://keycloak:8080"
+    EXTERNAL = "https://gateway.example.com"
+
+    def _full_openid_config(self, base_url: str) -> dict:
+        """A discovery document covering the fields the allowlist missed."""
+        realm = f"{base_url}/realms/test-realm"
+        oidc = f"{realm}/protocol/openid-connect"
+        return {
+            "issuer": realm,
+            "authorization_endpoint": f"{oidc}/auth",
+            "token_endpoint": f"{oidc}/token",
+            "userinfo_endpoint": f"{oidc}/userinfo",
+            "jwks_uri": f"{oidc}/certs",
+            "end_session_endpoint": f"{oidc}/logout",
+            "introspection_endpoint": f"{oidc}/token/introspect",
+            "revocation_endpoint": f"{oidc}/revoke",
+            "device_authorization_endpoint": f"{oidc}/auth/device",
+            "registration_endpoint": f"{base_url}/realms/test-realm/clients-registrations/openid-connect",
+            # Fields the allowlist never covered:
+            "check_session_iframe": f"{oidc}/login-status-iframe.html",
+            "backchannel_authentication_endpoint": f"{oidc}/ext/ciba/auth",
+            "pushed_authorization_request_endpoint": f"{oidc}/ext/par/request",
+            "mtls_endpoint_aliases": {
+                "token_endpoint": f"{oidc}/token",
+                "revocation_endpoint": f"{oidc}/revoke",
+                "introspection_endpoint": f"{oidc}/token/introspect",
+                "device_authorization_endpoint": f"{oidc}/auth/device",
+                "registration_endpoint": f"{base_url}/realms/test-realm/clients-registrations/openid-connect",
+                "userinfo_endpoint": f"{oidc}/userinfo",
+                "pushed_authorization_request_endpoint": f"{oidc}/ext/par/request",
+                "backchannel_authentication_endpoint": f"{oidc}/ext/ciba/auth",
+            },
+            # Non-URL values that must survive untouched.
+            "response_types_supported": ["code", "id_token"],
+            "request_parameter_supported": True,
+            "require_request_uri_registration": False,
+        }
+
+    def _provider(self, mock_get, config: dict, external: str | None = None):
+        from auth_server.providers.keycloak import KeycloakProvider
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = config
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+        return KeycloakProvider(
+            keycloak_url=self.INTERNAL,
+            keycloak_external_url=self.EXTERNAL if external is None else external,
+            realm="test-realm",
+            client_id="c",
+            client_secret="s",
+        )
+
+    @staticmethod
+    def _all_strings(node):
+        """Yield every string anywhere in a nested JSON structure."""
+        if isinstance(node, str):
+            yield node
+        elif isinstance(node, dict):
+            for value in node.values():
+                yield from TestKeycloakMetadataRewritesEveryUrl._all_strings(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from TestKeycloakMetadataRewritesEveryUrl._all_strings(value)
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_no_internal_url_survives_anywhere(self, mock_get):
+        """The whole-document invariant, stated once.
+
+        Asserting on the document as a whole rather than on named fields is the
+        point of the fix: a field Keycloak adds in a future release is covered
+        without anyone updating a list.
+        """
+        provider = self._provider(mock_get, self._full_openid_config(self.INTERNAL))
+
+        metadata = provider.authorization_server_metadata()
+
+        leaked = [s for s in self._all_strings(metadata) if self.INTERNAL in s]
+        assert not leaked, f"internal URL survived in {len(leaked)} value(s): {leaked}"
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "check_session_iframe",
+            "backchannel_authentication_endpoint",
+            "pushed_authorization_request_endpoint",
+        ],
+    )
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_previously_missed_top_level_fields(self, mock_get, field):
+        """Each field the reporter found still internal on 1.29.0."""
+        provider = self._provider(mock_get, self._full_openid_config(self.INTERNAL))
+
+        metadata = provider.authorization_server_metadata()
+
+        assert metadata[field].startswith(self.EXTERNAL), metadata[field]
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_nested_mtls_endpoint_aliases_rewritten(self, mock_get):
+        """The nested object was not walked at all, so every key inside leaked."""
+        provider = self._provider(mock_get, self._full_openid_config(self.INTERNAL))
+
+        aliases = provider.authorization_server_metadata()["mtls_endpoint_aliases"]
+
+        assert aliases, "mtls_endpoint_aliases missing from the rewritten document"
+        for key, value in aliases.items():
+            assert value.startswith(self.EXTERNAL), f"{key} -> {value}"
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_non_url_values_are_untouched(self, mock_get):
+        """Lists, booleans and unrelated strings must pass through unchanged."""
+        config = self._full_openid_config(self.INTERNAL)
+        provider = self._provider(mock_get, config)
+
+        metadata = provider.authorization_server_metadata()
+
+        assert metadata["response_types_supported"] == ["code", "id_token"]
+        assert metadata["request_parameter_supported"] is True
+        assert metadata["require_request_uri_registration"] is False
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_rewrite_anchors_on_a_url_boundary(self, mock_get):
+        """A different port on the same host must not be rewritten.
+
+        "http://keycloak:8080" is a string prefix of "http://keycloak:80801",
+        which is a different service. A bare startswith would rewrite it.
+        """
+        config = self._full_openid_config(self.INTERNAL)
+        config["token_endpoint"] = "http://keycloak:80801/realms/test-realm/token"
+        provider = self._provider(mock_get, config)
+
+        metadata = provider.authorization_server_metadata()
+
+        assert metadata["token_endpoint"] == "http://keycloak:80801/realms/test-realm/token"
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_bare_internal_origin_is_rewritten(self, mock_get):
+        """An exact match with no path is a boundary too, not a near-miss."""
+        config = self._full_openid_config(self.INTERNAL)
+        config["issuer"] = self.INTERNAL
+        provider = self._provider(mock_get, config)
+
+        assert provider.authorization_server_metadata()["issuer"] == self.EXTERNAL
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_cached_configuration_is_not_mutated(self, mock_get):
+        """The rewrite must not poison the lru_cache it reads from.
+
+        _get_openid_configuration is lru_cached, so rewriting nested objects in
+        place would corrupt the document for every later caller -- including the
+        internal-URL consumers that must keep pointing at the cluster host.
+        """
+        provider = self._provider(mock_get, self._full_openid_config(self.INTERNAL))
+
+        first = provider.authorization_server_metadata()
+        cached = provider._get_openid_configuration()
+        second = provider.authorization_server_metadata()
+
+        assert cached["token_endpoint"].startswith(self.INTERNAL)
+        assert cached["mtls_endpoint_aliases"]["token_endpoint"].startswith(self.INTERNAL)
+        assert first == second
+
+    @patch("auth_server.providers.keycloak.requests.get")
+    def test_passthrough_when_internal_equals_external(self, mock_get):
+        """No external URL configured: the document is returned as-is."""
+        config = self._full_openid_config(self.INTERNAL)
+        provider = self._provider(mock_get, config, external=self.INTERNAL)
+
+        assert provider.authorization_server_metadata() == config
+
+
 # =============================================================================
 # KEYCLOAK_EXTERNAL_URL STARTUP DIAGNOSTIC
 # =============================================================================


### PR DESCRIPTION
Refs #1649

This is the second half of #1649. [#1657](https://github.com/agentic-community/mcp-gateway-registry/pull/1657) passed `KEYCLOAK_EXTERNAL_URL` to the registry service, which fixed the primary endpoints. The issue stayed open because the URL rewriting itself is incomplete, as I reported in [the follow-up comment](https://github.com/agentic-community/mcp-gateway-registry/issues/1649#issuecomment-5305118445) after verifying on 1.29.0. This closes that half.

## What was wrong

`authorization_server_metadata` rewrote the internal Keycloak URL onto the external host for **ten named fields**. Everything not on that list kept the internal Docker URL, and the nested `mtls_endpoint_aliases` object was not walked at all, so every key inside it leaked.

Still internal on a deployment with `KEYCLOAK_EXTERNAL_URL` correctly set:

| Field | |
|---|---|
| `check_session_iframe` | OIDC session management |
| `backchannel_authentication_endpoint` | CIBA |
| `pushed_authorization_request_endpoint` | PAR |
| `mtls_endpoint_aliases.*` | all eight nested endpoints |

The primary endpoints — `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`, `registration_endpoint` — were correct, so the document looks right at a glance. A client that uses PAR, CIBA, mTLS client auth or OIDC session management is handed an unreachable internal host and fails in a way that is hard to attribute back to discovery.

An allowlist also means every field a future Keycloak release adds starts out broken by default, and nobody finds out until a client happens to use it.

## The fix

Walk the whole document. A value is rewritten because it points at the internal host, not because someone remembered to list its field name, so new fields and nested objects are covered without maintenance.

Two things fall out of doing it properly:

**The match is anchored at a URL boundary.** The old code used a bare `startswith`, so an internal base of `http://keycloak:8080` also matched `http://keycloak:80801` — a different port on the same host — and rewrote it. Only `/`, `?`, `#` or end-of-string now count as a boundary. This was a pre-existing defect; it is fixed here because the recursive walk would otherwise have spread it to more fields.

**New containers are built rather than mutating in place.** `_get_openid_configuration` is `lru_cache`d, so rewriting a nested dict in place would poison the cache for every later caller — including the internal-URL consumers that must keep pointing at the cluster host. A test pins this.

## Verification

Ten new tests in `TestKeycloakMetadataRewritesEveryUrl`. The primary one asserts the invariant over the whole document rather than over named fields:

```python
leaked = [s for s in self._all_strings(metadata) if self.INTERNAL in s]
assert not leaked
```

That is deliberately the shape of the fix: naming fields in the test would reintroduce the same blind spot the code had. The remaining tests cover each field from the report individually, the nested `mtls_endpoint_aliases`, non-URL values passing through untouched, the boundary case, a bare origin with no path, cache integrity, and the unchanged passthrough when no external URL is configured.

**Six of the ten fail against the pre-fix tree.** The four that pass do so correctly: non-URL values were never touched, a bare origin was already rewritten by the old `startswith` + `replace`, the old shallow copy did not corrupt the cache, and the passthrough path is unchanged.

Full suites: `tests/auth_server/unit/providers/test_keycloak.py` 53 passed, `tests/auth_server/unit/providers/` 263 passed. `pre-commit run --files <changed files>` passes with `SKIP=pytest-fast`, matching `.github/workflows/pre-commit.yaml`; Bandit and MyPy both cover `keycloak.py`.

## Scope

Keycloak only. It is the only provider that brokers an internal/external split — Cognito, Entra, Okta, Auth0 and PingFederate build their documents from a single cloud-facing host, so there is no internal URL to rewrite. I grepped for the same allowlist pattern elsewhere and found none.

Marked `Refs` rather than `Closes` so you can decide whether #1649 is now fully addressed; between this and #1657 I believe it is, but that call is yours.
