### PR TITLE
fix(security): fail closed when failed-scan auto-disable cannot disable a server

### DIFF
--- a/cli/service_mgmt.sh
+++ b/cli/service_mgmt.sh
@@ -545,37 +545,49 @@ except Exception as e:
         # Disable the just-registered (auto-enabled) server via the public,
         # user-authenticated toggle endpoint, reusing the same gateway JWT the
         # rest of this script uses (the ingress token from credentials-provider).
+        #
+        # This is the security-scan safety net. A server that FAILED its scan was
+        # auto-enabled at registration and must be disabled here. If it cannot be
+        # disabled (no token, expired token, or a token lacking toggle_service on
+        # this server), fail closed with exit 1 rather than leave an unscanned
+        # server enabled and reachable. The ingress identity must hold
+        # toggle_service (admin or per-server) for the servers it registers.
         local token_file="$PROJECT_ROOT/.oauth-tokens/ingress.json"
         local auth_token
         auth_token=$(python3 -c "import json; d=json.load(open('$token_file')); print(d.get('access_token') or d.get('tokens', {}).get('access_token') or '')" 2>/dev/null)
 
         if [ -z "$auth_token" ]; then
             print_error "No gateway token at $token_file - cannot disable server (run credentials-provider/generate_creds.sh)"
-        else
-            # Set the server to disabled (false); it was auto-enabled at registration.
-            print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
-            print_info "Service path: $service_path"
-
-            output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
-                -H "Authorization: Bearer $auth_token" \
-                --data-urlencode "path=$service_path" \
-                --data-urlencode "new_state=false" 2>&1)
-
-            # Extract HTTP status code from response
-            http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
-            response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
-
-            print_info "Toggle API HTTP Status: $http_status"
-            print_info "Toggle API Response: $response_body"
-
-            if [ "$http_status" = "200" ]; then
-                print_success "Server disabled due to failed security scan"
-            else
-                print_error "Failed to disable server - HTTP Status: $http_status"
-                print_error "Response: $response_body"
-            fi
-            print_info "Review the security scan report before enabling this server"
+            print_error "Failing closed: the server failed its security scan and could not be disabled."
+            exit 1
         fi
+
+        # Set the server to disabled (false); it was auto-enabled at registration.
+        print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
+        print_info "Service path: $service_path"
+
+        output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
+            -H "Authorization: Bearer $auth_token" \
+            --data-urlencode "path=$service_path" \
+            --data-urlencode "new_state=false" 2>&1)
+
+        # Extract HTTP status code from response
+        http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
+        response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
+
+        print_info "Toggle API HTTP Status: $http_status"
+        print_info "Toggle API Response: $response_body"
+
+        if [ "$http_status" != "200" ]; then
+            print_error "Failed to disable server - HTTP Status: $http_status"
+            print_error "Response: $response_body"
+            print_error "Failing closed: the server failed its security scan and could not be disabled."
+            print_info "Ensure the gateway identity has toggle_service permission for this server."
+            exit 1
+        fi
+
+        print_success "Server disabled due to failed security scan"
+        print_info "Review the security scan report before enabling this server"
     fi
 
     # Run health check

