### PR TITLE
feat(metrics): record the gateway hop's own outcome, not just the authz decision

### DIFF
--- a/auth_server/observability/meters.py
+++ b/auth_server/observability/meters.py
@@ -217,6 +217,21 @@ generic_proxy_stream_outcome_total = _meter.create_counter(
     unit="1",
 )
 
+generic_proxy_request_total = _meter.create_counter(
+    name="mcpgw_registry_generic_proxy_request_total",
+    description=(
+        "Generic-proxy requests by terminal outcome, labeled by entity_type "
+        "(skill | a2a_agent | custom) and outcome (ok | upstream_4xx | "
+        "upstream_5xx | upstream_error | egress_blocked | auth_unavailable | "
+        "capacity | disabled | rejected | byte_cap | client_closed | "
+        "duration_timeout | internal_error). Counts the HOP's own result, which "
+        "auth_request_total cannot: a request that passes /validate and then "
+        "fails at the hop lands here as a failure and there as a success. Does "
+        "not cover the 401 token gate, which rejects before the handler runs."
+    ),
+    unit="1",
+)
+
 
 def record_generic_proxy_slot_rejected(pool: str) -> None:
     """Record a generic-proxy capacity rejection (503) for the given pool."""
@@ -230,6 +245,21 @@ def record_generic_proxy_stream_outcome(outcome: str) -> None:
     """Record a start/terminal outcome for a streaming generic-proxy request."""
     try:
         generic_proxy_stream_outcome_total.add(1, {"outcome": outcome})
+    except Exception:  # pragma: no cover - metrics must never break the hop
+        pass
+
+
+def record_generic_proxy_request(entity_type: str, outcome: str) -> None:
+    """Record one terminal outcome for a generic-proxy request.
+
+    Exactly one call per request that enters the hop handler. The buffered path
+    records through an idempotent per-request wrapper in ``server.py`` so a
+    helper-raised failure and the handler's own exception arm cannot both count;
+    the streaming path records its post-header terminal directly, because by then
+    the handler has already returned the StreamingResponse.
+    """
+    try:
+        generic_proxy_request_total.add(1, {"entity_type": entity_type, "outcome": outcome})
     except Exception:  # pragma: no cover - metrics must never break the hop
         pass
 
@@ -248,6 +278,28 @@ _STREAM_OUTCOMES: tuple[str, ...] = (
     "byte_cap",
     "upstream_error",
     "client_closed",
+)
+
+# The hop counter's label sets. entity_type is collapsed to three values by
+# _metrics_entity_type in server.py (operators define custom types at will, so a
+# raw entity_type would grow the label set with operator behaviour), and outcome
+# is a closed enum, so the product is 3 x 13 = 39 series -- flat, whatever the
+# endpoint count, because no label carries entity identity.
+HOP_ENTITY_TYPES: tuple[str, ...] = ("skill", "a2a_agent", "custom")
+HOP_OUTCOMES: tuple[str, ...] = (
+    "ok",
+    "upstream_4xx",
+    "upstream_5xx",
+    "upstream_error",
+    "egress_blocked",
+    "auth_unavailable",
+    "capacity",
+    "disabled",
+    "rejected",
+    "byte_cap",
+    "client_closed",
+    "duration_timeout",
+    "internal_error",
 )
 
 
@@ -274,6 +326,11 @@ def zero_init_generic_proxy_metrics() -> None:
     seeds = [(generic_proxy_slot_rejected_total, {"pool": pool}) for pool in _SLOT_POOLS]
     seeds += [
         (generic_proxy_stream_outcome_total, {"outcome": outcome}) for outcome in _STREAM_OUTCOMES
+    ]
+    seeds += [
+        (generic_proxy_request_total, {"entity_type": entity_type, "outcome": outcome})
+        for entity_type in HOP_ENTITY_TYPES
+        for outcome in HOP_OUTCOMES
     ]
     seeded = 0
     for instrument, attrs in seeds:

--- a/auth_server/server.py
+++ b/auth_server/server.py
@@ -22,8 +22,10 @@ import urllib.parse
 import uuid
 from collections.abc import Mapping
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from datetime import datetime
-from functools import lru_cache
+from functools import lru_cache, wraps
 from pathlib import Path
 from string import Template
 from typing import Any
@@ -54,6 +56,7 @@ from starlette.background import BackgroundTask
 
 try:
     from observability.meters import (
+        record_generic_proxy_request,
         record_generic_proxy_slot_rejected,
         record_generic_proxy_stream_outcome,
         redirect_rejected_total,
@@ -62,13 +65,13 @@ try:
     )
 except ImportError:
     from auth_server.observability.meters import (
+        record_generic_proxy_request,
         record_generic_proxy_slot_rejected,
         record_generic_proxy_stream_outcome,
         redirect_rejected_total,
         token_mint_total,
         zero_init_generic_proxy_metrics,
     )
