### PR TITLE
fix(gateway-proxy): centralize the Authorization carve-out so registration and the storage decrypt cannot disagree

### DIFF
--- a/registry/api/egress_auth_routes.py
+++ b/registry/api/egress_auth_routes.py
@@ -518,11 +518,17 @@ async def vend_generic_upstream_headers(
     # at validation and its bearer is guarded by the equal-token check at the hop);
     # every other reserved name is dropped so the hop can never inject / forward a
     # gateway-internal header (X-Internal-Token*, X-User, ...) to the backend.
-    from registry.constants import RESERVED_CUSTOM_HEADER_NAMES
+    from registry.constants import (
+        CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES,
+        RESERVED_CUSTOM_HEADER_NAMES,
+    )
 
     def _allowed_upstream_name(name: str) -> bool:
         lower = name.lower()
-        return lower not in RESERVED_CUSTOM_HEADER_NAMES or lower == "authorization"
+        return (
+            lower not in RESERVED_CUSTOM_HEADER_NAMES
+            or lower in CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES
+        )
 
     raw_registered = doc.get("custom_header_names") or []
     raw_overridable = doc.get("custom_header_overridable_names") or []

--- a/registry/constants.py
+++ b/registry/constants.py
@@ -181,3 +181,15 @@ RESERVED_CUSTOM_HEADER_NAMES: frozenset[str] = frozenset(
         "x-body-uninspectable",
     }
 )
+
+# The ONE sanctioned exception to the reserved-name denylist above.
+#
+# ``Authorization`` may be registered as an upstream header, but ONLY as a
+# caller-OVERRIDABLE slot (validate_custom_headers enforces the overridable
+# requirement): a fixed operator bearer belongs in the egress credential vault.
+# An overridable slot may still carry an operator DEFAULT value, so the name has
+# to survive every layer that touches stored headers -- registration validation,
+# the strict storage-integrity decrypt, and the vend backstop. Keeping the
+# carve-out here means those layers cannot drift apart: a name that registration
+# accepts but the decrypt rejects is an entity that 502s on every request.
+CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES: frozenset[str] = frozenset({"authorization"})

--- a/registry/utils/credential_encryption.py
+++ b/registry/utils/credential_encryption.py
@@ -71,9 +71,6 @@ def _validate_custom_header_value(value: object, *, allow_empty: bool = False) -
     return value
 
 
-_CALLER_OVERRIDABLE_RESERVED_NAMES: frozenset[str] = frozenset({"authorization"})
-
-
 def _validate_custom_header_overridable(value: object) -> bool:
     """Require an explicit boolean override flag; reject ambiguous truthy values."""
     if not isinstance(value, bool):
