### PR TITLE
fix(a2a): build the agent-card route from the URL origin, not the JSON-RPC endpoint

### DIFF
--- a/registry/core/nginx_service.py
+++ b/registry/core/nginx_service.py
@@ -2484,6 +2484,16 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         dns_resolver_timeout = os.environ.get("NGINX_DNS_RESOLVER_TIMEOUT", "5")
         safe_name = self._sanitize_for_nginx_comment(agent_name)
         route = f"{AGENT_ROUTE_PREFIX}/{agent_path}"
+        # Per the A2A spec the card document lives at a well-known path on the
+        # ORIGIN, while the card's own "url" names the JSON-RPC endpoint and may
+        # carry a path. Appending the suffix to backend_url asks the backend one
+        # level too deep (https://host/a2a/.well-known/... -> 404), which broke the
+        # card route for every spec-following agent while path-less ones looked
+        # fine, since both spellings coincide there. _build_agent_health_urls in
+        # registry/api/agent_routes.py derives this same URL from the origin; the
+        # two must agree or the health check calls an agent healthy while its
+        # gateway card route fails (issue #1724).
+        card_origin = f"{parsed_url.scheme}://{upstream_host}"
 
         return f"""
     # A2A agent card (discovery): {safe_name}
@@ -2494,7 +2504,7 @@ map "$uri:$http_x_mcp_server_version" $versioned_backend {{
         resolver_timeout {dns_resolver_timeout}s;
         auth_request /validate;
         auth_request_set $auth_scopes $upstream_http_x_scopes;
-        proxy_pass {backend_url}/.well-known/agent-card.json;
+        proxy_pass {card_origin}/.well-known/agent-card.json;
         proxy_http_version 1.1;
         proxy_ssl_server_name on;
         proxy_set_header Host {host_header};

--- a/registry/utils/agent_validator.py
+++ b/registry/utils/agent_validator.py
@@ -11,6 +11,7 @@ Based on: docs/design/a2a-protocol-integration.md
 import logging
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel
@@ -218,7 +219,13 @@ def _check_endpoint_reachability(
     from .url_guard import PROXY_PROFILE, guarded_client
 
     try:
-        well_known_url = f"{url}/.well-known/agent-card.json"
+        # Same origin rule as the nginx card route and _build_agent_health_urls:
+        # the A2A spec puts the card at a well-known path on the ORIGIN, while the
+        # registered url names the JSON-RPC endpoint and may carry a path. Appending
+        # to the url probes one level too deep, so a spec-following agent was
+        # reported unreachable at registration (issue #1724).
+        parsed = urlparse(url)
+        well_known_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/agent-card.json"
 
         with guarded_client(profile=PROXY_PROFILE, timeout=5.0) as client:
             response = client.get(well_known_url)

--- a/tests/unit/test_agent_nginx.py
+++ b/tests/unit/test_agent_nginx.py
@@ -90,6 +90,88 @@ class TestGenerateAgentLocationBlocks:
         assert "{{ROOT_PATH}}/agent/flight-booking-agent/.well-known/agent-card.json" in result
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "backend_url",
+        [
+            "https://support.example.com/a2a",
+            "https://support.example.com/api/v1/a2a",
+            "http://support.example.com:9000/a2a/",
+        ],
+    )
+    async def test_card_route_targets_the_origin_not_the_endpoint(
+        self, patched_agent_service, backend_url
+    ):
+        """Per the A2A spec the card lives at a well-known path on the ORIGIN.
+
+        The registered url names the JSON-RPC endpoint and may carry a path, so
+        appending the well-known suffix to it asks the backend one level too deep
+        and 404s. _build_agent_health_urls (registry/api/agent_routes.py) already
+        derives the card from the origin, and the two must not disagree: the health
+        check would otherwise report an agent healthy while its gateway card route
+        fails (issue #1724).
+        """
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/support-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="/support-agent", url=backend_url)
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        origin = backend_url.split("/a2a")[0].split("/api")[0].rstrip("/")
+        assert f"proxy_pass {origin}/.well-known/agent-card.json;" in result
+        # The endpoint path must not survive into the card target.
+        assert "/a2a/.well-known/agent-card.json" not in result
+
+    @pytest.mark.asyncio
+    async def test_card_route_unchanged_for_a_path_less_url(self, patched_agent_service):
+        """A path-less url is why this went unnoticed: appending to the url and to
+        the origin produce the same string, so these routes were always correct and
+        must stay byte-identical."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/travel-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="/travel-agent", url="http://travel-agent:9000/")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "proxy_pass http://travel-agent:9000/.well-known/agent-card.json;" in result
+
+    @pytest.mark.asyncio
+    async def test_jsonrpc_route_keeps_the_endpoint_path(self, patched_agent_service):
+        """Only the card route moves to the origin. The JSON-RPC route must keep the
+        registered path, or the endpoint itself breaks."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/support-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="/support-agent", url="https://support.example.com/a2a")
+        )
+        service = NginxConfigService()
+
+        result = await service._generate_agent_location_blocks()
+
+        assert "proxy_pass https://support.example.com/a2a/;" in result
+
+    @pytest.mark.asyncio
+    async def test_card_route_keeps_its_credential_strips(self, patched_agent_service):
+        """Moving the target must not disturb the egress trust model: X-Authorization
+        carries the caller's gateway credential and must never reach a
+        registrant-controlled backend (the #1391 class of bug)."""
+        patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/support-agent"])
+        patched_agent_service.get_agent_info = AsyncMock(
+            return_value=_agent(path="/support-agent", url="https://support.example.com/a2a")
+        )
+        service = NginxConfigService()
+
+        card_block = (await service._generate_agent_location_blocks()).split(
+            "# A2A agent JSON-RPC endpoint"
+        )[0]
+
+        assert 'proxy_set_header X-Authorization "";' in card_block
+        assert 'proxy_set_header Cookie "";' in card_block
+        assert "body_filter_by_lua_file /etc/nginx/lua/agent_card_rewrite.lua;" in card_block
+
+    @pytest.mark.asyncio
     async def test_block_enforces_auth_request(self, patched_agent_service):
         """Generated blocks are protected by the /validate auth subrequest."""
         patched_agent_service.get_enabled_agents = AsyncMock(return_value=["/flight-booking-agent"])

--- a/tests/unit/utils/test_agent_validator_ssrf.py
+++ b/tests/unit/utils/test_agent_validator_ssrf.py
@@ -46,3 +46,45 @@ class TestReachabilitySsrfGuard:
                 assert reachable is True
                 assert error is None
                 mock_client.get.assert_called_once()
+
+
+class TestReachabilityProbesTheOrigin:
+    """The probe fetches the card from the ORIGIN, not from the registered path.
+
+    Per the A2A spec the card document sits at a well-known path on the origin,
+    while the registered url names the JSON-RPC endpoint and may carry a path.
+    Appending the suffix to the url probes one level too deep, so a spec-following
+    agent was reported unreachable at registration (issue #1724).
+    """
+
+    def test_path_carrying_url_is_probed_at_its_origin(self):
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [(None, None, None, None, ("140.82.112.3", 443))]
+
+            with patch("registry.utils.url_guard.guarded_client") as mock_client_factory:
+                mock_client = mock_client_factory.return_value.__enter__.return_value
+                mock_client.get.return_value.status_code = 200
+
+                reachable, _ = _check_endpoint_reachability("https://good.example/api/v1/a2a")
+
+                assert reachable is True
+                assert (
+                    mock_client.get.call_args[0][0]
+                    == "https://good.example/.well-known/agent-card.json"
+                )
+
+    def test_path_less_url_probe_is_unchanged(self):
+        """Both spellings coincide for a path-less url, which is why this went unnoticed."""
+        with patch("registry.utils.url_guard.socket.getaddrinfo") as mock_resolve:
+            mock_resolve.return_value = [(None, None, None, None, ("140.82.112.3", 9000))]
+
+            with patch("registry.utils.url_guard.guarded_client") as mock_client_factory:
+                mock_client = mock_client_factory.return_value.__enter__.return_value
+                mock_client.get.return_value.status_code = 200
+
+                _check_endpoint_reachability("http://good.example:9000")
+
+                assert (
+                    mock_client.get.call_args[0][0]
+                    == "http://good.example:9000/.well-known/agent-card.json"
+                )


### PR DESCRIPTION
Closes #1724

## Problem

Every spec-following A2A agent registered with a path in its URL had a broken agent-card route through the gateway. On the registry where this was found, **94 of 122 live agents** were affected and none could serve a card.

The A2A spec puts the card document at a well-known path on the **origin**, and lets the card's own `url` field name the JSON-RPC endpoint anywhere. The route generator appended the suffix to the registered URL instead, so for an agent registered as `https://host/a2a` the gateway asked one level too deep:

```
backend /.well-known/agent-card.json       200  856B
backend /a2a/.well-known/agent-card.json   404      <- what the gateway asked for
```

Reverse-proxy routing itself was fine. Only the card path was wrong.

## Two sites, one defect

The second was found while verifying the first:

| Site | Effect |
|---|---|
| `registry/core/nginx_service.py` | the generated card location 404ed through the gateway |
| `registry/utils/agent_validator.py` | the registration-time reachability probe reported a spec-following agent unreachable |

`_build_agent_health_urls` (`registry/api/agent_routes.py`) already derived the card from the origin, so **three call sites disagreed and only one matched the spec**. That is why the health check reported these agents healthy while their gateway card route 404ed. All three now agree.

The JSON-RPC route still appends the registered path, which is correct there.

## Not a data problem

The agent is right, the registry stored the card's `url` verbatim, and no code inserts the path — a grep across `registry/` and `auth_server/` for a `/a2a` concatenation returns only protocol identifiers, the ARD media type, and comments. **No record is modified and no migration is needed.**

A path-less URL is why this went unnoticed: appending to the url and to the origin produce the same string, so those routes were always correct.

## Verification, on a rebuilt stack against a live agent

```
BEFORE  proxy_pass https://support-….helpagent.club/a2a/.well-known/agent-card.json;   404
AFTER   proxy_pass https://support-….helpagent.club/.well-known/agent-card.json;        200
```

| Check | Result |
|---|---|
| fix present in the running container | confirmed, not assumed |
| rendered card route targets the origin | yes |
| card route through the gateway | `200 application/json` |
| it is the real card | `name = "Absolute Fire Sprinklers Support Agent"` |
| `url` rewritten by `agent_card_rewrite.lua` | `http://localhost/agent/absolute-fire-sprinklers-customer-support-agent/` |
| JSON-RPC route | byte-identical to a direct backend POST |
| path-less agent's route | unchanged |
| all rendered card routes on that stack | 8 of 8 target an origin, 0 nest a path |
| other agents spot-checked through the gateway | 5 of 5 return 200 with rewritten urls |

The rewritten `url` is the load-bearing row: the Lua filter can only produce it from a card body it actually parsed, so it proves the whole chain rather than a status code. A sixth agent returns 502 — `travel-assistant-agent`, whose backend container does not exist on this host. Its route is the path-less one this change leaves byte-identical, so that is pre-existing.

## Tests

Six new nginx cases and two validator cases: a path suffix, a multi-segment path, a port, the path-less regression guard, the JSON-RPC route keeping its path, and the card route retaining its `X-Authorization` and `Cookie` strips (the #1391 egress trust model — moving the target must not disturb it).

**The three path-carrying cases and one validator case were confirmed to fail without the source change.** Full suite `7989 passed, 57 skipped`; the 4 failures on my machine are a pre-existing local `.env` TTL bleed absent in CI.

## Notes for review

- The rationale comment sits outside the f-string. Putting it inside would have emitted nine lines of Python reasoning into every agent's nginx block; I checked the rendered output to confirm it does not leak.
- `_NGINX_AGENT_URL_SAFE` enforces `^https?://`, so scheme and netloc are always present and the origin reconstruction cannot produce a malformed `://`.
- Out of scope per the issue: `proxy_pass_url` being unset on these records (a separate question about the import path), and the `agent.json` vs `agent-card.json` filename question.
