### PR TITLE
Docs: optional TOA verify for registry diligence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,3 +24,7 @@ Markdown here in the repository.
 
 Add or edit Markdown files anywhere under `docs/`. Use repository-relative links so they resolve
 both on GitHub and in forks. No build step or navigation config is required.
+
+## Optional TOA register gate
+
+See [toa-optional-register-gate.md](toa-optional-register-gate.md).

--- a/docs/toa-optional-register-gate.md
+++ b/docs/toa-optional-register-gate.md
@@ -1,0 +1,21 @@
+# Optional TOA verify for registry diligence
+
+The MCP Gateway & Registry centralizes discovery, OAuth, and audit for MCP
+servers and other AI assets. Registry diligence answers governed inventory. It
+does not prove tool delivery quality from an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is adjacent signed
+delivery evidence. Optional offline verify before approving a new registry
+entry or enabling a route.
+
+```yaml
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Example: [`examples/toa-after-register.yml`](../examples/toa-after-register.yml).
+
+Not a wire protocol. Not per-call. No AgentStatus account required to verify.

--- a/docs/toa-optional-register-gate.md
+++ b/docs/toa-optional-register-gate.md
@@ -12,8 +12,8 @@ entry or enabling a route.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Example: [`examples/toa-after-register.yml`](../examples/toa-after-register.yml).

--- a/docs/toa-optional-register-gate.md
+++ b/docs/toa-optional-register-gate.md
@@ -12,7 +12,7 @@ entry or enabling a route.
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -1,0 +1,13 @@
+# Example only.
+name: Registry diligence and optional TOA
+on: [workflow_dispatch]
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -9,5 +9,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before approving a registry entry / enable.

- `docs/toa-optional-register-gate.md`
- `examples/toa-after-register.yml`
- Docs index pointer

Does not change gateway/registry runtime. No AgentStatus account required to verify.

## Test plan

- [ ] Docs clearly optional / diligence-style
- [ ] Example YAML gated on `toa.json`

Made with [Cursor](https://cursor.com)