### PR TITLE
fix(servers): make PATCH a field-scoped, revision-guarded write

### DIFF
--- a/registry/api/server_routes.py
+++ b/registry/api/server_routes.py
@@ -6249,8 +6249,20 @@ async def update_server_endpoint(
             detail=f"Registration denied by policy gate: {gate_result.error_message}",
         )
 
-    success = await server_service.update_server(path, merged)
+    # PUT replaces the card, so it keeps the full-field write; the
+    # revision guard moves into the same repository write as the $set so
+    # the If-Match check above is not just advisory (issue #1716).
+    success = await server_service.update_server(
+        path,
+        merged,
+        expected_updated_at=(existing.get("updated_at") if client_ts is not None else None),
+    )
     if not success:
+        if client_ts is not None:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "Failed to save server"},
@@ -6398,6 +6410,12 @@ async def patch_server_endpoint(
             detail="Empty patch body",
         )
 
+    # Only fields the client supplied are written, so a concurrently
+    # updated field absent from the patch survives (issue #1716).
+    # Null-valued fields stay in the scope: the merge stores None for
+    # them, same as before.
+    patch_fields = sorted(patch_dict.keys())
+
     # Changing the lifecycle status requires a dedicated permission (Issue #1330),
     # separate from modify_service, so a scope can grant "edit metadata" without
     # "promote/deprecate". Only enforced when the status actually changes.
@@ -6430,8 +6448,21 @@ async def patch_server_endpoint(
             detail=f"Registration denied by policy gate: {gate_result.error_message}",
         )
 
-    success = await server_service.update_server(path, merged)
+    success = await server_service.update_server(
+        path,
+        merged,
+        updated_fields=patch_fields,
+        expected_updated_at=(existing.get("updated_at") if client_ts is not None else None),
+    )
     if not success:
+        # A revision-guarded write that matched nothing means the card
+        # changed after the caller read it; anything else is a failed
+        # save (issue #1716).
+        if client_ts is not None:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail="If-Match does not match current server version",
+            )
         return JSONResponse(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content={"detail": "Failed to save server"},

--- a/registry/repositories/documentdb/server_repository.py
+++ b/registry/repositories/documentdb/server_repository.py
@@ -417,8 +417,33 @@ class DocumentDBServerRepository(ServerRepositoryBase):
         self,
         path: str,
         server_info: dict[str, Any],
+        *,
+        updated_fields: list[str] | None = None,
+        expected_updated_at: str | None = None,
     ) -> bool:
-        """Update an existing server."""
+        """Update an existing server.
+
+        Args:
+            path: Server path as used by callers (with or without a
+                trailing slash).
+            server_info: Full merged server dict (callers build this by
+                layering their change over a fetched card). Only the
+                fields named in ``updated_fields`` (plus ``updated_at``)
+                are written, so concurrent writers touching other fields
+                are not overwritten (issue #1716). When omitted, every
+                field is written (legacy full-card behaviour).
+            expected_updated_at: Optional ``updated_at`` value the caller
+                read. When given, it participates in the same
+                ``update_one`` filter as the ``_id`` match, so the
+                compare-and-set is atomic: if another writer persisted a
+                change since this caller read the card, the filter
+                matches nothing and the update fails (issue #1716).
+
+        Like :meth:`get`, a card stored under the slash variant of
+        ``path`` is written through the variant that exists, so a read
+        that found the card is never followed by a write that silently
+        misses it (issue #1716).
+        """
         logger.debug(
             f"DocumentDB WRITE: Updating server at '{path}' in collection '{self._collection_name}'"
         )
@@ -429,6 +454,9 @@ class DocumentDBServerRepository(ServerRepositoryBase):
         try:
             doc = {**server_info}
             doc.pop("path", None)
+            if updated_fields is not None:
+                field_set = set(updated_fields) | {"updated_at"}
+                doc = {k: v for k, v in doc.items() if k in field_set}
             populate_normalized_identity_url(doc, ENTITY_TYPE_SERVER)
             unset_ops: dict[str, str] = {}
             # update() may carry no proxy_pass_url at all (a partial
@@ -446,10 +474,31 @@ class DocumentDBServerRepository(ServerRepositoryBase):
             update_spec: dict[str, dict[str, Any]] = {"$set": doc}
             if unset_ops:
                 update_spec["$unset"] = unset_ops
