### PR TITLE
fix(scopes): grant registry-admins HTTP verbs on gateway-proxied entities

### DIFF
--- a/scripts/registry-admins.json
+++ b/scripts/registry-admins.json
@@ -10,6 +10,11 @@
       "tools": ["all"]
     },
     {
+      "server": "*",
+      "methods": ["http:*"],
+      "tools": []
+    },
+    {
       "agent": "*",
       "actions": ["list_agents", "get_agent", "publish_agent", "modify_agent", "delete_agent", "toggle_agent", "invoke_agent"]
     }

--- a/tests/auth_server/unit/test_admin_seed_http_verbs.py
+++ b/tests/auth_server/unit/test_admin_seed_http_verbs.py
@@ -1,0 +1,93 @@
+"""The admin scope seed must authorize HTTP verbs on gateway-proxied entities.
+
+The generic proxy authorizes a request by HTTP verb, and the resolver splits the
+value spaces deliberately: for an HTTP verb the legacy ``all`` / ``*`` wildcard
+does NOT grant. That guard exists so flipping an entity to ``is_proxied`` cannot
+silently turn an existing MCP wildcard into DELETE/PUT authority
+(``_HTTP_VERB_WILDCARD`` in ``auth_server/server.py``).
+
+The consequence for the shipped seed is that an administrator holding
+``methods: ["all"]`` is denied every proxied route. It surfaces as a 403 that
+reads like a registration or routing failure rather than a missing grant, and it
+cannot be repaired through the management API, which refuses wildcard
+``server_access`` entries -- so ``scripts/registry-admins.json`` is the only
+path, and a fresh install depends on it.
+
+This drives the real resolver with the on-disk seed rather than asserting the
+file's shape, so it keeps holding if the wildcard token or the split is reworked.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# A proxied custom record's authz key is "<entity_type>/<path minus leading slash>",
+# which for a UUID-keyed custom record reads doubled. Using the real shape keeps
+# the test honest about what the gateway actually sends to /validate.
+PROXIED_AUTHZ_KEY = "rest-endpoint/rest-endpoint/1a546ca6-4336-4164-8fd3-b5d7e6bccb56"
+ADMIN_SEED = "scripts/registry-admins.json"
+ADMIN_SCOPE = "registry-admins"
+
+
+@pytest.fixture(scope="module")
+def admin_server_access() -> list[dict]:
+    """The shipped admin seed's server_access rules, read from the repository."""
+    # tests/auth_server/unit/<this file> -> repository root is three levels up.
+    repo_root = Path(__file__).resolve().parents[3]
+    return json.loads((repo_root / ADMIN_SEED).read_text())["server_access"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("verb", ["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def test_admin_seed_authorizes_http_verbs_on_a_proxied_entity(
+    admin_server_access: list[dict], verb: str
+) -> None:
+    from auth_server.server import validate_server_tool_access
+
+    repo = AsyncMock()
+    repo.get_server_scopes = AsyncMock(
+        side_effect=lambda scope: admin_server_access if scope == ADMIN_SCOPE else []
+    )
+
+    with patch("auth_server.server.get_scope_repository", return_value=repo):
+        allowed = await validate_server_tool_access(
+            PROXIED_AUTHZ_KEY, verb, "", [ADMIN_SCOPE], is_http_verb=True
+        )
+
+    assert allowed, (
+        f"{ADMIN_SEED} does not authorize {verb} on a proxied entity, so administrators "
+        f"get a 403 on every gateway-proxied route on a fresh install. Add "
+        f'{{"server": "*", "methods": ["http:*"], "tools": []}} to server_access.'
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_wildcard_alone_does_not_authorize_an_http_verb() -> None:
+    """Pins the escalation guard the seed rule works around.
+
+    If ``all`` ever starts granting HTTP verbs, the seed rule becomes redundant --
+    and every non-admin group holding an MCP wildcard silently gains DELETE on
+    each entity that is flipped to proxied. That is the failure this asserts
+    against, so the guard cannot be relaxed without this test objecting.
+    """
+    from auth_server.server import validate_server_tool_access
+
+    repo = AsyncMock()
+    repo.get_server_scopes = AsyncMock(
+        return_value=[{"server": "*", "methods": ["all"], "tools": ["all"]}]
+    )
+
+    with patch("auth_server.server.get_scope_repository", return_value=repo):
+        allowed = await validate_server_tool_access(
+            PROXIED_AUTHZ_KEY, "DELETE", "", ["some-group"], is_http_verb=True
+        )
+
+    assert not allowed, (
+        "methods:['all'] authorized an HTTP verb. The value-space split is the guard "
+        "that stops an MCP wildcard from becoming DELETE/PUT authority when an entity "
+        "is flipped to is_proxied."
+    )

--- a/tests/security/test_scope_seed_group_mappings.py
+++ b/tests/security/test_scope_seed_group_mappings.py
@@ -14,7 +14,10 @@ union of these arrays. A group missing here is silently dropped from the
 session, so a wrong entry degrades authorization in two places at once.
 
 These are static assertions over the seed JSON, so they hold without a live
-Keycloak or DocumentDB.
+Keycloak or DocumentDB. The admin seed's HTTP-verb grant is covered in
+tests/auth_server/unit/test_admin_seed_http_verbs.py instead, because asserting
+it properly means driving the resolver, whose import needs the auth-server path
+setup this suite does not have.
 """
 
 import json


### PR DESCRIPTION
## Problem

An administrator is denied **every** gateway-proxied route on a fresh install.

The generic proxy authorizes by HTTP verb, and the resolver splits the value spaces deliberately — for an HTTP verb the legacy `all` / `*` wildcard does **not** grant:

```python
# auth_server/server.py:1961-1970
if is_http_verb:
    has_wildcard_methods = _HTTP_VERB_WILDCARD in allowed_methods   # "http:*"
else:
    has_wildcard_methods = "all" in allowed_methods or "*" in allowed_methods
```

That guard is correct: it stops an entity flipped to `is_proxied` from silently turning an existing MCP wildcard into DELETE/PUT authority. The gap is that the shipped admin seed carries only `methods: ["all"]`, so admins hold the MCP wildcard and **no HTTP verb at all**.

## Why it is hard to diagnose, and why the seed is the only fix

The symptom is a `403` that reads like a routing or registration failure rather than a missing grant. It cannot be repaired through the API:

| Path | Result |
|---|---|
| `PATCH /api/management/iam/groups/registry-admins` with a wildcard rule | `400 Wildcards must be seeded server-side` |
| Read-modify-write of the whole group | `422` — `GET` returns `scope_name`-shaped entries that `PATCH` rejects |
| UI scope editor | same two failures |

`scripts/registry-admins.json` is loaded straight into `mcp_scopes_default` by `scripts/init-documentdb-indexes.py` (`load_default_scopes`), so the seed file is the sanctioned path for a wildcard.

## The change

```json
{ "server": "*", "methods": ["http:*"], "tools": [] }
```

`tools: []` because tools are an MCP concept and do not apply to an HTTP verb.

## Scope of the grant

`registry-admins` already holds every MCP method and tool on every server, plus every agent action. HTTP verbs on proxied entities add no authority it could not already reach by editing the entity. **The value-space split keeps protecting every other group**, which is what it was written for: a non-admin group's MCP wildcard still grants no HTTP verb, and this PR adds a test pinning that.

## Verification

**Observed live before the fix:** `GET` through a proxied entity returned `403` with the group holding `methods: ["all"]`. After pushing exactly this rule into the collection, the OpenAI and Bedrock proxy suites passed end to end (125 models, 9 SSE chunks, 13 Bedrock event-stream frames).

**Tests drive the real resolver with the on-disk seed** rather than asserting the file's shape, so they keep holding if the wildcard token or the split is reworked. Both were confirmed to fail against the state they guard:

| Test | Fails when |
|---|---|
| 5 verb cases (GET/POST/PUT/DELETE/PATCH) | the `http:*` rule is removed from the seed |
| MCP wildcard alone grants no HTTP verb | the split is relaxed so `all` also grants verbs |

Full suite `7976 passed, 57 skipped`. The 4 failures on my machine are a pre-existing local `.env` bleed (`MCP_TOKEN_DEFAULT_TTL_HOURS`) absent in CI.

## Notes for review

- HTTP-verb coverage lives in `tests/auth_server/unit/` rather than beside the other seed assertions in `tests/security/`, because importing `auth_server.server` needs the auth-server `sys.path` setup only that suite provides. A pointer comment was left in the security suite's docstring.
- **Existing deployments are unaffected** by merging this: the seed is read at DocumentDB init, so a live install needs the init task re-run (or the rule applied to `mcp_scopes_default`) to pick it up. It is not a hot-reload path.
- Independent of #1731; this is the authorization half of making the proxy usable.
