### PR TITLE
Remove `/api/internal/*` from the public listeners

### DIFF
--- a/cli/service_mgmt.sh
+++ b/cli/service_mgmt.sh
@@ -542,43 +542,39 @@ except Exception as e:
         echo ""
         echo "====Disabling the server===="
 
-        # Generate JWT token for internal auth using shared SECRET_KEY
-        if [ -z "$SECRET_KEY" ]; then
-            print_error "SECRET_KEY not set in environment - cannot disable server"
+        # Disable the just-registered (auto-enabled) server via the public,
+        # user-authenticated toggle endpoint, reusing the same gateway JWT the
+        # rest of this script uses (the ingress token from credentials-provider).
+        local token_file="$PROJECT_ROOT/.oauth-tokens/ingress.json"
+        local auth_token
+        auth_token=$(python3 -c "import json; d=json.load(open('$token_file')); print(d.get('access_token') or d.get('tokens', {}).get('access_token') or '')" 2>/dev/null)
+
+        if [ -z "$auth_token" ]; then
+            print_error "No gateway token at $token_file - cannot disable server (run credentials-provider/generate_creds.sh)"
         else
-            local auth_token
-            auth_token=$(python3 -c "
-from registry.auth.internal import generate_internal_token
-print(generate_internal_token(subject='cli-service-mgmt', purpose='toggle-service'))
-" 2>/dev/null)
+            # Set the server to disabled (false); it was auto-enabled at registration.
+            print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
+            print_info "Service path: $service_path"
 
-            if [ -z "$auth_token" ]; then
-                print_error "Failed to generate auth token - cannot disable server"
+            output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
+                -H "Authorization: Bearer $auth_token" \
+                --data-urlencode "path=$service_path" \
+                --data-urlencode "new_state=false" 2>&1)
+
+            # Extract HTTP status code from response
+            http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
+            response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
+
+            print_info "Toggle API HTTP Status: $http_status"
+            print_info "Toggle API Response: $response_body"
+
+            if [ "$http_status" = "200" ]; then
+                print_success "Server disabled due to failed security scan"
             else
-                # Call the internal toggle endpoint to set service to disabled (false)
-                # Since the server was just auto-enabled during registration, we need to toggle it OFF
-                print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/internal/toggle"
-                print_info "Service path: $service_path"
-
-                output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/internal/toggle" \
-                    -H "Authorization: Bearer $auth_token" \
-                    --data-urlencode "service_path=$service_path" 2>&1)
-
-                # Extract HTTP status code from response
-                http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
-                response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
-
-                print_info "Toggle API HTTP Status: $http_status"
-                print_info "Toggle API Response: $response_body"
-
-                if [ "$http_status" = "200" ]; then
-                    print_success "Server disabled due to failed security scan"
-                else
-                    print_error "Failed to disable server - HTTP Status: $http_status"
-                    print_error "Response: $response_body"
-                fi
-                print_info "Review the security scan report before enabling this server"
+                print_error "Failed to disable server - HTTP Status: $http_status"
+                print_error "Response: $response_body"
             fi
+            print_info "Review the security scan report before enabling this server"
         fi
     fi
 

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -64,7 +64,6 @@ map $uri $mcp_gateway_register_key {
     default                              "";
     "~*/api/register/?$"                 $binary_remote_addr;
     "~*/api/servers/register/?$"         $binary_remote_addr;
-    "~*/api/internal/register/?$"        $binary_remote_addr;
 }
 
 # Resolve `require "cjson"` to OpenResty's lua-cjson (built into the registry