-            result = await collection.update_one({"_id": path}, update_spec)
+
+            # Try the exact _id first; on a miss, a card stored under the
+            # slash variant (readable that way via get(), issue #1716)
+            # still gets the write, guarded by the same revision
+            # predicate. Each update_one is atomic on its own; a miss on
+            # both forms means either the card is gone or the stored
+            # updated_at moved, and both must fail the write.
+            def _filter_for(id_value: str) -> dict[str, Any]:
+                if expected_updated_at is None:
+                    return {"_id": id_value}
+                return {"_id": id_value, "updated_at": expected_updated_at}
+
+            result = await collection.update_one(_filter_for(path), update_spec)
+            if result.matched_count == 0:
+                alternate_path = path.rstrip("/") if path.endswith("/") else path + "/"
+                if alternate_path != path:
+                    result = await collection.update_one(_filter_for(alternate_path), update_spec)
 
             if result.matched_count == 0:
-                logger.error(f"Server at '{path}' not found in DocumentDB")
+                if expected_updated_at is not None:
+                    logger.info(
+                        f"Server at '{path}' revision mismatch or missing; concurrent update won"
+                    )
+                else:
+                    logger.error(f"Server at '{path}' not found in DocumentDB")
                 return False
 
             logger.info(

--- a/registry/repositories/interfaces.py
+++ b/registry/repositories/interfaces.py
@@ -128,8 +128,12 @@ class ServerRepositoryBase(ABC):
         self,
         path: str,
         server_info: dict[str, Any],
+        *,
+        updated_fields: list[str] | None = None,
+        expected_updated_at: str | None = None,
     ) -> bool:
-        """Update an existing server."""
+        """Update an existing server (see the DocumentDB impl for the
+        issue #1716 field-scoping and revision-guard semantics)."""
         pass
 
     @abstractmethod

--- a/registry/services/server_service.py
+++ b/registry/services/server_service.py
@@ -231,8 +231,23 @@ class ServerService:
             "is_new_version": False,
         }
 