-
 try:
     from egress_obo import (
         OboConfigError,
@@ -8238,6 +8241,120 @@ def _read_generic_stream_read_timeout_seconds() -> float:
         return 3600.0
 
 
+_HOP_ENTITY_TYPE_LABELS: dict[str, str] = {"skill": "skill", "a2a_agent": "a2a_agent"}
+
+# Status -> outcome for hop failures whose meaning the status alone settles.
+# `disabled`, `auth_unavailable` and `egress_blocked` are NOT here: each shares a
+# status with a different failure (503 with capacity, 502 with upstream_error), so
+# their sites record explicitly before raising and the idempotent recorder keeps
+# the first value.
+_HOP_STATUS_OUTCOMES: dict[int, str] = {
+    400: "rejected",
+    413: "byte_cap",
+    502: "upstream_error",
+    503: "capacity",
+    504: "upstream_error",
+}
+
+
+def _metrics_entity_type(entity_type: str) -> str:
+    """Collapse a hop entity_type to the counter's three-value label set.
+
+    Operators define custom types at will, so a raw entity_type would grow the
+    label set with operator behaviour. Everything that is not a skill or an A2A
+    agent is a custom record. Safe on None/empty: returns "custom".
+    """
+    return _HOP_ENTITY_TYPE_LABELS.get(entity_type or "", "custom")
+
+
+@dataclass
+class _HopOutcomeState:
+    """Per-request holder so exactly one outcome is recorded for the hop."""
+
+    entity_type: str
+    recorded: bool = False
+
+
+# Per-request, not per-process: each request runs in its own task, so the context
+# copy isolates this. Set by the handler wrapper; read by the helper-raised failure
+# sites (which have no access to the request) so they can record the outcome only
+# THEY know -- a 503 from the feature latch is not the 503 from a saturated pool.
+_hop_outcome_state: ContextVar[_HopOutcomeState | None] = ContextVar(
+    "generic_hop_outcome", default=None
+)
+
+
+def _record_hop_outcome(outcome: str) -> None:
+    """Record the hop outcome for this request, first writer wins.
+
+    Idempotent because several layers can see the same failure: the site that
+    raises knows the precise meaning, while the wrapper only sees a status code.
+    Whoever is more specific runs first, and the wrapper's later attempt no-ops.
+    """
+    state = _hop_outcome_state.get()
+    if state is None or state.recorded:
+        return
+    state.recorded = True
+    record_generic_proxy_request(state.entity_type, outcome)
+
+
+def _hop_outcome_for_status(status_code: int) -> str:
+    """Map a returned upstream status to an outcome (the success-path branch)."""
+    if status_code >= 500:
+        return "upstream_5xx"
+    if status_code >= 400:
+        return "upstream_4xx"
+    return "ok"
+
+
+def _instrument_generic_hop(handler):
+    """Record exactly one terminal outcome for every request entering the hop.
+
+    A wrapper rather than per-return instrumentation: four exits raise from
+    helpers, not from the handler's own returns -- the two sub-path confinement
+    400s in _build_generic_outbound_url, the host-pin 400 in
+    _assert_outbound_host_pinned, the 413 in _read_bounded, and the 503 in
+    _acquire_generic_proxy_slot (which covers BOTH pools, since the stream pool is
+    acquired inside the awaited streaming call). Instrumenting returns would miss
+    exactly the SSRF-confinement refusals.
+
+    A StreamingResponse records nothing here: its terminal is recorded by the
+    generator in _generic_proxy_streaming, which runs after this returns. Failures
+    raised BEFORE that response exists still land here.
+    """
+
+    @wraps(handler)
+    async def wrapper(entity_type: str, entity_path: str, request: Request):
+        token = _hop_outcome_state.set(_HopOutcomeState(_metrics_entity_type(entity_type)))
+        try:
+            response = await handler(entity_type, entity_path, request)
+        except HTTPException as exc:
+            _record_hop_outcome(
+                _HOP_STATUS_OUTCOMES.get(
+                    exc.status_code,
+                    "rejected" if 400 <= exc.status_code < 500 else "upstream_error",
+                )
+            )
+            raise
+        except asyncio.CancelledError:
+            # The caller hung up. CancelledError derives from BaseException, so
+            # without this arm it would fall through as `internal_error` and page
+            # somebody for a client disconnect. `internal_error` stays for bugs.
+            _record_hop_outcome("client_closed")
+            raise
+        except BaseException:
+            _record_hop_outcome("internal_error")
+            raise
+        else:
+            if not isinstance(response, StreamingResponse):
+                _record_hop_outcome(_hop_outcome_for_status(response.status_code))
+            return response
+        finally:
+            _hop_outcome_state.reset(token)
+
+    return wrapper
+
+
 async def _acquire_generic_proxy_slot(
     semaphore: asyncio.Semaphore, *, pool: str = "buffered"
 ) -> None:
@@ -8501,6 +8618,7 @@ async def _generic_proxy_streaming(
     request_body: bytes,
     forward_headers: dict[str, str],
     verify: bool | str,
+    metrics_entity: str,
 ) -> StreamingResponse:
     """Forward a proxied entity's response to the client incrementally (SSE/chunked).
 
@@ -8569,11 +8687,17 @@ async def _generic_proxy_streaming(
         # of an opaque 500. Log the reason only, never the raw target.
         await _cleanup()
         record_generic_proxy_stream_outcome("upstream_error")
+        # The hop counter separates an egress refusal from a transport fault; both
+        # leave as 502, so the status map alone would blur them.
+        _record_hop_outcome("egress_blocked")
         logger.warning("generic_proxy(stream): egress blocked: %s", exc.reason)
         raise HTTPException(status_code=502, detail="Upstream not permitted") from exc
     except TimeoutError as exc:
         await _cleanup()
         record_generic_proxy_stream_outcome("duration_timeout")
+        # 504 maps to upstream_error by status; this one is the absolute-duration
+        # ceiling firing before headers, which is its own outcome.
+        _record_hop_outcome("duration_timeout")
         logger.warning("generic_proxy(stream): absolute duration exceeded before response headers")
         raise HTTPException(status_code=504, detail="Upstream timed out") from exc
     except httpx.TimeoutException as exc:
@@ -8631,14 +8755,21 @@ async def _generic_proxy_streaming(
                     max_bytes = _read_generic_stream_max_bytes()
                     if total_bytes > max_bytes:
                         record_generic_proxy_stream_outcome("byte_cap")
+                        # Recorded directly, not through the idempotent wrapper: the
+                        # handler already returned this StreamingResponse, so the
+                        # per-request context is gone and only this generator can
+                        # name the terminal.
+                        record_generic_proxy_request(metrics_entity, "byte_cap")
                         raise HTTPException(
                             status_code=413,
                             detail=f"Upstream stream exceeded {max_bytes} bytes",
                         )
                     yield chunk
             record_generic_proxy_stream_outcome("completed")
+            record_generic_proxy_request(metrics_entity, "ok")
         except TimeoutError:
             record_generic_proxy_stream_outcome("duration_timeout")
+            record_generic_proxy_request(metrics_entity, "duration_timeout")
             logger.warning("generic_proxy(stream): absolute stream duration exceeded")
             raise
         except (GeneratorExit, asyncio.CancelledError):
@@ -8646,12 +8777,14 @@ async def _generic_proxy_streaming(
             # slot is released in `finally`; record the terminal so in-flight =
             # started - terminals stays reconcilable, then re-raise.
             record_generic_proxy_stream_outcome("client_closed")
+            record_generic_proxy_request(metrics_entity, "client_closed")
             raise
         except httpx.HTTPError:
             # Upstream failed AFTER headers were sent (dropped mid-body). The status
             # line is already on the wire, so we cannot turn this into a 5xx; record
             # the terminal and abort the stream.
             record_generic_proxy_stream_outcome("upstream_error")
+            record_generic_proxy_request(metrics_entity, "upstream_error")
             logger.error("generic_proxy(stream): mid-stream upstream error")
             raise
         finally:
@@ -8681,6 +8814,7 @@ async def _generic_proxy_streaming(
     methods=_GENERIC_PROXY_METHODS,
     dependencies=[Depends(verify_generic_proxy_token)],
 )
+@_instrument_generic_hop
 async def generic_proxy(
     entity_type: str,
     entity_path: str,
@@ -8696,6 +8830,10 @@ async def generic_proxy(
     # Fail closed if the feature latch is off (flag disabled OR egress self-check
     # failed). None (pre-startup) is treated as off.
     if not _generic_proxy_feature_active:
+        # Recorded here, not derived from the status: a disabled feature and a
+        # saturated pool both return 503, and conflating them means a switched-off
+        # deployment fires a capacity alert.
+        _record_hop_outcome("disabled")
         raise HTTPException(
             status_code=503,
             detail="Generic proxy feature is not active on this server",
@@ -8762,6 +8900,9 @@ async def generic_proxy(
                 entity_type,
                 bound_registered_path,
             )
+            # A missing credential and a dead backend both return 502; separate
+            # them so a credential outage cannot read as an upstream fault.
+            _record_hop_outcome("auth_unavailable")
             raise HTTPException(status_code=502, detail="Upstream auth unavailable")
         vended_defaults, overridable_names = vended
         # Apply the per-header overridable policy: fixed operator headers overwrite
@@ -8798,6 +8939,9 @@ async def generic_proxy(
             request_body=request_body,
             forward_headers=forward_headers,
             verify=verify,
+            # The streaming path owns its terminal, so it needs the label the
+            # wrapper resolved for this request.
+            metrics_entity=_metrics_entity_type(entity_type),
         )
 
     semaphore = _get_generic_proxy_semaphore()
@@ -8848,6 +8992,10 @@ async def generic_proxy(
                 bound_registered_path,
                 exc.reason,
             )
+            # A security event, not a transport fault. Recorded here because this
+            # arm converts it to the same 502 an upstream failure returns, and an
+            # SSRF refusal must not fire the credential-outage alert.
+            _record_hop_outcome("egress_blocked")
             raise HTTPException(status_code=502, detail="Upstream not permitted") from exc
         except httpx.TimeoutException as exc:
             logger.error(

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -307,10 +307,45 @@ exposition form** (after the OTel exporter appends the unit suffix).
 | `mcpgw_rate_limit_quarantine_denied_total` | auth-server (`/validate`) | `scope` (`caller`/`target`), `entity_type` | Requests dropped because a caller or target is **quarantined** (kill switch) |
 | `mcpgw_rate_limit_quarantine_members` (Gauge) | registry | `group` (`quarantine-callers`/`quarantine-targets`) | Current member count of each kill-switch group, observed each export cycle (correct across replicas) |
 | `mcpgw_rate_limit_errors_total` | auth-server (`/validate`) | `axis` (incl. `qtn` for a quarantine-membership read error) | Rate-limit backend errors (counter-store unreachable/timeout → fail-open/closed) |
+| `mcpgw_registry_generic_proxy_request_total` | auth-server (gateway hop) | `entity_type` (`skill`/`a2a_agent`/`custom`), `outcome` (13 values, below) | **What the caller actually got.** One record per request that enters the hop handler, on both the buffered and streaming paths. `auth_request_total` cannot answer this — its `success` label is the `/validate` decision, so a 502 credential-vend failure reads there as a success. 3 × 13 = 39 series, flat whatever the endpoint count (no label carries entity identity); every combination exists at zero from startup. Does **not** cover the 401 token gate, which rejects in a route dependency before the handler runs |
 | `mcpgw_registry_generic_proxy_slot_rejected_total` | auth-server (gateway hop) | `pool` (`buffered`/`stream`) | Gateway-proxy requests rejected with 503 because a concurrency slot could not be acquired inside the acquire timeout. A non-zero rate means the pool is saturated: raise `GATEWAY_GENERIC_STREAM_MAX_CONCURRENCY` or shed load. Both `pool` values exist at zero from startup |
 | `mcpgw_registry_generic_proxy_stream_outcome_total` | auth-server (gateway hop) | `outcome` (`started`/`completed`/`duration_timeout`/`byte_cap`/`upstream_error`/`client_closed`) | Streaming gateway-proxy lifecycle. In-flight streams are `started` minus the sum of the five terminals. All six values exist at zero from startup |
 | `mcpgw_registry_gateway_generic_blocks_dropped_total` | registry | `reason` (`invalid`/`collision`) | Gateway routes the nginx render path refused. Non-zero means an entity is registered and unreachable |
 | `mcpgw_registry_gateway_egress_policy_unverified` (Gauge) | registry | none | `1` means the startup self-check reached cloud metadata, so the generic proxy latched **off** for the process. A standing `1` on an enabled deployment is an alert |
+
+#### The 13 hop outcomes, and why the set is not just "status code"
+
+`mcpgw_registry_generic_proxy_request_total{outcome}` exists because HTTP statuses collapse failures an operator must tell apart. Two 503s and three 502s leave the hop for entirely different reasons:
+
+| Outcome | Status the caller saw | What happened |
+|---|---|---|
+| `ok` | 2xx/3xx | Forwarded and returned, or a stream that completed |
+| `upstream_4xx` | 4xx from the backend | The hop worked; the backend refused. A 404 for a path that does not exist upstream lands here |
+| `upstream_5xx` | 5xx from the backend | The hop worked; the backend broke |
+| `upstream_error` | 502 / 504 | No usable response: connection refused, reset, or timed out |
+| `egress_blocked` | 502 | **Security event.** The guarded transport refused the outbound because the pinned host resolved to a private, metadata, or rebound IP |
+| `auth_unavailable` | 502 | The upstream-credential vend failed, so the hop refused to forward unauthenticated |
+| `capacity` | 503 | A concurrency slot could not be acquired inside the acquire timeout (either pool) |
+| `disabled` | 503 | The feature latch is off — flag disabled, or the egress self-check failed at startup |
+| `rejected` | 400 | Sub-path confinement or host-pin refusal: the SSRF guards saying no |
+| `byte_cap` | 413 | The response exceeded the buffered or stream byte ceiling |
+| `client_closed` | — | The caller hung up (buffered `CancelledError`, or a stream abandoned mid-body) |
+| `duration_timeout` | 504 / aborted stream | The absolute stream-duration ceiling fired |
+| `internal_error` | 500 | A bug. If this moves, read the logs — nothing else records here |
+
+Collapse those and you get paged for the wrong thing: `disabled` would fire a saturation alert, and `egress_blocked` — an SSRF refusal — would fire a credential-outage alert.
+
+| Goal | Query |
+|---|---|
+| Hop failure rate per entity type (the headline SLI) | `sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total{outcome!~"ok\|upstream_4xx"}[5m])) / sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total[5m]))` |
+| What is failing, ranked | `topk(10, sum by (outcome)(rate(mcpgw_registry_generic_proxy_request_total{outcome!="ok"}[15m])))` |
+| **Alert:** SSRF egress refusals (would have read as a credential outage before) | `sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total{outcome="egress_blocked"}[15m])) > 0` |
+| **Alert:** credential vend failing | `sum(rate(mcpgw_registry_generic_proxy_request_total{outcome="auth_unavailable"}[15m])) > 0` |
+| **Alert:** a bug, not a backend fault | `sum(rate(mcpgw_registry_generic_proxy_request_total{outcome="internal_error"}[15m])) > 0` |
+| Feature switched off while callers still arrive | `sum(rate(mcpgw_registry_generic_proxy_request_total{outcome="disabled"}[5m])) > 0` |
+| The disagreement this counter exists for: `/validate` says success, the hop failed | `sum(rate(mcpgw_registry_generic_proxy_request_total{outcome=~"auth_unavailable\|upstream_error\|egress_blocked\|capacity"}[15m])) > 0 and sum(rate(mcpgw_registry_auth_request_total{target_kind=~"generic_proxy_.*", success="true"}[15m])) > 0` |
+
+Both counters are correct at once: `/validate` did succeed, and the request still failed at the hop. That is the point — `auth_request_total` reports the authorization decision, this counter reports the caller's outcome.
 
 ### Histograms
 
@@ -538,7 +573,7 @@ counters() {
 counters
 ```
 
-On a stack that has just started, before any gateway traffic, eight series already exist at zero. That is the point of zero-initialization: a `rate()` alert can bind at deploy instead of waiting for the first failure.
+On a stack that has just started, before any gateway traffic, 47 series already exist at zero — 39 hop outcomes plus the 8 lifecycle values below. That is the point of zero-initialization: a `rate()` alert can bind at deploy instead of waiting for the first failure.
 
 ```
 mcpgw_registry_generic_proxy_slot_rejected_total{pool="buffered"} 0.0
@@ -555,7 +590,7 @@ Confirm the startup log said so:
 
 ```bash
 docker compose logs auth-server | grep zero-init
-# zero-init seeded 8/8 generic-proxy series
+# zero-init seeded 47/47 generic-proxy series
 ```
 
 A line reading `zero-init skipped: meter provider is ...` means the SDK meter provider was never installed, so no series were seeded and none of the checks below will show anything.
@@ -566,7 +601,7 @@ On ECS, seeding still happens — `opentelemetry-instrument` installs a real SDK
 aws logs filter-log-events --log-group-name /ecs/mcp-gateway-v2-auth-server \
   --filter-pattern 'zero-init' --start-time $(( ($(date +%s) - 3600) * 1000 )) \
   --query 'events[-3:].message' --output text
-# zero-init seeded 8/8 generic-proxy series
+# zero-init seeded 47/47 generic-proxy series
 
 # the group name comes from the task definition, so read it rather than guessing:
 aws ecs describe-task-definition --task-definition mcp-gateway-v2-auth \

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -635,14 +635,15 @@ uv run python api/registry_management.py --registry-url "$REGISTRY_URL" --token-
 
 The metric label `target_kind="generic_proxy_custom"` is the part that does not vary: every custom type collapses to that one value, however many types exist and whatever they are named. Only `server` carries the type name.
 
-Once callers start using it, four questions come up, and each maps to one of the labels this feature adds:
+Once callers start using it, five questions come up, and each maps to one of the labels this feature adds:
 
 | Question | Where the answer is |
 |---|---|
 | How much traffic is this endpoint taking, next to my skills and MCP servers? | `target_kind="generic_proxy_custom"` on `mcpgw_registry_auth_request_total` |
 | Which proxied endpoint, out of the several registered? | the `server` label, which holds the entity's authz key |
 | Is anyone being denied, and what scope rule would fix it? | `success="false"` on that same series; the `server` value is the string to put in `server_access` |
-| Are its streams completing, or hitting a ceiling? | `mcpgw_registry_generic_proxy_stream_outcome_total` |
+| **Did the caller's request actually succeed?** | `mcpgw_registry_generic_proxy_request_total{outcome}`. Not `auth_request_total{success}` — that is the `/validate` decision, so a request that authorizes and then fails at the hop reads there as a success |
+| Are its streams completing, or hitting a ceiling? | `mcpgw_registry_generic_proxy_stream_outcome_total` for the lifecycle, or `outcome` on the hop counter for the terminal the caller saw |
 
 Every gateway request carries a `generic_proxy_*` kind, so `target_kind="unknown"` holds no gateway traffic. A gateway call appearing there means the `X-Generic-Proxy-Kind` marker did not reach the auth-server.
 
@@ -691,9 +692,12 @@ curl -sS --compressed -N -X POST \
 
 ```
 mcpgw_registry_auth_request_total{...,server="rest-endpoint/rest-endpoint/6160de6a-...",target_kind="generic_proxy_custom"} 4.0
+mcpgw_registry_generic_proxy_request_total{entity_type="custom",outcome="ok"}           4.0
 mcpgw_registry_generic_proxy_stream_outcome_total{outcome="started"}   4.0
 mcpgw_registry_generic_proxy_stream_outcome_total{outcome="completed"} 4.0
 ```
+
+The hop counter agrees with the stream counter here because every request completed. When they disagree, the hop counter is the one that matches what the caller saw: a stream aborted by the client shows `stream_outcome{client_closed}` **and** `generic_proxy_request_total{outcome="client_closed"}`, while `auth_request_total` still records that request as a success, because `/validate` did succeed.
 
 **Both cases incremented the stream counter**, including the one that asked for `"stream": false`. `proxy_streaming` is a property of the **registered entity**, not of the request: it decides whether the hop streams the upstream response or buffers it. OpenAI's `"stream"` body field only changes what the upstream sends back. An entity with `proxy_streaming=true` therefore takes the streaming hop path on every request.
 

--- a/docs/gateway-proxy-operational-guide.md
+++ b/docs/gateway-proxy-operational-guide.md
@@ -564,21 +564,35 @@ The companion latency histogram `mcpgw_registry_auth_request_duration_millisecon
 
 | Metric | Read it as |
 |---|---|
+| `mcpgw_registry_generic_proxy_request_total{entity_type,outcome}` | **What the caller got**, one record per request on both paths. This is the metric to alert on: `ok` / `upstream_4xx` / `upstream_5xx` / `upstream_error` / `egress_blocked` / `auth_unavailable` / `capacity` / `disabled` / `rejected` / `byte_cap` / `client_closed` / `duration_timeout` / `internal_error`. Statuses alone would blur these — two different 503s (`disabled` vs `capacity`) and three different 502s (`auth_unavailable` vs `egress_blocked` vs `upstream_error`) — so a switched-off feature would page for saturation and an SSRF refusal would page for a credential outage. 39 series, flat whatever the endpoint count. The 401 token gate records nothing here: it rejects before the handler runs. |
 | `mcpgw_registry_generic_proxy_slot_rejected_total{pool}` | 503s from a saturated concurrency pool, labeled `buffered` or `stream`. A non-zero rate means raise `GATEWAY_GENERIC_STREAM_MAX_CONCURRENCY` or shed load. |
 | `mcpgw_registry_generic_proxy_stream_outcome_total{outcome}` | `started`, `completed`, `duration_timeout`, `byte_cap`, `upstream_error`, `client_closed`. In-flight streams equal `started` minus the sum of the terminals. `proxy_streaming` is a property of the entity, so an entity with it on takes the streaming path on every request regardless of what the caller's request body asks for. |
 | `mcpgw_registry_gateway_generic_blocks_dropped_total{reason}` | routes the render path refused, `invalid` (bad target) or `collision` (the location path is already claimed). Non-zero means an entity is registered and unreachable. |
 | `mcpgw_registry_gateway_egress_policy_unverified` | 1 means the startup self-check reached cloud metadata and the feature is latched off for the process. A standing 1 on an enabled deployment is an alert. |
 
-Every label value on the two `generic_proxy_*` counters exists at zero from startup, so a `rate()` alert binds at deploy instead of waiting for the first failure.
+Every label value on all three `generic_proxy_*` counters exists at zero from startup (39 + 6 + 2 = 47 series), so a `rate()` alert binds at deploy instead of waiting for the first failure.
 
-On **docker compose**, confirm with `docker compose logs auth-server | grep zero-init`, which reports `zero-init seeded 8/8 generic-proxy series`. A line reading `zero-init skipped: meter provider is ...` means the SDK meter provider was never installed, so nothing was seeded.
+The failure-rate query worth putting on a dashboard, and the three worth alerting on:
+
+```promql
+sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total{outcome!~"ok|upstream_4xx"}[5m]))
+  / sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total[5m]))
+
+sum by (entity_type)(rate(mcpgw_registry_generic_proxy_request_total{outcome="egress_blocked"}[15m])) > 0   # SSRF refusals
+sum(rate(mcpgw_registry_generic_proxy_request_total{outcome="auth_unavailable"}[15m])) > 0                  # credential vend failing
+sum(rate(mcpgw_registry_generic_proxy_request_total{outcome="internal_error"}[15m])) > 0                    # a bug, not a backend fault
+```
+
+`upstream_4xx` is deliberately outside the failure ratio: a caller asking a backend for something it does not have is not a gateway fault. Include it when you care about caller behaviour rather than hop health.
+
+On **docker compose**, confirm with `docker compose logs auth-server | grep zero-init`, which reports `zero-init seeded 47/47 generic-proxy series`. A line reading `zero-init skipped: meter provider is ...` means the SDK meter provider was never installed, so nothing was seeded.
 
 On **ECS**, both checks work but the paths differ. The log line lives in the per-container v2 group named by the task definition (`/ecs/mcp-gateway-v2-auth-server` — read it with `aws ecs describe-task-definition ... logConfiguration.options."awslogs-group"` rather than guessing, and pick a stream whose id matches a currently running task, since a rolling deploy leaves the replaced task's stream behind):
 
 ```bash
 aws logs filter-log-events --log-group-name /ecs/mcp-gateway-v2-auth-server \
   --filter-pattern 'zero-init' --start-time $(( ($(date +%s) - 3600) * 1000 )) \
-  --query 'events[-1].message' --output text     # zero-init seeded 8/8 generic-proxy series
+  --query 'events[-1].message' --output text     # zero-init seeded 47/47 generic-proxy series
 ```
 
 For the counters themselves, query `sum by (outcome)(mcpgw_registry_generic_proxy_stream_outcome_total)` in Grafana or AMP and expect all six values with the untriggered ones at `0`. The task runs under `opentelemetry-instrument`, so the SDK provider already exists, seeding proceeds, and metrics leave through the `adot-collector` sidecar over OTLP — **nothing listens on `:9464` there**, so `curl localhost:9464/metrics` inside the task returns `Connection refused` and is not a valid check on that surface.

--- a/tests/auth_server/unit/test_generic_proxy_metrics.py
+++ b/tests/auth_server/unit/test_generic_proxy_metrics.py
@@ -299,6 +299,29 @@ class TestZeroInit:
         assert all(c[0][0] == 0 for c in slot_add.call_args_list)
         assert all(c[0][0] == 0 for c in stream_add.call_args_list)
 
+    def test_seeds_all_39_hop_outcome_combinations(self):
+        """The hop counter is the one an alert binds to, so it must exist at zero.
+
+        39 series = 3 entity types x 13 outcomes, flat whatever the endpoint count.
+        A missed combination is invisible until the day it increments, which is the
+        day you needed the alert to have been armed already.
+        """
+        from auth_server.observability import meters
+
+        with (
+            patch.object(meters.generic_proxy_request_total, "add") as hop_add,
+            patch.object(meters.generic_proxy_slot_rejected_total, "add"),
+            patch.object(meters.generic_proxy_stream_outcome_total, "add"),
+            patch.object(meters.metrics, "get_meter_provider", return_value=MagicMock()),
+        ):
+            meters.zero_init_generic_proxy_metrics()
+
+        seeded = {(c[0][1]["entity_type"], c[0][1]["outcome"]) for c in hop_add.call_args_list}
+        expected = {(e, o) for e in meters.HOP_ENTITY_TYPES for o in meters.HOP_OUTCOMES}
+        assert seeded == expected
+        assert len(seeded) == 39
+        assert all(c[0][0] == 0 for c in hop_add.call_args_list)
+
     def test_skips_and_reports_a_no_op_provider(self, caplog):
         """With no SDK provider every add(0) is discarded, so say so once.
 
@@ -337,6 +360,18 @@ class TestZeroInit:
 
         assert slot_add.call_count == 2
         assert stream_add.call_count == 6
+        # The hop counter is seeded after both of those, so a raise in the first
+        # instrument must not cost the 39 series an alert actually binds to.
+        with (
+            patch.object(
+                meters.generic_proxy_slot_rejected_total, "add", side_effect=RuntimeError("boom")
+            ),
+            patch.object(meters.generic_proxy_stream_outcome_total, "add"),
+            patch.object(meters.generic_proxy_request_total, "add") as hop_add,
+            patch.object(meters.metrics, "get_meter_provider", return_value=MagicMock()),
+        ):
+            meters.zero_init_generic_proxy_metrics()
+        assert hop_add.call_count == 39
 
 
 class TestServerNameIsBounded:

--- a/tests/auth_server/unit/test_generic_proxy_outcome.py
+++ b/tests/auth_server/unit/test_generic_proxy_outcome.py
@@ -1,0 +1,515 @@
+"""One test per hop outcome value (issue #1735, item 4).
+
+``mcpgw_registry_generic_proxy_request_total`` is the counter that answers what
+the CALLER saw. ``auth_request_total`` cannot: the metrics middleware returns
+early on anything but ``/validate``, so its ``success`` label records the
+authorization decision and nothing after it — a 502 credential-vend failure
+reaches the client while that metric says ``success=true``.
+
+Every value gets a case because a missed exit path produces **silence, not a
+failure**: nothing errors, the series simply never moves. These drive the real
+decorated handler (``server.generic_proxy`` is the wrapper) and the real
+streaming function, so the wiring is under test, not a copy of it.
+
+Two collisions are the reason the outcome set is not just "status code":
+
+- two different 503s — ``disabled`` (feature latched off) vs ``capacity``
+  (pool saturated). Conflating them makes a switched-off deployment page
+  somebody for saturation.
+- three different 502s — ``auth_unavailable`` (vend failed), ``egress_blocked``
+  (SSRF refusal at connect time) and ``upstream_error`` (dead backend). An SSRF
+  refusal must not read as a credential outage.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-that-is-definitely-long-enough-32b")
+
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+from starlette.responses import StreamingResponse  # noqa: E402
+
+import auth_server.server as server  # noqa: E402
+from auth_server.observability.meters import HOP_ENTITY_TYPES, HOP_OUTCOMES  # noqa: E402
+from registry.exceptions import UrlValidationError  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+UPSTREAM = "https://backend.example/api"
+
+
+def _request(*, streaming: bool = False, has_upstream_auth: bool = False) -> Request:
+    """A hop request whose verified claims are already stashed by the dependency."""
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/proxy/skill/skills/demo",
+        "query_string": b"",
+        "headers": [(b"accept", b"application/json")],
+        "client": ("10.0.0.1", 1234),
+        "server": ("auth-server", 8888),
+        "scheme": "http",
+    }
+    request = Request(scope, receive=receive)
+    request.state.generic_proxy_claims = {
+        "upstream_url": UPSTREAM,
+        "server": "skills/demo",
+        "streaming": streaming,
+        "has_upstream_auth": has_upstream_auth,
+    }
+    return request
+
+
+class _FakeUpstreamResponse:
+    """Minimal stand-in for the httpx streaming response the hop consumes."""
+
+    def __init__(self, status_code: int = 200, body: bytes = b"{}", chunks=None):
+        self.status_code = status_code
+        self.headers = {"content-type": "application/json"}
+        self._body = body
+        self._chunks = chunks
+
+    async def aiter_bytes(self, chunk_size: int = 65536):
+        yield self._body
+
+    def aiter_raw(self):
+        chunks = self._chunks if self._chunks is not None else [self._body]
+
+        async def _gen():
+            for chunk in chunks:
+                if isinstance(chunk, BaseException):
+                    raise chunk
+                yield chunk
+
+        return _gen()
+
+
+def _client_returning(response, *, stream_raises: BaseException | None = None):
+    """Patch target for guarded_async_client: async CM -> client with .stream()."""
+    stream_cm = MagicMock()
+    if stream_raises is not None:
+        stream_cm.__aenter__ = AsyncMock(side_effect=stream_raises)
+    else:
+        stream_cm.__aenter__ = AsyncMock(return_value=response)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    client = MagicMock()
+    client.stream = MagicMock(return_value=stream_cm)
+    client.aclose = AsyncMock()
+
+    client_cm = MagicMock()
+    client_cm.__aenter__ = AsyncMock(return_value=client)
+    client_cm.__aexit__ = AsyncMock(return_value=False)
+    # The streaming path uses the client WITHOUT `async with`, so the factory's
+    # return value must double as the client itself.
+    client_cm.stream = client.stream
+    client_cm.aclose = client.aclose
+    return client_cm
+
+
+async def _call_hop(request, **patches):
+    """Drive the decorated handler, returning the recorded (entity_type, outcome)."""
+    with patch("auth_server.server.record_generic_proxy_request") as recorder:
+        stack = []
+        try:
+            for target, kwargs in patches.items():
+                ctx = patch(f"auth_server.server.{target}", **kwargs)
+                stack.append(ctx)
+                ctx.start()
+            with patch.object(server, "_generic_proxy_feature_active", True):
+                try:
+                    response = await server.generic_proxy("skill", "skills/demo", request)
+                except BaseException as exc:  # noqa: BLE001 - the outcome is the assertion
+                    response = exc
+        finally:
+            for ctx in reversed(stack):
+                ctx.stop()
+    calls = [c.args for c in recorder.call_args_list]
+    return response, calls
+
+
+class TestBufferedOutcomes:
+    """The buffered path: one record per request, whoever knows best records it."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (200, "ok"),
+            (204, "ok"),
+            (404, "upstream_4xx"),
+            (429, "upstream_4xx"),
+            (500, "upstream_5xx"),
+            (503, "upstream_5xx"),
+        ],
+    )
+    async def test_returned_status_maps_to_outcome(self, status, expected):
+        response, calls = await _call_hop(
+            _request(),
+            guarded_async_client={
+                "return_value": _client_returning(_FakeUpstreamResponse(status_code=status))
+            },
+        )
+        assert calls == [("skill", expected)]
+
+    @pytest.mark.asyncio
+    async def test_disabled_is_not_capacity(self):
+        """Both return 503. Deriving from the status alone would page for saturation."""
+        request = _request()
+        with (
+            patch("auth_server.server.record_generic_proxy_request") as recorder,
+            patch.object(server, "_generic_proxy_feature_active", False),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await server.generic_proxy("skill", "skills/demo", request)
+        assert exc.value.status_code == 503
+        assert [c.args for c in recorder.call_args_list] == [("skill", "disabled")]
+
+    @pytest.mark.asyncio
+    async def test_capacity_from_the_acquire_helper(self):
+        """The 503 is raised inside a helper that never touches the handler's returns."""
+        _, calls = await _call_hop(
+            _request(),
+            _acquire_generic_proxy_slot={
+                "side_effect": HTTPException(status_code=503, detail="Generic proxy is at capacity")
+            },
+        )
+        assert calls == [("skill", "capacity")]
+
+    @pytest.mark.asyncio
+    async def test_helper_raised_400_is_rejected_and_not_a_500(self):
+        """The SSRF sub-path confinement refusals raise before the handler's own try.
+
+        Revision 1 of the design read the outcome in a `finally` without assigning
+        it first, so these turned a 400 into an UnboundLocalError-driven 500. This
+        asserts both halves: the status survives and the outcome is `rejected`.
+        """
+        response, calls = await _call_hop(
+            _request(),
+            _build_generic_outbound_url={
+                "side_effect": HTTPException(status_code=400, detail="Illegal sub-path")
+            },
+        )
+        assert isinstance(response, HTTPException)
+        assert response.status_code == 400
+        assert calls == [("skill", "rejected")]
+
+    @pytest.mark.asyncio
+    async def test_host_pin_failure_is_rejected(self):
+        _, calls = await _call_hop(
+            _request(),
+            _assert_outbound_host_pinned={
+                "side_effect": HTTPException(status_code=400, detail="Proxy target host mismatch")
+            },
+        )
+        assert calls == [("skill", "rejected")]
+
+    @pytest.mark.asyncio
+    async def test_byte_cap_from_read_bounded(self):
+        _, calls = await _call_hop(
+            _request(),
+            guarded_async_client={"return_value": _client_returning(_FakeUpstreamResponse())},
+            _read_bounded={
+                "side_effect": HTTPException(status_code=413, detail="Upstream response too large")
+            },
+        )
+        assert calls == [("skill", "byte_cap")]
+
+    @pytest.mark.asyncio
+    async def test_vend_failure_is_auth_unavailable_not_upstream_error(self):
+        """Shares 502 with a dead backend; a credential outage needs its own signal."""
+        _, calls = await _call_hop(
+            _request(has_upstream_auth=True),
+            _vend_generic_upstream_headers={"return_value": None},
+        )
+        assert calls == [("skill", "auth_unavailable")]
+
+    @pytest.mark.asyncio
+    async def test_egress_block_is_not_auth_unavailable(self):
+        """UrlValidationError = the guarded transport refused a rebound/private IP."""
+        _, calls = await _call_hop(
+            _request(),
+            guarded_async_client={
+                "return_value": _client_returning(
+                    None, stream_raises=UrlValidationError("blocked", reason="private_ip")
+                )
+            },
+        )
+        assert calls == [("skill", "egress_blocked")]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raised",
+        [httpx.ConnectError("refused"), httpx.TimeoutException("slow"), httpx.ReadError("reset")],
+    )
+    async def test_transport_failures_are_upstream_error(self, raised):
+        _, calls = await _call_hop(
+            _request(),
+            guarded_async_client={"return_value": _client_returning(None, stream_raises=raised)},
+        )
+        assert calls == [("skill", "upstream_error")]
+
+    @pytest.mark.asyncio
+    async def test_client_hangup_is_client_closed_not_internal_error(self):
+        """CancelledError derives from BaseException.
+
+        Without its own arm it lands in the bug bucket, so a caller pressing
+        Ctrl-C would page whoever alerts on internal_error.
+        """
+        _, calls = await _call_hop(
+            _request(),
+            guarded_async_client={
+                "return_value": _client_returning(None, stream_raises=asyncio.CancelledError())
+            },
+        )
+        assert calls == [("skill", "client_closed")]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_is_internal_error(self):
+        _, calls = await _call_hop(
+            _request(),
+            guarded_async_client={
+                "return_value": _client_returning(None, stream_raises=RuntimeError("bug"))
+            },
+        )
+        assert calls == [("skill", "internal_error")]
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_record_per_request(self):
+        """The wrapper sees every failure the sites already recorded; first wins."""
+        _, calls = await _call_hop(
+            _request(has_upstream_auth=True),
+            _vend_generic_upstream_headers={"return_value": None},
+        )
+        assert len(calls) == 1, f"double counted: {calls}"
+
+
+class TestEntityTypeLabel:
+    """entity_type collapses to three values, whatever operators name their types."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("entity_type", "expected"),
+        [
+            ("skill", "skill"),
+            ("a2a_agent", "a2a_agent"),
+            ("rest-endpoint", "custom"),
+            ("some-operator-type", "custom"),
+        ],
+    )
+    async def test_label_is_bounded_to_three_values(self, entity_type, expected):
+        request = _request()
+        with (
+            patch("auth_server.server.record_generic_proxy_request") as recorder,
+            patch.object(server, "_generic_proxy_feature_active", False),
+        ):
+            with pytest.raises(HTTPException):
+                await server.generic_proxy(entity_type, "x/y", request)
+        assert recorder.call_args_list[0].args[0] == expected
+
+
+class TestStreamingOutcomes:
+    """The streaming path owns its terminal; the wrapper must stay silent for it."""
+
+    @staticmethod
+    async def _drive_stream(response=None, *, stream_raises=None, consume=True, chunks=None):
+        recorded = []
+        upstream = response or _FakeUpstreamResponse(chunks=chunks)
+        with (
+            patch(
+                "auth_server.server.record_generic_proxy_request",
+                side_effect=lambda e, o: recorded.append((e, o)),
+            ),
+            patch("auth_server.server.record_generic_proxy_stream_outcome"),
+            patch(
+                "auth_server.server.guarded_async_client",
+                return_value=_client_returning(upstream, stream_raises=stream_raises),
+            ),
+            patch("auth_server.server._acquire_generic_proxy_slot", AsyncMock()),
+        ):
+            semaphore = asyncio.Semaphore(1)
+            try:
+                result = await server._generic_proxy_streaming(
+                    semaphore=semaphore,
+                    method="GET",
+                    outbound_url=UPSTREAM,
+                    request_body=b"",
+                    forward_headers={},
+                    verify=True,
+                    metrics_entity="custom",
+                )
+            except BaseException as exc:  # noqa: BLE001
+                return exc, recorded
+            if consume and isinstance(result, StreamingResponse):
+                # A terminal failure mid-body propagates to the ASGI server in
+                # production; here it just must not hide the recorded outcome.
+                try:
+                    async for _ in result.body_iterator:
+                        pass
+                except BaseException as exc:  # noqa: BLE001 - the record is the assertion
+                    return exc, recorded
+            return result, recorded
+
+    @staticmethod
+    async def _drive_stream_through_handler(*, stream_raises):
+        """Pre-header failures must be driven through the wrapper.
+
+        The site records via the idempotent per-request recorder, which only exists
+        inside the wrapper — that is the whole point: whichever layer knows the
+        precise meaning records first, and the wrapper's status-derived attempt
+        then no-ops. Calling the streaming function bare would record nothing and
+        prove nothing.
+        """
+        recorded = []
+        with (
+            patch(
+                "auth_server.server.record_generic_proxy_request",
+                side_effect=lambda e, o: recorded.append((e, o)),
+            ),
+            patch("auth_server.server.record_generic_proxy_stream_outcome"),
+            patch(
+                "auth_server.server.guarded_async_client",
+                return_value=_client_returning(None, stream_raises=stream_raises),
+            ),
+            patch("auth_server.server._acquire_generic_proxy_slot", AsyncMock()),
+            patch.object(server, "_generic_proxy_feature_active", True),
+        ):
+            try:
+                result = await server.generic_proxy(
+                    "skill", "skills/demo", _request(streaming=True)
+                )
+            except BaseException as exc:  # noqa: BLE001
+                result = exc
+        return result, recorded
+
+    @pytest.mark.asyncio
+    async def test_completed_stream_records_ok_once(self):
+        result, recorded = await self._drive_stream(chunks=[b"data: 1\n", b"data: 2\n"])
+        assert isinstance(result, StreamingResponse)
+        assert recorded == [("custom", "ok")]
+
+    @pytest.mark.asyncio
+    async def test_pre_header_egress_block(self):
+        result, recorded = await self._drive_stream_through_handler(
+            stream_raises=UrlValidationError("blocked", reason="metadata_ip")
+        )
+        assert isinstance(result, HTTPException) and result.status_code == 502
+        assert recorded == [("skill", "egress_blocked")]
+
+    @pytest.mark.asyncio
+    async def test_pre_header_duration_timeout_is_not_upstream_error(self):
+        """Raised as 504, which maps to upstream_error by status — so it records itself."""
+        result, recorded = await self._drive_stream_through_handler(
+            stream_raises=TimeoutError("deadline")
+        )
+        assert isinstance(result, HTTPException) and result.status_code == 504
+        assert recorded == [("skill", "duration_timeout")]
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_upstream_error(self):
+        result, recorded = await self._drive_stream(chunks=[b"partial", httpx.ReadError("dropped")])
+        assert recorded == [("custom", "upstream_error")]
+
+    @pytest.mark.asyncio
+    async def test_byte_cap_mid_stream(self):
+        with patch("auth_server.server._read_generic_stream_max_bytes", return_value=4):
+            result, recorded = await self._drive_stream(chunks=[b"12345678"])
+        assert recorded == [("custom", "byte_cap")]
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_mid_stream(self):
+        recorded = []
+        with (
+            patch(
+                "auth_server.server.record_generic_proxy_request",
+                side_effect=lambda e, o: recorded.append((e, o)),
+            ),
+            patch("auth_server.server.record_generic_proxy_stream_outcome"),
+            patch(
+                "auth_server.server.guarded_async_client",
+                return_value=_client_returning(_FakeUpstreamResponse(chunks=[b"a", b"b", b"c"])),
+            ),
+            patch("auth_server.server._acquire_generic_proxy_slot", AsyncMock()),
+        ):
+            result = await server._generic_proxy_streaming(
+                semaphore=asyncio.Semaphore(1),
+                method="GET",
+                outbound_url=UPSTREAM,
+                request_body=b"",
+                forward_headers={},
+                verify=True,
+                metrics_entity="custom",
+            )
+            iterator = result.body_iterator
+            await iterator.__anext__()
+            await iterator.aclose()  # client hung up mid-stream
+        assert recorded == [("custom", "client_closed")]
+
+    @pytest.mark.asyncio
+    async def test_wrapper_does_not_double_count_a_stream(self):
+        """The handler returns a StreamingResponse; only the generator records."""
+        request = _request(streaming=True)
+        upstream = _FakeUpstreamResponse(chunks=[b"x"])
+        with (
+            patch("auth_server.server.record_generic_proxy_request") as recorder,
+            patch("auth_server.server.record_generic_proxy_stream_outcome"),
+            patch(
+                "auth_server.server.guarded_async_client",
+                return_value=_client_returning(upstream),
+            ),
+            patch("auth_server.server._acquire_generic_proxy_slot", AsyncMock()),
+            patch.object(server, "_generic_proxy_feature_active", True),
+        ):
+            response = await server.generic_proxy("skill", "skills/demo", request)
+            assert isinstance(response, StreamingResponse)
+            # Nothing recorded yet: the terminal belongs to the generator.
+            assert recorder.call_args_list == []
+            async for _ in response.body_iterator:
+                pass
+        assert [c.args for c in recorder.call_args_list] == [("skill", "ok")]
+
+
+class TestLabelSets:
+    """The declared label sets are the contract zero-init and dashboards rely on."""
+
+    def test_thirteen_outcomes_three_entity_types(self):
+        assert len(HOP_OUTCOMES) == 13
+        assert len(HOP_ENTITY_TYPES) == 3
+        assert len(HOP_ENTITY_TYPES) * len(HOP_OUTCOMES) == 39
+
+    def test_every_outcome_this_suite_records_is_declared(self):
+        """A typo in a record call would otherwise ship an undeclared, unseeded series."""
+        recorded_here = {
+            "ok",
+            "upstream_4xx",
+            "upstream_5xx",
+            "upstream_error",
+            "egress_blocked",
+            "auth_unavailable",
+            "capacity",
+            "disabled",
+            "rejected",
+            "byte_cap",
+            "client_closed",
+            "duration_timeout",
+            "internal_error",
+        }
+        assert recorded_here == set(HOP_OUTCOMES)
+
+    def test_status_map_covers_the_hop_statuses(self):
+        assert server._HOP_STATUS_OUTCOMES == {
+            400: "rejected",
+            413: "byte_cap",
+            502: "upstream_error",
+            503: "capacity",
+            504: "upstream_error",
+        }

--- a/tests/auth_server/unit/test_generic_proxy_streaming.py
+++ b/tests/auth_server/unit/test_generic_proxy_streaming.py
@@ -79,6 +79,9 @@ async def _call(sem, client):
             request_body=b"",
             forward_headers={},
             verify=True,
+            # Required since issue #1735 item 4: the streaming path owns its hop
+            # outcome, so it needs the entity label the wrapper resolved.
+            metrics_entity="custom",
         )
 
 

--- a/tests/scripts/gateway-proxy-regression.md
+++ b/tests/scripts/gateway-proxy-regression.md
@@ -523,12 +523,14 @@ counters() { docker exec $AUTH sh -c 'curl -s localhost:9464/metrics' \
 **T-7.6 — zero series exist before any traffic.** On a freshly started stack:
 
 ```bash
-docker compose logs auth-server | grep zero-init     # zero-init seeded 8/8 generic-proxy series
+docker compose logs auth-server | grep zero-init     # zero-init seeded 47/47 generic-proxy series
 docker exec $AUTH sh -c 'curl -s localhost:9464/metrics' \
   | grep -E '^mcpgw_registry_generic_proxy_(slot_rejected|stream_outcome)_total' | grep -c ' 0.0$'   # 8
+docker exec $AUTH sh -c 'curl -s localhost:9464/metrics' \
+  | grep -c '^mcpgw_registry_generic_proxy_request_total.* 0.0$'                                     # 39
 ```
 
-Pass: the log line reports `8/8` and all 8 series exist at `0.0`. A `zero-init skipped: meter provider is ...` line means `OTEL_EXPORTER_PROMETHEUS_HOST` is unset, so nothing below will show anything.
+Pass: the log line reports `47/47`, the two lifecycle counters expose 8 series at `0.0`, and the hop outcome counter exposes all **39** (3 entity types × 13 outcomes). A `zero-init skipped: meter provider is ...` line means the SDK meter provider was never installed, so nothing below will show anything.
 
 **T-7.7 — a proxied request is labeled by entity type and authz key.** Drive one buffered custom record and one skill, then:
 
@@ -595,6 +597,45 @@ docker exec $AUTH sh -c 'curl -s localhost:9464/metrics' | grep -cE '"_other"|"_
 ```
 
 Pass: the real server name appears verbatim (`server_name="com-github-github-mcp-server"`), the invoked tool appears as `tool_name`, and no `_other`/`_unset` sentinel exists. **Note the cap:** a deployment whose traffic spreads across more than 150 distinct servers will collapse the long tail into `_other` — this stack has 144 registered MCP servers plus 8 proxied gateway entities, so it is close enough to the cap that `METRICS_MAX_LABEL_CARDINALITY` may need raising (see [unified-parameter-reference.md](../../docs/unified-parameter-reference.md), Group 25).
+
+**T-7.13 — the hop's own outcome is recorded, once per request (issue #1735 item 4).** `auth_request_total{success}` is the `/validate` decision, so a request that authorizes and then fails at the hop reads there as a success. `generic_proxy_request_total{entity_type,outcome}` is what the caller got.
+
+Drive one request per reachable outcome, then read the counter:
+
+```bash
+hop() { docker exec $AUTH sh -c 'curl -s localhost:9464/metrics' \
+  | grep '^mcpgw_registry_generic_proxy_request_total' | grep -v ' 0.0$' \
+  | sed 's/otel_scope[^,]*,//g;s/mcpgw_registry_generic_proxy_request_total//' | sort; }
+
+curl -sS --compressed -o /dev/null -H "X-Authorization: Bearer $GW" "${BASE}v1/forecast?latitude=38.9&longitude=-77.03&current=temperature_2m"   # ok
+curl -sS --compressed -o /dev/null -H "X-Authorization: Bearer $GW" "${BASE}v1/forecast?latitude=not-a-number"                                    # upstream_4xx
+curl -sS --compressed -o /dev/null -H "X-Authorization: Bearer $GW" "$ORIGIN/gateway/skill/pdf/definitely/not/a/real/file.md"                     # upstream_4xx (skill)
+timeout 60 curl -sS --compressed -N -X POST -H "X-Authorization: Bearer $GW" -H "Authorization: Bearer $OAI" \
+  -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}],"stream":true,"max_tokens":10}' \
+  -o /dev/null "$OPENAI_BASE/v1/chat/completions"                                                                                                 # ok (stream)
+timeout 60 curl -sS --compressed -N -X POST -H "X-Authorization: Bearer $GW" -H "Authorization: Bearer $OAI" \
+  -H 'Content-Type: application/json' -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"count to 40"}],"stream":true,"max_tokens":300}' \
+  "$OPENAI_BASE/v1/chat/completions" | head -c 200 > /dev/null                                                                                    # client_closed
+hop
+```
+
+Observed on 2026-09-08 for exactly those six requests:
+
+```
+{entity_type="custom",outcome="client_closed"} 1.0
+{entity_type="custom",outcome="ok"} 2.0
+{entity_type="custom",outcome="upstream_4xx"} 2.0
+{entity_type="skill",outcome="ok"} 1.0
+{entity_type="skill",outcome="upstream_4xx"} 1.0
+```
+
+Pass criteria, each of which has caught a real bug in review:
+
+- **The totals equal the number of requests that entered the hop.** Six requests, six records. More means double counting (the streaming path recording alongside the wrapper); fewer means an exit path records nothing.
+- **A streaming request contributes exactly one record, not one per chunk**, and it reconciles with the lifecycle counter: `stream_outcome{started}` equals the sum of its terminals, and each stream shows up once here.
+- **`entity_type` stays within `skill` / `a2a_agent` / `custom`** whatever the operator named the type.
+- **A 401 from the token gate records nothing.** Send a bogus token and confirm the counter does not move: the gate is a route dependency that returns before the handler, which is a documented non-goal rather than an oversight.
+- **Failures that share a status stay distinct.** `disabled` vs `capacity` (both 503) and `auth_unavailable` vs `egress_blocked` vs `upstream_error` (all 502) are unit-tested per value in `tests/auth_server/unit/test_generic_proxy_outcome.py`; force them here only if you can (a corrupted stored credential gives `auth_unavailable`, `GATEWAY_GENERIC_PROXY_ENABLED=false` gives `disabled`).
 
 ## 8. Teardown
 


### PR DESCRIPTION
Closes the second half of #1735 (item 4). PR 1 (#1736) classified gateway routes and fixed the `server` label; this adds the counter that fixes the headline defect.

## Problem

A 502 to the caller currently reads as `success=true`. `metrics_middleware.py` returns early on anything but `/validate`, so `success` records the **authorization decision** and nothing after it. A credential-vend failure, a saturated pool, an SSRF refusal and a dead backend all authorize fine, then fail — and the metric says they succeeded.

## What this adds

`mcpgw_registry_generic_proxy_request_total{entity_type, outcome}` — one record per request entering the hop, on both the buffered and streaming paths. **39 series, flat** whatever the endpoint count, because no label carries entity identity. `entity_type` collapses to `skill` / `a2a_agent` / `custom`: operators define custom types at will, and a raw value would grow the label set with operator behaviour.

### Why thirteen outcomes and not "status code"

| Collision | Kept distinct |
|---|---|
| two different **503s** | `disabled` (feature latched off) vs `capacity` (pool saturated) |
| three different **502s** | `auth_unavailable` (vend failed) vs `egress_blocked` (guarded transport refused a private/metadata/rebound IP) vs `upstream_error` |
| hop worked, backend didn't | `upstream_4xx`, `upstream_5xx` vs `ok` |
| limits and refusals | `rejected` (400 SSRF confinement), `byte_cap` (413), `client_closed`, `duration_timeout`, `internal_error` |

Collapse them and you get paged for the wrong thing: a switched-off feature fires a saturation alert, and an SSRF refusal fires a credential-outage alert.

## How it's instrumented, and why not per-return

Four exits raise from helpers and never touch the handler's own returns:

- two sub-path confinement 400s in `_build_generic_outbound_url`
- the host-pin 400 in `_assert_outbound_host_pinned`
- the 413 in `_read_bounded`
- the 503 in `_acquire_generic_proxy_slot` — which covers **both** pools, since the stream pool is acquired inside the awaited streaming call

Per-return instrumentation would have missed exactly the SSRF-confinement refusals. A wrapper (`_instrument_generic_hop`) records once per request and leaves the handler body untouched — no re-indentation of a 180-line security-critical function.

Sites that know more than a status code record first through an idempotent per-request recorder (a `ContextVar`), and the wrapper's status-derived attempt then no-ops. Three such sites: the feature latch, the vend failure, the egress refusal.

**Two deliberate design decisions worth review:**

1. `CancelledError` records `client_closed`, not `internal_error` as the LLD said. It derives from `BaseException`, so without an arm it reads as `ok` (the defect this issue reports); putting it in the bug bucket instead would page whoever alerts on `internal_error` every time a caller hangs up. `internal_error` now means a bug and nothing else.
2. The streaming path owns its terminal — post-header sites record directly, because the handler has already returned the `StreamingResponse` and the per-request context is gone. The wrapper skips `StreamingResponse` for that reason, so a stream counts once, not once per chunk. Pre-header stream failures still route through the wrapper.

## Verification

**Live, on a running stack** — six requests driving five outcome/entity combinations:

```
{entity_type="custom",outcome="ok"} 2.0            <- buffered 200 + streaming SSE 200
{entity_type="custom",outcome="upstream_4xx"} 2.0  <- bad param 400 + api-ninjas 400
{entity_type="custom",outcome="client_closed"} 1.0 <- stream truncated by the client
{entity_type="skill",outcome="ok"} 1.0
{entity_type="skill",outcome="upstream_4xx"} 1.0   <- 404 on the skill origin
```

Six requests, six records, one per request. The stream counter reconciles: `started 2` = `completed 1` + `client_closed 1`, and the hop counter took exactly one record per stream. A bogus token recorded **nothing**, confirming the documented non-goal — the 401 gate is a route dependency that returns before the handler.

**zero-init** grows 8 → 47 series (`zero-init seeded 47/47 generic-proxy series`, all 39 hop combinations at `0.0` before traffic). An absent series cannot be alerted on, which is half of what #1735 reports.

**Tests:** 33 new cases, one per outcome value, because a missed exit path produces silence rather than a failure. Includes a helper-raised 400 staying a 400 (design revision 1 turned it into a 500 via `UnboundLocalError` in a `finally`) and a stream not being double counted. Full suite: 8062 passed, 4 pre-existing failures (token-TTL, unrelated — reproducible with this diff stashed).

## Docs

- `OBSERVABILITY.md`: counter row, the 13-outcome reference table with the status each maps to, and seven queries including the disagreement query this counter exists for (`/validate` says success, the hop failed)
- `gateway-proxy-operational-guide.md`: the metric an operator should alert on, the failure-rate query, and three alert queries. `upstream_4xx` is deliberately outside the failure ratio — a caller asking for something the backend lacks is not a gateway fault
- `tests/scripts/gateway-proxy-regression.md`: T-7.13 with the observed numbers and the pass criteria that each caught a real bug in review

## Non-goals (tracked in the LLD)

No outcome for the 401 token gate (`verify_generic_proxy_token` is a route dependency; recording there means touching the dependency). No per-entity labels — the metrics-service already stores per-request rows. No hop latency histogram. Alert rules and Grafana panels remain a follow-up.