### PR TITLE
fix(auth): normalize IdP group names before matching scope mappings

### DIFF
--- a/auth_server/group_filter.py
+++ b/auth_server/group_filter.py
@@ -57,6 +57,18 @@ if ALLOWED_IDP_GROUPS_RAW:
     logger.info("ALLOWED_IDP_GROUPS allowlist active: %d entries", len(ALLOWED_IDP_GROUPS))
 
 
+def _normalize_group_name(name: str) -> str:
+    """Strip leading/trailing slashes for group-name comparison.
+
+    Some IdPs (e.g. Keycloak's Group Membership mapper with "Full group path"
+    enabled) emit the full group path, such as '/mcp-admins', while scope
+    mappings are seeded without the leading slash. Mirrors
+    auth_server.server._normalize_server_name, which handles the identical
+    slash mismatch for server names.
+    """
+    return name.strip("/") if name else name
+
+
 async def _filter_by_scope_mappings(
     groups: list[str],
     username_hash: str,
@@ -88,6 +100,7 @@ async def _filter_by_scope_mappings(
         )
         return groups
 
+    mapped = {_normalize_group_name(g) for g in mapped}
     filtered = [g for g in groups if g in mapped]
     logger.info(
         "Group filter (scope-derived) user=%s: %d -> %d",
@@ -115,9 +128,11 @@ async def filter_session_groups(
     if not groups:
         return groups
 
+    groups = [_normalize_group_name(g) for g in groups]
+
     # Design B takes precedence when configured.
     if ALLOWED_IDP_GROUPS:
-        allowed = set(ALLOWED_IDP_GROUPS)
+        allowed = {_normalize_group_name(g) for g in ALLOWED_IDP_GROUPS}
         filtered = [g for g in groups if g in allowed]
         logger.info(
             "Group filter (allowlist) user=%s: %d -> %d",

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -1470,6 +1470,18 @@ def safe_identity_summary(claims: dict) -> dict:
     return summary
 
 
+def _normalize_group_name(name: str) -> str:
+    """Strip leading/trailing slashes for group-name comparison.
+
+    Some IdPs (e.g. Keycloak's Group Membership mapper with "Full group path"
+    enabled) emit the full group path, such as '/mcp-admins', while scope
+    mappings are seeded without the leading slash. Mirrors
+    _normalize_server_name, which handles the identical slash mismatch for
+    server names.
+    """
+    return name.strip("/") if name else name
+
+
 async def map_groups_to_scopes(groups: list[str]) -> list[str]:
     """
     Map identity provider groups to MCP scopes by querying DocumentDB directly.
@@ -1481,6 +1493,7 @@ async def map_groups_to_scopes(groups: list[str]) -> list[str]:
         List of MCP scopes
     """
     scopes = []
+    groups = [_normalize_group_name(g) for g in groups]
 
     # Resolve all groups to scopes in a single query. Issuing one query per
     # group serialized a DB round-trip per group on every authenticated

--- a/tests/auth_server/unit/test_group_filter.py
+++ b/tests/auth_server/unit/test_group_filter.py
@@ -91,6 +91,42 @@ class TestFilterSessionGroups:
         assert result == ["a", "b"]
 
     @pytest.mark.asyncio
+    async def test_scope_derived_normalizes_leading_slash(self):
+        """Design C: a full-group-path IdP claim matches an unslashed mapping.
+
+        Keycloak's Group Membership mapper with "Full group path" enabled
+        emits '/mcp-admins' instead of 'mcp-admins'; scope mappings are seeded
+        without the leading slash, so the comparison must normalize both.
+        """
+        repo = _make_scope_repo({"registry-admins", "registry-readonly"})
+        with patch.object(group_filter, "ALLOWED_IDP_GROUPS", []):
+            with patch(
+                "registry.repositories.factory.get_scope_repository",
+                return_value=repo,
+            ):
+                result = await group_filter.filter_session_groups(
+                    ["/registry-admins", "some-other-group"],
+                    username_hash="h",
+                )
+        assert result == ["registry-admins"]
+
+    @pytest.mark.asyncio
+    async def test_allowlist_mode_normalizes_leading_slash(self):
+        """Design B: the allowlist comparison also normalizes leading slashes."""
+        repo = _make_scope_repo({"should-not-be-used"})
+        with patch.object(group_filter, "ALLOWED_IDP_GROUPS", ["keep-a", "keep-b"]):
+            with patch(
+                "registry.repositories.factory.get_scope_repository",
+                return_value=repo,
+            ) as mock_get_repo:
+                result = await group_filter.filter_session_groups(
+                    ["/keep-a", "drop-x"],
+                    username_hash="h",
+                )
+        assert result == ["keep-a"]
+        mock_get_repo.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_identifier_mismatch_stores_empty(self):
         """Mappings keyed by names but token emits GUIDs -> empty intersection.
 

--- a/tests/auth_server/unit/test_server.py
+++ b/tests/auth_server/unit/test_server.py
@@ -413,6 +413,25 @@ class TestGroupToScopeMapping:
             assert "read:tools" in scopes
 
     @pytest.mark.asyncio
+    async def test_map_groups_to_scopes_normalizes_leading_slash(self, mock_scopes_config):
+        """A full-group-path IdP claim ('/mcp-admins') still resolves to scopes.
+
+        Keycloak's Group Membership mapper with "Full group path" enabled emits
+        the leading slash; scope mappings are seeded without it, so the bulk
+        query must be issued with the normalized names.
+        """
+        from auth_server.server import map_groups_to_scopes
+
+        mock_repo = AsyncMock()
+        mock_repo.get_group_mappings_bulk.return_value = ["read:servers"]
+
+        with patch("auth_server.server.get_scope_repository", return_value=mock_repo):
+            scopes = await map_groups_to_scopes(["/mcp-admins"])
+
+            assert scopes == ["read:servers"]
+            mock_repo.get_group_mappings_bulk.assert_awaited_once_with(["mcp-admins"])
+
+    @pytest.mark.asyncio
     async def test_map_groups_to_scopes_unknown_group(self, mock_scopes_config):
         """Test mapping with unknown group."""
         from auth_server.server import map_groups_to_scopes


### PR DESCRIPTION
## Root cause

`_normalize_server_name` (`auth_server/server.py`) strips leading/trailing
slashes so a scope entry written as `/cloudflare-docs` still matches a
request for `cloudflare-docs`. Group names never got the same treatment, so
every comparison point matched verbatim:

- `group_filter.py::_filter_by_scope_mappings` (Design C): `[g for g in groups if g in mapped]`
- `group_filter.py::filter_session_groups` (Design B): `[g for g in groups if g in allowed]`
- `server.py::map_groups_to_scopes`, which calls `get_group_mappings_bulk(groups)` (a MongoDB `$in` against unslashed stored `group_mappings`) and falls back to the same exact-match lookup against `SCOPES_CONFIG`

Keycloak's Group Membership mapper emits the full group path (`/mcp-admins`)
when "Full group path" is enabled, while scope mappings are seeded without
the leading slash. A user in that group then silently resolves to zero
scopes for it, both in the session (dropped by the login-time filter) and on
every subsequent authorization check.

## Fix

Added a small `_normalize_group_name` helper (same logic as
`_normalize_server_name`: strip surrounding slashes) at each comparison
point:

- `filter_session_groups` normalizes the incoming groups once, before either
  the Design B allowlist or the Design C scope-derived branch; the allowlist
  and the scope-mapped set are normalized too, so both sides agree.
- `map_groups_to_scopes` normalizes its `groups` argument before calling
  `get_group_mappings_bulk` and before the in-memory fallback lookup, which
  covers all five call sites of this function.

## Scope

This addresses the normalization gap only (the first half of #1689). The
issue also asks for the group filter to log dropped group *names*, not just
counts, plus a documentation note on the bearer-token/session asymmetry;
neither is touched here, so this is `Refs #1689` rather than `Fixes #1689`.

## Verification

- New regression tests in both affected modules (leading-slash IdP claim
  matching an unslashed mapping, allowlist entry, and the bulk scope query),
  confirmed failing against unmodified `auth_server/group_filter.py` and
  `auth_server/server.py` and passing against this branch, in a clean
  `python:3.14-slim` container.
- Full `tests/auth_server/` suite: 820 passed, no regressions, same
  container.
- `ruff check`, `ruff format --check`, and the repo's scoped `mypy` invocation
  (`--ignore-missing-imports --no-strict-optional` on `registry|auth_server`)
  all clean; `bandit` reports no new findings.
- Did not run the registry-wide test suite (needs a MongoDB service
  container); this diff touches only `auth_server/`, and its own tests
  exercise every changed line.
