### PR TITLE
feat(gateway-proxy): connect affordance, operator notes, and a CLI create path

### DIFF
--- a/api/registry_management.py
+++ b/api/registry_management.py
@@ -810,6 +810,61 @@ def cmd_custom_record_create(args: argparse.Namespace) -> int:
         return 1
 
 
+def cmd_custom_proxy_create(args: argparse.Namespace) -> int:
+    """
+    Create a proxied custom-entity record that fronts a REST/HTTP endpoint.
+
+    Convenience over ``custom-record-create``: builds the gateway-proxy fields
+    from flags (target URL, streaming on/off, optional caller-overridable
+    Authorization passthrough) instead of a hand-written JSON record. The custom
+    type must already exist (see ``custom-type-create``); a type with required
+    attribute fields still needs ``custom-record-create`` with a full JSON body.
+
+    Streaming is set via ``--streaming true|false`` (the record's proxy_streaming
+    field). ``--auth-passthrough`` adds a caller-overridable Authorization header:
+    a fixed Authorization credential is rejected by the registry, so the caller
+    supplies the backend Bearer token at request time and the gateway forwards it.
+
+    ``--connect-notes`` sets proxy_connect_notes: free-text usage guidance shown to
+    clients in the UI Connect panel (e.g. the sub-path to append and a ready-to-run
+    invocation command). It is never interpreted by the gateway.
+
+    Args:
+        args: Command arguments (type, name, target_url, streaming,
+            auth_passthrough, connect_notes, visibility, description).
+
+    Returns:
+        Exit code (0 for success, 1 for failure).
+    """
+    try:
+        record: dict[str, Any] = {
+            "name": args.name,
+            "description": args.description or f"Proxied REST endpoint -> {args.target_url}",
+            "visibility": args.visibility,
+            "is_proxied": True,
+            "proxy_target_url": args.target_url,
+            "proxy_streaming": args.streaming == "true",
+            **({"proxy_connect_notes": args.connect_notes} if args.connect_notes else {}),
+        }
+        if args.auth_passthrough:
+            # Authorization is accepted only as a caller-overridable header (a
+            # fixed value is rejected); no stored value, the caller supplies it.
+            record["custom_headers"] = [{"name": "Authorization", "overridable": True}]
+
+        client = _create_client(args)
+        response = client.create_custom_record(args.type, record)
+        logger.info(
+            f"Proxied custom record created: {response.get('path')} "
+            f"(streaming={record['proxy_streaming']}, target={args.target_url})"
+        )
+        if args.json:
+            print(json.dumps(response, indent=2, default=str))
+        return 0
+    except Exception as e:
+        logger.error(f"Proxied custom record creation failed: {e}")
+        return 1
+
+
 def cmd_custom_record_list(args: argparse.Namespace) -> int:
     """
     List records of a custom type the caller can view.
@@ -6253,14 +6308,20 @@ Examples:
         """,
     )
 
-    parser.add_argument("--registry-url", help="Registry base URL (overrides REGISTRY_URL env var)")
+    parser.add_argument(
+        "--registry-url",
+        default="http://localhost",
+        help="Registry base URL (overrides REGISTRY_URL env var). Default: http://localhost",
+    )
 
     parser.add_argument("--aws-region", help="AWS region (overrides AWS_REGION env var)")
 
     parser.add_argument("--keycloak-url", help="Keycloak base URL (overrides KEYCLOAK_URL env var)")
 
     parser.add_argument(
-        "--token-file", help="Path to file containing JWT token (bypasses token script)"
+        "--token-file",
+        default=".token",
+        help="Path to file containing JWT token (bypasses token script). Default: .token",
     )
 
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
@@ -6304,6 +6365,50 @@ Examples:
         "--config", required=True, help="Path to custom record JSON file"
     )
     custom_record_create_parser.add_argument(
+        "--json", action="store_true", help="Print raw JSON response"
+    )
+
+    custom_proxy_create_parser = subparsers.add_parser(
+        "custom-proxy-create",
+        help="Create a proxied custom record fronting a REST/HTTP endpoint (e.g. an LLM API)",
+    )
+    custom_proxy_create_parser.add_argument(
+        "--type",
+        required=True,
+        help="Custom type name (must already exist; see custom-type-create)",
+    )
+    custom_proxy_create_parser.add_argument("--name", required=True, help="Record name")
+    custom_proxy_create_parser.add_argument(
+        "--target-url",
+        required=True,
+        help="Backend/origin URL the gateway proxies to (proxy_target_url), e.g. https://api.openai.com",
+    )
+    custom_proxy_create_parser.add_argument(
+        "--streaming",
+        choices=["true", "false"],
+        default="false",
+        help="Enable response streaming (proxy_streaming). Default: false",
+    )
+    custom_proxy_create_parser.add_argument(
+        "--auth-passthrough",
+        action="store_true",
+        help=(
+            "Add a caller-overridable Authorization header so the caller's Bearer "
+            "token is forwarded to the backend (a fixed Authorization is rejected)"
+        ),
+    )
+    custom_proxy_create_parser.add_argument(
+        "--visibility", default="private", help="Record visibility (default: private)"
+    )
+    custom_proxy_create_parser.add_argument("--description", help="Record description")
+    custom_proxy_create_parser.add_argument(
+        "--connect-notes",
+        help=(
+            "Operator usage notes stored on the record (proxy_connect_notes) and shown "
+            "in the UI Connect panel, e.g. the API sub-path plus an example command"
+        ),
+    )
+    custom_proxy_create_parser.add_argument(
         "--json", action="store_true", help="Print raw JSON response"
     )
 
