### PR TITLE
fix(gateway-proxy): strip internal headers on generic hop, close prefix-match, document config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1657,6 +1657,57 @@ MCP_PROXY_TIMEOUT=30
 TOOL_FILTER_AUDIT_LOG_LEVEL=INFO
 
 # -----------------------------------------------------------------------------
+# Gateway generic proxy (proxy any registry entity: skills / agents / custom)
+# -----------------------------------------------------------------------------
+# Ships DARK. Every flag below defaults off/safe; with the feature disabled no
+# generic-proxy nginx block is rendered, no generic token is minted, and zero
+# extra per-tick DB queries are issued. Do NOT enable until the network egress
+# policy (SSRF layer 1) is deployed. See docs/design/gateway-generic-proxy.md.
+
+# Master switch for generating generic-proxy location blocks for proxied
+# non-MCP entities. Default: false (feature ships dark).
+GATEWAY_GENERIC_PROXY_ENABLED=false
+
+# Emit canonical /entity_type/path blocks alongside the legacy flat aliases.
+# Placeholder for a later slice; keep false until the /validate entity-derivation
+# lands. Default: false
+GATEWAY_CANONICAL_NAMESPACE_ENABLED=false
+
+# SSRF egress policy. When false, proxy_target_url hosts in loopback/private/
+# reserved ranges are rejected at registration and render. Link-local/metadata
+# and the unspecified address are denied regardless of this flag. Set true only
+# for trusted on-cluster service URLs. Default: false
+GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=false
+
+# CSRF defense: refuse a state-changing verb on a generic route (403 at
+# /validate, before any token mint) when the caller authenticated with a session
+# cookie rather than a Bearer token. Default: true
+GATEWAY_GENERIC_REQUIRE_BEARER_FOR_WRITES=true
+
+# nginx client_max_body_size for generic-proxy blocks (inbound request body).
+# Must be an nginx size token (digits + optional k/m/g). Default: 1m
+GATEWAY_GENERIC_CLIENT_MAX_BODY_SIZE=1m
+
+# Upper bound (bytes) on the buffered upstream RESPONSE body the generic hop
+# reads before returning. Worst-case auth-server heap is roughly this times
+# GATEWAY_GENERIC_MAX_CONCURRENCY. Default: 10485760 (10 MiB)
+GENERIC_PROXY_MAX_BODY_BYTES=10485760
+
+# Semaphore cap on in-flight generic-hop requests (OOM guard). Default: 32
+GATEWAY_GENERIC_MAX_CONCURRENCY=32
+
+# TLS verification for the generic hop's client to HTTPS targets. 'true' =
+# system trust store; a filesystem path = custom CA bundle; 'false' = disable
+# (NOT recommended; emits a startup WARNING). Default: true
+GATEWAY_GENERIC_TLS_VERIFY=true
+
+# Startup egress self-check: when the generic proxy is enabled, probe-connect to
+# the cloud metadata IPs; if reachable, log CRITICAL, emit
+# gateway_egress_policy_unverified=1, and disable the feature for the process
+# (not pod readiness). Default: true
+GATEWAY_EGRESS_SELFCHECK_ENABLED=true
+
+# -----------------------------------------------------------------------------
 # /mcp-proxy internal-token hardening
 # -----------------------------------------------------------------------------
 

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -6618,6 +6618,27 @@ _EGRESS_STRIP_HEADERS: frozenset[str] = frozenset(
 )
 
 