@@ -906,11 +905,21 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Internal service-to-service routes are NOT publicly reachable. Session
+    # routes ride the internal-only /_internal/sessions/ subrequest; the egress
+    # vend + service-management routes ride the dedicated :8091 internal listener
+    # below. Blocking the prefix here removes /api/internal/* from the
+    # internet-facing listeners; the app-level gates (validate_internal_auth /
+    # validate_internal_session_secret) remain as defense-in-depth.
+    location ^~ {{ROOT_PATH}}/api/internal/ {
+        return 404;
+    }
+
     location {{ROOT_PATH}}/api/ {
         # Inbound rate limiting: bound the /validate auth fan-out (see zones above).
-        # The registration zone additionally throttles /api/register,
-        # /api/servers/register and /api/internal/register (its key is empty for
-        # every other request, so only registration is subject to the tighter cap).
+        # The registration zone additionally throttles /api/register and
+        # /api/servers/register (its key is empty for every other request, so
+        # only registration is subject to the tighter cap).
         limit_req zone=mcp_gateway_edge burst=100 nodelay;
         limit_req zone=mcp_gateway_register burst=10 nodelay;
         limit_conn mcp_gateway_conn 100;
@@ -1821,11 +1830,18 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Internal service-to-service routes are NOT publicly reachable (see the
+    # matching block on the 8080 listener). /api/internal/* is served only via
+    # the /_internal/sessions/ subrequest and the dedicated :8091 listener.
+    location ^~ {{ROOT_PATH}}/api/internal/ {
+        return 404;
+    }
+
     location {{ROOT_PATH}}/api/ {
         # Inbound rate limiting: bound the /validate auth fan-out (see zones above).
-        # The registration zone additionally throttles /api/register,
-        # /api/servers/register and /api/internal/register (its key is empty for
-        # every other request, so only registration is subject to the tighter cap).
+        # The registration zone additionally throttles /api/register and
+        # /api/servers/register (its key is empty for every other request, so
+        # only registration is subject to the tighter cap).
         limit_req zone=mcp_gateway_edge burst=100 nodelay;
         limit_req zone=mcp_gateway_register burst=10 nodelay;
         limit_conn mcp_gateway_conn 100;

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -64,7 +64,6 @@ map $uri $mcp_gateway_register_key {
     default                              "";
     "~*/api/register/?$"                 $binary_remote_addr;
     "~*/api/servers/register/?$"         $binary_remote_addr;
-    "~*/api/internal/register/?$"        $binary_remote_addr;
 }
 
 # Resolve `require "cjson"` to OpenResty's lua-cjson (built into the registry
@@ -390,11 +389,21 @@ server {
         proxy_read_timeout 30s;
     }
 
+    # Internal service-to-service routes are NOT publicly reachable. Session
+    # routes ride the internal-only /_internal/sessions/ subrequest; the egress
+    # vend + service-management routes ride the dedicated :8091 internal listener
+    # below. Blocking the prefix here removes /api/internal/* from the
+    # internet-facing listener; the app-level gates (validate_internal_auth /
+    # validate_internal_session_secret) remain as defense-in-depth.
+    location ^~ {{ROOT_PATH}}/api/internal/ {
+        return 404;
+    }
+
     location {{ROOT_PATH}}/api/ {
         # Inbound rate limiting: bound the /validate auth fan-out (see zones above).
-        # The registration zone additionally throttles /api/register,
-        # /api/servers/register and /api/internal/register (its key is empty for
-        # every other request, so only registration is subject to the tighter cap).
+        # The registration zone additionally throttles /api/register and
+        # /api/servers/register (its key is empty for every other request, so
+        # only registration is subject to the tighter cap).
         limit_req zone=mcp_gateway_edge burst=100 nodelay;
         limit_req zone=mcp_gateway_register burst=10 nodelay;
         limit_conn mcp_gateway_conn 100;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -618,7 +618,19 @@ This section implements the official [Anthropic MCP Registry API specification](
 
 ### Internal Admin Endpoints
 
-**Authentication:** HTTP Basic Auth (admin credentials)
+> **Not publicly reachable.** The public gateway listeners (8080/8443) return
+> `404` for the `/api/internal/` prefix. These are legacy service-to-service
+> routes; operator tooling (e.g. `cli/service_mgmt.sh`) now uses the public,
+> user-authenticated `/api/servers/*` siblings (e.g. `POST /api/servers/toggle`)
+> with a gateway JWT. The two subsets that are still called machine-to-machine
+> keep their own dedicated internal paths: the egress-token vend on the internal
+> `registry:8091` listener (auth-server only, never ALB-/Ingress-fronted,
+> unpublished in Compose) and the virtual-server session store via the internal
+> `/_internal/sessions/` nginx subrequest.
+
+**Authentication:** Internal service token — a short-lived, single-use Bearer JWT
+signed with the shared `SECRET_KEY` (`registry.auth.internal`), re-verified by the
+`validate_internal_auth` route gate. Not a user/admin login token.
 
 #### 11. Internal Register Service
 

--- a/terraform/aws-ecs/scripts/service_mgmt.sh
+++ b/terraform/aws-ecs/scripts/service_mgmt.sh
@@ -560,43 +560,39 @@ except Exception as e:
         echo ""
         echo "====Disabling the server===="
 
-        # Generate JWT token for internal auth using shared SECRET_KEY
-        if [ -z "$SECRET_KEY" ]; then
-            print_error "SECRET_KEY not set in environment - cannot disable server"
+        # Disable the just-registered (auto-enabled) server via the public,
+        # user-authenticated toggle endpoint, reusing the same gateway JWT the
+        # rest of this script uses (the ingress token from credentials-provider).
+        local token_file="$PROJECT_ROOT/.oauth-tokens/ingress.json"
+        local auth_token
+        auth_token=$(python3 -c "import json; d=json.load(open('$token_file')); print(d.get('access_token') or d.get('tokens', {}).get('access_token') or '')" 2>/dev/null)
+
+        if [ -z "$auth_token" ]; then
+            print_error "No gateway token at $token_file - cannot disable server (run credentials-provider/generate_creds.sh)"
         else
-            local auth_token
-            auth_token=$(python3 -c "
-from registry.auth.internal import generate_internal_token
-print(generate_internal_token(subject='cli-service-mgmt', purpose='toggle-service'))
-" 2>/dev/null)
+            # Set the server to disabled (false); it was auto-enabled at registration.
+            print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
+            print_info "Service path: $service_path"
 
-            if [ -z "$auth_token" ]; then
-                print_error "Failed to generate auth token - cannot disable server"
+            output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
+                -H "Authorization: Bearer $auth_token" \
+                --data-urlencode "path=$service_path" \
+                --data-urlencode "new_state=false" 2>&1)
+
+            # Extract HTTP status code from response
+            http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
+            response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
+
+            print_info "Toggle API HTTP Status: $http_status"
+            print_info "Toggle API Response: $response_body"
+
+            if [ "$http_status" = "200" ]; then
+                print_success "Server disabled due to failed security scan"
             else
-                # Call the internal toggle endpoint to set service to disabled (false)
-                # Since the server was just auto-enabled during registration, we need to toggle it OFF
-                print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/internal/toggle"
-                print_info "Service path: $service_path"
-
-                output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/internal/toggle" \
-                    -H "Authorization: Bearer $auth_token" \
-                    --data-urlencode "service_path=$service_path" 2>&1)
-
-                # Extract HTTP status code from response
-                http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
-                response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
-
-                print_info "Toggle API HTTP Status: $http_status"
-                print_info "Toggle API Response: $response_body"
-
-                if [ "$http_status" = "200" ]; then
-                    print_success "Server disabled due to failed security scan"
-                else
-                    print_error "Failed to disable server - HTTP Status: $http_status"
-                    print_error "Response: $response_body"
-                fi
-                print_info "Review the security scan report before enabling this server"
+                print_error "Failed to disable server - HTTP Status: $http_status"
+                print_error "Response: $response_body"
             fi
+            print_info "Review the security scan report before enabling this server"
         fi
     fi
 

--- a/tests/unit/core/test_nginx_service.py
+++ b/tests/unit/core/test_nginx_service.py
@@ -2148,7 +2148,7 @@ def test_conf_declares_rate_limit_zones(conf_path):
     # Registration patterns must allow an optional trailing slash so a request to
     # /api/register/ cannot bypass the stricter registration cap (only the generous
     # edge limit would apply). Match must be anchored to the register path suffix.
-    for register_path in ("register", "servers/register", "internal/register"):
+    for register_path in ("register", "servers/register"):
         assert f'"~*/api/{register_path}/?$"' in text, (
             f"register classifier for /api/{register_path} must accept an optional "
             "trailing slash to prevent a trailing-slash throttle bypass"
@@ -2169,10 +2169,42 @@ def test_conf_applies_edge_limit_on_general_api_location(conf_path):
     idx = text.index(marker)
     body = text[idx : idx + 800]
     assert "limit_req zone=mcp_gateway_edge burst=100 nodelay;" in body
-    # Registration endpoints (/api/register, /api/servers/register,
-    # /api/internal/register) fall through this location and get the tighter cap.
+    # Registration endpoints (/api/register, /api/servers/register) fall through
+    # this location and get the tighter cap.
     assert "limit_req zone=mcp_gateway_register burst=10 nodelay;" in body
     assert "limit_conn mcp_gateway_conn 100;" in body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("conf_path", [_HTTP_ONLY_CONF, _HTTP_AND_HTTPS_CONF])
+def test_internal_routes_blocked_on_public_listeners(conf_path):
+    """Service-to-service /api/internal/* routes must not be reachable on the
+    public listeners.
+
+    The public `/api/` catch-all would otherwise proxy every `/api/internal/*`
+    path (egress-token vend, virtual-server sessions, service management) to the
+    app, leaving the app-level gates as the sole defense. Each public server
+    block must `return 404` for the prefix. The egress vend and session subsets
+    keep their own dedicated internal locations (/_egress_internal/egress-token
+    on :8091, /_internal/sessions/ subrequest); the management routes are
+    superseded by the user-authenticated /api/servers/* endpoints, so nothing
+    proxies the /api/internal/ prefix through on any listener.
+    """
+    text = conf_path.read_text()
+    expected_public_blocks = 2 if conf_path == _HTTP_AND_HTTPS_CONF else 1
+    assert text.count("location ^~ {{ROOT_PATH}}/api/internal/ {") == expected_public_blocks, (
+        "each public server block must 404 the /api/internal/ prefix"
+    )
+    # No listener proxies the /api/internal/ prefix through to the app: the vend
+    # endpoint has its own exact-match location, and the management routes are no
+    # longer nginx-routable (migrated to the public /api/servers/* siblings).
+    assert "location ^~ /api/internal/ {" not in text
+    assert "proxy_pass http://127.0.0.1:7860/api/internal/;" not in text
+    # The egress vend endpoint is still served on the internal listener.
+    assert "proxy_pass http://127.0.0.1:7860/api/internal/egress-token;" in text
+    # The dead public register-rate-limit classifier for internal/register is gone
+    # (the endpoint is no longer publicly routable, so it needs no throttle key).
+    assert '"~*/api/internal/register/?$"' not in text
 
 
 def _assert_all_locations_rate_limited(


### PR DESCRIPTION
### Summary

Completes the network isolation started in #1655. That PR moved the egress-token vend onto the dedicated `:8091` internal listener, but the public `location /api/` catch-all still proxied **every** `/api/internal/*` path — the vend, the virtual-server session store, and the service-management routes — straight to the app on the internet-facing 8080/8443 listeners. The app-level gates held (401/403), but the network reachability the internal listener was meant to remove was still there via the public `/api/` fallthrough.

This PR blocks the whole `/api/internal/` prefix on the public listeners and migrates the one remaining public caller to a user-authenticated endpoint.

### What changed

**nginx** (`docker/nginx_rev_proxy_http_and_https.conf`, `docker/nginx_rev_proxy_http_only.conf`)
- `return 404` for `^~ {{ROOT_PATH}}/api/internal/` in every public server block (8080 ×1 in http-only, 8080 + 8443 in http+https). `^~` outranks the plain `/api/` prefix.
- Removed the dead `/api/internal/register` key from the registration rate-limit classifier map + updated the surrounding comments.
- **Unaffected:** the egress vend (`/_egress_internal/egress-token` on `:8091`) and the session store (`/_internal/sessions/`, `internal;`) both `proxy_pass` directly to `127.0.0.1:7860`, so those upstream requests never re-enter public location matching.

**Operator scripts** (`cli/service_mgmt.sh`, `terraform/aws-ecs/scripts/service_mgmt.sh`)
- The failed-scan auto-disable now calls the public, user-authenticated `POST /api/servers/toggle` (`path` + `new_state=false`) with the gateway JWT already loaded from `.oauth-tokens/ingress.json`, instead of minting a SECRET_KEY service token for the internal `POST /api/internal/toggle`.
- `verify_csrf_token_flexible` skips CSRF for Bearer clients, so no CSRF token is needed.
- This keeps the operator scripts working over the public ALB from anywhere (no Service Connect / NetworkPolicy dependency).

**Tests** (`tests/unit/core/test_nginx_service.py`)
- New `test_internal_routes_blocked_on_public_listeners`: asserts the per-server 404 blocks, that no listener proxies the `/api/internal/` prefix, that the egress vend location survives, and that the dead register map key is gone.
- Fixed `test_conf_declares_rate_limit_zones` (dropped `internal/register` from the register-classifier tuple).

**Docs** (`docs/api-reference.md`)
- The Internal Admin Endpoints section now states the routes are not publicly reachable (public listeners 404 the prefix; tooling uses `/api/servers/*`; the vend + sessions keep their dedicated internal paths) and corrects the auth line to the single-use `SECRET_KEY`-signed service JWT.

### Testing

- `pytest tests/unit/core/test_nginx_service.py` — 118 passed.
- Both templates: brace-balanced; `bash -n` clean on both scripts.
- Live-verified on EKS deployment:
  - Public ALB: `/health` → 200; `POST /api/internal/{egress-token,toggle,register}`, `GET /api/internal/{sessions/x,list-groups}` → **404**.
  - auth-server → `registry:8091/_egress_internal/egress-token` → **401** (reachable + gated = working); `registry:8000/api/internal/egress-token` → 404 (public path blocked).

### Deployment notes

- **Depends on the #1655 Helm wiring being applied.** The auth-server must reach the vend on the internal listener, which requires:
  - `registry.egressAuth.enabled=true` → renders the `:8091` Service port + `egress-internal` containerPort (+ the `registry-egress-internal` NetworkPolicy), and
  - `auth-server` `EGRESS_REGISTRY_INTERNAL_URL=http://registry:8091` (chart default).
  If the auth-server is still pointed at `registry:8000` (the public `:8080` listener), the vend will 404 after this change. Verified/fixed live on `mcp-sub` by adding the `:8091` Service port and repointing the auth-server env.

### Backward compatibility

- The `/api/internal/*` FastAPI routes are unchanged and still served on the app loopback (gated by `validate_internal_auth`); they are simply no longer reachable through nginx on the public listeners. Service management moves to the `/api/servers/*` user-authenticated siblings, which already existed.
- No changes to the egress vend or session-store request paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
