### PR TITLE
fix(dedup): filter duplicate advisories on cosine similarity, not display rank

### DIFF
--- a/registry/core/config.py
+++ b/registry/core/config.py
@@ -1503,7 +1503,11 @@ class Settings(BaseSettings):
         default=0.7,
         ge=0.0,
         le=1.0,
-        description="Minimum semantic-search score (0..1) for an advisory match to be returned.",
+        description=(
+            "Minimum cosine similarity (0..1) between the incoming entity's "
+            "name plus description and an existing one's for an advisory "
+            "match to be returned."
+        ),
     )
     dedup_max_suggestions: int = Field(
         default=3,

--- a/registry/repositories/documentdb/search_repository.py
+++ b/registry/repositories/documentdb/search_repository.py
@@ -287,6 +287,40 @@ def _reciprocal_rank_fusion(
 SCORE_DISPLAY_FLOOR: float = 0.10
 
 
+def _attach_similarity_scores(
+    grouped_results: dict[str, list[dict[str, Any]]],
+    selected_results: list[tuple[dict, float]],
+    query_embedding: list[float] | None,
+) -> None:
+    """Stamp each hit with its raw cosine similarity to the query, in place.
+
+    ``relevance_score`` is a ranking signal: under RRF it is rank-relative,
+    and ``_normalize_scores`` maps the best hit to exactly 1.0 whatever its
+    real similarity. Callers that need an absolute "how alike are these"
+    number, rather than "what came first", read ``similarity_score``.
+
+    Hits are matched to their source document by ``path``. Entries without
+    one (tools extracted from a parent server) are left untouched, as are
+    all entries when the query could not be embedded.
+    """
+    if not query_embedding:
+        return
+
+    similarity_by_path: dict[str, float] = {}
+    for doc, _ in selected_results:
+        path = doc.get("path")
+        if path:
+            similarity_by_path[str(path)] = cosine_similarity(
+                query_embedding, doc.get("embedding") or []
+            )
+
+    for entries in grouped_results.values():
+        for entry in entries:
+            path = entry.get("path")
+            if path is not None and str(path) in similarity_by_path:
+                entry["similarity_score"] = similarity_by_path[str(path)]
+
+
 def _normalize_scores(
     scored_results: list[tuple[dict, float]],
     max_results: int = 10,
@@ -2040,6 +2074,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                 else:
                     grouped_results["custom"].append(_format_custom_result(doc, relevance_score))
 
+            _attach_similarity_scores(grouped_results, selected, query_embedding)
+
             logger.info(
                 "Client-side search returned "
                 "%d servers, %d tools, %d agents, %d skills, "
@@ -2721,6 +2757,8 @@ class DocumentDBSearchRepository(SearchRepositoryBase):
                     # Custom entity types (admin-defined). Generic envelope —
                     # the schema-driven UI renders attributes from the descriptor.
                     grouped_results["custom"].append(_format_custom_result(doc, relevance_score))
+
+            _attach_similarity_scores(grouped_results, selected_results, query_embedding)
 
             # Sort each group by relevance_score (descending) to ensure highest matches
             # appear first. This is needed because the DB sorts by text_boost only,

--- a/registry/services/duplicate_check_service.py
+++ b/registry/services/duplicate_check_service.py
@@ -85,6 +85,19 @@ _SIMILARITY_OVERFETCH_FACTOR: int = 10
 _QUERY_TEXT_CHAR_CAP: int = 500
 
 
+def _similarity_of(candidate: dict) -> float:
+    """Absolute cosine similarity of a search hit to the query.
+
+    Returns 0.0 when the backend could not supply one, which keeps the
+    candidate below any configured threshold: an entity we cannot compare
+    is not an entity we should call a possible duplicate.
+    """
+    similarity = candidate.get("similarity_score")
+    if similarity is None:
+        return 0.0
+    return float(similarity)
+
+
 class DuplicateCheckService:
     """Cross-entity duplicate detection for entity registration.
 
@@ -306,6 +319,11 @@ class DuplicateCheckService:
         the configured similarity threshold and the caller's
         visibility scope, then capped to ``dedup_max_suggestions``
         across all entity types (the cap is global, not per-type).
+
+        Ranking and filtering read ``similarity_score``, the hit's cosine
+        similarity to the query, not ``relevance_score``: the latter is a
+        position in a result list, so the best hit carries the top value
+        even when nothing in the registry is remotely similar.
         """
         threshold = self._settings.dedup_score_threshold
         max_suggestions = self._settings.dedup_max_suggestions
@@ -334,11 +352,11 @@ class DuplicateCheckService:
             return [], False
 
         candidates = self._flatten_search_results(raw_results)
-        candidates.sort(key=lambda c: float(c[1].get("relevance_score") or 0.0), reverse=True)
+        candidates.sort(key=lambda c: _similarity_of(c[1]), reverse=True)
 
         advisory: list[ExistingEntity] = []
         for entity_type, candidate in candidates:
-            score = float(candidate.get("relevance_score") or 0.0)
+            score = _similarity_of(candidate)
             if score < threshold:
                 continue
             candidate_path = str(candidate.get("path") or "")

--- a/tests/unit/api/test_check_duplicates_endpoints.py
+++ b/tests/unit/api/test_check_duplicates_endpoints.py
@@ -205,7 +205,7 @@ class TestServerCheckDuplicatesEndpoint:
                     {
                         "path": "/sim",
                         "server_name": "Similar",
-                        "relevance_score": 0.85,
+                        "similarity_score": 0.85,
                     }
                 ]
             }
@@ -236,7 +236,7 @@ class TestServerCheckDuplicatesEndpoint:
                     {
                         "path": "/sim",
                         "server_name": "Similar",
-                        "relevance_score": 0.85,
+                        "similarity_score": 0.85,
                     }
                 ]
             },
