### PR TITLE
fix(terraform): remove ">" from the auth-server SG rule description

### DIFF
--- a/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
+++ b/terraform/aws-ecs/modules/mcp-gateway/ecs-services.tf
@@ -2178,7 +2178,10 @@ module "ecs_service_registry" {
     # no token is injected, and the upstream 3rd-party server 401s (surfacing in
     # the client as "Protected resource ... does not match").
     auth_internal = {
-      description                  = "auth-server -> registry:8091 egress-token vend hop (dedicated internal nginx listener)"
+      # AWS restricts rule descriptions to "a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*", so no
+      # ">" here. An arrow makes AuthorizeSecurityGroupIngress fail the whole apply
+      # with "InvalidParameterValue: Invalid rule description".
+      description                  = "auth-server to registry:8091 egress-token vend hop (dedicated internal nginx listener)"
       from_port                    = 8091
       to_port                      = 8091
       ip_protocol                  = "tcp"


### PR DESCRIPTION
## Problem

AWS restricts security-group rule descriptions to the character set `a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*`. The `auth_internal` ingress rule used an arrow, so `AuthorizeSecurityGroupIngress` rejected it and failed the whole apply:

```
Error: creating VPC Security Group Rule

  with module.mcp_gateway.module.ecs_service_registry
       .aws_vpc_security_group_ingress_rule.this["auth_internal"],

operation error EC2: AuthorizeSecurityGroupIngress, api error InvalidParameterValue:
Invalid rule description. Valid descriptions are strings less than 256 characters
from the following set:  a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*
```

## Impact

Any deployment that had not yet created this rule could not be applied at all — including deployments that never enable the gateway generic proxy, since the rule is unconditional. Deployments that already hold the rule were unaffected, which is why it went unnoticed until a fresh apply hit it.

The rule matters: it is the only path for `auth-server → registry:8091`, the dedicated internal vend listener used by the egress credential vault and by the gateway generic proxy's upstream-header vend. Without it the vend hop times out and credentialed routes fail closed with 502.

## Fix

Replace `->` with `to` and record the constraint inline so it is not reintroduced. The rule itself is unchanged — same ports, same protocol, same referenced security group.

## Verification

- Audited **all 182** AWS-validated descriptions under `terraform/` (security-group rules and outputs, excluding `variable` blocks which never reach the API). This was the only violation.
- `terraform fmt -check` clean.
- `terraform validate` passes; the only warnings are pre-existing deprecated `data.aws_region.current.name` usages in `documentdb.tf`.
- Confirmed on a live deployment: after this change the apply created the rule, and the resulting SG shows

```
registry ingress 8091 ref=auth  "auth-server to registry:8091 egress-token vend hop (dedicated internal nginx listener)"
```

with `EGRESS_REGISTRY_INTERNAL_URL=http://registry:8091` on the auth-server task, and the credential-vend path working end to end for the first time on that deployment.

## Scope

One line plus a comment. No behaviour change beyond making the apply succeed.
