### PR TITLE
feat(observability): nudge operators about recommended-but-optional config

### DIFF
--- a/frontend/src/components/ConfigPanel.tsx
+++ b/frontend/src/components/ConfigPanel.tsx
@@ -39,10 +39,20 @@ interface ConfigGroup {
   subgroups?: ConfigSubgroup[];
 }
 
+interface Recommendation {
+  id: string;
+  setting: string;
+  component: string;
+  severity: string;
+  message: string;
+  configured: boolean;
+}
+
 interface ConfigResponse {
   groups: ConfigGroup[];
   total_groups: number;
   is_local_dev: boolean;
+  recommendations?: Recommendation[];
 }
 
 type ExportFormat = 'env' | 'json' | 'tfvars' | 'yaml';
@@ -500,6 +510,33 @@ const ConfigPanel: React.FC<ConfigPanelProps> = ({ onError, showToast }) => {
           </button>
         </div>
       </div>
+
+      {/* Recommended-but-optional settings left unset (nudge) */}
+      {(config.recommendations ?? []).some((r) => !r.configured) && (
+        <div
+          className="rounded-lg border border-yellow-300 bg-yellow-50 px-4 py-3
+                     dark:border-yellow-700/60 dark:bg-yellow-900/20"
+          data-testid="recommended-config-warning"
+        >
+          <div className="flex items-start space-x-2">
+            <ExclamationCircleIcon className="h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-400" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                Recommended configuration not set
+              </p>
+              <ul className="list-disc space-y-1 pl-5 text-sm text-yellow-800 dark:text-yellow-300">
+                {config.recommendations!
+                  .filter((r) => !r.configured)
+                  .map((r) => (
+                    <li key={r.id}>
+                      <span className="font-mono">{r.setting}</span>: {r.message}
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Search */}
       <div className="relative">

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -426,6 +426,10 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("egress_state_ttl_seconds", "OAuth State TTL (s)", False),
             ("egress_registry_internal_url", "Registry Internal Vend URL", False),
             ("egress_obo_allowed_audiences", "OBO Allowed Audiences", False),
+            # application-layer credential encryption (key is masked; only its
+            # presence/absence is shown, never the value)
+            ("egress_credential_encryption_key", "Credential Encryption Key", True),
+            ("egress_credential_require_encrypted", "Require Encrypted (strict)", False),
             # secrets-manager backend
             ("secrets_manager_kms_key_id", "Secrets Manager KMS Key ID", True),
             ("secrets_manager_path_prefix", "Secrets Manager Path Prefix", False),
@@ -670,7 +674,19 @@ def _build_config_response() -> dict[str, Any]:
         "groups": groups,
         "total_groups": len(groups),
         "is_local_dev": settings.is_local_dev,
+        # Recommended-but-optional settings that apply to this deployment, with
+        # their configured status, so the UI can badge any that are unset. Sourced
+        # from registry.core.recommended_config (same source as the startup warning
+        # and the recommended-config metric). Never contains secret values.
+        "recommendations": _build_recommendations(),
     }
+
+
+def _build_recommendations() -> list[dict[str, Any]]:
+    """Return applicable recommended-config entries with their configured status."""
+    from registry.core.recommended_config import evaluate_recommendations
+
+    return evaluate_recommendations(settings)
 
 
 # ---------------------------------------------------------------------------

--- a/registry/core/recommended_config.py
+++ b/registry/core/recommended_config.py
@@ -1,0 +1,140 @@
+"""Registry of recommended-but-optional configuration and its evaluation.
+
+Some settings are optional (the app starts and runs without them) yet strongly
+recommended for a secure/robust deployment -- e.g. the egress credential vault
+runs without ``EGRESS_CREDENTIAL_ENCRYPTION_KEY`` but then stores third-party
+credentials in plaintext at rest. Leaving such a setting unset is easy to do
+silently, so we nudge operators through three surfaces that all read from this
+one source of truth:
+
+- a startup ``WARNING`` log (see ``log_recommended_config_warnings``),
+- an OpenTelemetry ``ObservableGauge`` (see ``registry.observability.meters``),
+- the System Config UI badge (via ``GET /api/config/full`` ``recommendations``).
+
+Add a new nudge by appending one :class:`RecommendedConfig` descriptor here; all
+three surfaces pick it up automatically. Each descriptor is gated by ``applies``
+so a deployment that does not use the feature is never nagged about it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RecommendedConfig:
+    """One recommended-but-optional configuration setting.
+
+    Args:
+        id: Stable identifier, also used as a metric label. kebab/snake, no PII.
+        setting: The ``Settings`` attribute name this recommendation concerns
+            (lets the UI cross-reference the config field).
+        component: Coarse area label for grouping/alerting (e.g. ``"egress"``).
+        severity: Why it matters (e.g. ``"security"``, ``"reliability"``).
+        message: Operator-facing nudge. Must not contain secrets.
+        applies: Returns True when this recommendation is relevant to the current
+            deployment (e.g. the feature it protects is enabled). Non-applicable
+            recommendations are omitted entirely, so unused features are not nagged.
+        is_configured: Returns True when the setting is satisfied.
+    """
+
+    id: str
+    setting: str
+    component: str
+    severity: str
+    message: str
+    applies: Callable[[Any], bool]
+    is_configured: Callable[[Any], bool]
+
+
+def _egress_encryption_key_set(settings: Any) -> bool:
+    """True when the egress credential encryption root key is set (non-blank)."""
+    value = getattr(settings, "egress_credential_encryption_key", "") or ""
+    return bool(value.strip())
+
+
+# The single source of truth. Keep label cardinality bounded: this is a fixed,
+# code-defined list, never derived from user input.
+_RECOMMENDED: tuple[RecommendedConfig, ...] = (
+    RecommendedConfig(
+        id="egress_credential_encryption",
+        setting="egress_credential_encryption_key",
+        component="egress",
+        severity="security",
+        message=(
+            "Egress credential vault is enabled but EGRESS_CREDENTIAL_ENCRYPTION_KEY "
+            "is unset: per-user third-party credentials are stored in PLAINTEXT at "
+            "rest. Set the key to encrypt them (generate: "
+            'python3 -c "import secrets; print(secrets.token_urlsafe(32))").'
+        ),
+        applies=lambda s: bool(getattr(s, "egress_auth_enabled", False)),
+        is_configured=_egress_encryption_key_set,
+    ),
+)
+
+
+def evaluate_recommendations(
+    settings: Any,
+) -> list[dict[str, Any]]:
+    """Evaluate every recommendation that APPLIES to the current deployment.
+
+    Non-applicable recommendations are skipped so unused features are not nagged.
+    Fails safe: if ``applies``/``is_configured`` raises, the recommendation is
+    reported as NOT configured (a nudge) rather than silently dropped.
+
+    Args:
+        settings: The application ``Settings`` object.
+
+    Returns:
+        One dict per applicable recommendation with keys ``id``, ``setting``,
+        ``component``, ``severity``, ``message``, and ``configured`` (bool).
+        Never raises.
+    """
+    results: list[dict[str, Any]] = []
+    for rec in _RECOMMENDED:
+        try:
+            if not rec.applies(settings):
+                continue
+        except Exception as exc:  # defensive: a broken gate must not break callers
+            logger.debug("recommended-config applies() failed for %s: %s", rec.id, exc)
+            continue
+        try:
+            configured = bool(rec.is_configured(settings))
+        except Exception as exc:
+            logger.debug("recommended-config is_configured() failed for %s: %s", rec.id, exc)
+            configured = False  # fail closed -> treat as a nudge
+        results.append(
+            {
+                "id": rec.id,
+                "setting": rec.setting,
+                "component": rec.component,
+                "severity": rec.severity,
+                "message": rec.message,
+                "configured": configured,
+            }
+        )
+    return results
+
+
+def log_recommended_config_warnings(
+    settings: Any,
+) -> None:
+    """Emit a startup ``WARNING`` for each applicable recommendation left unset.
+
+    Called once at startup. Configured recommendations and non-applicable ones
+    produce no output. Never raises.
+    """
+    for rec in evaluate_recommendations(settings):
+        if not rec["configured"]:
+            logger.warning(
+                "Recommended configuration not set [%s/%s severity=%s]: %s",
+                rec["component"],
+                rec["id"],
+                rec["severity"],
+                rec["message"],
+            )

--- a/registry/main.py
+++ b/registry/main.py
@@ -175,6 +175,13 @@ def _log_startup_configuration() -> None:
 
     logger.info("=" * 60)
 
+    # Nudge operators about recommended-but-optional settings left unset (e.g. the
+    # egress credential encryption key when the vault is enabled). Same source of
+    # truth as the recommended-config metric and the System Config UI badge.
+    from registry.core.recommended_config import log_recommended_config_warnings
+
+    log_recommended_config_warnings(settings)
+
 
 def _initialize_deployment_metrics() -> None:
     """Initialize deployment mode Prometheus metrics.

--- a/registry/observability/meters.py
+++ b/registry/observability/meters.py
@@ -429,6 +429,45 @@ _meter.create_observable_gauge(
 )
 
 
+def _recommended_config_callback(options: Any) -> Any:
+    """ObservableGauge: 1 when a recommended-but-optional setting is NOT set, else 0.
+
+    Runs on the metrics-export cycle (NOT the request path). Reads the current
+    settings each cycle so the gauge self-corrects once an operator configures the
+    setting -- no manual reset. Only recommendations that APPLY to this deployment
+    are emitted (an unused feature is never nagged). Labels are bounded (a fixed,
+    code-defined recommendation list), so cardinality is safe. Lazy imports avoid
+    a startup circular import (settings -> meters).
+    """
+    try:
+        from registry.core.config import settings
+        from registry.core.recommended_config import evaluate_recommendations
+
+        for rec in evaluate_recommendations(settings):
+            yield metrics.Observation(
+                0 if rec["configured"] else 1,
+                {
+                    "setting": rec["id"],
+                    "component": rec["component"],
+                    "severity": rec["severity"],
+                },
+            )
+    except Exception as exc:  # pragma: no cover - defensive; never break export
+        logger.debug("recommended_config callback failed: %s", exc)
+        return
+
+
+_meter.create_observable_gauge(
+    name="mcpgw_registry_recommended_config_not_set",
+    callbacks=[_recommended_config_callback],
+    description=(
+        "1 when a recommended-but-optional setting that applies to this deployment "
+        "is not configured (an active operator nudge), else 0. Labeled by setting."
+    ),
+    unit="1",
+)
+
+
 # Mode-blocked requests (registry/core/metrics.py:43)
 _mode_blocked_requests_counter = _meter.create_counter(
     name="mcpgw_registry_mode_blocked_requests_total",

--- a/tests/unit/core/test_recommended_config.py
+++ b/tests/unit/core/test_recommended_config.py
@@ -1,0 +1,99 @@
+"""Tests for registry.core.recommended_config.
+
+The egress credential encryption key is the first recommended-but-optional
+setting: the vault runs without it but then stores credentials in plaintext, so
+we nudge (startup warning + metric + UI badge) only when the vault is enabled and
+the key is unset. These tests pin the evaluate/gate/fail-closed behavior that all
+three surfaces depend on.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+from registry.core.recommended_config import (
+    evaluate_recommendations,
+    log_recommended_config_warnings,
+)
+
+
+def _settings(egress_auth_enabled=True, egress_credential_encryption_key=""):
+    s = MagicMock()
+    s.egress_auth_enabled = egress_auth_enabled
+    s.egress_credential_encryption_key = egress_credential_encryption_key
+    return s
+
+
+class TestEvaluateRecommendations:
+    """The applies() gate and configured status."""
+
+    def test_not_applicable_when_egress_disabled(self):
+        """A deployment that doesn't use the vault is never nagged about the key."""
+        result = evaluate_recommendations(_settings(egress_auth_enabled=False))
+        assert all(r["id"] != "egress_credential_encryption" for r in result)
+
+    def test_applicable_and_key_unset_is_a_nudge(self):
+        result = evaluate_recommendations(
+            _settings(egress_auth_enabled=True, egress_credential_encryption_key="")
+        )
+        rec = next(r for r in result if r["id"] == "egress_credential_encryption")
+        assert rec["configured"] is False
+        assert rec["component"] == "egress"
+        assert rec["severity"] == "security"
+
+    def test_applicable_and_key_set_is_configured(self):
+        result = evaluate_recommendations(
+            _settings(egress_auth_enabled=True, egress_credential_encryption_key="a" * 43)
+        )
+        rec = next(r for r in result if r["id"] == "egress_credential_encryption")
+        assert rec["configured"] is True
+
+    def test_whitespace_only_key_is_not_configured(self):
+        result = evaluate_recommendations(
+            _settings(egress_auth_enabled=True, egress_credential_encryption_key="   ")
+        )
+        rec = next(r for r in result if r["id"] == "egress_credential_encryption")
+        assert rec["configured"] is False
+
+    def test_message_contains_no_secret_value(self):
+        key = "super-secret-key-value-do-not-leak-1234567890"
+        result = evaluate_recommendations(
+            _settings(egress_auth_enabled=True, egress_credential_encryption_key=key)
+        )
+        rec = next(r for r in result if r["id"] == "egress_credential_encryption")
+        assert key not in rec["message"]
+
+    def test_fail_closed_on_broken_settings(self):
+        """A settings object that raises must not crash evaluation; treat as a nudge."""
+
+        class _Boom:
+            egress_auth_enabled = True
+
+            @property
+            def egress_credential_encryption_key(self):
+                raise RuntimeError("boom")
+
+        result = evaluate_recommendations(_Boom())
+        rec = next(r for r in result if r["id"] == "egress_credential_encryption")
+        assert rec["configured"] is False  # fail closed
+
+
+class TestLogRecommendedConfigWarnings:
+    def test_warns_when_unset(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="registry.core.recommended_config"):
+            log_recommended_config_warnings(_settings(egress_auth_enabled=True))
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "egress_credential_encryption" in m and "not set" in m.lower() for m in warnings
+        ), warnings
+
+    def test_no_warning_when_configured(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="registry.core.recommended_config"):
+            log_recommended_config_warnings(
+                _settings(egress_auth_enabled=True, egress_credential_encryption_key="a" * 43)
+            )
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+    def test_no_warning_when_not_applicable(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="registry.core.recommended_config"):
+            log_recommended_config_warnings(_settings(egress_auth_enabled=False))
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]


### PR DESCRIPTION
Follow-up to #1675.

## Motivation

Some settings are optional (the app runs without them) yet strongly recommended for a secure/robust deployment. The first case is `EGRESS_CREDENTIAL_ENCRYPTION_KEY`: when the egress credential vault is enabled but the key is unset, per-user third-party credentials are stored **in plaintext at rest**, and today that's easy to miss (only an INFO log line). This PR adds a reusable mechanism to nudge operators about such settings.

## What changed

**Single source of truth** — `registry/core/recommended_config.py` holds a list of `RecommendedConfig` descriptors, each with an `applies()` gate (so deployments not using a feature are never nagged) and an `is_configured()` predicate. Adding a future nudge is one appended entry.

That one list drives three surfaces:

1. **Metric** — a new OpenTelemetry `ObservableGauge` `mcpgw_registry_recommended_config_not_set` (1 = applies-but-unset, 0 = configured), labeled by `setting`/`component`/`severity`. It's *observable* (re-read each export cycle) so it self-corrects once configured, matching the existing `deployment_mode`/`quarantine_members` gauges. Labels are bounded (fixed code-defined list).
2. **Startup warning** — `_log_startup_configuration()` emits a `WARNING` for each applicable-but-unset recommendation.
3. **System Config UI** — `GET /api/config/full` now returns a `recommendations` array; `ConfigPanel` renders a warning badge listing any unset ones.

**First recommendation:** `egress_credential_encryption` — `applies` when `egress_auth_enabled`, `is_configured` when the encryption key is set. Fails closed (an evaluation error is treated as a nudge).

**CONFIG_GROUPS** — surfaces the egress encryption key (masked; present/absent only) and the non-secret `EGRESS_CREDENTIAL_ENCRYPTION_REQUIRE_ENCRYPTED` toggle in the egress vault group (closes the gap noted in the #1675 review).

## Tests

New `tests/unit/core/test_recommended_config.py`: applies-gate, configured/unset status, whitespace-only key, message-carries-no-secret, fail-closed on a broken settings object, and the startup-warning behavior (warns when unset, silent when configured or not applicable). Full targeted config/observability suites pass; the recommended-config gauge respects the existing label-bounding test.

## Notes

- No new configuration parameters are introduced (this consumes existing ones), so no unified-parameter-reference change is required.
- Bounded label cardinality by design; the callback lazy-imports settings to avoid a startup circular import.