@@ -397,7 +397,7 @@ class TestSkillCheckDuplicatesEndpoint:
                     {
                         "path": "/skills/sim",
                         "skill_name": "Similar Skill",
-                        "relevance_score": 0.88,
+                        "similarity_score": 0.88,
                     }
                 ]
             }

--- a/tests/unit/repositories/test_search_similarity_scores.py
+++ b/tests/unit/repositories/test_search_similarity_scores.py
@@ -1,0 +1,90 @@
+"""Unit tests for the absolute similarity carried alongside relevance_score.
+
+``relevance_score`` answers "where did this hit rank"; under RRF fusion it is
+min-max rescaled so the best hit is 1.0 regardless of how alike the two things
+actually are. ``similarity_score`` answers "how alike are they", which is what
+the duplicate-check advisory needs (issue #1696).
+
+Covers:
+- The top RRF hit normalizes to 1.0 while its similarity stays low
+- Hits are matched to their source document by path
+- Entries with no path (tools lifted out of a parent server) are left alone
+- A query that could not be embedded stamps nothing
+"""
+
+from registry.repositories.documentdb.search_repository import (
+    _attach_similarity_scores,
+    _normalize_scores,
+    _reciprocal_rank_fusion,
+)
+
+QUERY = [1.0, 0.0, 0.0]
+NEAR = [0.96, 0.28, 0.0]
+FAR = [0.26, 0.97, 0.0]
+
+
+def _doc(path: str, embedding: list[float]) -> dict:
+    return {"_id": path, "path": path, "name": path.rsplit("/", 1)[-1], "embedding": embedding}
+
+
+def test_display_score_of_one_can_accompany_a_low_similarity() -> None:
+    """The regression this file exists for: rank 1.0 does not mean similar."""
+    far = _doc("/servers/payroll", FAR)
+    scored = _reciprocal_rank_fusion([far, _doc("/servers/weather", FAR)], [])
+    normalized = _normalize_scores(scored, max_results=30)
+
+    assert normalized[0][1] == 1.0
+
+    grouped = {"servers": [{"path": "/servers/payroll", "relevance_score": 1.0}]}
+    _attach_similarity_scores(grouped, normalized, QUERY)
+
+    assert grouped["servers"][0]["relevance_score"] == 1.0
+    assert grouped["servers"][0]["similarity_score"] < 0.4
+
+
+def test_similarity_reflects_the_embedding_not_the_ranking() -> None:
+    selected = [(_doc("/servers/near", NEAR), 1.0), (_doc("/servers/far", FAR), 0.0)]
+    grouped = {
+        "servers": [{"path": "/servers/near"}, {"path": "/servers/far"}],
+    }
+    _attach_similarity_scores(grouped, selected, QUERY)
+
+    near, far = grouped["servers"]
+    assert near["similarity_score"] > 0.9
+    assert far["similarity_score"] < 0.4
+
+
+def test_entries_without_a_path_are_left_untouched() -> None:
+    selected = [(_doc("/servers/near", NEAR), 1.0)]
+    grouped = {
+        "servers": [{"path": "/servers/near"}],
+        "tools": [{"server_path": "/servers/near", "tool_name": "do_thing"}],
+    }
+    _attach_similarity_scores(grouped, selected, QUERY)
+
+    assert "similarity_score" in grouped["servers"][0]
+    assert "similarity_score" not in grouped["tools"][0]
+
+
+def test_unknown_path_is_left_untouched() -> None:
+    selected = [(_doc("/servers/near", NEAR), 1.0)]
+    grouped = {"servers": [{"path": "/servers/somewhere-else"}]}
+    _attach_similarity_scores(grouped, selected, QUERY)
+
+    assert "similarity_score" not in grouped["servers"][0]
+
+
+def test_missing_query_embedding_stamps_nothing() -> None:
+    selected = [(_doc("/servers/near", NEAR), 1.0)]
+    grouped = {"servers": [{"path": "/servers/near"}]}
+    _attach_similarity_scores(grouped, selected, None)
+
+    assert "similarity_score" not in grouped["servers"][0]
+
+
+def test_document_without_an_embedding_scores_zero() -> None:
+    selected = [({"_id": "x", "path": "/servers/no-vector"}, 1.0)]
+    grouped = {"servers": [{"path": "/servers/no-vector"}]}
+    _attach_similarity_scores(grouped, selected, QUERY)
+
+    assert grouped["servers"][0]["similarity_score"] == 0.0