+# Headers stripped before forwarding to a generic-proxy upstream. The generic hop
+# fronts arbitrary (potentially third-party) registered backends, so the caller's
+# gateway identity/scopes and every gateway-internal routing/auth header must be
+# removed -- otherwise a proxied backend would receive the caller's X-User/X-Scopes
+# (identity + authorization-topology disclosure) and a valid signed
+# X-Internal-Token-Generic (replayable for the token TTL). This is the generic-hop
+# analogue of _EGRESS_STRIP_HEADERS (applied on the mcp-proxy vault path); it adds
+# the markers the generic nginx location block injects. Applied on EVERY generic
+# request, since the hop has no notion of a "trusted internal" upstream.
+_GENERIC_HOP_STRIP_HEADERS: frozenset[str] = _EGRESS_STRIP_HEADERS | frozenset(
+    {
+        "x-internal-token-generic",
+        "x-generic-proxy-kind",
+        "x-entity-path",
+        "x-resolved-generic-upstream",
+        "x-resolved-upstream",
+        "x-original-method",
+    }
+)
+
+
 class EgressVendUnavailable(Exception):
     """The registry's egress-token vend failed *transiently* -- the registry was
     unreachable/timed out, or it answered 5xx after riding out its own bounded
@@ -8082,7 +8103,16 @@ async def generic_proxy(
         raise HTTPException(status_code=400, detail="Invalid request body") from exc
 
     max_body_bytes = _read_generic_max_body_bytes()
-    forward_headers = _forward_headers(dict(request.headers))
+    # Strip the gateway-internal identity/routing family before forwarding to the
+    # (possibly third-party) upstream: neither the caller's X-User/X-Scopes nor the
+    # signed X-Internal-Token-Generic may leak to a proxied backend. _forward_headers
+    # already drops cookie/authorization/x-upstream-url/hop-by-hop; this removes the
+    # remaining internal headers the generic nginx block injects.
+    forward_headers = {
+        key: value
+        for key, value in _forward_headers(dict(request.headers)).items()
+        if key.lower() not in _GENERIC_HOP_STRIP_HEADERS
+    }
     verify = _generic_tls_verify()
 
     logger.info(

--- a/docs/unified-parameter-reference.md
+++ b/docs/unified-parameter-reference.md
@@ -857,6 +857,24 @@ Application-level, identity/group/target-aware request limiting enforced at the 
 
 ---
 
+## Group 33 — Gateway Generic Proxy
+
+Extends gateway reverse-proxying to non-MCP entities (skills, agents, custom entities) through a uniform auth-server hop. **Ships dark:** every flag defaults off/safe, so with `GATEWAY_GENERIC_PROXY_ENABLED=false` no generic-proxy nginx block is rendered, no generic token is minted, and zero extra per-tick DB queries are issued. Consumed by the `registry` (render + SSRF validation) and the `auth-server` (the `/proxy` hop). See [gateway generic proxy design](design/gateway-generic-proxy.md). The Terraform and Helm columns are blank pending the enabling slice that wires the runtime surfaces (this feature is dark today; a `.env` override is sufficient for Docker/local enablement and testing).
+
+| Parameter | Docker (`.env`) | Terraform (`.tfvars`) | Helm (`values.yaml`) | Purpose |
+|-----------|-----------------|-----------------------|----------------------|---------|
+| Generic proxy enabled | `GATEWAY_GENERIC_PROXY_ENABLED` | — (not yet wired) | — (not yet wired) | Master switch for generic-proxy blocks. Default `false` (ships dark). |
+| Canonical namespace enabled | `GATEWAY_CANONICAL_NAMESPACE_ENABLED` | — (not yet wired) | — (not yet wired) | Emit canonical `/entity_type/path` blocks alongside the legacy flat aliases. Placeholder for a later slice. Default `false`. |
+| Allow private targets | `GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS` | — (not yet wired) | — (not yet wired) | SSRF egress policy. `false` rejects loopback/private/reserved targets. Link-local/metadata/unspecified are denied regardless. Default `false`. |
+| Require Bearer for writes | `GATEWAY_GENERIC_REQUIRE_BEARER_FOR_WRITES` | — (not yet wired) | — (not yet wired) | CSRF defense: refuse a state-changing verb under ambient cookie auth (403 before any token mint). Default `true`. |
+| Client max body size | `GATEWAY_GENERIC_CLIENT_MAX_BODY_SIZE` | — (not yet wired) | — (not yet wired) | nginx `client_max_body_size` for generic blocks (inbound request body). nginx size token. Default `1m`. |
+| Upstream response max body | `GENERIC_PROXY_MAX_BODY_BYTES` | — (not yet wired) | — (not yet wired) | Bytes of upstream response the hop buffers before returning. Default `10485760` (10 MiB). |
+| Max concurrency | `GATEWAY_GENERIC_MAX_CONCURRENCY` | — (not yet wired) | — (not yet wired) | Semaphore cap on in-flight generic-hop requests (OOM guard). Default `32`. |
+| TLS verify | `GATEWAY_GENERIC_TLS_VERIFY` | — (not yet wired) | — (not yet wired) | Generic hop TLS verification: `true` / CA-bundle path / `false` (emits a startup WARNING). Default `true`. |
+| Egress self-check enabled | `GATEWAY_EGRESS_SELFCHECK_ENABLED` | — (not yet wired) | — (not yet wired) | Probe metadata IPs at startup; if reachable, disable the feature for the process (not readiness). Default `true`. |
+
+---
+
 ## Checklist for new parameters
 
 When you add a new configuration parameter:

--- a/registry/api/config_routes.py
+++ b/registry/api/config_routes.py
@@ -470,6 +470,21 @@ CONFIG_GROUPS: dict[str, dict[str, Any]] = {
             ("rum_allowed_hosts", "RUM Allowed Hosts", False),
         ],
     },
+    "gateway_generic_proxy": {
+        "title": "Gateway Generic Proxy",
+        "order": 29,
+        "fields": [
+            ("gateway_generic_proxy_enabled", "Generic Proxy Enabled", False),
+            ("gateway_canonical_namespace_enabled", "Canonical Namespace Enabled", False),
+            ("gateway_proxy_allow_private_targets", "Allow Private Targets", False),
+            ("gateway_generic_require_bearer_for_writes", "Require Bearer for Writes", False),
+            ("gateway_generic_client_max_body_size", "Client Max Body Size (nginx)", False),
+            ("generic_proxy_max_body_bytes", "Upstream Response Max Body Bytes", False),
+            ("gateway_generic_max_concurrency", "Max Concurrency", False),
+            ("gateway_generic_tls_verify", "TLS Verify", False),
+            ("gateway_egress_selfcheck_enabled", "Egress Self-Check Enabled", False),
+        ],
+    },
 }
 
 

--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -1863,7 +1863,15 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         norm_path = path if path.startswith("/") else "/" + path
         entity_path = path.strip("/")
         proxy_target = f"{settings.auth_server_url.rstrip('/')}/proxy/{entity_type}/{entity_path}/"
-        location_path = f"/{entity_type}{norm_path}"
+        # Normalise to a trailing slash for the same reason as real and virtual
+        # servers (issue #1501): a bare `location /skill/foo` prefix-matches
+        # unrelated routes like `/skill/foobar`, hijacking them into this entity's
+        # /validate auth subrequest. `location /skill/foo/` only matches the
+        # subtree, and — paired with the trailing-slash proxy_pass target — appends
+        # a client sub-path cleanly onto the pinned base. It also makes the
+        # cross-block collision dedup exact-match correctly against the MCP/virtual
+        # location paths, which already carry a trailing slash.
+        location_path = f"/{entity_type}{norm_path}".rstrip("/") + "/"
         body_size = settings.gateway_generic_client_max_body_size
         return f"""
     # Proxied {entity_type}: {location_path}