-    async def update_server(self, path: str, server_info: dict[str, Any]) -> bool:
+    async def update_server(
+        self,
+        path: str,
+        server_info: dict[str, Any],
+        *,
+        updated_fields: list[str] | None = None,
+        expected_updated_at: str | None = None,
+    ) -> bool:
         """Update an existing server.
+
+        Args:
+            updated_fields: When given, only these fields (plus
+                ``updated_at``) are persisted; concurrent writes to other
+                fields survive (issue #1716). None writes every field.
+            expected_updated_at: When given, the update only lands if the
+                stored ``updated_at`` still equals this value, enforced
+                atomically in the repository write (issue #1716).
 
         Raises:
             UrlValidationError: If the update sets a proxy_pass_url that fails
@@ -282,7 +297,12 @@ class ServerService:
                 # Re-enabling clears any prior refresh auto-disable.
                 server_info["proxy_disabled_reason"] = None
 
-        result = await self._repo.update(path, server_info)
+        result = await self._repo.update(
+            path,
+            server_info,
+            updated_fields=updated_fields,
+            expected_updated_at=expected_updated_at,
+        )
 
         if result:
             # Update search index

--- a/tests/integration/test_server_patch_concurrency.py
+++ b/tests/integration/test_server_patch_concurrency.py
@@ -1,0 +1,176 @@
+"""Persistence-level regression tests for PATCH /servers writes (issue #1716).
+
+Exercises DocumentDBServerRepository.update — the write primitive under
+PATCH /api/servers/{path} — against a real MongoDB: the trailing-slash
+_id asymmetry that made a description-only PATCH fail with a 500, the
+field-scoped $set that stops a metadata PATCH from clobbering a
+concurrent credential/egress write, and the atomic revision predicate
+that backs If-Match. Requires a running MongoDB (the test harness
+points DOCUMENTDB_HOST at localhost); skipped automatically if
+unreachable.
+"""
+
+import uuid
+
+import pytest
+
+from registry.repositories.documentdb.server_repository import (
+    DocumentDBServerRepository,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _card() -> dict:
+    return {
+        "server_name": "legacy",
+        "description": "initial",
+        "tags": ["old"],
+        "license": "MIT",
+        "deployment": "remote",
+        "proxy_pass_url": "http://upstream:9000",
+        "registered_by": "alice",
+        "id": f"asset-{uuid.uuid4().hex[:8]}",
+        "is_enabled": True,
+        "is_active": True,
+        "version": "v1.0.0",
+        "num_tools": 1,
+        "tool_list": [{"name": "search", "inputSchema": {"$schema": "x", "type": "object"}}],
+        "auth_credential_encrypted": "ENC::keepme",
+        "egress_oauth": {"provider": "github", "scopes": ["repo"]},
+        "registered_at": "2026-01-01T00:00:00",
+        "updated_at": "2026-01-01T00:00:00",
+    }
+
+
+@pytest.fixture
+async def repo():
+    """Repository backed by a real collection; cleans up cards it created."""
+    r = DocumentDBServerRepository()
+    try:
+        col = await r._get_collection()
+        await col.database.command("ping")
+    except Exception as e:
+        pytest.skip(f"MongoDB not reachable: {e}")
+    created: list[str] = []
+    r._created = created
+    yield r
+    col = await r._get_collection()
+    if created:
+        await col.delete_many({"_id": {"$in": created}})
+
+
+class TestSlashVariantWrite:
+    async def test_update_resolves_slash_variant_id(self, repo):
+        """A card stored under '/x/' must be writable as '/x' (issue #1716).
+
+        get() falls back to the slash variant when reading, so a
+        read-then-write flow on such a card resolved nothing and the
+        route returned 'Failed to save server'.
+        """
+        col = await repo._get_collection()
+        card = _card()
+        await col.insert_one({"_id": "/legacy-1716/", **card})
+        repo._created.append("/legacy-1716/")
+
+        existing = await repo.get("/legacy-1716")
+        assert existing is not None
+
+        merged = {**existing, "description": "patched"}
+        assert await repo.update("/legacy-1716", merged, updated_fields=["description"])
+
+        doc = await col.find_one({"_id": "/legacy-1716/"})
+        assert doc["description"] == "patched"
+
+
+class TestFieldScopedWrite:
+    async def test_scoped_update_preserves_concurrent_credential_write(self, repo):
+        """A PATCH must not overwrite fields another writer owns (issue #1716).
+
+        The PATCH read its card before the credential rotation landed;
+        the old full-card $set persisted the stale credential.
+        """
+        col = await repo._get_collection()
+        card = _card()
+        await col.insert_one({"_id": "/racy-1716", **card})
+        repo._created.append("/racy-1716")
+
+        stale_read = await repo.get("/racy-1716")
+        await col.update_one(
+            {"_id": "/racy-1716"},
+            {"$set": {"auth_credential_encrypted": "ENC::rotated"}},
+        )
+
+        merged = {**stale_read, "description": "patched"}
+        assert await repo.update("/racy-1716", merged, updated_fields=["description"])
+
+        doc = await col.find_one({"_id": "/racy-1716"})
+        assert doc["description"] == "patched"
+        assert doc["auth_credential_encrypted"] == "ENC::rotated"
+        assert doc["egress_oauth"] == card["egress_oauth"]
+        assert doc["tool_list"] == card["tool_list"]
+
+    async def test_repeated_identical_patch_is_harmless(self, repo):
+        col = await repo._get_collection()
+        card = _card()
+        await col.insert_one({"_id": "/idem-1716", **card})
+        repo._created.append("/idem-1716")
+
+        for _ in range(2):
+            existing = await repo.get("/idem-1716")
+            merged = {**existing, "description": "same"}
+            assert await repo.update("/idem-1716", merged, updated_fields=["description"])
+
+        doc = await col.find_one({"_id": "/idem-1716"})
+        assert doc["description"] == "same"
+        assert doc["num_tools"] == card["num_tools"]
+
+
+class TestRevisionGuardedWrite:
+    async def test_stale_revision_fails_atomically(self, repo):
+        col = await repo._get_collection()
+        card = _card()
+        await col.insert_one({"_id": "/cas-1716", **card})
+        repo._created.append("/cas-1716")
+
+        existing = await repo.get("/cas-1716")
+        # Another writer lands between our read and our write.
+        await col.update_one(
+            {"_id": "/cas-1716"},
+            {
+                "$set": {
+                    "auth_credential_encrypted": "ENC::theirs",
+                    "updated_at": "2030-01-01T00:00:00",
+                }
+            },
+        )
+
+        merged = {**existing, "description": "must not land"}
+        result = await repo.update(
+            "/cas-1716",
+            merged,
+            updated_fields=["description"],
+            expected_updated_at=existing["updated_at"],
+        )
+        assert result is False
+
+        doc = await col.find_one({"_id": "/cas-1716"})
+        assert doc["description"] == "initial"
+        assert doc["auth_credential_encrypted"] == "ENC::theirs"
+
+    async def test_fresh_revision_writes(self, repo):
+        col = await repo._get_collection()
+        card = _card()
+        await col.insert_one({"_id": "/cas2-1716", **card})
+        repo._created.append("/cas2-1716")
+
+        existing = await repo.get("/cas2-1716")
+        merged = {**existing, "description": "landed"}
+        assert await repo.update(
+            "/cas2-1716",
+            merged,
+            updated_fields=["description"],
+            expected_updated_at=existing["updated_at"],
+        )
+        doc = await col.find_one({"_id": "/cas2-1716"})
+        assert doc["description"] == "landed"

--- a/tests/unit/api/test_server_routes_patch.py
+++ b/tests/unit/api/test_server_routes_patch.py
@@ -492,6 +492,97 @@ class TestServerPatch:
         assert called_path == "/test-server"
         assert called_dict["description"] == "patched"
 
+    def test_patch_write_is_scoped_to_supplied_fields(self, client):
+        """Only client-supplied fields are persisted (issue #1716).
+
+        The merged card is still computed for gates and webhooks, but the
+        repository write must carry the patch's field scope so a field a
+        concurrent writer updated is not overwritten by this PATCH.
+        """
+        existing = _existing(auth_credential_encrypted="ENC::keepme")
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+            )
+
+        assert response.status_code == 200
+        kwargs = svc.update_server.call_args.kwargs
+        assert kwargs["updated_fields"] == ["description"]
+
+    def test_patch_write_carries_read_revision_for_if_match(self, client):
+        """With If-Match, the revision joins the atomic repository write (issue #1716)."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        if_match = f'W/"{int(ts.timestamp() * 1000)}"'
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, existing])
+            svc.update_server = AsyncMock(return_value=True)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+                headers={"If-Match": if_match},
+            )
+
+        assert response.status_code == 200
+        kwargs = svc.update_server.call_args.kwargs
+        assert kwargs["expected_updated_at"] == existing["updated_at"]
+
+    def test_patch_412_when_revision_guard_fails_save(self, client):
+        """A guarded write that matched nothing is a lost-update race, not a 500 (issue #1716)."""
+        ts = datetime(2026, 1, 1, tzinfo=UTC)
+        existing = _existing(updated_at=ts)
+        if_match = f'W/"{int(ts.timestamp() * 1000)}"'
+        with (
+            patch("registry.api.server_routes.server_service") as svc,
+            patch(
+                "registry.auth.dependencies.user_has_ui_permission_for_service",
+                return_value=True,
+            ),
+            patch(
+                "registry.api.server_routes.check_registration_gate",
+                AsyncMock(return_value=_gate_allow()),
+            ),
+            patch("registry.api.server_routes.send_registration_webhook", AsyncMock()),
+        ):
+            svc.get_server_info = AsyncMock(side_effect=[existing, None])
+            svc.update_server = AsyncMock(return_value=False)
+
+            response = client.patch(
+                "/servers/test-server",
+                json={"description": "patched"},
+                headers={"If-Match": if_match},
+            )
+
+        assert response.status_code == 412
+        assert "If-Match" in response.json()["detail"]
+
 
 @pytest.mark.unit
 @pytest.mark.api

--- a/tests/unit/repositories/test_documentdb_server_repository.py
+++ b/tests/unit/repositories/test_documentdb_server_repository.py
@@ -220,6 +220,57 @@ class TestUpdate:
         mock_collection.update_one.side_effect = Exception("db error")
         assert await repo.update("/a", {"server_name": "A"}) is False
 
+    async def test_writes_slash_variant_id(self, repo, mock_collection):
+        """A card stored under '/a/' is writable as '/a' (issue #1716).
+
+        get() already falls back to the slash variant when reading, so a
+        read-then-write flow on such a card must resolve the same _id or
+        the write matches nothing and the route reports a save failure.
+        """
+        mock_collection.update_one.return_value = MagicMock(matched_count=0)
+        result = await repo.update("/a", {"server_name": "A"})
+        assert result is False
+        # The exact _id misses, then the slash variant is tried.
+        assert mock_collection.update_one.call_args_list[0][0][0] == {"_id": "/a"}
+        assert mock_collection.update_one.call_args_list[1][0][0] == {"_id": "/a/"}
+
+    async def test_writes_exact_id_first(self, repo, mock_collection):
+        """The common path is a single update_one on the exact _id."""
+        mock_collection.update_one.return_value = MagicMock(matched_count=1)
+        assert await repo.update("/a", {"server_name": "A"}) is True
+        assert mock_collection.update_one.call_count == 1
+        assert mock_collection.update_one.call_args[0][0] == {"_id": "/a"}
+
+    async def test_scoped_fields_write_only_those_fields(self, repo, mock_collection):
+        """updated_fields scopes the $set so other fields are not clobbered."""
+        mock_collection.update_one.return_value = MagicMock(matched_count=1)
+        await repo.update(
+            "/a",
+            {"server_name": "A", "description": "kept", "tags": ["also kept"]},
+            updated_fields=["description"],
+        )
+        spec = mock_collection.update_one.call_args[0][1]
+        assert set(spec["$set"].keys()) == {"description", "updated_at"}
+
+    async def test_expected_updated_at_in_filter(self, repo, mock_collection):
+        """The revision predicate shares the update_one filter (atomic CAS)."""
+        mock_collection.update_one.return_value = MagicMock(matched_count=0)
+        result = await repo.update(
+            "/a",
+            {"server_name": "A"},
+            expected_updated_at="2026-01-01T00:00:00",
+        )
+        assert result is False
+        # Both attempted writes carry the revision in the same filter.
+        assert mock_collection.update_one.call_args_list[0][0][0] == {
+            "_id": "/a",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+        assert mock_collection.update_one.call_args_list[1][0][0] == {
+            "_id": "/a/",
+            "updated_at": "2026-01-01T00:00:00",
+        }
+
 
 class TestDelete:
     async def test_deletes_existing(self, repo, mock_collection):


### PR DESCRIPTION
## Summary

I changed `PATCH /api/servers/{path}` from a read-merge-full-card-write into a field-scoped, revision-guarded write, and moved the If-Match check into the repository `update_one` itself.

What was happening (issue #1716), on the MongoDB CE backend:

- `update_server_endpoint`/`patch_server_endpoint` read the full card, merged the narrow patch, then `DocumentDBServerRepository.update()` persisted the whole merged card with an unconditional full-card `$set`
- a card stored under the slash variant of its path (readable that way because `get()` falls back to the alternate `_id`) never matched the update filter, so a description-only PATCH came back `500 Failed to save server`
- any field written between the PATCH's read and its write, a rotated backend credential, an egress OAuth config, health status, was overwritten even though the patch never mentioned that field

What changed:

- `DocumentDBServerRepository.update()` scopes its `$set` to `updated_fields` (plus `updated_at`) when given, tries the slash-variant `_id` on a miss the same way `get()` does, and takes an optional `expected_updated_at` that joins the `_id` in the same `update_one` filter, so the If-Match compare-and-set is one atomic database operation, not a client-side pre-check
- `PATCH` passes the patch's field scope plus the revision it read; a guarded write that matches nothing is a `412`, not a `500`
- `PUT` keeps its full-card replacement semantics, but its If-Match now also rides the repository write

## Testing

- before, on current `main`, against a real mongo:8.2: a description-only PATCH on a card stored under `/legacy/` read fine but `update_one` matched 0 documents and the route returned `500 Failed to save server`
- before: a credential rotation landing between the PATCH's read and write was clobbered by the stale full-card `$set` (stored `auth_credential_encrypted` reverted to the pre-rotation value)
- after: `pytest tests/integration/test_server_patch_concurrency.py tests/unit/repositories/test_documentdb_server_repository.py tests/unit/api/test_server_routes_patch.py tests/unit/api/test_server_routes_put.py`: the slash-variant card patches with 2xx, the concurrent credential survives, a stale If-Match fails atomically with nothing written, an identical replay is harmless, and clearing `proxy_pass_url` still `$unset`s the identity-url sidecar

The new integration test follows the existing `test_agent_batch_repository.py` pattern (real collection, skip when MongoDB is unreachable), so it runs in CI alongside the mongo:8.2 service the workflow already starts.

Fixes #1716