--- a/tests/unit/services/test_duplicate_check_service.py
+++ b/tests/unit/services/test_duplicate_check_service.py
@@ -136,7 +136,7 @@ class TestBothChecksRunIndependently:
             },
             search_results={
                 "servers": [
-                    {"path": "/sim", "server_name": "Similar", "relevance_score": 0.85},
+                    {"path": "/sim", "server_name": "Similar", "similarity_score": 0.85},
                 ]
             },
         )
@@ -159,8 +159,8 @@ class TestBothChecksRunIndependently:
             search_results={
                 "servers": [
                     # Same path as the URL match — should be filtered.
-                    {"path": "/exact", "server_name": "ExactMatch", "relevance_score": 0.95},
-                    {"path": "/other", "server_name": "Other", "relevance_score": 0.85},
+                    {"path": "/exact", "server_name": "ExactMatch", "similarity_score": 0.95},
+                    {"path": "/other", "server_name": "Other", "similarity_score": 0.85},
                 ]
             },
         )
@@ -371,7 +371,7 @@ class TestExactMatchCheck:
             server_match={"path": "/foo"},  # would have matched if repo were healthy
             search_results={
                 "servers": [
-                    {"path": "/sim", "server_name": "Similar", "relevance_score": 0.85},
+                    {"path": "/sim", "server_name": "Similar", "similarity_score": 0.85},
                 ]
             },
         )
@@ -508,9 +508,9 @@ class TestSimilarityAdvisory:
             monkeypatch,
             search_results={
                 "servers": [
-                    {"path": "/alpha", "server_name": "Alpha", "relevance_score": 0.91},
-                    {"path": "/beta", "server_name": "Beta", "relevance_score": 0.55},  # below
-                    {"path": "/gamma", "server_name": "Gamma", "relevance_score": 0.81},
+                    {"path": "/alpha", "server_name": "Alpha", "similarity_score": 0.91},
+                    {"path": "/beta", "server_name": "Beta", "similarity_score": 0.55},  # below
+                    {"path": "/gamma", "server_name": "Gamma", "similarity_score": 0.81},
                 ]
             },
         )