--- a/docker/nginx_rev_proxy_http_and_https.conf
+++ b/docker/nginx_rev_proxy_http_and_https.conf
@@ -911,6 +911,9 @@ server {
     # below. Blocking the prefix here removes /api/internal/* from the
     # internet-facing listeners; the app-level gates (validate_internal_auth /
     # validate_internal_session_secret) remain as defense-in-depth.
+    # Note: this matches only the {{ROOT_PATH}}-prefixed path. In a ROOT_PATH-set
+    # deployment the bare /api/internal/* (no prefix) falls to the catch-all
+    # location / and stays covered by the app gate, not by this block.
     location ^~ {{ROOT_PATH}}/api/internal/ {
         return 404;
     }
@@ -1833,6 +1836,8 @@ server {
     # Internal service-to-service routes are NOT publicly reachable (see the
     # matching block on the 8080 listener). /api/internal/* is served only via
     # the /_internal/sessions/ subrequest and the dedicated :8091 listener.
+    # Note: matches only the {{ROOT_PATH}}-prefixed path; the bare /api/internal/*
+    # in a ROOT_PATH-set deployment is covered by the app gate, not this block.
     location ^~ {{ROOT_PATH}}/api/internal/ {
         return 404;
     }

--- a/docker/nginx_rev_proxy_http_only.conf
+++ b/docker/nginx_rev_proxy_http_only.conf
@@ -395,6 +395,9 @@ server {
     # below. Blocking the prefix here removes /api/internal/* from the
     # internet-facing listener; the app-level gates (validate_internal_auth /
     # validate_internal_session_secret) remain as defense-in-depth.
+    # Note: this matches only the {{ROOT_PATH}}-prefixed path. In a ROOT_PATH-set
+    # deployment the bare /api/internal/* (no prefix) falls to the catch-all
+    # location / and stays covered by the app gate, not by this block.
     location ^~ {{ROOT_PATH}}/api/internal/ {
         return 404;
     }

--- a/docs/egress-credential-vault.md
+++ b/docs/egress-credential-vault.md
@@ -682,6 +682,13 @@ Users can review and revoke their connections in the UI at **Connected Accounts*
   NetworkPolicy that admits only the auth-server pod). It is removed from the
   internet-facing `8080`/`8443` listeners entirely, so the app-level token gate
   is no longer the sole defense against a reachable caller.
+  - **Deployment requirement:** because the public listeners now return `404`
+    for the whole `/api/internal/` prefix, the auth-server **must** point
+    `EGRESS_REGISTRY_INTERNAL_URL` at the internal listener (`http://registry:8091`,
+    the chart default). If it is still set to the public listener
+    (`registry:8000` / `:8080`), the vend returns `404` and egress auth fails.
+    On Helm, set `registry.egressAuth.enabled=true` so the `:8091` Service port
+    and NetworkPolicy are rendered.
 - **Upstream cross-check.** The vend endpoint re-verifies the internal token and
   confirms the token's `upstream_url` falls within the registered server's
   `proxy_pass_url` (and version allowlist) before vending — a forged upstream is

--- a/terraform/aws-ecs/scripts/service_mgmt.sh
+++ b/terraform/aws-ecs/scripts/service_mgmt.sh
@@ -563,37 +563,49 @@ except Exception as e:
         # Disable the just-registered (auto-enabled) server via the public,
         # user-authenticated toggle endpoint, reusing the same gateway JWT the
         # rest of this script uses (the ingress token from credentials-provider).
+        #
+        # This is the security-scan safety net. A server that FAILED its scan was
+        # auto-enabled at registration and must be disabled here. If it cannot be
+        # disabled (no token, expired token, or a token lacking toggle_service on
+        # this server), fail closed with exit 1 rather than leave an unscanned
+        # server enabled and reachable. The ingress identity must hold
+        # toggle_service (admin or per-server) for the servers it registers.
         local token_file="$PROJECT_ROOT/.oauth-tokens/ingress.json"
         local auth_token
         auth_token=$(python3 -c "import json; d=json.load(open('$token_file')); print(d.get('access_token') or d.get('tokens', {}).get('access_token') or '')" 2>/dev/null)
 
         if [ -z "$auth_token" ]; then
             print_error "No gateway token at $token_file - cannot disable server (run credentials-provider/generate_creds.sh)"
-        else
-            # Set the server to disabled (false); it was auto-enabled at registration.
-            print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
-            print_info "Service path: $service_path"
-
-            output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
-                -H "Authorization: Bearer $auth_token" \
-                --data-urlencode "path=$service_path" \
-                --data-urlencode "new_state=false" 2>&1)
-
-            # Extract HTTP status code from response
-            http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
-            response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
-
-            print_info "Toggle API HTTP Status: $http_status"
-            print_info "Toggle API Response: $response_body"
-
-            if [ "$http_status" = "200" ]; then
-                print_success "Server disabled due to failed security scan"
-            else
-                print_error "Failed to disable server - HTTP Status: $http_status"
-                print_error "Response: $response_body"
-            fi
-            print_info "Review the security scan report before enabling this server"
+            print_error "Failing closed: the server failed its security scan and could not be disabled."
+            exit 1
         fi
+
+        # Set the server to disabled (false); it was auto-enabled at registration.
+        print_info "Calling toggle endpoint with: ${GATEWAY_URL}/api/servers/toggle"
+        print_info "Service path: $service_path"
+
+        output=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "${GATEWAY_URL}/api/servers/toggle" \
+            -H "Authorization: Bearer $auth_token" \
+            --data-urlencode "path=$service_path" \
+            --data-urlencode "new_state=false" 2>&1)
+
+        # Extract HTTP status code from response
+        http_status=$(echo "$output" | grep "HTTP_STATUS:" | cut -d':' -f2)
+        response_body=$(echo "$output" | sed '/HTTP_STATUS:/d')
+
+        print_info "Toggle API HTTP Status: $http_status"
+        print_info "Toggle API Response: $response_body"
+
+        if [ "$http_status" != "200" ]; then
+            print_error "Failed to disable server - HTTP Status: $http_status"
+            print_error "Response: $response_body"
+            print_error "Failing closed: the server failed its security scan and could not be disabled."
+            print_info "Ensure the gateway identity has toggle_service permission for this server."
+            exit 1
+        fi
+
+        print_success "Server disabled due to failed security scan"
+        print_info "Review the security scan report before enabling this server"
     fi
 
     # Run health check