--- a/tests/auth_server/unit/test_generic_proxy_handler.py
+++ b/tests/auth_server/unit/test_generic_proxy_handler.py
@@ -24,14 +24,70 @@ from fastapi import HTTPException  # noqa: E402
 
 from auth_server.server import (  # noqa: E402
     _GATEWAY_SET_SECURITY_HEADERS,
+    _GENERIC_HOP_STRIP_HEADERS,
     _assert_outbound_host_pinned,
     _build_generic_outbound_url,
+    _forward_headers,
     _generic_tls_verify,
     _run_egress_selfcheck,
     _select_forwarded_generic_response_headers,
 )
 
 pytestmark = pytest.mark.unit
+
+
+class TestGenericHopHeaderStrip:
+    """The generic hop fronts arbitrary (third-party) backends, so no gateway
+    identity/credential/routing header may leak to the upstream. Replicates the
+    handler's filter: _forward_headers(...) minus _GENERIC_HOP_STRIP_HEADERS.
+    """
+
+    def _forwarded(self, incoming: dict[str, str]) -> dict[str, str]:
+        return {
+            key: value
+            for key, value in _forward_headers(dict(incoming)).items()
+            if key.lower() not in _GENERIC_HOP_STRIP_HEADERS
+        }
+
+    def test_strips_internal_identity_token_and_markers(self):
+        incoming = {
+            "X-Internal-Token-Generic": "signed.jwt.value",
+            "X-User": "alice",
+            "X-Scopes": "read write",
+            "X-Groups": "admins",
+            "X-Original-URL": "https://gw/skill/skills/x",
+            "X-Generic-Proxy-Kind": "skill",
+            "X-Entity-Path": "skills/x",
+            "Authorization": "Bearer caller-token",
+            "Cookie": "mcp_gateway_session=abc",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+        forwarded_lower = {k.lower() for k in self._forwarded(incoming)}
+        # A proxied backend must never receive the signed internal token, the
+        # caller's identity/scopes, ambient credentials, or the routing markers.
+        for leaked in (
+            "x-internal-token-generic",
+            "x-user",
+            "x-scopes",
+            "x-groups",
+            "x-original-url",
+            "x-generic-proxy-kind",
+            "x-entity-path",
+            "authorization",
+            "cookie",
+        ):
+            assert leaked not in forwarded_lower
+
+    def test_keeps_legitimate_client_headers(self):
+        incoming = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Internal-Token-Generic": "signed.jwt.value",
+        }
+        forwarded = self._forwarded(incoming)
+        assert forwarded.get("Content-Type") == "application/json"
+        assert forwarded.get("Accept") == "application/json"
 
 
 class TestBuildOutboundUrl:

--- a/tests/unit/core/test_nginx_generic_proxy.py
+++ b/tests/unit/core/test_nginx_generic_proxy.py
@@ -161,7 +161,16 @@ class TestCreateBlock:
 
     def test_location_is_entity_type_namespaced(self):
         block = self._block()
-        assert "location {{ROOT_PATH}}/skill/skills/proxy-demo {" in block
+        assert "location {{ROOT_PATH}}/skill/skills/proxy-demo/ {" in block
+
+    def test_location_has_trailing_slash_no_prefix_hijack(self):
+        # Issue #1501 class: a bare `location /skill/foo` prefix-matches sibling
+        # routes like `/skill/foobar`, pulling them into this entity's /validate
+        # auth subrequest. The rendered location MUST carry a trailing slash so it
+        # only matches the subtree (same guard real/virtual servers apply).
+        block = self._block(path="/skills/foo")
+        assert "location {{ROOT_PATH}}/skill/skills/foo/ {" in block
+        assert "location {{ROOT_PATH}}/skill/skills/foo {" not in block
 
     def test_proxy_pass_targets_auth_server_generic_hop(self):
         block = self._block()
@@ -335,11 +344,14 @@ class TestGenerateGenericBlocks:
             {"entity_type": "skill", "path": "/skills/a", "target_url": "https://a/"},
             {"entity_type": "skill", "path": "/skills/b", "target_url": "https://b/"},
         ]
-        claimed = {"/skill/skills/a"}
+        # Claimed paths carry a trailing slash (that is how MCP/virtual blocks
+        # render their location), and the generic block now normalises to a
+        # trailing slash too — so the exact-match collision dedup catches it.
+        claimed = {"/skill/skills/a/"}
         blocks = await self._generate(resources, claimed)
         # only /skills/b survives; the colliding /skills/a is dropped
         assert len(blocks) == 1
-        assert "/skill/skills/b" in blocks[0]
+        assert "/skill/skills/b/" in blocks[0]
 
     async def test_generic_vs_generic_first_seen_wins(self):
         # Two entities rendering the SAME location path: deterministic first-wins