@@ -96,7 +93,11 @@ def validate_custom_headers(
     if raw is None:
         return None
 
-    from registry.constants import MAX_CUSTOM_HEADERS_PER_SERVER, RESERVED_CUSTOM_HEADER_NAMES
+    from registry.constants import (
+        CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES,
+        MAX_CUSTOM_HEADERS_PER_SERVER,
+        RESERVED_CUSTOM_HEADER_NAMES,
+    )
 
     if not isinstance(raw, list):
         raise ValueError("custom_headers must be a list")
@@ -122,7 +123,7 @@ def validate_custom_headers(
 
         lower = name.lower()
         if lower in RESERVED_CUSTOM_HEADER_NAMES:
-            if lower not in _CALLER_OVERRIDABLE_RESERVED_NAMES:
+            if lower not in CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES:
                 raise ValueError(
                     f"Header '{name}' is managed by the gateway and cannot be set as a custom header"
                 )
@@ -450,7 +451,10 @@ def decrypt_custom_headers(
     strict: bool = False,
 ) -> list[dict]:
     """Decrypt safe stored headers, optionally failing closed on any bad entry."""
-    from registry.constants import RESERVED_CUSTOM_HEADER_NAMES
+    from registry.constants import (
+        CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES,
+        RESERVED_CUSTOM_HEADER_NAMES,
+    )
 
     if not encrypted_list:
         return []
@@ -476,7 +480,14 @@ def decrypt_custom_headers(
             logger.warning("Stored custom header has an invalid name; skipping.")
             continue
         lower = name.lower()
-        if lower in RESERVED_CUSTOM_HEADER_NAMES:
+        # Mirror validate_custom_headers: a reserved name is refused EXCEPT the
+        # sanctioned caller-overridable carve-out (Authorization), which may carry
+        # a stored operator default. Rejecting it here would fail-close every
+        # request for an entity registration already accepted.
+        if (
+            lower in RESERVED_CUSTOM_HEADER_NAMES
+            and lower not in CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES
+        ):
             if strict:
                 raise ValueError(f"stored custom header '{name}' is gateway-managed")
             logger.warning(f"Stored custom header '{name}' is gateway-managed; skipping.")

--- a/tests/unit/utils/test_validate_custom_headers.py
+++ b/tests/unit/utils/test_validate_custom_headers.py
@@ -82,10 +82,20 @@ def test_encryption_defensively_validates_before_mutation():
 
 
 def test_non_strict_decrypt_skips_malformed_duplicate_and_unsafe_entries():
+    # Every stored entry that cannot be trusted is skipped: not an object, an
+    # unsafe name, a duplicate name, an unsafe decrypted value, no ciphertext.
+    #
+    # Authorization is the ONE reserved name that survives, matching
+    # validate_custom_headers: it is registrable as a caller-overridable slot,
+    # and such a slot may carry an operator DEFAULT. Rejecting it here would
+    # fail-close every request for an entity whose registration was accepted
+    # (see CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES in registry/constants.py).
+    # Every OTHER reserved name is still dropped -- see
+    # test_non_strict_decrypt_drops_gateway_managed_names.
     entries = [
         "not-an-object",
         {"name": "X-Bad\rInjected", "value_encrypted": "bad-name"},
-        {"name": "Authorization", "value_encrypted": "reserved"},
+        {"name": "Authorization", "value_encrypted": "operator-default"},
         {"name": "X-Good", "value_encrypted": "good"},
         {"name": "x-good", "value_encrypted": "duplicate"},
         {"name": "X-Control", "value_encrypted": "control"},
@@ -94,7 +104,7 @@ def test_non_strict_decrypt_skips_malformed_duplicate_and_unsafe_entries():
 
     def decrypt(ciphertext):
         return {
-            "reserved": "must-not-emit",
+            "operator-default": "Bearer caller-overridable-default",
             "good": "safe",
             "duplicate": "other",
             "control": "bad\nvalue",
@@ -104,7 +114,25 @@ def test_non_strict_decrypt_skips_malformed_duplicate_and_unsafe_entries():
         "registry.utils.credential_encryption.decrypt_credential",
         side_effect=decrypt,
     ):
-        assert decrypt_custom_headers(entries) == [{"name": "X-Good", "value": "safe"}]
+        assert decrypt_custom_headers(entries) == [
+            {"name": "Authorization", "value": "Bearer caller-overridable-default"},
+            {"name": "X-Good", "value": "safe"},
+        ]
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["X-Authorization", "X-Internal-Token-Generic", "X-User", "X-Scopes", "X-Upstream-Url"],
+)
+def test_non_strict_decrypt_drops_gateway_managed_names(reserved):
+    # The carve-out above is Authorization ONLY. A stored entry for any other
+    # gateway-managed name never reaches egress, however it got into storage.
+    entries = [{"name": reserved, "value_encrypted": "planted"}]
+    with patch(
+        "registry.utils.credential_encryption.decrypt_credential",
+        side_effect=lambda c: "must-not-emit",
+    ):
+        assert decrypt_custom_headers(entries) == []
 
 
 def test_non_strict_decrypt_rejects_non_list_without_raising():
@@ -339,6 +367,31 @@ class TestBuildCustomHeadersStorageFields:
             h["name"]: h["value"] for h in decrypt_custom_headers(out["custom_headers_encrypted"])
         }
         assert decrypted == {"X-Api-Key": "sk-1"}
+
+    def test_overridable_authorization_default_survives_the_round_trip(self):
+        # The regression this carve-out exists for. validate_custom_headers accepts
+        # Authorization as a caller-OVERRIDABLE slot, and such a slot may carry an
+        # operator DEFAULT. If the storage decrypt then refuses the name, the vend
+        # fails and the fail-closed hop answers 502 on EVERY request to an entity
+        # whose registration was accepted. Assert the value makes it back out, in
+        # strict mode too, since that is the path the vend uses.
+        from registry.utils.credential_encryption import (
+            build_custom_headers_storage_fields,
+            decrypt_custom_headers,
+        )
+
+        out = build_custom_headers_storage_fields(
+            [{"name": "Authorization", "value": "Bearer operator-default", "overridable": True}]
+        )
+        assert out["custom_header_names"] == ["Authorization"]
+        assert out["custom_header_overridable_names"] == ["Authorization"]
+
+        for strict in (False, True):
+            decrypted = {
+                h["name"]: h["value"]
+                for h in decrypt_custom_headers(out["custom_headers_encrypted"], strict=strict)
+            }
+            assert decrypted == {"Authorization": "Bearer operator-default"}, f"{strict=}"
 
     def test_empty_list_clears_all_fields(self):
         from registry.utils.credential_encryption import build_custom_headers_storage_fields


### PR DESCRIPTION
## Problem

`validate_custom_headers` accepts `Authorization` as a caller-**overridable** upstream header, and such a slot may carry an operator **default** value. The storage-integrity decrypt refused the same name. So an entity the API accepted at registration had its credential dropped on the way back out: the vend returned nothing, and the fail-closed hop answered **502 on every request** to that entity.

Each layer was defensible on its own. The bug was that the exception lived in three places, spelled three different ways:

| Layer | Before |
|---|---|
| `credential_encryption.validate_custom_headers` | module-local `_CALLER_OVERRIDABLE_RESERVED_NAMES` |
| `credential_encryption.decrypt_custom_headers` | **no exemption at all** |
| `egress_auth_routes._allowed_upstream_name` | inline `== "authorization"` |

## Fix

Define the carve-out once, in `registry/constants.py`, beside the `RESERVED_CUSTOM_HEADER_NAMES` denylist it carves out of, and have all three layers read it. Every other reserved name stays refused at every layer.

```python
CALLER_OVERRIDABLE_RESERVED_HEADER_NAMES: frozenset[str] = frozenset({"authorization"})
```

The comment records why the name has to survive all three layers, so the next reader does not "tidy" one of them back out of sync.

Why `Authorization` is the only exception: a **fixed** operator bearer is still refused at registration, because a bearer usually stands for a person and belongs in the per-user egress credential vault. Only the overridable form is allowed, and the hop's equal-token guard still prevents the gateway's own credential from reaching a backend.

## Tests

**New round-trip regression test**, which is the coverage this path never had:

```python
def test_overridable_authorization_default_survives_the_round_trip(self):
    out = build_custom_headers_storage_fields(
        [{"name": "Authorization", "value": "Bearer operator-default", "overridable": True}]
    )
    for strict in (False, True):   # strict is the path the vend uses
        ...
        assert decrypted == {"Authorization": "Bearer operator-default"}
```

Verified to be a real guard, not a tautology — with the source fix stashed and only the test applied:

```
without fix: 1 failed
  WARNING credential_encryption.py:482
  Stored custom header 'Authorization' is gateway-managed; skipping.
with fix:    1 passed
```

That warning is the mechanism: the decrypt silently drops the credential, so the vend has nothing to return and the hop fail-closes.

**Updated** `test_non_strict_decrypt_skips_malformed_duplicate_and_unsafe_entries` — it expected `Authorization` to be dropped. Now expects it to survive, with the reason inline.

**Added boundary test**, because loosening a security check needs its limit asserted:

```python
@pytest.mark.parametrize("reserved",
    ["X-Authorization", "X-Internal-Token-Generic", "X-User", "X-Scopes", "X-Upstream-Url"])
def test_non_strict_decrypt_drops_gateway_managed_names(reserved):
```

## Results

- Credential suites: **297 passed**
- Wider unit set (`tests/unit/utils`, `egress_auth`, `schemas`, skill upstream-headers route): **1634 passed**
- Full suite: **7970 passed, 57 skipped**

The 4 failures in the full run are pre-existing and unrelated — a local `.env` sets `MCP_TOKEN_DEFAULT_TTL_HOURS=2` while two test classes assert the shipped default of 8. They fail identically on `main` without this change, and CI has no such `.env`.

## Not verified here

Unit-level only. The end-to-end confirmation is registering an entity with `{"name": "Authorization", "value": "<token>", "overridable": true}` and getting a 200 with the default injected, plus a caller-supplied `Authorization` overriding it. Worth doing on a deployment before release.
