### PR TITLE
fix(charts): ingress ssl policy

### DIFF
--- a/charts/mcp-gateway-registry-stack/values.yaml
+++ b/charts/mcp-gateway-registry-stack/values.yaml
@@ -56,6 +56,11 @@ global:
   # also fronted by the registry pod's in-cluster nginx reverse proxy.
   ingress:
     inboundCidrs: # optional comma separated list of allowed inbound CIDR ranges
+    # Optional ALB ssl-policy applied to the HTTPS listener. Leave empty to
+    # let the AWS Load Balancer Controller use its own default
+    # (ELBSecurityPolicy-2016-08). Set a modern policy such as
+    # ELBSecurityPolicy-TLS-1-2-Ext-2018-06 when clients require newer TLS.
+    sslPolicy:
     # Default ALB scheme applied to every ingress in the stack. Stack-level
     # override of each subchart's own global.ingress.scheme. Individual
     # ingresses can still override via <subchart>.ingress.scheme for cases

--- a/charts/registry/templates/ingress.yaml
+++ b/charts/registry/templates/ingress.yaml
@@ -33,6 +33,9 @@ metadata:
     {{- if .Values.global.ingress.inboundCidrs }}
     alb.ingress.kubernetes.io/inbound-cidrs: {{ .Values.global.ingress.inboundCidrs }}
     {{- end }}
+    {{- if .Values.global.ingress.sslPolicy }}
+    alb.ingress.kubernetes.io/ssl-policy: {{ .Values.global.ingress.sslPolicy }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -16,6 +16,12 @@ global:
   # deploy via the umbrella.
   ingress:
     scheme: internet-facing
+    inboundCidrs: # optional comma separated list of allowed inbound CIDR ranges
+    # Optional ALB ssl-policy applied to the HTTPS listener. Leave empty to
+    # let the AWS Load Balancer Controller use its own default
+    # (ELBSecurityPolicy-2016-08). Set a modern policy such as
+    # ELBSecurityPolicy-TLS-1-2-Ext-2018-06 when clients require newer TLS.
+    sslPolicy:
     tls: false
     routingMode: subdomain
     paths:


### PR DESCRIPTION
*Issue #, if available:*

Closes: #1661 

*Description of changes:*

Adds an overrideable field to change the default ssl policy for the registry ingress 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