@@ -8005,6 +8110,7 @@ Examples:
         "custom-type-create": cmd_custom_type_create,
         "custom-type-list": cmd_custom_type_list,
         "custom-record-create": cmd_custom_record_create,
+        "custom-proxy-create": cmd_custom_proxy_create,
         "custom-record-list": cmd_custom_record_list,
         "list": cmd_list,
         "toggle": cmd_toggle,

--- a/frontend/src/components/CustomEntityCard.tsx
+++ b/frontend/src/components/CustomEntityCard.tsx
@@ -15,6 +15,7 @@ import {
 import { labelFor } from '../utils/humanize';
 import StarRatingWidget from './StarRatingWidget';
 import { TagList, ENTITY_ACCENTS } from './cards';
+import ProxyConnectButton from './ProxyConnectButton';
 
 interface CustomEntityCardProps {
   descriptor: CustomTypeDescriptor;
@@ -150,6 +151,13 @@ const CustomEntityCard: React.FC<CustomEntityCardProps> = ({
           onShowToast={onShowToast}
         />
         <div className="flex items-center gap-1">
+          {/* Always rendered: a disabled Connect explains that the record is not
+              routed through the gateway, which an absent control cannot. */}
+          <ProxyConnectButton
+            clientUrl={record.proxy_client_url}
+            targetUrl={record.proxy_target_url}
+            connectNotes={record.proxy_connect_notes}
+          />
           <button
             type="button"
             onClick={() => onView(record)}

--- a/frontend/src/components/CustomEntityDetail.tsx
+++ b/frontend/src/components/CustomEntityDetail.tsx
@@ -4,6 +4,7 @@ import {
   CustomTypeDescriptor,
 } from '../types/customEntity';
 import { labelFor } from '../utils/humanize';
+import { gatewayClientUrl } from '../utils/gatewayClientUrl';
 import { formatValue } from './CustomEntityCard';
 import { EntityModal, CopyButton } from './modals';
 
@@ -81,6 +82,49 @@ const CustomEntityDetail: React.FC<CustomEntityDetailProps> = ({
             {record.tags.length > 0 ? record.tags.join(', ') : '—'}
           </dd>
         </dl>
+
+        {/* --- Gateway proxy --- */}
+        {record.is_proxied && (
+          <dl className="grid grid-cols-3 gap-x-4 gap-y-2 text-sm pt-2 border-t border-gray-200 dark:border-gray-700">
+            <dt className="text-gray-500 dark:text-gray-400">Gateway URL</dt>
+            <dd className="col-span-2 text-gray-900 dark:text-white">
+              {record.proxy_client_url ? (
+                <span className="flex items-start gap-2">
+                  <code className="flex-1 text-xs break-all bg-gray-50 dark:bg-gray-900 rounded px-2 py-1">
+                    {gatewayClientUrl(record.proxy_client_url)}
+                  </code>
+                  <CopyButton
+                    variant="subtle"
+                    label="Copy"
+                    copiedLabel="Copied"
+                    getText={() => gatewayClientUrl(record.proxy_client_url)}
+                    title="Copy the client URL"
+                  />
+                </span>
+              ) : (
+                '—'
+              )}
+            </dd>
+
+            {record.proxy_target_url && (
+              <>
+                <dt className="text-gray-500 dark:text-gray-400">Backend URL</dt>
+                <dd className="col-span-2 text-gray-900 dark:text-white break-all">
+                  {record.proxy_target_url}
+                </dd>
+              </>
+            )}
+
+            {record.proxy_connect_notes && (
+              <>
+                <dt className="text-gray-500 dark:text-gray-400">Connect notes</dt>
+                <dd className="col-span-2 text-gray-900 dark:text-white whitespace-pre-wrap break-words">
+                  {record.proxy_connect_notes}
+                </dd>
+              </>
+            )}
+          </dl>
+        )}
 
         {/* --- Per-type attributes --- */}
         {descriptor.fields.length > 0 && (

--- a/frontend/src/components/CustomEntityForm.tsx
+++ b/frontend/src/components/CustomEntityForm.tsx
@@ -44,7 +44,11 @@ const VISIBILITIES = ['public', 'private', 'group-restricted'] as const;
 // the dedicated ProxyField widget. If an admin's custom-type descriptor happens
 // to define a field with one of these names, skip its descriptor-driven widget
 // so it can't collide with (and clobber) the ProxyField-owned value.
-const PROXY_RESERVED_ATTR_KEYS = new Set(['is_proxied', 'proxy_target_url']);
+const PROXY_RESERVED_ATTR_KEYS = new Set([
+  'is_proxied',
+  'proxy_target_url',
+  'proxy_connect_notes',
+]);
 
 // Custom-entity forms use a teal focus accent.
 const INPUT_CLASS = fieldClass('teal');
@@ -128,6 +132,8 @@ const CustomEntityForm: React.FC<CustomEntityFormProps> = ({
   // when is_proxied is true.
   const [isProxied, setIsProxied] = useState(false);
   const [proxyTargetUrl, setProxyTargetUrl] = useState('');
+  // Optional operator-authored usage notes, shown in the Connect panel.
+  const [proxyConnectNotes, setProxyConnectNotes] = useState('');
   // Read-only, server-derived client path (present on edit once saved).
   const [proxyClientUrl, setProxyClientUrl] = useState('');
   // Upstream headers (per-header overridable). On edit these are the registered
@@ -162,6 +168,7 @@ const CustomEntityForm: React.FC<CustomEntityFormProps> = ({
         record.proxy_target_url ??
           (typeof attrs.proxy_target_url === 'string' ? attrs.proxy_target_url : ''),
       );
+      setProxyConnectNotes(record.proxy_connect_notes ?? '');
       setProxyClientUrl(record.proxy_client_url ?? '');
       // Rebuild header editor rows from the registered NAMES (values write-only).
       setCustomHeaders(
@@ -173,6 +180,7 @@ const CustomEntityForm: React.FC<CustomEntityFormProps> = ({
       );
       delete attrs.is_proxied;
       delete attrs.proxy_target_url;
+      delete attrs.proxy_connect_notes;
       setAttributes(attrs);
     }
   }, [record]);
@@ -346,6 +354,7 @@ const CustomEntityForm: React.FC<CustomEntityFormProps> = ({
       attributes: attributesWithDefaults,
       is_proxied: isProxied,
       ...(isProxied ? { proxy_target_url: proxyTargetUrl.trim() } : {}),
+      ...(isProxied ? { proxy_connect_notes: proxyConnectNotes.trim() } : {}),
     };
 
     // Upstream headers only apply when proxied. Block submit client-side on any
@@ -500,6 +509,19 @@ const CustomEntityForm: React.FC<CustomEntityFormProps> = ({
             error={fieldErrors.proxy_target_url}
             clientUrl={proxyClientUrl}
           />
+
+          {isProxied && (
+            <FormField label="Connect notes">
+              <textarea
+                rows={3}
+                maxLength={2000}
+                value={proxyConnectNotes}
+                onChange={(e) => setProxyConnectNotes(e.target.value)}
+                className={INPUT_CLASS}
+                placeholder="Optional usage notes shown to clients in the Connect panel (e.g. the API sub-path to append)."
+              />
+            </FormField>
+          )}
 
           {isProxied && (
             <UpstreamHeadersField

--- a/frontend/src/components/ProxyConnectButton.tsx
+++ b/frontend/src/components/ProxyConnectButton.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { LinkIcon } from '@heroicons/react/24/outline';
+import { CopyButton } from './modals';
+import { gatewayClientUrl } from '../utils/gatewayClientUrl';
+
+// Shown when the resource is not served through the gateway, so there is no
+// client URL to hand out. Deliberately short: on the icon-only card control it
+// renders as a tooltip, where there is no room for prose.
+const DISABLED_HINT =
+  'Not routed through the gateway. Enable gateway routing on this resource to connect.';
+// Visible companion to DISABLED_HINT for the inline (labelled) variant, where a
+// few words fit next to the label without crowding the row.
+const DISABLED_SUFFIX = 'enable gateway routing';
+
+interface ProxyConnectButtonProps {
+  /** Server-derived client path, e.g. "/gateway/skill/pdf". Absent = not proxied. */
+  clientUrl?: string | null;
+  /** Backend origin the gateway forwards to (shown for context only). */
+  targetUrl?: string | null;
+  /** Optional operator-authored usage notes; rendered only when present. */
+  connectNotes?: string | null;
+  /**
+   * Render as an inline icon+text control (for modal action rows) instead of the
+   * icon-only card button. The popover then aligns left, matching the row.
+   */
+  label?: string;
+}
+
+/**
+ * "Connect" affordance for a registry entity. Opens a small popover with the full
+ * client-facing URL a caller uses to reach the resource through the gateway, a
+ * one-line auth note, and a copy button.
+ *
+ * The URL is the same-origin client path (window.location.origin + clientUrl).
+ * It is shown as selectable text plus copy, never a live link, because a caller
+ * must append their own API sub-path and send auth headers, so the base URL is
+ * not directly navigable.
+ *
+ * The control is always rendered so its absence never has to be interpreted: an
+ * entity that is not proxied has no client URL, so the trigger is disabled and
+ * explains what would make it work. Presence of clientUrl is the single source of
+ * truth for "is this reachable through the gateway" -- the server derives it only
+ * for a proxied entity, so no separate is_proxied prop can drift out of sync.
+ */
+const ProxyConnectButton: React.FC<ProxyConnectButtonProps> = ({
+  clientUrl,
+  targetUrl,
+  connectNotes,
+  label,
+}) => {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const enabled = Boolean(clientUrl);
+  const inline = Boolean(label);
+  const fullUrl = gatewayClientUrl(clientUrl);
+
+  const triggerClass = inline
+    ? `flex items-center gap-1 text-sm transition-colors ${
+        enabled
+          ? 'text-cyan-700 dark:text-cyan-300 hover:underline'
+          : 'text-gray-400 dark:text-gray-500 cursor-not-allowed'
+      }`
+    : `p-2 rounded-lg transition-colors ${
+        enabled
+          ? 'text-gray-400 hover:text-cyan-600 dark:hover:text-cyan-400'
+          : 'text-gray-300 dark:text-gray-600 cursor-not-allowed'
+      }`;
+
+  return (
+    <div
+      className={inline ? 'relative inline-flex items-center gap-1' : 'relative'}
+      ref={wrapperRef}
+    >
+      <button
+        type="button"
+        disabled={!enabled}
+        aria-disabled={!enabled}
+        onClick={() => setOpen((v) => !v)}
+        className={triggerClass}
+        title={enabled ? 'Show the client URL for this resource' : DISABLED_HINT}
+        aria-label={
+          enabled
+            ? 'Connect: show the client URL for this proxied resource'
+            : `Connect unavailable: ${DISABLED_HINT}`
+        }
+        aria-expanded={enabled ? open : undefined}
+        aria-haspopup={enabled ? 'dialog' : undefined}
+      >
+        <LinkIcon className="h-4 w-4" />
+        {inline && <span>{label}</span>}
+      </button>
+      {inline && !enabled && (
+        <span className="text-xs text-gray-400 dark:text-gray-500" title={DISABLED_HINT}>
+          &mdash; {DISABLED_SUFFIX}
+        </span>
+      )}
+      {open && enabled && (
+        <div
+          role="dialog"
+          aria-label="Connection details"
+          className={`absolute ${
+            inline ? 'left-0' : 'right-0'
+          } z-20 mt-1 w-80 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-lg p-3 text-left`}
+        >
+          <p className="text-xs font-semibold text-gray-900 dark:text-white mb-1">Connect</p>
+          <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Clients connect at:</p>
+          <div className="flex items-start gap-2">
+            <code className="flex-1 text-xs break-all bg-gray-50 dark:bg-gray-900 rounded px-2 py-1 text-gray-800 dark:text-gray-200">
+              {fullUrl}
+            </code>
+            <CopyButton
+              variant="subtle"
+              label="Copy"
+              copiedLabel="Copied"
+              getText={() => fullUrl}
+              title="Copy the client URL"
+            />
+          </div>
+          {targetUrl && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 break-all">
+              Forwards to {targetUrl}
+            </p>
+          )}
+          {connectNotes && (
+            <p
+              className="text-xs text-gray-700 dark:text-gray-300 mt-2 whitespace-pre-wrap break-words max-h-40 overflow-y-auto rounded border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-2 py-1"
+              title={connectNotes}
+            >
+              {connectNotes}
+            </p>
+          )}
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+            Send the gateway token in the X-Authorization header; the backend credential goes in
+            Authorization.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProxyConnectButton;

--- a/frontend/src/components/SkillCard.tsx
+++ b/frontend/src/components/SkillCard.tsx
@@ -28,6 +28,7 @@ import SecurityScanModal from './SecurityScanModal';
 import useEscapeKey from '../hooks/useEscapeKey';
 import ResourceBoundTokenButton from './ResourceBoundTokenButton';
 import SkillResources from './SkillResources';
+import ProxyConnectButton from './ProxyConnectButton';
 import { SafeLink, safeMarkdownAnchor } from './SafeLink';
 import { toScanSummary } from '../utils/securityScan';
 
@@ -490,6 +491,14 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
                   {React.createElement(getSecurityIconState().Icon, { className: `h-4 w-4 ${loadingSecurityScan ? 'animate-pulse' : ''}` })}
                 </button>
 
+                {/* Connect Button — always rendered so its absence never has to
+                    be interpreted; disabled, with the reason as a tooltip, when
+                    the skill is not routed through the gateway. */}
+                <ProxyConnectButton
+                  clientUrl={skill.proxy_client_url}
+                  targetUrl={skill.proxy_target_url}
+                />
+
                 {/* Details Button */}
                 <button
                   onClick={handleViewDetails}
@@ -752,6 +761,11 @@ const SkillCard: React.FC<SkillCardProps> = React.memo(({
 
             {/* Action buttons */}
             <div className="flex items-center gap-4 mb-4 pb-4 border-b border-gray-200 dark:border-gray-700">
+              <ProxyConnectButton
+                label="Connect"
+                clientUrl={skill.proxy_client_url}
+                targetUrl={skill.proxy_target_url}
+              />
               {skill.skill_md_url && (
                 <SafeLink
                   href={skill.skill_md_url}

--- a/frontend/src/components/__tests__/ProxyConnectButton.test.tsx
+++ b/frontend/src/components/__tests__/ProxyConnectButton.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProxyConnectButton from '../ProxyConnectButton';
+
+describe('ProxyConnectButton', () => {
+  it('renders a disabled trigger, not nothing, when there is no client URL', () => {
+    // An absent control cannot explain itself. A greyed, non-clickable Connect
+    // states what would make it work, so "not proxied" is never a silent gap.
+    render(<ProxyConnectButton clientUrl={null} />);
+    const button = screen.getByRole('button', { name: /connect unavailable/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', expect.stringMatching(/enable gateway routing/i));
+    // Clicking a disabled trigger must never reveal the popover.
+    fireEvent.click(button);
+    expect(screen.queryByRole('dialog', { name: /connection details/i })).toBeNull();
+  });
+
+  it('shows a concise visible reason next to the label when disabled inline', () => {
+    // The icon-only card control has no room for text, so it relies on the
+    // tooltip; the labelled (modal row) variant has room and shows the reason.
+    render(<ProxyConnectButton clientUrl={null} label="Connect" />);
+    expect(screen.getByText(/enable gateway routing/i)).toBeInTheDocument();
+  });
+
+  it('enables the trigger and drops the disabled reason once proxied', () => {
+    render(<ProxyConnectButton clientUrl="/gateway/skill/pdf" label="Connect" />);
+    const button = screen.getByRole('button', { name: /show the client URL/i });
+    expect(button).toBeEnabled();
+    expect(screen.queryByText(/enable gateway routing/i)).toBeNull();
+
+    fireEvent.click(button);
+    // Trailing slash is deliberate: the nginx location ends in "/", so the bare
+    // path 301s and a POST following that redirect gets downgraded to GET.
+    expect(
+      screen.getByText(`${window.location.origin}/gateway/skill/pdf/`),
+    ).toBeInTheDocument();
+  });
+
+  it('opens a popover with the full same-origin client URL on click', () => {
+    render(
+      <ProxyConnectButton
+        clientUrl="/gateway/rest-endpoint/abc"
+        targetUrl="https://api.openai.com"
+        connectNotes="Append /v1/chat/completions"
+      />,
+    );
+    // Popover is closed until the button is clicked.
+    expect(screen.queryByRole('dialog', { name: /connection details/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    expect(screen.getByRole('dialog', { name: /connection details/i })).toBeInTheDocument();
+    // Full URL = origin + clientUrl + "/" (jsdom origin is http://localhost).
+    expect(
+      screen.getByText(`${window.location.origin}/gateway/rest-endpoint/abc/`),
+    ).toBeInTheDocument();
+    // Backend target, the operator-authored notes, and the fixed auth one-liner.
+    expect(screen.getByText(/api\.openai\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/Append \/v1\/chat\/completions/)).toBeInTheDocument();
+    expect(screen.getByText(/X-Authorization/)).toBeInTheDocument();
+  });
+
+  it('omits the notes paragraph when no connectNotes are provided', () => {
+    render(<ProxyConnectButton clientUrl="/gateway/rest-endpoint/abc" />);
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+    // The fixed auth one-liner still shows; there is no operator-notes text.
+    expect(screen.getByText(/X-Authorization/)).toBeInTheDocument();
+    expect(screen.queryByText(/Append/)).toBeNull();
+  });
+
+  it('renders long notes as a wrap-safe, height-bounded block', () => {
+    // Operator notes are free text up to 2000 chars and routinely contain an
+    // unbroken URL or curl line far wider than the w-80 popover. Without a break
+    // rule the text overflows the panel horizontally, and without a height cap the
+    // popover grows past the card; both are layout-only, so the classes are the
+    // contract jsdom can see.
+    const notes =
+      'Append /v1/forecast?latitude=39.2&longitude=-77.3&current=temperature_2m. ' +
+      'Example: curl -s "http://localhost/gateway/rest-endpoint/abc/v1/forecast?latitude=39.2"';
+    render(<ProxyConnectButton clientUrl="/gateway/rest-endpoint/abc" connectNotes={notes} />);
+    fireEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    const block = screen.getByText(notes);
+    expect(block).toHaveClass('whitespace-pre-wrap', 'break-words');
+    expect(block).toHaveClass('max-h-40', 'overflow-y-auto');
+    // Full text stays reachable as a tooltip even while the block is scrolled.
+    expect(block).toHaveAttribute('title', notes);
+  });
+
+  it('toggles the popover closed on a second click', () => {
+    render(<ProxyConnectButton clientUrl="/gateway/rest-endpoint/abc" />);
+    const button = screen.getByRole('button', { name: /connect/i });
+
+    fireEvent.click(button);
+    expect(screen.getByRole('dialog', { name: /connection details/i })).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.queryByRole('dialog', { name: /connection details/i })).toBeNull();
+  });
+});

--- a/frontend/src/components/formFields/ProxyField.tsx
+++ b/frontend/src/components/formFields/ProxyField.tsx
@@ -61,8 +61,12 @@ const ProxyField: React.FC<ProxyFieldProps> = ({
             onChange={(e) => onIsProxiedChange(e.target.checked)}
             className="h-4 w-4 rounded border-gray-300 dark:border-gray-600"
           />
+          {/* Action label, NOT a state readout: a checkbox label names what
+              checking it DOES. The prior state text flipped to "Not proxied"
+              when unchecked, which reads as a double negative ("check this to
+              make it not proxied"). The box itself carries the state. */}
           <span className="text-sm text-gray-600 dark:text-gray-400">
-            {isProxied ? 'Proxied' : 'Not proxied'}
+            Enable proxying
           </span>
         </label>
       </FormField>

--- a/frontend/src/components/formFields/__tests__/formFields.test.tsx
+++ b/frontend/src/components/formFields/__tests__/formFields.test.tsx
@@ -162,6 +162,17 @@ describe('ProxyField', () => {
     expect(screen.getByText('Backend URL')).toBeInTheDocument();
   });
 
+  it('labels the checkbox with a stable action, not a flipping state readout', () => {
+    // Regression: the label used to render "Not proxied" while unchecked, which
+    // reads as a double negative ("check this to make it not proxied"). The box
+    // carries the state, so the label must name the action and never change.
+    const { rerender } = render(<ProxyField isProxied={false} {...base} />);
+    expect(screen.getByLabelText('Enable proxying')).not.toBeChecked();
+    expect(screen.queryByText('Not proxied')).not.toBeInTheDocument();
+    rerender(<ProxyField isProxied={true} {...base} />);
+    expect(screen.getByLabelText('Enable proxying')).toBeChecked();
+  });
+
   it('pops up the client URL as plain text when proxied and provided', () => {
     render(
       <ProxyField isProxied={true} {...base} clientUrl="/gateway/skill/demo" />,

--- a/frontend/src/types/customEntity.ts
+++ b/frontend/src/types/customEntity.ts
@@ -60,6 +60,8 @@ export interface CustomEntityRecord {
   is_proxied?: boolean;
   proxy_target_url?: string | null;
   proxy_client_url?: string | null;
+  // Optional operator-authored usage notes, shown in the Connect panel when set.
+  proxy_connect_notes?: string | null;
   // Upstream custom-header NAMES (values encrypted, never returned).
   // custom_header_overridable_names is the caller-overridable subset.
   custom_header_names?: string[];
@@ -83,6 +85,7 @@ export interface CustomEntityCreate {
   attributes: Record<string, unknown>;
   is_proxied?: boolean;
   proxy_target_url?: string | null;
+  proxy_connect_notes?: string | null;
   custom_headers?: CustomEntityHeader[];
 }
 
@@ -96,6 +99,7 @@ export interface CustomEntityUpdate {
   attributes?: Record<string, unknown> | null;
   is_proxied?: boolean;
   proxy_target_url?: string | null;
+  proxy_connect_notes?: string | null;
 }
 
 /** Shape of the 400 validation-error body: { detail: [{ field, message }, ...] }. */

--- a/frontend/src/utils/__tests__/gatewayClientUrl.test.ts
+++ b/frontend/src/utils/__tests__/gatewayClientUrl.test.ts
@@ -1,0 +1,28 @@
+import { gatewayClientUrl } from '../gatewayClientUrl';
+
+describe('gatewayClientUrl', () => {
+  it('returns an absolute same-origin URL with a trailing slash', () => {
+    // The nginx location for a proxied entity ends in "/", so the bare path 301s.
+    // A URL we hand a user to copy must already carry the slash.
+    expect(gatewayClientUrl('/gateway/skill/pdf')).toBe(
+      `${window.location.origin}/gateway/skill/pdf/`,
+    );
+  });
+
+  it('never doubles an existing trailing slash', () => {
+    expect(gatewayClientUrl('/gateway/skill/pdf/')).toBe(
+      `${window.location.origin}/gateway/skill/pdf/`,
+    );
+    expect(gatewayClientUrl('/gateway/skill/pdf///')).toBe(
+      `${window.location.origin}/gateway/skill/pdf/`,
+    );
+  });
+
+  it('returns an empty string when the entity is not proxied', () => {
+    // No client path exists unless the server derived one, so callers can treat
+    // "" as "nothing to show" rather than rendering a bare origin.
+    expect(gatewayClientUrl(null)).toBe('');
+    expect(gatewayClientUrl(undefined)).toBe('');
+    expect(gatewayClientUrl('')).toBe('');
+  });
+});

--- a/frontend/src/utils/gatewayClientUrl.ts
+++ b/frontend/src/utils/gatewayClientUrl.ts
@@ -1,0 +1,18 @@
+/**
+ * Client-facing URL for a gateway-proxied entity.
+ *
+ * The registry stores `proxy_client_url` without a trailing slash (see
+ * build_proxy_client_path in registry/schemas/proxy_mixin.py), but the nginx
+ * location it generates ends in "/". nginx answers a request for the bare path
+ * with a 301 that adds the slash, and most HTTP clients downgrade a POST to GET
+ * when following a 301 -- so a URL we hand a user to copy must already carry it,
+ * or a copied base URL silently loses its method and body on a write.
+ *
+ * @param clientUrl - Server-derived client path, e.g. "/gateway/skill/pdf".
+ * @returns Absolute same-origin URL with exactly one trailing slash, or "" when
+ *   the entity is not proxied (no client path).
+ */
+export const gatewayClientUrl = (clientUrl: string | null | undefined): string => {
+  if (!clientUrl) return '';
+  return `${window.location.origin}${clientUrl.replace(/\/+$/, '')}/`;
+};

--- a/registry/schemas/custom_entity_models.py
+++ b/registry/schemas/custom_entity_models.py
@@ -316,6 +316,7 @@ class CustomEntityCreate(BaseModel):
     is_proxied: bool = Field(default=False)
     proxy_target_url: str | None = Field(default=None)
     proxy_streaming: bool = Field(default=False)
+    proxy_connect_notes: str | None = Field(default=None, max_length=2000)
     custom_headers: list[dict[str, Any]] | None = Field(
         default=None,
         description=(
@@ -383,6 +384,7 @@ class CustomEntityUpdate(BaseModel):
     # Gateway-proxy opt-in (patchable; None = leave unchanged).
     is_proxied: bool | None = None
     proxy_target_url: str | None = None
+    proxy_connect_notes: str | None = None
 
     @field_validator("visibility")
     @classmethod

--- a/registry/schemas/proxy_mixin.py
+++ b/registry/schemas/proxy_mixin.py
@@ -83,6 +83,7 @@ PROXY_FIELD_NAMES: frozenset[str] = frozenset(
         "proxy_target_host",
         "proxy_disabled_reason",
         "proxy_client_url",
+        "proxy_connect_notes",
         # Upstream auth secrets must NEVER travel to/from a peer. Stripped both
         # ways (a peer must not plant creds, and we must not leak our own).
         # The plaintext "custom_headers" key is normally never persisted, but is
@@ -228,6 +229,16 @@ class ProxyableMixin(BaseModel):
             "type). When false (default) the response is buffered up to "
             "GENERIC_PROXY_MAX_BODY_BYTES. The value is bound into the signed "
             "generic-proxy token, so the hop never trusts a forgeable inbound header."
+        ),
+    )
+    proxy_connect_notes: str | None = Field(
+        default=None,
+        max_length=2000,
+        description=(
+            "Optional operator-authored usage notes for clients connecting through "
+            "the gateway (e.g. the API sub-path to append, the request shape). Free "
+            "text, surfaced in the UI Connect panel only when set and only for a "
+            "proxied entity. Not interpreted by the gateway."
         ),
     )
     custom_headers_encrypted: list[CustomHeaderEncrypted] | None = Field(

--- a/registry/services/custom_entity_service.py
+++ b/registry/services/custom_entity_service.py
@@ -242,6 +242,7 @@ class CustomEntityService:
             is_proxied=request.is_proxied,
             proxy_target_url=request.proxy_target_url,
             proxy_streaming=getattr(request, "proxy_streaming", False),
+            proxy_connect_notes=getattr(request, "proxy_connect_notes", None),
             custom_headers_encrypted=custom_headers_encrypted,
             custom_header_names=custom_header_names,
             custom_header_overridable_names=custom_header_overridable_names,
@@ -303,6 +304,8 @@ class CustomEntityService:
             updates["is_proxied"] = request.is_proxied
         if request.proxy_target_url is not None:
             updates["proxy_target_url"] = request.proxy_target_url
+        if request.proxy_connect_notes is not None:
+            updates["proxy_connect_notes"] = request.proxy_connect_notes
         if request.attributes is not None:
             # Merge-then-validate: merge client patch into stored bag, then validate.
             merged_attrs = dict(existing.attributes)

--- a/tests/unit/api/test_custom_entity_routes.py
+++ b/tests/unit/api/test_custom_entity_routes.py
@@ -167,6 +167,35 @@ class TestCreate:
         resp = client.post(f"/api/custom/{TYPE}", json={"name": "x"})
         assert resp.status_code == 400
 
+    def test_connect_notes_reaches_the_service(self, patched_service):
+        # The field has to survive request parsing to be persisted at all: an
+        # older build silently drops it as an unknown key, so the request looks
+        # like a success while the notes never arrive.
+        client = _make_client(USER_CTX)
+        resp = client.post(
+            f"/api/custom/{TYPE}",
+            json={
+                "name": "x",
+                "is_proxied": True,
+                "proxy_target_url": "https://api.example.com/v1",
+                "proxy_connect_notes": "Append /v1/chat/completions",
+            },
+        )
+        assert resp.status_code == 201
+        # The route passes the parsed body positionally: create_record(type, body, owner=...)
+        body = patched_service.create_record.call_args[0][1]
+        assert body.proxy_connect_notes == "Append /v1/chat/completions"
+
+    def test_connect_notes_over_max_length_400(self, patched_service):
+        # Operator free text is capped at 2000 so a paste cannot bloat the record.
+        client = _make_client(USER_CTX)
+        resp = client.post(
+            f"/api/custom/{TYPE}",
+            json={"name": "x", "proxy_connect_notes": "z" * 2001},
+        )
+        assert resp.status_code in (400, 422)
+        patched_service.create_record.assert_not_awaited()
+
 
 @pytest.mark.unit
 class TestUpdateDelete:

--- a/tests/unit/schemas/test_proxy_federation_isolation.py
+++ b/tests/unit/schemas/test_proxy_federation_isolation.py
@@ -31,6 +31,9 @@ class TestStripProxyFields:
             "proxy_resolved_ips": ["1.2.3.4"],
             "proxy_target_host": "internal.example",
             "proxy_disabled_reason": "blocked",
+            # Operator notes describe a local backend's request shape, so they are
+            # neither exported to a peer nor accepted from one.
+            "proxy_connect_notes": "Append /v1/chat/completions",
         }
         out = strip_proxy_fields(doc)
         assert set(out) == {"name", "path"}

--- a/tests/unit/services/test_custom_entity_service.py
+++ b/tests/unit/services/test_custom_entity_service.py
@@ -414,3 +414,60 @@ class TestUpdateRecordUpstreamHeaders:
         assert out is existing
         entities.update.assert_awaited_once()
         search.index_custom_entity.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestUpdateRecordConnectNotes:
+    """proxy_connect_notes is operator free text, so the patch semantics are the contract.
+
+    None means leave unchanged, which makes the empty string the only way to clear
+    notes that were set. Both directions are asserted because a reader cannot tell
+    them apart from the field declaration alone.
+    """
+
+    async def test_notes_are_persisted(self, service):
+        svc, entities, _, _ = service
+        existing = _record(
+            owner="bob", is_proxied=True, proxy_target_url="https://api.example.com/v1"
+        )
+        entities.get = AsyncMock(return_value=existing)
+        entities.update = AsyncMock(return_value=existing)
+        await svc.update_record(
+            TYPE,
+            f"/{TYPE}/abc",
+            CustomEntityUpdate(proxy_connect_notes="Append /v1/chat/completions"),
+            BOB,
+        )
+        assert entities.update.call_args[0][1]["proxy_connect_notes"] == (
+            "Append /v1/chat/completions"
+        )
+
+    async def test_empty_string_clears_notes(self, service):
+        svc, entities, _, _ = service
+        existing = _record(
+            owner="bob",
+            is_proxied=True,
+            proxy_target_url="https://api.example.com/v1",
+            proxy_connect_notes="old notes",
+        )
+        entities.get = AsyncMock(return_value=existing)
+        entities.update = AsyncMock(return_value=existing)
+        await svc.update_record(
+            TYPE, f"/{TYPE}/abc", CustomEntityUpdate(proxy_connect_notes=""), BOB
+        )
+        # Empty string is not None, so it reaches the update and blanks the field.
+        assert entities.update.call_args[0][1]["proxy_connect_notes"] == ""
+
+    async def test_omitted_leaves_stored_notes_untouched(self, service):
+        svc, entities, _, _ = service
+        existing = _record(
+            owner="bob",
+            is_proxied=True,
+            proxy_target_url="https://api.example.com/v1",
+            proxy_connect_notes="keep me",
+        )
+        entities.get = AsyncMock(return_value=existing)
+        entities.update = AsyncMock(return_value=existing)
+        await svc.update_record(TYPE, f"/{TYPE}/abc", CustomEntityUpdate(visibility="private"), BOB)
+        # Editing an unrelated field must not blank notes the operator wrote.
+        assert "proxy_connect_notes" not in entities.update.call_args[0][1]


### PR DESCRIPTION
## Problem

Three gaps for anyone actually using the generic proxy:

1. A caller had no way to discover the URL to call. The client path is server-derived and UUID-keyed (`/gateway/rest-endpoint/<uuid>/`), so it cannot be guessed or hand-assembled from the record name.
2. An operator had nowhere to record *how* to call it — which sub-path to append, what the request looks like.
3. Registering a proxied record meant hand-writing a JSON body.

## Connect affordance

`ProxyConnectButton` opens a popover with the client URL, the backend it forwards to, the operator's notes, and a copy button. Wired into the custom-entity card, the detail modal, and the skill card.

**The control always renders**, disabled when the entity is not proxied, so its absence never has to be interpreted — a missing button is indistinguishable from a bug. `proxy_client_url` is the single source of truth for "reachable through the gateway": the server derives it only for a proxied entity, so no separate `is_proxied` prop can drift out of sync.

**The URL is selectable text plus copy, never a live link.** A caller must append their own API sub-path and send auth headers, so the base URL is not navigable on its own. `gatewayClientUrl` centralises the trailing slash — the nginx location ends in one, so the bare path answers `301` and a POST would be silently downgraded to GET.

`ProxyField`'s label becomes an action instead of a state readout; it previously said "Proxied" / "Not proxied" beside the toggle that already showed exactly that.

## proxy_connect_notes

Optional operator free text on a proxied entity, capped at 2000 characters, never interpreted by the gateway. It answers what a client URL alone cannot.

**Patch semantics follow `proxy_target_url`:** `None` means leave unchanged, so an empty string is the only way to clear notes. Both directions are tested, because a reader cannot tell them apart from the field declaration alone.

The field joins `PROXY_FIELD_NAMES`, so **federation strips it both ways** — notes describe a local backend, so a peer must not receive ours and must not plant its own.

## CLI

`custom-proxy-create` builds the proxy fields from flags rather than a JSON record: `--target-url`, `--streaming`, `--auth-passthrough` (caller-overridable `Authorization` slot), `--connect-notes`. `--registry-url` and `--token-file` now default to `http://localhost` and `.token`.

## Verification

**Browser, with the app stylesheet loaded.** Without it the Tailwind positioning classes are inert and a visual check proves nothing — I hit exactly that first and fixed the harness before drawing any conclusion.

| Check | Result |
|---|---|
| popover geometry | `position: absolute`, `z-index: 20`, 320px, inside viewport |
| notes at the 2000-char max | clips to 158px (`max-h-40`), scrolls (808px content), dialog stays 354px and in viewport |
| Escape / outside mousedown | closes; only one popover open at a time |
| disabled trigger | click opens nothing |
| copy | label → `Copied`, clipboard holds the trailing-slash URL |
| dark mode | readable contrast throughout |

**Tests.** 34 frontend tests across 3 suites; full frontend run `384` tests with the same 7 suites / 12 tests failing before and after (pre-existing jsdom harness issues), and `+11` passing from this branch. Backend `7975 passed`; the 4 failures are a pre-existing local `.env` bleed absent in CI. `tsc --noEmit` reports the same 15 pre-existing errors before and after, none in these files.

**Every new test was confirmed to fail with the source change removed.**

**One finding worth the review time.** A live `custom-proxy-create` against the current deployment returned `201` with `proxy_connect_notes: None` — the deployed build has no such field, so pydantic dropped the unknown key and the call *looked* like a success. That is why coverage is at the **route boundary** as well as the service: the route test fails without the model field, and so does the max-length test, since 2001 characters are accepted when the field does not exist. A service-only test would have missed the whole class.

## Notes for review

- Ships inert: nothing here is reachable unless `GATEWAY_GENERIC_PROXY_ENABLED` and `CUSTOM_ENTITY_TYPES_ENABLED` are on. The notes field is additive and optional; no migration, no backfill.
- The smoke record created on the shared deployment during verification was deleted (`204`).
- `ruff` 0.11.13 (the pinned pre-commit version) clean on both check and format.