### PR DESCRIPTION
## Summary

Follow-up to #1697. That PR moved the operator scripts' failed-scan auto-disable from the internal `SECRET_KEY` route (`POST /api/internal/toggle`) to the user-authenticated `POST /api/servers/toggle`. The internal route had no per-user check, so the disable always succeeded on a running deployment. The new route requires the gateway token to hold `toggle_service` on the just-registered server, so the auto-disable can now fail when the token is missing, expired, or under-privileged. In that case the block only logged the error and fell through, leaving a server that **failed its security scan** enabled and publicly reachable (fail-open). That server was auto-enabled at registration, so this disable is the sole runtime safety net.

## What changed

**Operator scripts** (`cli/service_mgmt.sh`, `terraform/aws-ecs/scripts/service_mgmt.sh`, kept byte-identical in the edited block)
- Fail closed: `exit 1` on a missing token OR a non-200 toggle response, so a scan-failing server is never left reachable.
- Flattened the `if/else` and added a comment explaining the safety-net semantics.
- Documented that the ingress identity must hold `toggle_service` (admin or per-server) for the servers it registers, or the safety net is a no-op.

**nginx** (`docker/nginx_rev_proxy_http_and_https.conf`, `docker/nginx_rev_proxy_http_only.conf`)
- Comment-only: note that the `^~ {{ROOT_PATH}}/api/internal/` 404 block matches only the `ROOT_PATH`-prefixed path. In a `ROOT_PATH`-set deployment the bare `/api/internal/*` falls to the catch-all `location /` and stays covered by the app gate (`validate_internal_auth`), not by this block.

**Docs** (`docs/egress-credential-vault.md`)
- Deployment requirement: after #1697 the public listeners `404` the whole `/api/internal/` prefix, so the auth-server **must** point `EGRESS_REGISTRY_INTERNAL_URL` at the internal listener (`http://registry:8091`, the chart default / the #1655 wiring). If it still points at `registry:8000`/`:8080`, the egress vend returns `404` and egress auth fails.

## Testing

- `pytest tests/unit/core/test_nginx_service.py` — 118 passed (nginx change is comment-only).
- `bash -n` clean on both scripts; the edited block is byte-identical across the two.

## Notes

- A separate operator alert on auto-disable failure was considered a nice-to-have in review. The `exit 1` here already makes the failure loud (non-zero exit any wrapper/CI will catch); a dedicated alert path can follow if deployments want it.
- No change to the nginx 404 blocking behavior or the toggle endpoint (its authorization is already at parity with the legacy UI route).