### PR TITLE
test(gateway-proxy): operator test clients, preflight gate, and regression suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -31,6 +31,13 @@ tests/
 ├── integration/                        # Integration tests
 │   ├── __init__.py
 │   └── conftest.py                     # Integration test fixtures
+├── scripts/                            # Operator-run clients; need a live stack, not pytest
+│   ├── gateway_test_support.py         # Shared gateway plumbing: credential split, discovery, scope
+│   ├── openai_gateway_client.py        # Generic proxy driven against the OpenAI API
+│   ├── bedrock_gateway_client.py       # Generic proxy driven against Amazon Bedrock
+│   ├── verify_caller_creds.py          # Confirm a caller-supplied key reaches the backend
+│   ├── gateway-proxy-preflight.sh      # Credential and config gate; run before the suite
+│   └── gateway-proxy-regression.md     # Manual regression suite for the generic proxy
 └── auth_server/                        # Auth server tests
     ├── __init__.py
     ├── conftest.py                     # Auth server fixtures
@@ -39,6 +46,16 @@ tests/
         ├── mock_jwt.py                 # JWT utilities
         └── mock_providers.py           # Mock auth providers
 ```
+
+Everything under `scripts/` runs against a deployed stack and a real backend, so `pytest` skips it. These scripts read real secrets from files outside version control (`.token`, `.scratchpad/.oai`, `.scratchpad/.bedrock`, `.scratchpad/pr-1714/api-ninja`).
+
+Before running the gateway suite, run its gate:
+
+```bash
+./tests/scripts/gateway-proxy-preflight.sh
+```
+
+It checks every credential file, decodes the gateway JWT and rejects an expired one, checks the `.env` settings and `/health`, and exits non-zero on the first missing prerequisite. Start `scripts/gateway-proxy-regression.md` only after it prints `PREFLIGHT PASSED`; a partial run turns a missing key into what looks like a proxy bug.
 
 ## Key Features
 

--- a/tests/scripts/bedrock_gateway_client.py
+++ b/tests/scripts/bedrock_gateway_client.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Drive the Amazon Bedrock Converse API through the gateway's generic proxy.
+
+Sibling of ``openai_gateway_client.py``: same gateway feature (PR #1714), a
+different upstream. Bedrock accepts a long-term API key as a plain
+``Authorization: Bearer`` header, so it exercises the identical caller-passthrough
+path -- no SigV4, no boto3 -- and the request the gateway forwards is exactly:
+
+    POST https://bedrock-runtime.<region>.amazonaws.com/model/<model-id>/converse
+    Authorization: Bearer <bedrock api key>
+    {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
+
+Credential split (both required; swapping them fails closed):
+
+- ``.token``               -> ``X-Authorization``  gateway JWT authenticating ingress.
+- ``.scratchpad/.bedrock`` -> ``Authorization``    the Bedrock API key the gateway
+  forwards, admitted only because the entity registers ``Authorization`` as
+  caller-OVERRIDABLE. Sending the gateway JWT in both trips the equal-token guard.
+
+Modes:
+
+- ``converse``  buffered hop: ``POST /model/<id>/converse``, prints the reply text.
+- ``stream``    ``POST /model/<id>/converse-stream``, whose body is an AWS
+                event-stream (length-prefixed binary frames, NOT SSE). Frames are
+                decoded with ``botocore.eventstream`` and reported with
+                time-to-first-chunk, chunk count, and the largest inter-chunk gap,
+                so a buffered response fails instead of passing on a 200.
+
+Examples::
+
+    # register the backing entity once (the custom type must already exist)
+    uv run python api/registry_management.py --registry-url http://localhost \\
+        --token-file .token custom-proxy-create --type rest-endpoint \\
+        --name bedrock-proxy --target-url https://bedrock-runtime.us-east-1.amazonaws.com \\
+        --streaming true --auth-passthrough
+
+    # then run the checks
+    uv run python tests/scripts/bedrock_gateway_client.py --ensure-scope
+    uv run python tests/scripts/bedrock_gateway_client.py --mode stream \\
+        --model us.anthropic.claude-opus-4-8 --prompt "Count slowly from 1 to 10."
+
+Neither secret is logged: both are read from files and only ever sent as headers.
+"""
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+# tests/scripts is not a package (these are run directly, like call_mcp_tool.py),
+# so make the sibling support module importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gateway_test_support as gw  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+API_KEY_ENV: str = "AWS_BEARER_TOKEN_BEDROCK"
+DEFAULT_API_KEY_FILE: str = ".scratchpad/.bedrock"
+DEFAULT_MODEL: str = "us.anthropic.claude-opus-4-8"
+DEFAULT_PROMPT: str = "Hello"
+DEFAULT_MAX_TOKENS: int = 128
+# Backend substring identifying this client's entity during discovery.
+TARGET_HINT: str = "bedrock-runtime"
+# Converse and ConverseStream are both POST; this client uses no GET surface.
+REQUIRED_VERBS: tuple[str, ...] = ("POST",)
+
+
+def _converse_payload(
+    prompt: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    """Build a minimal Converse request body.
+
+    Args:
+        prompt: User text.
+        max_tokens: Output cap, keeping test invocations cheap.
+
+    Returns:
+        The Converse JSON payload.
+    """
+    return {
+        "messages": [{"role": "user", "content": [{"text": prompt}]}],
+        "inferenceConfig": {"maxTokens": max_tokens},
+    }
+
+
+def _request_headers(
+    gateway_token: str,
+    api_key: str,
+) -> dict[str, str]:
+    """Build the two-credential header set for a proxied Bedrock call.
+
+    Args:
+        gateway_token: The gateway JWT (ingress).
+        api_key: The Bedrock API key (forwarded upstream).
+
+    Returns:
+        Headers for the gateway request.
+    """
+    return {
+        "X-Authorization": f"Bearer {gateway_token}",
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _reply_text(
+    body: dict[str, Any],
+) -> str:
+    """Extract the assistant text from a Converse response.
+
+    Args:
+        body: Decoded Converse response.
+
+    Returns:
+        Concatenated text blocks, or "" when the shape is unexpected.
+    """
+    blocks = body.get("output", {}).get("message", {}).get("content", []) or []
+    return "".join(block.get("text", "") for block in blocks if isinstance(block, dict)).strip()
+
+
+def check_converse(
+    base_url: str,
+    headers: dict[str, str],
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: int,
+) -> bool:
+    """Call ``/converse`` through the gateway (buffered hop, POST authz).
+
+    Args:
+        base_url: Gateway client URL for the entity, no trailing slash.
+        headers: Two-credential header set.
+        model: Bedrock model id.
+        prompt: User text.
+        max_tokens: Output cap.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        True when Bedrock returns 200 with assistant text.
+    """
+    url = f"{base_url}/model/{model}/converse"
+    started = time.monotonic()
+    response = requests.post(
+        url,
+        json=_converse_payload(prompt, max_tokens),
+        headers=headers,
+        timeout=timeout,
+    )
+    elapsed = time.monotonic() - started
+
+    if response.status_code != 200:
+        logger.error("converse    : FAILED - HTTP %s", response.status_code)
+        gw.explain_status(response.status_code, response.text)
+        return False
+
+    body = response.json()
+    text = _reply_text(body)
+    logger.info(
+        "converse    : OK in %.2fs (stop=%s, tokens=%s) -> %r",
+        elapsed,
+        body.get("stopReason"),
+        body.get("usage", {}).get("totalTokens"),
+        text[:160],
+    )
+    return bool(text)
+
+
+class _EventStreamReader:
+    """Decode AWS event-stream frames into Converse stream events.
+
+    Bedrock's ConverseStream body is ``application/vnd.amazon.eventstream``:
+    length-prefixed binary frames, not SSE, so it needs a real framing decoder.
+    ``botocore.eventstream`` ships one and botocore is already a dependency. If it
+    is unavailable, decoding degrades to counting raw chunks -- the
+    incremental-delivery timing (the property under test) still holds.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the frame buffer, degrading when botocore is absent."""
+        self.available = True
+        try:
+            from botocore.eventstream import EventStreamBuffer
+        except ImportError:  # pragma: no cover - environment dependent
+            self.available = False
+            logger.warning("botocore.eventstream unavailable; counting raw chunks only")
+            return
+        self._buffer = EventStreamBuffer()
+
+    def feed(
+        self,
+        data: bytes,
+    ) -> list[dict[str, Any]]:
+        """Add received bytes and return any newly completed events.
+
+        Args:
+            data: Raw bytes from the response body.
+
+        Returns:
+            Decoded event payloads (empty while a frame is still incomplete).
+        """
+        if not self.available:
+            return []
+        self._buffer.add_data(data)
+        events: list[dict[str, Any]] = []
+        for message in self._buffer:
+            try:
+                events.append(json.loads(message.payload))
+            except (ValueError, UnicodeDecodeError):
+                continue
+        return events
+
+
+def check_stream(
+    base_url: str,
+    headers: dict[str, str],
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    timeout: int,
+) -> bool:
+    """Call ``/converse-stream`` and assert the body arrives incrementally.
+
+    Times the first chunk, counts chunks, decodes event frames, and records the
+    largest inter-chunk gap. One chunk (or a zero span across many) means the
+    response was buffered somewhere -- the entity's ``proxy_streaming`` claim,
+    nginx ``proxy_buffering``, or the hop -- so the check fails.
+
+    Args:
+        base_url: Gateway client URL for the entity, no trailing slash.
+        headers: Two-credential header set.
+        model: Bedrock model id.
+        prompt: User text.
+        max_tokens: Output cap.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        True when more than one chunk arrived over a non-zero span.
+    """
+    url = f"{base_url}/model/{model}/converse-stream"
+    started = time.monotonic()
+    reader = _EventStreamReader()
+
+    with requests.post(
+        url,
+        json=_converse_payload(prompt, max_tokens),
+        headers=headers,
+        timeout=timeout,
+        stream=True,
+    ) as response:
+        if response.status_code != 200:
+            logger.error("stream      : FAILED - HTTP %s", response.status_code)
+            gw.explain_status(response.status_code, response.text)
+            return False
+
+        content_type = response.headers.get("content-type", "")
+        first_chunk_at: float | None = None
+        last_chunk_at = started
+        max_gap = 0.0
+        chunks = 0
+        events = 0
+        pieces: list[str] = []
+        stop_reason: str | None = None
+
+        for chunk in response.iter_content(chunk_size=None):
+            if not chunk:
+                continue
+            now = time.monotonic()
+            if first_chunk_at is None:
+                first_chunk_at = now
+            else:
+                max_gap = max(max_gap, now - last_chunk_at)
+            last_chunk_at = now
+            chunks += 1
+            for event in reader.feed(chunk):
+                events += 1
+                delta = event.get("delta")
+                if isinstance(delta, dict) and delta.get("text"):
+                    pieces.append(delta["text"])
+                if event.get("stopReason"):
+                    stop_reason = event["stopReason"]
+
+    if first_chunk_at is None:
+        logger.error("stream      : FAILED - the stream produced no chunks")
+        return False
+
+    span = last_chunk_at - first_chunk_at
+    logger.info(
+        "stream      : %d chunks / %d events, first at %.2fs, span %.2fs, max gap %.3fs, "
+        "content-type=%s, stop=%s",
+        chunks,
+        events,
+        first_chunk_at - started,
+        span,
+        max_gap,
+        content_type or "(none)",
+        stop_reason,
+    )
+    logger.info("stream      : text -> %r", "".join(pieces).strip()[:160])
+    if chunks <= 1 or span <= 0.0:
+        logger.error(
+            "stream      : FAILED - not incremental (chunks=%d, span=%.3fs). Check "
+            "proxy_streaming on the entity and that nginx rendered 'proxy_buffering "
+            "off' for this route.",
+            chunks,
+            span,
+        )
+        return False
+    logger.info("stream      : OK (incremental delivery confirmed)")
+    return True
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Exercise gateway generic-proxy routing against Amazon Bedrock Converse.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    gw.add_common_arguments(parser, API_KEY_ENV, DEFAULT_API_KEY_FILE)
+    parser.add_argument(
+        "--mode",
+        choices=["converse", "stream", "all"],
+        default="all",
+        help="Which checks to run (default: all)",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help=f"Bedrock model id or inference profile (default: {DEFAULT_MODEL})",
+    )
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="User prompt text")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=DEFAULT_MAX_TOKENS,
+        help=f"inferenceConfig.maxTokens (default: {DEFAULT_MAX_TOKENS})",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Resolve the target, verify prerequisites, and run the selected checks.
+
+    Returns:
+        0 when every selected check passed, 1 on a check failure, 2 on a
+        prerequisite/configuration error.
+    """
+    args = _parse_args()
+    gw.configure_logging(args.debug)
+
+    try:
+        token, api_key, client_path = gw.preflight(
+            args,
+            api_key_env=API_KEY_ENV,
+            verbs=REQUIRED_VERBS,
+            target_hint=TARGET_HINT,
+            expect_streaming=args.mode in {"stream", "all"},
+        )
+    except gw.GatewayClientError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    base_url = f"{args.registry_url.rstrip('/')}{client_path.rstrip('/')}"
+    headers = _request_headers(token, api_key)
+    logger.info("Bedrock base: %s", base_url)
+    logger.info("Model       : %s", args.model)
+
+    checks = {
+        "converse": lambda: check_converse(
+            base_url, headers, args.model, args.prompt, args.max_tokens, args.timeout
+        ),
+        "stream": lambda: check_stream(
+            base_url, headers, args.model, args.prompt, args.max_tokens, args.timeout
+        ),
+    }
+    selected = list(checks) if args.mode == "all" else [args.mode]
+    return gw.run_checks(checks, selected)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/gateway-proxy-preflight.sh
+++ b/tests/scripts/gateway-proxy-preflight.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Preflight gate for the gateway generic-proxy regression suite.
+#
+# Run this BEFORE any test in tests/scripts/gateway-proxy-regression.md. It fails
+# loudly and exits non-zero when a prerequisite is missing, so a run cannot start
+# half-configured and produce a result nobody can trust.
+#
+# Usage (from the repository root):
+#   ./tests/scripts/gateway-proxy-preflight.sh              # gate every section
+#   ./tests/scripts/gateway-proxy-preflight.sh 3 4 5 6      # gate only these sections
+#
+# Exit codes: 0 all required prerequisites present. 1 at least one is missing.
+
+set -uo pipefail
+
+RED=$'\033[0;31m'; YEL=$'\033[0;33m'; GRN=$'\033[0;32m'; BLD=$'\033[1m'; NC=$'\033[0m'
+FAILED=0
+SKIPPED=()
+
+die()  { printf '%s\n' "${RED}${BLD}FATAL${NC} ${RED}$1${NC}" >&2; FAILED=1; }
+warn() { printf '%s\n' "${YEL}WARN ${NC} $1" >&2; }
+ok()   { printf '%s\n' "${GRN}ok   ${NC} $1"; }
+head2() { printf '\n%s\n' "${BLD}$1${NC}"; }
+
+# --- where am I -------------------------------------------------------------
+if [ ! -f pyproject.toml ] || [ ! -d registry ]; then
+  die "run this from the repository root (pyproject.toml and registry/ must be here); every path in the suite is root-relative"
+  exit 1
+fi
+
+SECTIONS=("$@")
+want() {  # want <section-number> -> 0 if that section is in scope
+  [ ${#SECTIONS[@]} -eq 0 ] && return 0
+  local s; for s in "${SECTIONS[@]}"; do [ "$s" = "$1" ] && return 0; done
+  return 1
+}
+
+# --- credential and key files ----------------------------------------------
+# Every file the suite reads a secret from, with the sections that need it.
+# Format: path|sections|what it is|how to get it
+CRED_FILES=(
+".token|all|gateway JWT (admin, group authorizing HTTP verbs)|generate from the registry UI sidebar, or ./api/get-m2m-token.sh"
+".scratchpad/pr-1714/api-ninja|5 6|api-ninjas.com API key, one line|sign up at api-ninjas.com and write the key to this file"
+".scratchpad/.oai|7|OpenAI API key, one line|platform.openai.com API keys"
+".scratchpad/.bedrock|7|Amazon Bedrock long-term API key for us-east-2|Bedrock console, long-term API key"
+)
+
+head2 "CREDENTIAL FILES (secrets — never commit, never echo)"
+for row in "${CRED_FILES[@]}"; do
+  IFS='|' read -r path secs what how <<< "$row"
+  in_scope=0
+  if [ "$secs" = "all" ]; then in_scope=1; else
+    for s in $secs; do want "$s" && in_scope=1; done
+  fi
+  if [ "$in_scope" -eq 0 ]; then
+    printf '%s\n' "     ${path} — not needed for the requested sections"
+    continue
+  fi
+  if [ ! -e "$path" ]; then
+    die "MISSING CREDENTIAL FILE  ${path}
+          needed by section(s): ${secs}
+          contents: ${what}
+          obtain:   ${how}"
+    SKIPPED+=("$secs")
+  elif [ ! -s "$path" ]; then
+    die "EMPTY CREDENTIAL FILE    ${path} (needed by section(s) ${secs}: ${what})"
+    SKIPPED+=("$secs")
+  else
+    ok "${path} present, $(wc -c < "$path" | tr -d ' ') bytes — ${what}"
+  fi
+done
+
+# --- gateway token validity -------------------------------------------------
+head2 "GATEWAY TOKEN"
+if [ -s .token ]; then
+  TOKEN_LEFT=$(python3 - <<'PY' 2>/dev/null
+import base64, json, time
+try:
+    t = json.load(open('.token'))['tokens']['access_token']
+    p = t.split('.')[1]; p += '=' * (-len(p) % 4)
+    print(json.loads(base64.urlsafe_b64decode(p))['exp'] - int(time.time()))
+except Exception:
+    print('unreadable')
+PY
+)
+  case "$TOKEN_LEFT" in
+    unreadable) die ".token does not contain tokens.access_token as a decodable JWT" ;;
+    -*)         die "GATEWAY TOKEN EXPIRED $(( ${TOKEN_LEFT#-} / 60 )) minutes ago — regenerate before running anything, or every test returns 401" ;;
+    *)          if [ "$TOKEN_LEFT" -lt 900 ]; then
+                  warn "gateway token expires in $(( TOKEN_LEFT / 60 )) minutes; a full run may outlive it"
+                else
+                  ok "gateway token valid for $(( TOKEN_LEFT / 60 )) more minutes"
+                fi ;;
+  esac
+fi
+
+# --- configuration ----------------------------------------------------------
+head2 "CONFIGURATION (.env)"
+if [ ! -f .env ]; then
+  die "no .env at the repository root"
+else
+  getenv() { grep -m1 "^$1=" .env 2>/dev/null | cut -d= -f2- ; }
+  [ "$(getenv GATEWAY_GENERIC_PROXY_ENABLED)" = "true" ] \
+    && ok "GATEWAY_GENERIC_PROXY_ENABLED=true" \
+    || die "GATEWAY_GENERIC_PROXY_ENABLED is not true — the feature ships off and every route 404s"
+  [ "$(getenv DEPLOYMENT_MODE)" = "with-gateway" ] \
+    && ok "DEPLOYMENT_MODE=with-gateway" \
+    || die "DEPLOYMENT_MODE is not with-gateway — the generic proxy only renders in gateway mode"
+  [ -n "$(getenv SECRET_KEY)" ] \
+    && ok "SECRET_KEY set (derives the upstream-credential encryption key)" \
+    || die "SECRET_KEY is empty — sections 5 and 6 cannot encrypt or decrypt a stored credential"
+  if want 5 || want 6; then
+    [ -n "$(getenv DOCUMENTDB_PASSWORD)" ] \
+      && ok "DOCUMENTDB_PASSWORD set (sections 5 and 6 read Mongo directly)" \
+      || die "DOCUMENTDB_PASSWORD is empty — sections 5 and 6 inspect stored ciphertext"
+  fi
+fi
+
+# --- stack ------------------------------------------------------------------
+head2 "STACK"
+ORIGIN="${ORIGIN:-http://localhost}"
+HEALTH=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$ORIGIN/health" 2>/dev/null)
+[ "$HEALTH" = "200" ] \
+  && ok "$ORIGIN/health -> 200" \
+  || die "$ORIGIN/health -> ${HEALTH:-no response} — start the stack (docker compose up -d) before testing"
+
+if command -v docker >/dev/null 2>&1; then
+  if docker compose logs auth-server 2>/dev/null | grep -qi "generic-proxy feature DISABLED"; then
+    die "the auth-server logged 'generic-proxy feature DISABLED' — the egress self-check latched the feature off for the process. Set GATEWAY_EGRESS_SELFCHECK_ENABLED=false for local runs and restart."
+  else
+    ok "no 'generic-proxy feature DISABLED' line in the auth-server log"
+  fi
+fi
+
+# --- tooling ----------------------------------------------------------------
+head2 "TOOLING"
+for bin in curl jq python3 docker; do
+  command -v "$bin" >/dev/null 2>&1 && ok "$bin present" || die "$bin not on PATH — the suite needs it"
+done
+
+# --- verdict ----------------------------------------------------------------
+printf '\n'
+if [ "$FAILED" -ne 0 ]; then
+  printf '%s\n' "${RED}${BLD}=============================================================${NC}"
+  printf '%s\n' "${RED}${BLD} PREFLIGHT FAILED — DO NOT RUN THE SUITE${NC}"
+  printf '%s\n' "${RED}${BLD} Fix every FATAL above. A partial run produces results${NC}"
+  printf '%s\n' "${RED}${BLD} nobody can trust: a missing key looks like a proxy bug.${NC}"
+  printf '%s\n' "${RED}${BLD}=============================================================${NC}"
+  exit 1
+fi
+printf '%s\n' "${GRN}${BLD}PREFLIGHT PASSED — the suite may run.${NC}"
+exit 0

--- a/tests/scripts/gateway-proxy-regression.md
+++ b/tests/scripts/gateway-proxy-regression.md
@@ -1,0 +1,566 @@
+# Gateway generic proxy — regression suite
+
+Covers the generic reverse proxy that serves non-MCP registry entities (skills, agents, custom types) through the gateway: routing, ingress auth, per-verb authorization, response streaming, and the three upstream-credential models.
+
+Run this before tagging a release that touches `auth_server/server.py`, `registry/schemas/proxy_mixin.py`, `registry/api/egress_auth_routes.py`, `registry/core/nginx_service.py`, `registry/utils/credential_encryption.py`, or any `charts/` and `terraform/` file carrying a `GATEWAY_GENERIC_*` setting.
+
+Every test names its own command and its own pass line. Nothing depends on a previous test's output except where a fixture is named. Section 8 tears down everything section 2 creates.
+
+`pytest` never runs this file. It needs a deployed stack and real backend credentials, so an operator drives it. Every command assumes the repository root as the working directory, not this directory. The three Python clients it calls in section 7 sit beside it.
+
+---
+
+## STOP — required credential files
+
+This suite reads real secrets from four files. Nothing here works without them, and a missing key does not look like a missing key: it looks like a proxy bug. Section 5 in particular turns a missing credential into an upstream `400`, which reads exactly like the fail-open bug that section exists to catch.
+
+| File | Needed by | Contents | How to get it |
+|---|---|---|---|
+| `.token` | every section | gateway JWT for an admin whose group authorizes HTTP verbs | registry UI sidebar, or `./api/get-m2m-token.sh` |
+| `.scratchpad/pr-1714/api-ninja` | sections 5, 6 | api-ninjas.com API key, one line, no newline needed | sign up at api-ninjas.com |
+| `.scratchpad/.oai` | section 7 | OpenAI API key, one line | platform.openai.com, API keys |
+| `.scratchpad/.bedrock` | section 7 | Amazon Bedrock long-term API key valid for **us-east-2** | Bedrock console, long-term API key |
+
+All four live outside version control. `.scratchpad/` is git-ignored; `.token` is in `.gitignore`. Read each key from its file inside the command that needs it. Never paste one into a shell argument you keep, a test file, a commit, or a log.
+
+### Run the gate first
+
+```bash
+./tests/scripts/gateway-proxy-preflight.sh            # gate every section
+./tests/scripts/gateway-proxy-preflight.sh 3 4 5 6    # gate only these sections
+```
+
+It checks each credential file for existence and non-emptiness, decodes `.token` and fails on an expired JWT, checks the four `.env` settings the suite depends on, checks `/health`, checks that the auth-server has not latched the feature off, and checks that `curl`, `jq`, `python3`, and `docker` are on `PATH`. It prints one line per check and exits non-zero on the first missing prerequisite.
+
+**Do not start testing until it prints `PREFLIGHT PASSED`.** A failing run ends with:
+
+```
+=============================================================
+ PREFLIGHT FAILED — DO NOT RUN THE SUITE
+ Fix every FATAL above. A partial run produces results
+ nobody can trust: a missing key looks like a proxy bug.
+=============================================================
+```
+
+Section 1 below repeats the configuration detail the gate checks, for when you need to fix something it flagged.
+
+---
+
+## 1. Prerequisites
+
+### 1.1 Configuration
+
+Set these in `.env`, then rebuild. The feature ships off, so a release that leaves `GATEWAY_GENERIC_PROXY_ENABLED=false` skips this suite.
+
+```bash
+GATEWAY_GENERIC_PROXY_ENABLED=true
+DEPLOYMENT_MODE=with-gateway          # the proxy only renders in gateway mode
+GATEWAY_PROXY_PREFIX=gateway
+GATEWAY_PROXY_ALLOW_PRIVATE_TARGETS=false
+GATEWAY_GENERIC_TLS_VERIFY=true
+GATEWAY_GENERIC_REQUIRE_BEARER_FOR_WRITES=true
+GATEWAY_GENERIC_STREAM_READ_TIMEOUT_SECONDS=3600
+GATEWAY_GENERIC_STREAM_MAX_CONCURRENCY=8
+GATEWAY_GENERIC_ACQUIRE_TIMEOUT_SECONDS=5
+GATEWAY_GENERIC_STREAM_MAX_DURATION_SECONDS=3600
+GATEWAY_GENERIC_STREAM_MAX_BYTES=104857600
+```
+
+`SECRET_KEY` must stay stable across the run. It derives the encryption key for stored upstream credentials, so rotating it mid-suite turns every section 5 test into a 502.
+
+On an EC2 host whose containers can reach `169.254.169.254`, the startup egress self-check disables the feature for the process. Set `GATEWAY_EGRESS_SELFCHECK_ENABLED=false` for the run and leave it on everywhere else.
+
+### 1.2 Stack
+
+```bash
+docker compose up -d
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost/health        # expect 200
+docker compose logs auth-server | grep -iE "generic.proxy|egress" | tail -20
+```
+
+A line reading `generic-proxy feature DISABLED` means the self-check ran. Fix 1.1 and restart before going further.
+
+### 1.3 Shell variables
+
+```bash
+cd /path/to/mcp-gateway-registry          # repository root; every path below is relative to it
+export ORIGIN=http://localhost
+export DOCUMENTDB_PASSWORD=$(grep -m1 '^DOCUMENTDB_PASSWORD=' .env | cut -d= -f2-)
+
+# Read a secret from a file, or stop. Use this everywhere a key is needed so a
+# missing file fails on the spot instead of sending an empty header and turning
+# into an upstream 400 that reads like a proxy bug.
+secret() {
+  [ -s "$1" ] || { printf 'FATAL: missing or empty credential file %s\n' "$1" >&2; return 1; }
+  tr -d '\n' < "$1"
+}
+
+export GW=$(secret .token | jq -r .tokens.access_token)
+[ -n "$GW" ] && [ "$GW" != null ] || echo 'FATAL: no usable token in .token — run the preflight gate' >&2
+```
+
+**Against a CloudFront-fronted deployment, add `--compressed` to every `curl`.** CloudFront gzips JSON responses, and `curl` does not decompress unless asked, so a working call prints unreadable bytes — or nothing at all, if the shell swallows them. A `curl -w '%{http_code}'` reports 200 while the body looks empty, which reads as a gateway bug and is not one. `requests` and the scripted clients decompress transparently, so this only bites hand-run `curl`. Local `http://localhost` runs are unaffected, which is why it does not show up until you test a real deployment.
+
+```bash
+curl -sS --compressed -H "X-Authorization: Bearer $GW" "${BASE}v1/models" | jq '.data | length'
+```
+
+`$GW` must belong to a group that authorizes HTTP verbs on the entities under test. See 1.5.
+
+Tokens expire. When a test returns 401 for no obvious reason, check the lifetime first:
+
+```bash
+python3 - <<'PY'
+import base64, json, time
+t = json.load(open('.token'))['tokens']['access_token']
+p = t.split('.')[1]; p += '=' * (-len(p) % 4)
+left = json.loads(base64.urlsafe_b64decode(p))['exp'] - int(time.time())
+print(f"{left // 60} minutes left" if left > 0 else f"EXPIRED {abs(left) // 60} minutes ago")
+PY
+```
+
+### 1.4 Backend keys
+
+| File | Used by |
+|---|---|
+| `.scratchpad/pr-1714/api-ninja` | fixture F3, sections 5 and 6 |
+| `.scratchpad/.oai` | fixture F4, section 4 |
+| `.scratchpad/.bedrock` | fixture F5, section 4 |
+
+Read each key from its file inside the command. Never paste one into a shell argument you keep, a test file, or a log.
+
+### 1.5 Scope grant
+
+The generic hop authorizes `{entity_type}/{registered_path}` — for a custom record that reads `rest-endpoint/rest-endpoint/<uuid>`, for a skill `skill/skills/<name>`. A legacy `methods: ["all"]` rule does **not** grant an HTTP verb. That split is deliberate, so the group needs an explicit rule:
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" \
+  $ORIGIN/api/management/iam/groups/registry-admins | jq '.server_access'
+```
+
+Pass line: one rule matches the entity (or `"server": "*"`) and its `methods` contain either the verb or `http:*`.
+
+To add it, use the IAM scope editor or let a scripted client write it:
+
+```bash
+uv run python tests/scripts/openai_gateway_client.py --ensure-scope --mode models
+```
+
+## 2. Fixtures
+
+Six entities cover every path. Create the ones the sections you plan to run need.
+
+### F1 — the `rest-endpoint` custom type
+
+`custom-type-create` takes a JSON descriptor, not flags. Keep every field optional: a type with a required field cannot be registered through `custom-proxy-create` and needs a full `custom-record-create` body instead.
+
+```bash
+cat > /tmp/rest-endpoint-type.json <<'JSON'
+{
+  "name": "rest-endpoint",
+  "display_name": "REST Endpoint",
+  "description": "Proxied generic REST/HTTP endpoints",
+  "fields": [
+    {"name": "notes", "label": "Notes", "datatype": "string"}
+  ]
+}
+JSON
+
+uv run python api/registry_management.py custom-type-create --config /tmp/rest-endpoint-type.json
+```
+
+Skip this when `custom-type-list` already shows the type; creating it twice fails.
+
+### F2 — keyless upstream (Open-Meteo)
+
+```bash
+uv run python api/registry_management.py custom-proxy-create \
+  --type rest-endpoint --name openmeteo-forecast \
+  --target-url https://api.open-meteo.com \
+  --connect-notes 'Append /v1/forecast?latitude=&longitude=&current=temperature_2m'
+```
+
+### F3 — fixed operator credential (api-ninjas)
+
+`custom_headers` is accepted at create only. Omitting `overridable` makes the header fixed.
+
+```bash
+KEY=$(secret .scratchpad/pr-1714/api-ninja) || echo 'cannot register F3 without the key' >&2
+
+curl -sS -X POST $ORIGIN/api/custom/rest-endpoint \
+  -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' \
+  -d "$(jq -n --arg k "$KEY" '{
+    name: "api-ninjas-weather",
+    description: "API Ninjas weather, fixed operator X-Api-Key",
+    visibility: "private",
+    is_proxied: true,
+    proxy_target_url: "https://api.api-ninjas.com",
+    custom_headers: [{name: "X-Api-Key", value: $k}]
+  }')" -w '\nHTTP %{http_code}\n'
+```
+
+### F4 — caller passthrough plus streaming (OpenAI)
+
+```bash
+uv run python api/registry_management.py custom-proxy-create \
+  --type rest-endpoint --name openai-proxy \
+  --target-url https://api.openai.com --streaming true --auth-passthrough
+```
+
+### F5 — caller passthrough plus AWS event-stream (Bedrock)
+
+```bash
+uv run python api/registry_management.py custom-proxy-create \
+  --type rest-endpoint --name bedrock-proxy-use2 \
+  --target-url https://bedrock-runtime.us-east-2.amazonaws.com \
+  --streaming true --auth-passthrough
+```
+
+The key in `.scratchpad/.bedrock` must be valid for `us-east-2`, matching the target. A key from another region returns a Bedrock-side 403 and the passthrough still worked.
+
+### F6 — a proxied skill
+
+A skill has no native backend, so proxying one needs an explicit target. Flip an existing skill; no re-registration. `PUT` patches (it applies `exclude_unset`), but the three required fields must appear or the body fails validation.
+
+```bash
+curl -sS -X PUT $ORIGIN/api/skills/pdf \
+  -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' \
+  -d '{"name": "pdf",
+       "description": "Backwards compat update test",
+       "skill_md_url": "https://raw.githubusercontent.com/anthropics/courses/refs/heads/master/prompt_engineering_interactive_tutorial/README.md",
+       "is_proxied": true,
+       "proxy_target_url": "https://raw.githubusercontent.com"}' \
+  -w '\nHTTP %{http_code}\n'
+```
+
+`skill-register` carries no proxy flags, so this is API or UI only.
+
+### 2.1 Resolve the client URLs
+
+Never assemble a client URL by hand. The server derives it and the tests read it:
+
+```bash
+BASE_METEO=$(curl -sS -H "Authorization: Bearer $GW" $ORIGIN/api/custom/rest-endpoint \
+  | jq -r --arg n openmeteo-forecast --arg o "$ORIGIN" \
+      '.records[] | select(.name==$n) | $o + .proxy_client_url + "/"')
+
+BASE_NINJA=$(curl -sS -H "Authorization: Bearer $GW" $ORIGIN/api/custom/rest-endpoint \
+  | jq -r --arg n api-ninjas-weather --arg o "$ORIGIN" \
+      '.records[] | select(.name==$n) | $o + .proxy_client_url + "/"')
+
+BASE_OPENAI=$(curl -sS -H "Authorization: Bearer $GW" $ORIGIN/api/custom/rest-endpoint \
+  | jq -r --arg n openai-proxy --arg o "$ORIGIN" \
+      '.records[] | select(.name==$n) | $o + .proxy_client_url + "/"')
+```
+
+Two details the `jq` encodes on purpose. The trailing slash matters: the stored value has none, the nginx location ends in one, so the bare path answers 301 and most clients downgrade a POST to GET when they follow it. `select(.name==$n)` on a record that is not proxied yields an empty string rather than `null` pasted into a URL.
+
+List every proxied record with its route:
+
+```bash
+uv run python api/registry_management.py custom-record-list --type rest-endpoint --json 2>/dev/null \
+  | jq -r '.records[] | select(.is_proxied) | "\(.name)\t\(.proxy_client_url)/\t-> \(.proxy_target_url)"' \
+  | column -t -s$'\t'
+```
+
+Diagnostics go to stderr, JSON to stdout, so `2>/dev/null` leaves clean JSON. Listings paginate: compare `total_count` against the array length and pass `?limit=` when they differ, or a proxied record hides on page two and looks unregistered.
+
+## 3. Routing and ingress auth
+
+Fixture: F2.
+
+| ID | Command | Pass |
+|---|---|---|
+| **T-3.1** | `curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $GW" "${BASE_METEO}v1/forecast?latitude=38.9&longitude=-77.03&current=temperature_2m"` | `200` |
+| **T-3.2** | same with no `Authorization` header | `401` |
+| **T-3.3** | same with `-H "Authorization: Bearer not-a-jwt"` | `401` |
+| **T-3.4** | same with the token in `X-Authorization` instead | `200` — either header carries the gateway JWT |
+| **T-3.5** | `curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' -H "Authorization: Bearer $GW" "${BASE_METEO%/}"` | `301`, `Location` adds the trailing slash |
+
+**T-3.6 — an unmatched gateway path must not look like success.**
+
+```bash
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' -H "Authorization: Bearer $GW" \
+  "$ORIGIN/gateway/skill/some-skill-that-is-not-proxied/anything"
+```
+
+Today this returns `200 text/html` — the 889-byte frontend shell, because no proxy location matches and nginx falls through to the SPA. Record the result. A release that changes it to `404` is an improvement; a test that reads only the status code passes either way and tells you nothing, so assert on `content_type`.
+
+## 4. Keyless upstream
+
+Fixture: F2. Run this first when anything else fails. With no credential anywhere, it isolates the transport — nginx route, `/validate` markers, signed token, egress hop — from every credential concern.
+
+**T-4.1**
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" \
+  "${BASE_METEO}v1/forecast?latitude=38.9072&longitude=-77.0369&current=temperature_2m,wind_speed_10m"
+```
+
+Pass: `200` and a body carrying `"current"` with a `temperature_2m` number.
+
+**T-4.2 — the gateway strips its own credential before egress.** Send the JWT in `Authorization`, which the keyless upstream ignores. `_strip_generic_internal_headers` drops it and the whole gateway-internal header set on the way out. Pass: `200`, same as T-4.1.
+
+## 5. Static operator credential
+
+Fixture: F3. The operator stores a credential once; the registry encrypts it, vends it to the auth-server over an internal service-token-gated endpoint, and the hop injects it on egress. Callers never send it and never see it.
+
+api-ninjas returns three distinct answers, so each failure mode has a signature. All three are HTTP 400, so **assert on the body, not the status code**.
+
+| Upstream body | Meaning |
+|---|---|
+| `200` + weather JSON | the right key was injected |
+| `{"error": "Missing API Key."}` | the hop forwarded with no credential — fail-open, a bug |
+| `{"error": "Invalid API Key."}` | a key arrived and it was the wrong one |
+
+The free tier needs `lat` and `lon`. `city` costs a premium plan and returns 400 with a valid key.
+
+**T-5.1 — the create response hides the secret.**
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" \
+  "$ORIGIN/api/custom/rest-endpoint/$(basename ${BASE_NINJA%/})" | jq '{custom_header_names, custom_header_overridable_names, custom_headers_updated_at}'
+```
+
+Pass: `custom_header_names` is `["X-Api-Key"]`, `custom_header_overridable_names` is `[]`, no value or ciphertext field appears anywhere, and the plaintext key appears nowhere in the body.
+
+**T-5.2 — injection works and the caller sends nothing.**
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" "${BASE_NINJA}v1/weather?lat=39.2806&lon=-77.4136"
+```
+
+Pass: `200` with `"temp"` in the body. Fails on `Missing API Key.`
+
+**T-5.3 — the credential is encrypted at rest.**
+
+```bash
+docker exec mcp-mongodb mongosh --quiet -u admin -p "$DOCUMENTDB_PASSWORD" \
+  --authenticationDatabase admin --eval '
+  var c = db.getSiblingDB("mcp_registry");
+  var e = c.mcp_custom_entities_default.findOne({name: "api-ninjas-weather"}).custom_headers_encrypted[0];
+  print(Object.keys(e).join(",") + " len=" + e.value_encrypted.length + " " + e.value_encrypted.substring(0,8));'
+```
+
+Pass: entry keys are `name,value_encrypted`; the value starts `gAAAAA` (Fernet); the plaintext key appears nowhere in the document; no plaintext `custom_headers` field exists.
+
+**T-5.4 — a fixed header beats a caller header.**
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" -H "X-Api-Key: caller-garbage-value" \
+  "${BASE_NINJA}v1/weather?lat=39.2806&lon=-77.4136"
+```
+
+Pass: `200`. Fails on `Invalid API Key.`, which means the caller's value reached the backend.
+
+**T-5.5 — a failed vend refuses the request.** The highest-value test here. Save the restore command before breaking anything: an interrupted run leaves the record holding an undecryptable credential.
+
+```bash
+REC=$(curl -sS -H "Authorization: Bearer $GW" $ORIGIN/api/custom/rest-endpoint \
+  | jq -r '.records[] | select(.name=="api-ninjas-weather") | .path')
+M="docker exec mcp-mongodb mongosh --quiet -u admin -p $DOCUMENTDB_PASSWORD --authenticationDatabase admin --eval"
+
+ORIG=$($M "print(db.getSiblingDB('mcp_registry').mcp_custom_entities_default.findOne({_id:'$REC'}).custom_headers_encrypted[0].value_encrypted)")
+echo "$ORIG" > /tmp/orig-ciphertext.txt
+
+BAD="${ORIG:0:60}X${ORIG:61}"
+$M "db.getSiblingDB('mcp_registry').mcp_custom_entities_default.updateOne({_id:'$REC'},{\$set:{'custom_headers_encrypted.0.value_encrypted':'$BAD'}})"
+
+curl -sS -w '\nHTTP %{http_code}\n' -H "Authorization: Bearer $GW" \
+  "${BASE_NINJA}v1/weather?lat=39.2806&lon=-77.4136"
+
+$M "db.getSiblingDB('mcp_registry').mcp_custom_entities_default.updateOne({_id:'$REC'},{\$set:{'custom_headers_encrypted.0.value_encrypted':'$(cat /tmp/orig-ciphertext.txt)'}})"
+```
+
+Pass: `502 {"detail":"Upstream auth unavailable"}`. Fails on `Missing API Key.`, which means the hop forwarded the request stripped of its credential.
+
+Both layers must log a refusal:
+
+```
+registry     egress_auth_routes.py  generic upstream-headers REFUSED: stored credential decryption failed
+registry     POST /api/internal/generic-upstream-headers -> 500
+auth-server  generic upstream-headers vend failed ...; refusing to forward unauthenticated
+auth-server  GET /proxy/rest-endpoint/... -> 502
+```
+
+Re-run T-5.2 after the restore. Pass: `200`, and the registry logs `generic upstream-headers vended for ...: defaults=['X-Api-Key'] overridable=[]`, which also shows the vend runs per request with no cache.
+
+## 6. Credential rotation
+
+Fixture: F3. `PATCH /api/custom/{type}/{uuid}/upstream-headers` replaces the whole header set. An empty list clears it. Values are write-only.
+
+```bash
+UUID=$(basename ${BASE_NINJA%/})
+ROT=$ORIGIN/api/custom/rest-endpoint/$UUID/upstream-headers
+KEY=$(secret .scratchpad/pr-1714/api-ninja) || echo 'section 6 needs the api-ninjas key' >&2
+rot() { curl -sS -X PATCH "$ROT" -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' -d "$1" \
+        | jq -c '{custom_header_names, custom_header_overridable_names, custom_headers_updated_at}'; }
+```
+
+**Wait for the nginx reload after every rotation.** Adding or removing the last header rewrites the route and flips the `$generic_has_upstream_auth` marker. Probing inside that window returns stale behaviour: a rotation that adds the first credential reads as `Missing API Key.` until the reload lands. Sleep 4 seconds, or poll until the answer stops changing.
+
+| ID | Rotate to | Caller sends | Pass |
+|---|---|---|---|
+| **T-6.1** | `{"custom_headers":[{"name":"X-Api-Key","value":"'$KEY'","overridable":true}]}` | nothing | `200` — operator default applies |
+| **T-6.2** | (same) | `X-Api-Key: garbage` | `Invalid API Key.` — the caller wins on an overridable header |
+| **T-6.3** | (same) | `X-Api-Key: $KEY` | `200` |
+| **T-6.4** | `{"custom_headers":[{"name":"X-Api-Key","overridable":false}]}` | nothing | `200` — a blank value keeps the stored ciphertext |
+| **T-6.5** | `{"custom_headers":[]}` | nothing | `Missing API Key.` — cleared |
+| **T-6.6** | (cleared) | `X-Api-Key: $KEY` | `Missing API Key.` — an unregistered name is dropped, so a caller cannot inject a header at the backend |
+| **T-6.7** | `{"custom_headers":[{"name":"X-Api-Key","overridable":true}]}` | nothing | `Missing API Key.` — the slot is registered and empty |
+| **T-6.8** | (same) | `X-Api-Key: $KEY` | `200` — the caller supplies the credential |
+| **T-6.9** | `{"custom_headers":[{"name":"X-Api-Key","value":"'$KEY'"}]}` | nothing | `200` — back to fixed |
+
+`custom_headers_updated_at` must advance on every rotation and the two name arrays must track the new shape.
+
+T-6.4 is the one that protects the UI. `UpstreamHeadersField` renders registered names with empty value boxes, so a user who edits an unrelated field and saves must not wipe the credential. A blank value means keep.
+
+The same rule has a consequence worth remembering: rotating with the value omitted cannot turn an operator default into a caller-only slot, because omission keeps the old value. Clear first, then re-add — T-6.5 followed by T-6.7.
+
+**T-6.10 — the general update refuses headers.** `PUT` on the record with a `custom_headers` field must ignore it. Accepting it would skip create-path validation and write plaintext values straight to storage. Pass: the stored `custom_headers_encrypted` and `custom_headers_updated_at` are unchanged after the PUT.
+
+## 7. Caller passthrough, streaming, and skills
+
+### 7.1 Scripted clients
+
+Fixtures F4 and F5. Four files under `tests/scripts/`, none of them pytest tests. They need a live stack and a real backend key.
+
+| File | Role |
+|---|---|
+| `gateway_test_support.py` | credential split, entity discovery, per-verb scope check, status interpretation |
+| `openai_gateway_client.py` | modes `models` (GET authz), `chat` (POST authz plus CSRF bearer exemption), `stream` (SSE), `all` |
+| `bedrock_gateway_client.py` | modes `converse`, `stream` (AWS event-stream frames via `botocore.eventstream`), `all` |
+| `verify_caller_creds.py` | proves a **caller-supplied** key is the credential reaching the backend, and that the gateway stores none |
+
+```bash
+uv run python tests/scripts/openai_gateway_client.py --mode all --ensure-scope
+uv run python tests/scripts/bedrock_gateway_client.py --entity bedrock-proxy-use2 --mode all \
+  --model us.anthropic.claude-opus-4-8 --prompt "Count slowly from 1 to 10."
+```
+
+Shared flags: `--registry-url`, `--token-file`, `--api-key-file`, `--entity`, `--client-path`, `--ensure-scope`, `--scope-group`, `--timeout`, `--debug`.
+
+Pass: every mode reports OK. Both stream modes print time-to-first-chunk, chunk count, and the largest inter-chunk gap, and they fail when a response arrives buffered — one chunk, or every chunk at the same instant. A 200 alone does not pass a streaming test.
+
+Neither client covers section 5 or 6. Both send the credential themselves, which is the opposite of what an operator-injected header does.
+
+**T-7.1a — whose credential is actually in use.** A 200 on a caller-passthrough entity does not tell you: a stored operator default produces the same 200. Two calls are needed, and `verify_caller_creds.py` makes both:
+
+```bash
+uv run python tests/scripts/verify_caller_creds.py --entity openai-proxy
+```
+
+| Caller sends | Pass |
+|---|---|
+| the key | `200` with a model list |
+| nothing | `401` from the backend — nothing stored, so nothing to inject |
+
+A `200` on the second call is the failure: an operator default is being injected. Demote it to a caller-only slot with two rotations, because omitting a value **keeps** the stored one:
+
+```bash
+curl -sS -X PATCH "$ROT" -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' -d '{"custom_headers": []}'
+curl -sS -X PATCH "$ROT" -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' \
+  -d '{"custom_headers": [{"name": "Authorization", "overridable": true}]}'
+```
+
+The script also refuses an expired token up front and names the cause of a 401, 403, 404, or unknown entity, rather than raising. A gateway JWT is only valid for the deployment whose auth-server signed it: `iss` and `aud` are identical across deployments while each signs with its own `SECRET_KEY`, so pointing a valid-looking token at the wrong registry yields a 401 that looks like a scope problem.
+
+### 7.2 The credential split
+
+The gateway JWT goes in `X-Authorization`. The backend key goes in `Authorization`, and the hop forwards it only because the entity registers `Authorization` as caller-overridable. A fixed `Authorization` is refused at registration: an operator bearer belongs in the per-user egress vault.
+
+**T-7.1 — the equal-token guard.** Send the same gateway JWT in both `Authorization` and `X-Authorization`. Pass: `401` from the gateway. This stops the gateway's own credential from reaching a backend.
+
+### 7.3 Skills
+
+Fixture: F6. A skill differs from a custom record in three ways.
+
+The client URL is name-based. `build_proxy_client_path` strips the leading namespace segment and prefixes the entity-type token, which is singular:
+
+| Identifier | Value |
+|---|---|
+| Registry path (Mongo `_id`) | `/skills/pdf` |
+| Client URL | `/gateway/skill/pdf` |
+| Authz key | `skill/skills/pdf` |
+
+**T-7.2 — the hop forwards bytes unchanged.**
+
+```bash
+curl -sS -H "Authorization: Bearer $GW" \
+  "$ORIGIN/gateway/skill/pdf/anthropics/skills/refs/heads/main/skills/pdf/SKILL.md" > /tmp/gw.md
+curl -sS https://raw.githubusercontent.com/anthropics/skills/refs/heads/main/skills/pdf/SKILL.md > /tmp/direct.md
+cmp /tmp/gw.md /tmp/direct.md && echo IDENTICAL
+```
+
+Pass: `cmp` reports identical, and the response carries the upstream `etag` and `cache-control`.
+
+**T-7.3 — the plural path is not a 404.** Request `/gateway/skills/pdf/...`. Today it returns `200 text/html`, the SPA shell. Same class of trap as T-3.6.
+
+**T-7.4 — a bare origin exposes the whole host.** Fetch an unrelated path through the same route:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $GW" \
+  "$ORIGIN/gateway/skill/pdf/anthropics/courses/refs/heads/master/prompt_engineering_interactive_tutorial/README.md"
+```
+
+Returns `200`. The sub-path stays inside the route prefix and the SSRF pin locks the host, so this is the documented behaviour. A target that names one file confines the route to that file, which is tighter. Record which shape each fixture uses.
+
+**T-7.5 — a PUT-flipped skill stores no `proxy_client_url`.** The field is server-derived, so it never appears in a request body and `exclude_unset` never writes it. Reads recompute it through `populate_proxy_client_url`, and nginx generation recomputes it too, so the API, the UI, and routing all agree. Pass: the API returns the client URL even though Mongo has no such field. A raw projection that skips the model sees `null`.
+
+## 8. Teardown
+
+```bash
+for n in api-ninjas-weather openmeteo-forecast openai-proxy bedrock-proxy-use2; do
+  U=$(curl -sS -H "Authorization: Bearer $GW" $ORIGIN/api/custom/rest-endpoint \
+      | jq -r --arg n "$n" '.records[] | select(.name==$n) | .path | split("/")[2]')
+  [ -n "$U" ] && curl -sS -X DELETE -H "Authorization: Bearer $GW" \
+    -o /dev/null -w "$n -> %{http_code}\n" "$ORIGIN/api/custom/rest-endpoint/$U"
+done
+
+curl -sS -X PUT $ORIGIN/api/skills/pdf \
+  -H "Authorization: Bearer $GW" -H 'Content-Type: application/json' \
+  -d '{"name":"pdf","description":"Backwards compat update test",
+       "skill_md_url":"https://raw.githubusercontent.com/anthropics/courses/refs/heads/master/prompt_engineering_interactive_tutorial/README.md",
+       "is_proxied":false}' -o /dev/null -w 'pdf unproxied -> %{http_code}\n'
+```
+
+Then confirm no route survives:
+
+```bash
+docker exec mcp-gateway-registry-registry-1 grep -c 'gateway/rest-endpoint\|gateway/skill' \
+  /etc/nginx/conf.d/nginx_rev_proxy.conf
+```
+
+## 9. Failure reference
+
+| Symptom | Cause |
+|---|---|
+| `301` | The trailing slash is missing. The location ends in one. `curl -L` follows it, and a POST becomes a GET when it does. |
+| `200 text/html`, 889 bytes | No proxy location matched, so nginx served the SPA. Wrong entity-type spelling (`skills` for `skill`), or the entity is not proxied. Check `content_type`, not the status. |
+| `401` from the gateway | Expired or missing token, or the equal-token guard fired because `Authorization` matched `X-Authorization`. |
+| `403` from the gateway | The group holds no rule granting this verb on this authz key. `methods: ["all"]` does not count. |
+| `502 {"detail":"Upstream auth unavailable"}` | The vend failed and the hop refused. Causes: `SECRET_KEY` changed since the credential was stored, corrupt ciphertext, the registry `:8091` vend listener unreachable, or a target-identity mismatch. Grep the registry log for `upstream-headers REFUSED`; it names the branch. |
+| `503` | The streaming slot pool is full (`GATEWAY_GENERIC_STREAM_MAX_CONCURRENCY`). |
+| `Missing API Key.` right after a rotation | The nginx reload has not landed. Wait and retry. |
+| Backend 401 or 403 | The key is stale, or wrong for the region. The passthrough itself worked. |
+
+## 10. Coverage gaps
+
+No test in this suite covers these yet.
+
+- Five of the six vend refusal branches: body and token mismatch, invalid target identity, token target against canonical URL, credential headers on a non-HTTPS target, duplicate stored names. Section 5 covers decrypt failure only.
+- Streaming limits: byte cap to 413, absolute duration ceiling, slot exhaustion to 503, idle read timeout, client disconnect. The scripted clients prove incremental delivery, nothing more.
+- The `Authorization` carve-out on a stored operator default. Registration accepts the name only as caller-overridable, and a mismatch between what registration accepts and what the strict decrypt allows produces an entity that 502s on every request.
+- Repoint clearing. Patch `proxy_target_url` to another host and confirm the stored headers are wiped so the old host's secret cannot reach the new one.
+- The scope boundary on a credentialed entity. Call F3 with a non-admin token. One operator credential serves every authorized caller, so the scope check is the only thing standing between a low-privilege caller and spending it.
+- Federation stripping of `proxy_connect_notes` and the header fields, both directions.
+- Non-admin redaction of `proxy_target_url` while `is_proxied` stays visible.
+- Agents. `a2a_agent` is a proxyable type and its target falls back to the agent's own `url`, so flipping `is_proxied` needs no explicit target. Patching `url` repoints the backend and must re-validate, re-pin, and clear stored headers.
+- `/api/config` exposure of the five streaming settings.
+- All six `stream_outcome_total{outcome}` values, so in-flight equals started minus the terminals.
+
+## 11. Result log
+
+| Date | Release | Sections run | Result | Notes |
+|---|---|---|---|---|
+| | | | | |

--- a/tests/scripts/gateway_test_support.py
+++ b/tests/scripts/gateway_test_support.py
@@ -144,7 +144,7 @@ def read_api_key(
     """
     env_key = (os.environ.get(env_var) or "").strip()
     if env_key:
-        logger.info("Backend key : from %s (sent as Authorization)", env_var)
+        logger.info("Backend key : loaded from environment (sent as Authorization)")
         return env_key
 
     if not api_key_file:
@@ -158,7 +158,7 @@ def read_api_key(
     key = path.read_text().strip()
     if not key:
         raise GatewayClientError(f"Backend key file is empty: {api_key_file}")
-    logger.info("Backend key : from %s (sent as Authorization)", api_key_file)
+    logger.info("Backend key : loaded from file (sent as Authorization)")
     return key
 
 

--- a/tests/scripts/gateway_test_support.py
+++ b/tests/scripts/gateway_test_support.py
@@ -247,8 +247,9 @@ def select_record(
 
     Args:
         records: Proxied custom records.
-        selector: Case-insensitive substring matched against name, path, and
-            client URL. Takes precedence over ``target_hint``.
+        selector: An exact name wins outright; otherwise a case-insensitive
+            substring matched against name, path, and client URL. Takes
+            precedence over ``target_hint``.
         target_hint: Substring of ``proxy_target_url`` identifying this client's
             backend (e.g. ``api.openai.com``), used when no selector is given so a
             registry holding several proxied entities still resolves cleanly.
@@ -268,6 +269,12 @@ def select_record(
 
     if selector:
         needle = selector.lower()
+        # An exact name wins before substring matching, so a selector that is also
+        # a prefix of another record ('openai-proxy' alongside
+        # 'openai-proxy-default-auth') resolves instead of reporting ambiguity.
+        exact = [r for r in records if str(r.get("name", "")).lower() == needle]
+        if len(exact) == 1:
+            return exact[0]
         matches = [
             r
             for r in records
@@ -517,7 +524,7 @@ def add_common_arguments(
     )
     parser.add_argument(
         "--entity",
-        help="Substring selecting the proxied custom record (name, path, or client URL)",
+        help="Proxied custom record: an exact name, else a substring of name, path, or client URL",
     )
     parser.add_argument(
         "--client-path",

--- a/tests/scripts/gateway_test_support.py
+++ b/tests/scripts/gateway_test_support.py
@@ -504,8 +504,7 @@ def add_common_arguments(
         "--token-file",
         default=DEFAULT_TOKEN_FILE,
         help=(
-            "File holding the gateway JWT, sent as X-Authorization "
-            f"(default: {DEFAULT_TOKEN_FILE})"
+            f"File holding the gateway JWT, sent as X-Authorization (default: {DEFAULT_TOKEN_FILE})"
         ),
     )
     parser.add_argument(

--- a/tests/scripts/gateway_test_support.py
+++ b/tests/scripts/gateway_test_support.py
@@ -1,0 +1,643 @@
+#!/usr/bin/env python3
+"""Shared plumbing for the gateway generic-proxy test clients.
+
+Both ``openai_gateway_client.py`` and ``bedrock_gateway_client.py`` drive a proxied
+custom-entity record through the gateway; only the upstream API shape differs.
+Everything that is about the GATEWAY -- credential split, entity discovery,
+per-verb scope authorization, failure interpretation -- lives here so the two
+clients cannot drift apart.
+
+The credential split is the load-bearing convention (see
+docs/design/gateway-generic-proxy.md, "Caller header passthrough"):
+
+- gateway JWT  -> ``X-Authorization``  authenticates ingress.
+- backend key  -> ``Authorization``    forwarded to the upstream, admitted only
+  because the entity registers ``Authorization`` as caller-OVERRIDABLE. Sending
+  the gateway JWT in both trips the equal-token guard (401).
+"""
+
+import argparse
+import base64
+import binascii
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TOKEN_FILE: str = ".token"
+DEFAULT_REGISTRY_URL: str = "http://localhost"
+DEFAULT_SCOPE_GROUP: str = "registry-admins"
+REQUEST_TIMEOUT_SECONDS: int = 60
+
+
+class GatewayClientError(RuntimeError):
+    """A prerequisite or gateway-side failure with an operator-facing message."""
+
+
+def configure_logging(
+    debug: bool = False,
+) -> None:
+    """Install the shared log format used by both clients.
+
+    Args:
+        debug: Enable DEBUG level.
+    """
+    logging.basicConfig(
+        level=logging.DEBUG if debug else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+
+def read_access_token(
+    token_file: str,
+) -> str:
+    """Read the gateway JWT from a raw-text or nested-JSON token file.
+
+    Accepts the three shapes the repo's tooling produces: a bare JWT,
+    ``{"access_token": ...}``, and the nested ``{"tokens": {"access_token": ...}}``
+    written by the credential providers.
+
+    Args:
+        token_file: Path to the token file.
+
+    Returns:
+        The bearer token value, stripped.
+
+    Raises:
+        GatewayClientError: The file is missing, empty, or carries no token.
+    """
+    path = Path(token_file)
+    if not path.exists():
+        raise GatewayClientError(
+            f"Gateway token file not found: {token_file}\n"
+            "Generate one, or point --token-file at an existing token."
+        )
+    raw = path.read_text().strip()
+    if not raw:
+        raise GatewayClientError(f"Gateway token file is empty: {token_file}")
+
+    try:
+        blob = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+    if isinstance(blob, dict):
+        nested = blob.get("tokens")
+        token = blob.get("access_token") or (
+            nested.get("access_token") if isinstance(nested, dict) else None
+        )
+        if token:
+            return str(token).strip()
+    raise GatewayClientError(f"Could not find an access token in {token_file}")
+
+
+def token_lifetime_seconds(
+    token: str,
+) -> int | None:
+    """Return seconds until the JWT expires, or None if it cannot be read.
+
+    Decodes the payload WITHOUT verifying the signature: a usability check (a
+    stale token yields a confusing 401), never an authorization decision.
+
+    Args:
+        token: The bearer token.
+
+    Returns:
+        Remaining lifetime in seconds, or None when undecodable / no ``exp``.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    payload = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return None
+    exp = claims.get("exp")
+    return int(exp - time.time()) if isinstance(exp, int | float) else None
+
+
+def read_api_key(
+    api_key_file: str | None,
+    env_var: str,
+) -> str:
+    """Resolve the upstream API key from the environment or a file.
+
+    The environment variable wins so CI can inject the key without touching disk.
+
+    Args:
+        api_key_file: Path to a file containing the key (raw text), or None.
+        env_var: Environment variable consulted first (e.g. ``OPENAI_API_KEY``).
+
+    Returns:
+        The API key, stripped.
+
+    Raises:
+        GatewayClientError: Neither source yields a key.
+    """
+    env_key = (os.environ.get(env_var) or "").strip()
+    if env_key:
+        logger.info("Backend key : from %s (sent as Authorization)", env_var)
+        return env_key
+
+    if not api_key_file:
+        raise GatewayClientError(
+            f"No backend key: set {env_var} or pass --api-key-file.\n"
+            "It is forwarded as the caller-overridable Authorization header."
+        )
+    path = Path(api_key_file)
+    if not path.exists():
+        raise GatewayClientError(f"Backend key file not found: {api_key_file} (or set {env_var})")
+    key = path.read_text().strip()
+    if not key:
+        raise GatewayClientError(f"Backend key file is empty: {api_key_file}")
+    logger.info("Backend key : from %s (sent as Authorization)", api_key_file)
+    return key
+
+
+def api_session(
+    token: str,
+) -> requests.Session:
+    """Build a session that authenticates to the registry management API.
+
+    The registry API itself takes the gateway JWT in ``Authorization``; only the
+    proxied hop needs the ``X-Authorization`` split.
+
+    Args:
+        token: The gateway JWT.
+
+    Returns:
+        A session with the bearer header applied.
+    """
+    session = requests.Session()
+    session.headers.update({"Authorization": f"Bearer {token}"})
+    return session
+
+
+def get_json(
+    session: requests.Session,
+    url: str,
+) -> Any:
+    """GET a registry endpoint and return the decoded JSON body.
+
+    Args:
+        session: An authenticated session.
+        url: Absolute URL to fetch.
+
+    Returns:
+        The decoded JSON body.
+
+    Raises:
+        GatewayClientError: Non-2xx status or an undecodable body.
+    """
+    response = session.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
+    if response.status_code >= 400:
+        raise GatewayClientError(f"GET {url} -> HTTP {response.status_code}: {response.text[:300]}")
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise GatewayClientError(f"GET {url} returned non-JSON: {response.text[:200]}") from exc
+
+
+def proxied_custom_records(
+    session: requests.Session,
+    registry_url: str,
+) -> list[dict[str, Any]]:
+    """List every proxied custom-entity record the caller can see.
+
+    Walks the custom-type descriptors, then each type's records, keeping rows that
+    carry ``is_proxied`` plus the server-derived ``proxy_client_url``. Same read
+    model ``registry_management.py custom-record-list`` prints: header NAMES are
+    present, values never are.
+
+    Args:
+        session: An authenticated session.
+        registry_url: Registry base URL, no trailing slash.
+
+    Returns:
+        Matching record dicts, each with ``entity_type`` filled in.
+    """
+    types_body = get_json(session, f"{registry_url}/api/custom-types")
+    type_names = [t["name"] for t in types_body.get("custom_types", []) if t.get("name")]
+
+    found: list[dict[str, Any]] = []
+    for type_name in type_names:
+        body = get_json(session, f"{registry_url}/api/custom/{type_name}?limit=200")
+        records = body.get("records") if isinstance(body, dict) else body
+        for record in records or []:
+            if record.get("is_proxied") and record.get("proxy_client_url"):
+                record.setdefault("entity_type", type_name)
+                found.append(record)
+    return found
+
+
+def select_record(
+    records: list[dict[str, Any]],
+    selector: str | None,
+    target_hint: str | None = None,
+) -> dict[str, Any]:
+    """Pick the record to test, by selector, backend hint, or sole candidate.
+
+    Args:
+        records: Proxied custom records.
+        selector: Case-insensitive substring matched against name, path, and
+            client URL. Takes precedence over ``target_hint``.
+        target_hint: Substring of ``proxy_target_url`` identifying this client's
+            backend (e.g. ``api.openai.com``), used when no selector is given so a
+            registry holding several proxied entities still resolves cleanly.
+
+    Returns:
+        The selected record.
+
+    Raises:
+        GatewayClientError: Nothing matched, or the choice is ambiguous.
+    """
+    if not records:
+        raise GatewayClientError(
+            "No proxied custom records found. Register one with is_proxied=true, a "
+            "proxy_target_url, and an overridable Authorization upstream header "
+            "(UI, or 'api/registry_management.py custom-proxy-create')."
+        )
+
+    if selector:
+        needle = selector.lower()
+        matches = [
+            r
+            for r in records
+            if needle in str(r.get("name", "")).lower()
+            or needle in str(r.get("path", "")).lower()
+            or needle in str(r.get("proxy_client_url", "")).lower()
+        ]
+        criterion = f"--entity {selector!r}"
+    elif target_hint and len(records) > 1:
+        matches = [r for r in records if target_hint in str(r.get("proxy_target_url", "")).lower()]
+        criterion = f"a backend containing {target_hint!r}"
+    else:
+        matches = records
+        criterion = "the only proxied record"
+
+    if not matches:
+        known = ", ".join(f"{r.get('entity_type')}/{r.get('name')}" for r in records)
+        raise GatewayClientError(f"No proxied record matches {criterion}. Known: {known}")
+    if len(matches) > 1:
+        known = ", ".join(f"{r.get('entity_type')}/{r.get('name')}" for r in matches)
+        raise GatewayClientError(f"Ambiguous target ({known}); narrow it with --entity.")
+    return matches[0]
+
+
+def authz_key(
+    record: dict[str, Any],
+) -> str:
+    """Return the scope key the generic hop authorizes against.
+
+    ``/validate`` composes ``{entity_type}/{registered_path}`` from the server-set
+    nginx markers, so a custom record whose path already carries its type token
+    yields a doubled-looking key (``rest-endpoint/rest-endpoint/<uuid>``). That is
+    the exact string a scope rule must name -- the bare path 403s.
+
+    Args:
+        record: A proxied record carrying ``entity_type`` and ``path``.
+
+    Returns:
+        The canonical authz key.
+    """
+    return f"{record['entity_type']}/{str(record.get('path', '')).strip('/')}"
+
+
+def report_record(
+    record: dict[str, Any],
+    expect_streaming: bool = False,
+) -> None:
+    """Log the proxy read model and warn about setups that cannot work.
+
+    Args:
+        record: The selected proxied record.
+        expect_streaming: True when the caller intends to run a streaming check,
+            so a buffered entity is worth warning about.
+    """
+    overridable = record.get("custom_header_overridable_names") or []
+    logger.info("Entity      : %s/%s", record.get("entity_type"), record.get("name"))
+    logger.info("Client URL  : %s", record.get("proxy_client_url"))
+    logger.info("Backend     : %s", record.get("proxy_target_url") or "(redacted for non-admin)")
+    logger.info("Streaming   : %s", bool(record.get("proxy_streaming")))
+    logger.info(
+        "Header names: %s (overridable: %s)",
+        record.get("custom_header_names") or [],
+        overridable,
+    )
+    logger.info("Authz key   : %s", authz_key(record))
+    if record.get("proxy_connect_notes"):
+        logger.info("Notes       : %s", record["proxy_connect_notes"])
+
+    if "authorization" not in {str(n).lower() for n in overridable}:
+        logger.warning(
+            "Authorization is NOT registered as an overridable upstream header: the "
+            "backend key will be dropped on egress and the upstream will answer 401/403."
+        )
+    if expect_streaming and not record.get("proxy_streaming"):
+        logger.warning(
+            "proxy_streaming is false: a streaming check still returns a body, but the "
+            "hop buffers it, so the incremental-delivery assertion will fail."
+        )
+
+
+def _rule_grants(
+    rule: dict[str, Any],
+    key: str,
+    verbs: tuple[str, ...],
+) -> bool:
+    """Report whether one ``server_access`` rule authorizes the verbs on the key.
+
+    Mirrors ``validate_server_tool_access``: an HTTP verb matches the methods list
+    case-insensitively, or the distinct ``http:*`` token. The legacy ``all``/``*``
+    methods wildcard does NOT grant a verb (the no-escalation split), and
+    ``server:"*"`` matches any entity.
+
+    Args:
+        rule: One rule from a group's ``server_access``.
+        key: The entity's authz key.
+        verbs: Verbs that must all be authorized.
+
+    Returns:
+        True when the rule grants every verb.
+    """
+    server = str(rule.get("server", "")).strip("/")
+    if server not in {"*", key}:
+        return False
+    methods = {str(m).upper() for m in rule.get("methods", [])}
+    if "HTTP:*" in methods:
+        return True
+    return all(v in methods for v in verbs)
+
+
+def ensure_scope_grant(
+    session: requests.Session,
+    registry_url: str,
+    group: str,
+    key: str,
+    verbs: tuple[str, ...],
+    apply_changes: bool,
+) -> bool:
+    """Check -- and optionally add -- the per-verb scope rule for an entity.
+
+    Args:
+        session: An authenticated admin session.
+        registry_url: Registry base URL, no trailing slash.
+        group: Group whose scope config carries the rule.
+        key: The entity's authz key.
+        verbs: Verbs the client needs.
+        apply_changes: When True, PATCH the group to append a missing rule.
+
+    Returns:
+        True when the grant is in place (already present, or just written).
+
+    Raises:
+        GatewayClientError: The group cannot be read, or the PATCH failed.
+    """
+    detail = get_json(session, f"{registry_url}/api/management/iam/groups/{group}")
+    rules = detail.get("server_access") or []
+
+    if any(_rule_grants(r, key, verbs) for r in rules):
+        logger.info("Scope grant : present in group '%s' for %s", group, ", ".join(verbs))
+        return True
+
+    remediation = (
+        f"Group '{group}' does not authorize {', '.join(verbs)} on '{key}'.\n"
+        "Add this rule to its server_access (IAM scope editor, or re-run with "
+        "--ensure-scope):\n"
+        f'  {{"server": "{key}", "methods": {json.dumps(list(verbs))}}}\n'
+        'Note: an existing methods:["all"] rule does NOT authorize HTTP verbs -- '
+        "that split is the deliberate no-escalation guard."
+    )
+    if not apply_changes:
+        logger.warning(remediation)
+        return False
+
+    new_rules = [*rules, {"server": key, "methods": list(verbs), "tools": []}]
+    response = session.patch(
+        f"{registry_url}/api/management/iam/groups/{group}",
+        json={"scope_config": {"server_access": new_rules}},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    if response.status_code >= 400:
+        raise GatewayClientError(
+            f"Adding the scope rule failed: HTTP {response.status_code}: "
+            f"{response.text[:300]}\n{remediation}"
+        )
+    logger.info("Scope grant : added %s on '%s' to group '%s'", ", ".join(verbs), key, group)
+    return True
+
+
+# Gateway-layer meaning of each status a client may see. The upstream can also
+# emit these (a 401 from the BACKEND means the passthrough worked and the key is
+# bad), so both readings are given where they are ambiguous.
+STATUS_HINTS: dict[int, str] = {
+    401: (
+        "401 from the GATEWAY means the equal-token guard fired (the outbound "
+        "Authorization equals the gateway credential) or the JWT is stale. 401 from "
+        "the BACKEND means the key is bad -- the passthrough itself worked."
+    ),
+    403: (
+        "Scope denial or the CSRF gate at the gateway (re-run with --ensure-scope, and "
+        "keep the gateway JWT in X-Authorization). From the BACKEND: the key lacks "
+        "permission for this model/action."
+    ),
+    404: (
+        "No route: the feature is off, nginx has not reloaded, or the client path is "
+        "wrong. Check GATEWAY_GENERIC_PROXY_ENABLED and restart the registry. From the "
+        "BACKEND: wrong upstream sub-path or model id."
+    ),
+    413: "Streaming byte cap (GATEWAY_GENERIC_STREAM_MAX_BYTES) exceeded.",
+    502: (
+        "The hop refused to forward: upstream-header vend failure (fail-closed) or an "
+        "egress-guard block on the pinned target."
+    ),
+    503: (
+        "Feature latch off (startup egress self-check failed -- see "
+        "GATEWAY_EGRESS_SELFCHECK_ENABLED) or no stream slot within "
+        "GATEWAY_GENERIC_ACQUIRE_TIMEOUT_SECONDS."
+    ),
+    504: "Upstream timeout, or the absolute streaming duration ceiling fired.",
+}
+
+
+def explain_status(
+    status: int | None,
+    body: str = "",
+) -> None:
+    """Log the gateway-layer meaning of an HTTP status.
+
+    Args:
+        status: The HTTP status code, if known.
+        body: Response body excerpt to include.
+    """
+    logger.error("Upstream/gateway reported HTTP %s: %s", status, body[:300])
+    if status in STATUS_HINTS:
+        logger.error("Hint: %s", STATUS_HINTS[status])
+
+
+def add_common_arguments(
+    parser: argparse.ArgumentParser,
+    api_key_env: str,
+    default_api_key_file: str | None = None,
+) -> None:
+    """Register the CLI arguments shared by every gateway test client.
+
+    Args:
+        parser: The parser to extend.
+        api_key_env: Environment variable naming the backend key.
+        default_api_key_file: Default path for ``--api-key-file``, if any.
+    """
+    parser.add_argument(
+        "--registry-url",
+        default=DEFAULT_REGISTRY_URL,
+        help=f"Gateway/registry base URL (default: {DEFAULT_REGISTRY_URL})",
+    )
+    parser.add_argument(
+        "--token-file",
+        default=DEFAULT_TOKEN_FILE,
+        help=(
+            "File holding the gateway JWT, sent as X-Authorization "
+            f"(default: {DEFAULT_TOKEN_FILE})"
+        ),
+    )
+    parser.add_argument(
+        "--api-key-file",
+        default=default_api_key_file,
+        help=(
+            f"File holding the backend key, sent as Authorization; {api_key_env} wins"
+            + (f" (default: {default_api_key_file})" if default_api_key_file else "")
+        ),
+    )
+    parser.add_argument(
+        "--entity",
+        help="Substring selecting the proxied custom record (name, path, or client URL)",
+    )
+    parser.add_argument(
+        "--client-path",
+        help=(
+            "Explicit gateway client path (e.g. /gateway/rest-endpoint/<uuid>); skips "
+            "custom-record discovery and the scope check"
+        ),
+    )
+    parser.add_argument(
+        "--ensure-scope",
+        action="store_true",
+        help="Write the missing per-verb scope rule to --scope-group instead of only reporting it",
+    )
+    parser.add_argument(
+        "--scope-group",
+        default=DEFAULT_SCOPE_GROUP,
+        help=f"Group whose scope config carries the rule (default: {DEFAULT_SCOPE_GROUP})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=REQUEST_TIMEOUT_SECONDS,
+        help=f"Per-request timeout in seconds (default: {REQUEST_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+
+def preflight(
+    args: argparse.Namespace,
+    api_key_env: str,
+    verbs: tuple[str, ...],
+    target_hint: str | None = None,
+    expect_streaming: bool = False,
+) -> tuple[str, str, str]:
+    """Resolve credentials and the client path, reporting every prerequisite.
+
+    Args:
+        args: Parsed arguments carrying the common options.
+        api_key_env: Environment variable naming the backend key.
+        verbs: HTTP verbs the client will use (checked against the scope config).
+        target_hint: Backend substring used to disambiguate discovery.
+        expect_streaming: Whether a streaming check will run.
+
+    Returns:
+        ``(gateway_token, api_key, client_path)``.
+
+    Raises:
+        GatewayClientError: Any prerequisite is missing or unusable.
+    """
+    registry_url = args.registry_url.rstrip("/")
+
+    token = read_access_token(args.token_file)
+    lifetime = token_lifetime_seconds(token)
+    if lifetime is not None:
+        if lifetime <= 0:
+            raise GatewayClientError(
+                f"The gateway token in {args.token_file} expired {-lifetime}s ago; "
+                "refresh it before testing."
+            )
+        logger.info(
+            "Gateway JWT : %s (expires in %ds, sent as X-Authorization)",
+            args.token_file,
+            lifetime,
+        )
+
+    api_key = read_api_key(args.api_key_file, api_key_env)
+    session = api_session(token)
+
+    if args.client_path:
+        client_path = args.client_path
+        logger.info("Client URL  : %s (explicit; skipping record + scope checks)", client_path)
+        return token, api_key, client_path
+
+    record = select_record(proxied_custom_records(session, registry_url), args.entity, target_hint)
+    report_record(record, expect_streaming=expect_streaming)
+    ensure_scope_grant(
+        session=session,
+        registry_url=registry_url,
+        group=args.scope_group,
+        key=authz_key(record),
+        verbs=verbs,
+        apply_changes=args.ensure_scope,
+    )
+    return token, api_key, str(record["proxy_client_url"])
+
+
+def run_checks(
+    checks: dict[str, Any],
+    selected: list[str],
+) -> int:
+    """Run the selected checks, isolating failures, and log a summary.
+
+    Args:
+        checks: Mapping of check name -> zero-arg callable returning a bool.
+        selected: Names to run, in order.
+
+    Returns:
+        Process exit code: 0 when all passed, 1 otherwise.
+    """
+    failures = 0
+    for name in selected:
+        try:
+            if not checks[name]():
+                failures += 1
+        except GatewayClientError as exc:
+            logger.error("%s: %s", name, exc)
+            failures += 1
+        except Exception as exc:  # noqa: BLE001 - report any transport/SDK failure per check
+            logger.error("%s: FAILED - %s: %s", name, type(exc).__name__, exc)
+            status = getattr(exc, "status_code", None)
+            if status is not None:
+                response = getattr(exc, "response", None)
+                explain_status(status, getattr(response, "text", "") or "")
+            failures += 1
+
+    logger.info(
+        "Summary     : %d/%d checks passed (%s)",
+        len(selected) - failures,
+        len(selected),
+        ", ".join(selected),
+    )
+    return 1 if failures else 0

--- a/tests/scripts/openai_gateway_client.py
+++ b/tests/scripts/openai_gateway_client.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Drive the OpenAI SDK through the gateway's generic proxy (PR #1714).
+
+Exercises the gateway-proxy-any-resource feature end to end against a proxied
+custom-entity record that fronts ``https://api.openai.com``: the official
+``openai`` client is pointed at the entity's gateway client URL, so the SDK's own
+``Authorization: Bearer <openai-key>`` header travels the caller-passthrough path.
+
+Credential split (both required; swapping them fails closed):
+
+- ``.token``           -> ``X-Authorization``  gateway JWT authenticating ingress.
+- ``.scratchpad/.oai`` -> ``Authorization``    the backend key the gateway forwards,
+  admitted only because the entity registers ``Authorization`` as caller-
+  OVERRIDABLE (a FIXED ``Authorization`` value is rejected by the registry --
+  operator-owned bearers belong in the egress credential vault). Sending the
+  gateway JWT in both trips ``_assert_generic_authorization_not_gateway_cred``.
+
+What each mode proves:
+
+- ``models``  GET verb authz + buffered hop (``GET /v1/models``).
+- ``chat``    POST verb authz + CSRF Bearer exemption + buffered hop.
+- ``stream``  the signed ``streaming`` token claim: SSE chunks are reported with
+              time-to-first-chunk, chunk count, and the largest inter-chunk gap,
+              so an accidentally BUFFERED response (one chunk, or every chunk at
+              the same instant) fails loudly instead of passing on a 200.
+
+Prerequisites (verified and reported before the first OpenAI call):
+
+1. ``GATEWAY_GENERIC_PROXY_ENABLED=true`` in ``.env``, stack rebuilt.
+2. A proxied custom record with ``proxy_target_url=https://api.openai.com`` and an
+   overridable ``Authorization`` upstream header. Inspect it with::
+
+       uv run python api/registry_management.py --registry-url http://localhost \\
+           --token-file .token custom-record-list --type rest-endpoint --json
+
+3. A scope grant for the entity's authz key. The legacy ``methods:["all"]``
+   wildcard deliberately does NOT authorize an HTTP verb, so the admin group needs
+   an explicit rule; ``--ensure-scope`` writes it idempotently.
+
+Examples::
+
+    uv run python tests/scripts/openai_gateway_client.py --ensure-scope
+    uv run python tests/scripts/openai_gateway_client.py --mode stream \\
+        --prompt "Count slowly from 1 to 10."
+    uv run python tests/scripts/openai_gateway_client.py \\
+        --client-path /gateway/skill/skills/openai-proxy --mode chat
+
+Neither secret is logged: the key goes straight to the SDK, the JWT only ever
+travels as a header.
+"""
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# tests/scripts is not a package (these are run directly, like call_mcp_tool.py),
+# so make the sibling support module importable.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import gateway_test_support as gw  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+API_KEY_ENV: str = "OPENAI_API_KEY"
+DEFAULT_API_KEY_FILE: str = ".scratchpad/.oai"
+DEFAULT_MODEL: str = "gpt-4o-mini"
+DEFAULT_PROMPT: str = "Say hello in exactly five words."
+# Backend substring identifying this client's entity during discovery.
+TARGET_HINT: str = "api.openai.com"
+# GET /v1/models and POST /v1/chat/completions.
+REQUIRED_VERBS: tuple[str, ...] = ("GET", "POST")
+
+
+def build_client(
+    base_url: str,
+    api_key: str,
+    gateway_token: str,
+    timeout: int,
+) -> Any:
+    """Construct an OpenAI SDK client that speaks through the gateway.
+
+    The SDK puts ``api_key`` in ``Authorization`` -- exactly the header the entity
+    registers as caller-overridable -- while the gateway credential rides in
+    ``X-Authorization``. Retries are disabled so a gateway 5xx surfaces instead of
+    being masked by a retry.
+
+    Args:
+        base_url: OpenAI-compatible base, i.e. the gateway client URL + ``/v1``.
+        api_key: The OpenAI API key (forwarded to the backend).
+        gateway_token: The gateway JWT authenticating ingress.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        A configured ``openai.OpenAI`` instance.
+
+    Raises:
+        GatewayClientError: The ``openai`` package is not installed.
+    """
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise gw.GatewayClientError(
+            "The 'openai' package is required: uv pip install openai"
+        ) from exc
+
+    return OpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        default_headers={"X-Authorization": f"Bearer {gateway_token}"},
+        timeout=float(timeout),
+        max_retries=0,
+    )
+
+
+def check_models(
+    client: Any,
+) -> bool:
+    """Run ``GET /v1/models`` through the gateway (buffered hop, GET authz).
+
+    Args:
+        client: The configured OpenAI client.
+
+    Returns:
+        True on success.
+    """
+    started = time.monotonic()
+    models = client.models.list()
+    ids = [m.id for m in models.data][:5]
+    logger.info(
+        "models      : OK %d models in %.2fs (e.g. %s)",
+        len(models.data),
+        time.monotonic() - started,
+        ", ".join(ids),
+    )
+    return True
+
+
+def check_chat(
+    client: Any,
+    model: str,
+    prompt: str,
+) -> bool:
+    """Run a non-streaming chat completion (buffered hop, POST authz + CSRF gate).
+
+    Args:
+        client: The configured OpenAI client.
+        model: Model id.
+        prompt: User prompt.
+
+    Returns:
+        True on success.
+    """
+    started = time.monotonic()
+    completion = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        stream=False,
+    )
+    content = (completion.choices[0].message.content or "").strip()
+    logger.info("chat        : OK in %.2fs -> %r", time.monotonic() - started, content[:160])
+    return True
+
+
+def check_stream(
+    client: Any,
+    model: str,
+    prompt: str,
+) -> bool:
+    """Run a streaming chat completion and report incremental-delivery evidence.
+
+    Times the first chunk, counts chunks, and records the largest inter-chunk gap.
+    A single chunk (or a zero span across many) means the response was buffered
+    somewhere -- the entity's ``proxy_streaming`` claim, nginx ``proxy_buffering``,
+    or the hop -- so the check fails instead of passing on a 200.
+
+    Args:
+        client: The configured OpenAI client.
+        model: Model id.
+        prompt: User prompt.
+
+    Returns:
+        True when more than one chunk arrived over a non-zero span.
+    """
+    started = time.monotonic()
+    first_chunk_at: float | None = None
+    last_chunk_at = started
+    max_gap = 0.0
+    chunks = 0
+    pieces: list[str] = []
+
+    stream = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        stream=True,
+    )
+    for chunk in stream:
+        now = time.monotonic()
+        if first_chunk_at is None:
+            first_chunk_at = now
+        else:
+            max_gap = max(max_gap, now - last_chunk_at)
+        last_chunk_at = now
+        chunks += 1
+        for choice in chunk.choices:
+            if choice.delta and choice.delta.content:
+                pieces.append(choice.delta.content)
+
+    if first_chunk_at is None:
+        logger.error("stream      : FAILED - the stream produced no chunks")
+        return False
+
+    span = last_chunk_at - first_chunk_at
+    logger.info(
+        "stream      : %d chunks, first at %.2fs, span %.2fs, max gap %.3fs -> %r",
+        chunks,
+        first_chunk_at - started,
+        span,
+        max_gap,
+        "".join(pieces).strip()[:160],
+    )
+    if chunks <= 1 or span <= 0.0:
+        logger.error(
+            "stream      : FAILED - not incremental (chunks=%d, span=%.3fs). Check "
+            "proxy_streaming on the entity and that nginx rendered 'proxy_buffering "
+            "off' for this route.",
+            chunks,
+            span,
+        )
+        return False
+    logger.info("stream      : OK (incremental delivery confirmed)")
+    return True
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Exercise gateway generic-proxy routing with the OpenAI SDK.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    gw.add_common_arguments(parser, API_KEY_ENV, DEFAULT_API_KEY_FILE)
+    parser.add_argument(
+        "--mode",
+        choices=["models", "chat", "stream", "all"],
+        default="all",
+        help="Which checks to run (default: all)",
+    )
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help=f"Model id (default: {DEFAULT_MODEL})"
+    )
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="User prompt for chat/stream")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Resolve the target, verify prerequisites, and run the selected checks.
+
+    Returns:
+        0 when every selected check passed, 1 on a check failure, 2 on a
+        prerequisite/configuration error.
+    """
+    args = _parse_args()
+    gw.configure_logging(args.debug)
+
+    try:
+        token, api_key, client_path = gw.preflight(
+            args,
+            api_key_env=API_KEY_ENV,
+            verbs=REQUIRED_VERBS,
+            target_hint=TARGET_HINT,
+            expect_streaming=args.mode in {"stream", "all"},
+        )
+        base_url = f"{args.registry_url.rstrip('/')}{client_path.rstrip('/')}/v1"
+        logger.info("OpenAI base : %s", base_url)
+        client = build_client(
+            base_url=base_url,
+            api_key=api_key,
+            gateway_token=token,
+            timeout=args.timeout,
+        )
+    except gw.GatewayClientError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    checks = {
+        "models": lambda: check_models(client),
+        "chat": lambda: check_chat(client, args.model, args.prompt),
+        "stream": lambda: check_stream(client, args.model, args.prompt),
+    }
+    selected = list(checks) if args.mode == "all" else [args.mode]
+    return gw.run_checks(checks, selected)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/verify_caller_creds.py
+++ b/tests/scripts/verify_caller_creds.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Confirm YOUR OpenAI key works through the gateway, and that the gateway holds none.
+
+Two calls against the same proxied entity:
+
+  1. WITH your key in Authorization  -> 200, model list. Your credential reached OpenAI.
+  2. WITHOUT it                      -> 401. The gateway stores no default, so there is
+                                        nothing to inject and the backend refuses.
+
+The gateway JWT always rides X-Authorization. Sending it in Authorization instead
+trips the equal-token guard and returns 401 from the gateway rather than OpenAI.
+
+Usage (from the repository root):
+
+    uv run python tests/scripts/verify_caller_creds.py
+    uv run python tests/scripts/verify_caller_creds.py --entity openai-proxy-default-auth
+    uv run python tests/scripts/verify_caller_creds.py --registry-url http://localhost
+"""
+
+import argparse
+import base64
+import json
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+DEFAULT_REGISTRY_URL = "http://localhost"
+DEFAULT_TOKEN_FILE = ".token"
+DEFAULT_API_KEY_FILE = ".scratchpad/.oai"
+DEFAULT_ENTITY = "openai-proxy"
+TIMEOUT_SECONDS = 60
+
+
+def _read_secret(path: str) -> str:
+    """Read a credential from a file, or exit with an operator-facing message.
+
+    Args:
+        path: File holding the secret.
+
+    Returns:
+        The secret, stripped.
+    """
+    p = Path(path)
+    if not p.is_file() or not p.stat().st_size:
+        sys.exit(f"FATAL: missing or empty credential file {path}")
+    return p.read_text().strip()
+
+
+def _gateway_token(token_file: str) -> str:
+    """Read the gateway JWT and refuse an expired one.
+
+    Args:
+        token_file: JSON file holding tokens.access_token.
+
+    Returns:
+        The access token.
+    """
+    raw = _read_secret(token_file)
+    token = json.loads(raw)["tokens"]["access_token"]
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    left = json.loads(base64.urlsafe_b64decode(payload))["exp"] - int(time.time())
+    if left <= 0:
+        sys.exit(f"FATAL: gateway token expired {abs(left) // 60} minutes ago; regenerate it")
+    print(f"gateway token : valid for {left // 60} more minutes")
+    return token
+
+
+def _resolve_base(registry_url: str, token: str, entity: str) -> str:
+    """Look up the entity's client URL instead of hand-assembling it.
+
+    Args:
+        registry_url: Registry base URL.
+        token: Gateway JWT.
+        entity: Record name to match.
+
+    Returns:
+        Absolute base URL with a trailing slash.
+    """
+    try:
+        r = requests.get(
+            f"{registry_url}/api/custom/rest-endpoint",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        sys.exit(
+            f"FATAL: cannot reach {registry_url} ({type(exc).__name__}).\n"
+            "       Check the URL, and that the stack is up."
+        )
+
+    # Explain the likely cause rather than raising. A token is scoped to the
+    # deployment whose auth-server signed it, and the failure mode that costs the
+    # most time is pointing a valid-looking token at the wrong registry.
+    if r.status_code == 401:
+        sys.exit(
+            f"FATAL: {registry_url} rejected the token from {DEFAULT_TOKEN_FILE!r} (401).\n"
+            "       A gateway JWT is only valid for the deployment whose auth-server\n"
+            "       signed it: iss and aud are identical across deployments, but each\n"
+            "       signs with its own SECRET_KEY. Generate a token from THIS registry's\n"
+            "       UI (Get JWT Token) and pass it with --token-file, or point\n"
+            "       --registry-url at the deployment the current token came from."
+        )
+    if r.status_code == 403:
+        sys.exit(
+            f"FATAL: {registry_url} returned 403 for the custom-record list.\n"
+            "       The caller lacks list_rest-endpoint_entity (or admin) on this registry."
+        )
+    if r.status_code == 404:
+        sys.exit(
+            f"FATAL: {registry_url} has no /api/custom/rest-endpoint route (404).\n"
+            "       CUSTOM_ENTITY_TYPES_ENABLED is false there, so the custom-entity\n"
+            "       routers are never registered (registry/main.py), or the\n"
+            "       'rest-endpoint' type does not exist yet."
+        )
+    if r.status_code != 200:
+        sys.exit(f"FATAL: {registry_url} returned HTTP {r.status_code}: {r.text[:200]}")
+
+    for rec in r.json().get("records", []):
+        if rec.get("name") == entity:
+            if not rec.get("proxy_client_url"):
+                sys.exit(f"FATAL: {entity} is not proxied (no proxy_client_url)")
+            print(f"entity        : {entity}")
+            print(f"upstream auth : names={rec.get('custom_header_names')} "
+                  f"overridable={rec.get('custom_header_overridable_names')}")
+            # Trailing slash matters: the nginx location ends in one, so the bare
+            # path answers 301 and a POST would be downgraded to GET.
+            return registry_url + rec["proxy_client_url"].rstrip("/") + "/"
+
+    names = sorted(x.get("name", "?") for x in r.json().get("records", []))
+    sys.exit(
+        f"FATAL: no proxied record named {entity!r} on {registry_url}.\n"
+        f"       records present: {', '.join(names) or '(none)'}"
+    )
+
+
+def main() -> int:
+    """Run both calls and report whether the caller's credential is the one in use."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--registry-url", default=DEFAULT_REGISTRY_URL)
+    ap.add_argument("--token-file", default=DEFAULT_TOKEN_FILE)
+    ap.add_argument("--api-key-file", default=DEFAULT_API_KEY_FILE)
+    ap.add_argument("--entity", default=DEFAULT_ENTITY)
+    args = ap.parse_args()
+
+    token = _gateway_token(args.token_file)
+    api_key = _read_secret(args.api_key_file)
+    base = _resolve_base(args.registry_url, token, args.entity)
+    print(f"client URL    : {base}\n")
+
+    # requests sets Accept-Encoding and decompresses for us. Plain curl does not,
+    # which is why the same call prints unreadable gzip bytes without --compressed.
+    with_key = requests.get(
+        f"{base}v1/models",
+        headers={"X-Authorization": f"Bearer {token}", "Authorization": f"Bearer {api_key}"},
+        timeout=TIMEOUT_SECONDS,
+    )
+    without_key = requests.get(
+        f"{base}v1/models",
+        headers={"X-Authorization": f"Bearer {token}"},
+        timeout=TIMEOUT_SECONDS,
+    )
+
+    ok_with = with_key.status_code == 200 and "data" in with_key.json()
+    models = len(with_key.json().get("data", [])) if ok_with else 0
+    print(f"with your key    : HTTP {with_key.status_code}  "
+          + (f"{models} models, first={with_key.json()['data'][0]['id']}" if ok_with
+             else with_key.text[:120]))
+
+    detail = ""
+    try:
+        body = without_key.json()
+        detail = body.get("error", {}).get("message") or body.get("detail") or ""
+    except ValueError:
+        detail = without_key.text[:120]
+    print(f"without your key : HTTP {without_key.status_code}  {detail}")
+
+    print()
+    if ok_with and without_key.status_code == 401:
+        print("PASS: your key is the credential in use, and the gateway stores none.")
+        return 0
+    if ok_with and without_key.status_code == 200:
+        print("FAIL: the call succeeded WITHOUT your key, so a stored operator default")
+        print("      is being injected. Clear it, then re-add the name only:")
+        print('        PATCH .../upstream-headers  {"custom_headers": []}')
+        print('        PATCH .../upstream-headers  {"custom_headers": [{"name": "Authorization", "overridable": true}]}')
+        return 1
+    print("FAIL: the authenticated call did not succeed. 401 from the GATEWAY means the")
+    print("      equal-token guard fired (JWT in both headers); 401 from OpenAI means the")
+    print("      key is bad; 403 means the group lacks an http verb grant on this entity.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/verify_caller_creds.py
+++ b/tests/scripts/verify_caller_creds.py
@@ -123,8 +123,10 @@ def _resolve_base(registry_url: str, token: str, entity: str) -> str:
             if not rec.get("proxy_client_url"):
                 sys.exit(f"FATAL: {entity} is not proxied (no proxy_client_url)")
             print(f"entity        : {entity}")
-            print(f"upstream auth : names={rec.get('custom_header_names')} "
-                  f"overridable={rec.get('custom_header_overridable_names')}")
+            print(
+                f"upstream auth : names={rec.get('custom_header_names')} "
+                f"overridable={rec.get('custom_header_overridable_names')}"
+            )
             # Trailing slash matters: the nginx location ends in one, so the bare
             # path answers 301 and a POST would be downgraded to GET.
             return registry_url + rec["proxy_client_url"].rstrip("/") + "/"
@@ -165,9 +167,14 @@ def main() -> int:
 
     ok_with = with_key.status_code == 200 and "data" in with_key.json()
     models = len(with_key.json().get("data", [])) if ok_with else 0
-    print(f"with your key    : HTTP {with_key.status_code}  "
-          + (f"{models} models, first={with_key.json()['data'][0]['id']}" if ok_with
-             else with_key.text[:120]))
+    print(
+        f"with your key    : HTTP {with_key.status_code}  "
+        + (
+            f"{models} models, first={with_key.json()['data'][0]['id']}"
+            if ok_with
+            else with_key.text[:120]
+        )
+    )
 
     detail = ""
     try:
@@ -185,7 +192,9 @@ def main() -> int:
         print("FAIL: the call succeeded WITHOUT your key, so a stored operator default")
         print("      is being injected. Clear it, then re-add the name only:")
         print('        PATCH .../upstream-headers  {"custom_headers": []}')
-        print('        PATCH .../upstream-headers  {"custom_headers": [{"name": "Authorization", "overridable": true}]}')
+        print(
+            '        PATCH .../upstream-headers  {"custom_headers": [{"name": "Authorization", "overridable": true}]}'
+        )
         return 1
     print("FAIL: the authenticated call did not succeed. 401 from the GATEWAY means the")
     print("      equal-token guard fired (JWT in both headers); 401 from OpenAI means the")


### PR DESCRIPTION
## Problem

The generic reverse proxy's two headline capabilities cannot be exercised by `pytest`. Per-entity response **streaming** and **static upstream auth headers** both need a live stack and a real backend credential, so neither had any coverage. A buffered response and a silently dropped credential both return `200`, which means a status-code check passes while the feature is broken.

## What this adds

Four scripts under `tests/scripts/`, none of them pytest tests, plus the manual suite they serve and a gate that runs first.

| File | Role |
|---|---|
| `gateway_test_support.py` | everything about the **gateway** rather than a particular upstream: credential split, entity discovery, per-verb scope check, status interpretation. Shared so the clients cannot drift. |
| `openai_gateway_client.py` | `models` (GET authz), `chat` (POST authz plus the CSRF bearer exemption), `stream` (SSE) |
| `bedrock_gateway_client.py` | `converse` and the AWS event-stream path |
| `verify_caller_creds.py` | proves a caller-supplied key is the credential reaching the backend, and that the gateway stores none |
| `gateway-proxy-preflight.sh` | credential and config gate; exits non-zero on the first missing prerequisite |
| `gateway-proxy-regression.md` | the manual suite, 566 lines, fixtures through teardown |

## Why the assertions are shaped this way

**A 200 does not pass a streaming test.** Each stream mode records time-to-first-chunk, chunk count, and the largest inter-chunk gap, and fails on one chunk or on every chunk arriving at the same instant. Without that, a fully buffered response passes.

**A 200 cannot attribute a credential.** `verify_caller_creds.py` makes two calls, because a stored operator default produces the same `200` a caller-supplied key does. The `401` with no caller key is the load-bearing half: nothing stored means nothing to inject.

**Bedrock needs its own client.** `ConverseStream` returns length-prefixed binary frames, not SSE, which is why `curl -N` shows no `data:` lines and why chunk counting there goes through `botocore.eventstream`.

**The gate exists so a missing key fails as a missing key.** It checks every credential file, decodes the gateway JWT and rejects an expired one, checks the `.env` settings and `/health`. Without it, an absent key becomes an empty header and surfaces as an upstream 400 that reads like a proxy bug.

## Two findings recorded in the suite

Both cost real time during verification and are invisible locally.

**`--compressed` on every `curl` against a CloudFront-fronted deployment.** CloudFront gzips JSON responses and `curl` does not decompress unless asked, so a working call prints unreadable bytes -- or nothing, if the shell swallows them -- while `-w '%{http_code}'` reports `200`. `requests` and the scripted clients decompress transparently, so this only bites hand-run `curl`, and `http://localhost` is unaffected.