@@ -534,7 +534,7 @@ class TestSimilarityAdvisory:
             monkeypatch,
             search_results={
                 "servers": [
-                    {"path": f"/s{i}", "server_name": f"S{i}", "relevance_score": 0.95}
+                    {"path": f"/s{i}", "server_name": f"S{i}", "similarity_score": 0.95}
                     for i in range(10)
                 ]
             },
@@ -548,8 +548,8 @@ class TestSimilarityAdvisory:
             monkeypatch,
             search_results={
                 "servers": [
-                    {"path": "/me", "server_name": "Me", "relevance_score": 0.99},
-                    {"path": "/other", "server_name": "Other", "relevance_score": 0.85},
+                    {"path": "/me", "server_name": "Me", "similarity_score": 0.99},
+                    {"path": "/other", "server_name": "Other", "similarity_score": 0.85},
                 ]
             },
         )
@@ -570,8 +570,8 @@ class TestSimilarityAdvisory:
             monkeypatch,
             search_results={
                 "servers": [
-                    {"path": "/alpha", "server_name": "Alpha", "relevance_score": 0.95},
-                    {"path": "/beta", "server_name": "Beta", "relevance_score": 0.92},
+                    {"path": "/alpha", "server_name": "Alpha", "similarity_score": 0.95},
+                    {"path": "/beta", "server_name": "Beta", "similarity_score": 0.92},
                 ]
             },
         )
@@ -618,9 +618,9 @@ class TestSimilarityAdvisory:
         service = _build_service(
             monkeypatch,
             search_results={
-                "servers": [{"path": "/s1", "server_name": "S1", "relevance_score": 0.9}],
-                "agents": [{"path": "/a1", "name": "A1", "relevance_score": 0.95}],
-                "skills": [{"path": "/k1", "skill_name": "K1", "relevance_score": 0.85}],
+                "servers": [{"path": "/s1", "server_name": "S1", "similarity_score": 0.9}],
+                "agents": [{"path": "/a1", "name": "A1", "similarity_score": 0.95}],
+                "skills": [{"path": "/k1", "skill_name": "K1", "similarity_score": 0.85}],
             },
         )
         result = await service.check(**_check_kwargs(name="X", description="Y"))
@@ -687,7 +687,7 @@ class TestExtractorFallbacks:
                             "registered_by": "alice",
                             "visibility": "public",
                         },
-                        "relevance_score": 0.9,
+                        "similarity_score": 0.9,
                     }
                 ]
             },
@@ -730,7 +730,7 @@ class TestExtractorFallbacks:
                     {
                         "path": "/skills/foo",
                         "name": "FallbackName",  # no skill_name
-                        "relevance_score": 0.85,
+                        "similarity_score": 0.85,
                     }
                 ]
             },
@@ -748,7 +748,7 @@ class TestExtractorFallbacks:
                     {
                         "path": "/server/foo",
                         "name": "FallbackName",  # no server_name
-                        "relevance_score": 0.85,
+                        "similarity_score": 0.85,
                     }
                 ]
             },
@@ -834,3 +834,94 @@ class TestComputedHasCollision:
         assert result.has_collision is True
         assert len(result.collision_with) == 1
         assert result.collision_with[0].entity_type == "skill"
