### PR TITLE
docs: Fix duplicate header in debug SKILL.md

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -24,8 +24,6 @@ State which persona is "speaking" when presenting a theory or counter-argument. 
 
 ## First Principles Debugging
 
-## First Principles Debugging
-
 ### Step 1: Reproduce and observe (do NOT theorize yet)
 
 - What exact error does the user see? (HTTP status, error message, timing)


### PR DESCRIPTION
Removed duplicate section header for First Principles Debugging.

*Issue #, if available:*

N/A

*Description of changes:*

Removes duplicate h2 header in the debug skill, because every token costs someone something 😄

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