@@ -351,7 +363,7 @@ class TestGenerateGenericBlocks:
             {"entity_type": "skill", "path": "/skills/dup", "target_url": "https://a/"},
         ]
         # Pre-claim the path; the single generic must be dropped, not duplicated.
-        blocks = await self._generate(resources, {"/skill/skills/dup"})
+        blocks = await self._generate(resources, {"/skill/skills/dup/"})
         assert blocks == []
 
     async def test_invalid_target_skipped_but_others_render(self):


### PR DESCRIPTION
## Summary

Follow-up to #1628 (gateway generic proxy, shipped dark). Addresses the two before-enabling security items and the config-parity gap surfaced in review. The feature remains dark (all flags default off), so this is a no-op in production; the fixes matter once a later slice enables it.

## What changed

**SF1 — strip gateway-internal headers on the generic hop (security)**
The generic hop fronts arbitrary (potentially third-party) registered backends, but `_forward_headers` stripped only `cookie`, `authorization`/`x-authorization`, `x-upstream-url`, `x-body*`, and hop-by-hop headers. The gateway-internal identity/routing family the generic nginx block injects — `X-Internal-Token-Generic`, `X-User`, `X-Scopes`, `X-Original-URL`, `X-Generic-Proxy-Kind`, `X-Entity-Path` — reached the upstream. That leaks the caller's identity + full scope list to a third party and hands out a valid signed internal token (replayable for the token TTL; replay is confined to the same entity/type/path, so no privilege escalation). The `_EGRESS_STRIP_HEADERS` set that already covers this family is only applied on the mcp-proxy vault path, never the generic hop.

Fix: add `_GENERIC_HOP_STRIP_HEADERS` (the `_EGRESS_STRIP_HEADERS` family plus the generic markers) and apply it in the generic hop before forwarding.

**SF2 — close the generic location prefix-match (issue #1501 class)**
The generic nginx `location` was rendered without the trailing-slash normalization that real and virtual servers apply, so `location /skill/foo` prefix-matched siblings like `/skill/foobar`, pulling them into this entity's `/validate` auth subrequest. (The auth-server hop's sub-path confinement already 400s a wrong-backend forward, so blast radius was low.)

Fix: normalize `location_path` to a trailing slash. This also makes the cross-block collision dedup exact-match correctly against MCP/virtual location paths (which already carry a trailing slash) and appends client sub-paths cleanly onto the pinned base.

**B1 — document the 9 new config parameters**
The `gateway_*` settings added in #1628 lived only on the registry `Settings` surface. This adds them to `.env.example`, `docs/unified-parameter-reference.md` (new Group 33), and `registry/api/config_routes.py` `CONFIG_GROUPS` (so they appear under Settings → System Config and in `GET /api/config/full`).

Terraform and Helm columns are marked "not yet wired" and deferred to the enabling slice: the feature is dark today and a `.env` override is sufficient for Docker/local enablement, and wiring the runtime surfaces belongs with the reserved-env-names + chart unittest updates in the slice that turns the feature on. This follows the reference doc's own convention (blank cell + explanation rather than silent omission).

## Testing

- `test_generic_proxy_handler.py`: new `TestGenericHopHeaderStrip` — the internal identity/token/marker headers are stripped, legitimate client headers survive.
- `test_nginx_generic_proxy.py`: rendered location carries a trailing slash and does not emit the bare (hijackable) form; collision fixtures updated to trailing-slash claimed paths.
- Affected suites green (generic proxy render + hop + validate + verb-authz, config routes, api): 1297 passed. Lint/format clean.

## Not in scope (tracked follow-ups)

- Full Terraform/Helm wiring for the 9 params (enabling slice).
- Nice-to-haves from the #1628 review: self-check probing Alibaba/ECS/EKS metadata, `jti`/single-use on the generic token, `Content-Encoding` handling on the response allowlist, and making `VirtualServerConfig._reject_proxy_target_url` read-safe.