+
+
+class TestAdvisoryThresholdReadsAbsoluteSimilarity:
+    """The advisory threshold must gate on similarity, not on rank.
+
+    Under the default ``rrf`` fusion the search repository hands back a
+    ``relevance_score`` that has been min-max rescaled for display, so the
+    best hit carries 1.0 whatever its real similarity. Gating on that value
+    admits the top hit in every registry, which is issue #1696.
+    """
+
+    async def test_top_ranked_but_dissimilar_hit_is_not_advised(self, monkeypatch) -> None:
+        service = _build_service(
+            monkeypatch,
+            search_results={
+                "servers": [
+                    {
+                        "path": "/payroll",
+                        "server_name": "payroll-mcp-server",
+                        "relevance_score": 1.0,
+                        "similarity_score": 0.2648,
+                    }
+                ]
+            },
+        )
+        result = await service.check(
+            **_check_kwargs(
+                name="topic-mcp-server",
+                description="Extracts discussion topics from a transcript.",
+            )
+        )
+        assert result.advisory_matches == []
+
+    async def test_genuinely_similar_hit_is_still_advised(self, monkeypatch) -> None:
+        service = _build_service(
+            monkeypatch,
+            search_results={
+                "servers": [
+                    {
+                        "path": "/topics",
+                        "server_name": "topic-extractor-mcp-server",
+                        "relevance_score": 1.0,
+                        "similarity_score": 0.93,
+                    }
+                ]
+            },
+        )
+        result = await service.check(
+            **_check_kwargs(
+                name="topic-mcp-server",
+                description="Extracts discussion topics from a transcript.",
+            )
+        )
+        assert [m.path for m in result.advisory_matches] == ["/topics"]
+        assert result.advisory_matches[0].relevance_score == 0.93
+
+    async def test_ordering_follows_similarity_not_display_rank(self, monkeypatch) -> None:
+        """Display rank and similarity can disagree; the cap must honour similarity."""
+        service = _build_service(
+            monkeypatch,
+            max_suggestions=1,
+            search_results={
+                "servers": [
+                    {
+                        "path": "/ranked-first",
+                        "server_name": "A",
+                        "relevance_score": 1.0,
+                        "similarity_score": 0.72,
+                    },
+                    {
+                        "path": "/most-similar",
+                        "server_name": "B",
+                        "relevance_score": 0.4,
+                        "similarity_score": 0.97,
+                    },
+                ]
+            },
+        )
+        result = await service.check(**_check_kwargs(name="X", description="Y"))
+        assert [m.path for m in result.advisory_matches] == ["/most-similar"]
+
+    async def test_hit_without_a_similarity_score_is_not_advised(self, monkeypatch) -> None:
+        """A backend that cannot supply a similarity cannot supply a duplicate claim."""
+        service = _build_service(
+            monkeypatch,
+            search_results={
+                "servers": [{"path": "/lexical-only", "server_name": "L", "relevance_score": 1.0}]
+            },
+        )
+        result = await service.check(**_check_kwargs(name="X", description="Y"))
+        assert result.advisory_matches == []


### PR DESCRIPTION
`DuplicateCheckService` compares `dedup_score_threshold` against `relevance_score`, but under the default `rrf` fusion that value is a position in a result list, not a similarity. `_normalize_scores` min-max rescales the fused scores, and all three of its return paths hand exactly 1.0 to the highest scorer (`search_repository.py:290`). Since 1.0 always clears 0.7, the filter at `duplicate_check_service.py:342` cannot reject the top candidate whatever the registry holds.

The normalization is doing its job. `d97a24b6` added it so the UI would stop rendering RRF scores as "1-3% match"; the advisory is just reading a display number as if it were a similarity.

That makes the shared `-mcp-server` suffix incidental to this report. Against a registry holding only `payroll-mcp-server` and `weather-mcp-server`, registering `topic-mcp-server` still returns an advisory at 1.0, on true cosines of 0.2648 and 0.2313.

## Fix

`search()` now carries `similarity_score` next to `relevance_score`: the cosine of the hit against the query embedding, stamped by `_attach_similarity_scores` on the hybrid and client-side paths. `relevance_score` and the UI are untouched. The advisory ranks and filters on `similarity_score`, and a hit arriving without one is treated as not comparable rather than admitted.

This also takes the non-default linear branch's `(cosine + 1) / 2` mapping out of the threshold's meaning, where a configured 0.7 was really asking for cosine 0.4.

The existing advisory fixtures set only `relevance_score`, which is no longer the field that gates, so I renamed it there to keep them testing what they were testing.

## Verification

- Four new behavioural tests in `test_duplicate_check_service.py` fail on `main` and pass here, plus `test_search_similarity_scores.py` for the helper.
- Full `tests/unit` suite on Python 3.14: 6594 passed, 8 skipped.
- `ruff check`, `ruff format` and `mypy` clean at the pinned pre-commit versions.
- Two gaps. The matching call on the MongoDB CE client-side fallback is not covered, since that method has no test harness in the repo. And a registration with an empty description still embeds the bare name, where `topic-mcp-server` and `category-mcp-server` sit at 0.7621, so the boilerplate effect described in the report survives that case.

Stripping catalog tokens before embedding would close that second one, but it changes what gets indexed rather than how a score is read, so it seemed worth keeping separate.

Refs #1696