**Demoting a stored operator default to a caller-only slot takes two rotations.** Omitting a value means *keep*, which is the write-only convention the UI editor depends on so editing an unrelated field cannot wipe a credential. A single PATCH omitting the value returns `200` and looks correct while the ciphertext survives.

## Error paths name their cause

A gateway JWT is only valid for the deployment whose auth-server signed it: `iss` and `aud` are identical across deployments while each signs with its own `SECRET_KEY`. Pointing a valid-looking token at the wrong registry yields a `401` that reads like a scope problem. That case, plus 403, 404, unreachable host, and unknown entity, each print the cause instead of a traceback -- the unknown-entity path lists the records that do exist.

## Verification

Verified against a live ECS deployment behind CloudFront.

```
openai   models : OK 125 models in 1.54s
         chat   : OK in 1.84s
         stream : 11 chunks, first at 0.96s, max gap 0.060s - incremental confirmed
bedrock  converse : OK in 2.03s, stop=end_turn, 117 tokens
         stream   : 13 chunks / 21 events, first at 1.01s, max gap 0.483s
caller creds  with key : 200, 125 models
              without  : 401 Missing bearer authentication in header
```

Full suite: `7970 passed, 57 skipped`. The 4 failures on this machine are a pre-existing local `.env` bleed (`MCP_TOKEN_DEFAULT_TTL_HOURS=2` versus tests asserting the shipped default of 8) and are unrelated to this branch; CI has no such `.env`.

`ruff check tests/scripts/` clean, every script compiles, `bash -n` clean on the gate.

## Notes for review

- No pytest tests are added, so suite runtime is unchanged; `pytest` does not collect these.
- No production code changes. Test tooling and docs only.
- Scripts read credentials from files outside version control (`.token`, `.scratchpad/*`) and never accept a key as an argument, so no secret reaches a shell history or a process list. Scanned clean before commit.
- `verify_caller_creds.py` defaults to `--registry-url http://localhost`, matching the sibling clients.
