### PR TITLE
docs(faq): registering OpenAI/Bedrock endpoints, and what the gateway proxy changes on upgrade

### DIFF
--- a/docs/faq/gateway-proxy-backwards-compatibility.md
+++ b/docs/faq/gateway-proxy-backwards-compatibility.md
@@ -1,0 +1,104 @@
+# What changes when I upgrade to a release with the gateway generic proxy?
+
+Nothing, until you opt in.
+
+The generic proxy lets the gateway front non-MCP entities — skills, A2A agents, and custom records such as a REST API — at `/{prefix}/{entity_type}/{name}/`. It ships disabled. On a default upgrade your deployment behaves as it did before: no new route renders, `/validate` mints no generic-proxy token, and the nginx render path issues no extra per-tick database queries.
+
+This page answers what an upgrade does and does not change. For how to use the feature, see the [operational guide](../gateway-proxy-operational-guide.md) and [registering OpenAI or Bedrock endpoints](registering-model-inference-endpoints.md).
+
+## What a default upgrade does not change
+
+**Existing routes stay where they are.** MCP servers keep `/mcp-proxy/...`. A2A agents keep `/agent/...`. The generic proxy adds paths alongside them and relocates nothing.
+
+**No schema migration, no backfill.** Eight fields join the entity models — `is_proxied`, `proxy_target_url`, `proxy_streaming`, `proxy_connect_notes`, `custom_headers_encrypted`, `custom_header_names`, `custom_header_overridable_names`, `custom_headers_updated_at`. Existing records do not have them and read as their defaults. Nothing rewrites your data.
+
+**Enabling the feature grants nobody anything.** A legacy `methods: ["all"]` rule authorizes no HTTP verb. That split is deliberate: an existing MCP grant must not turn into arbitrary HTTP access against a proxied backend. Every proxied entity needs an explicit verb rule, or `http:*`, on its authz key.
+
+**Per-entity opt-in.** With the feature on, still no route renders until an entity sets `is_proxied`.
+
+## What an upgrade does change
+
+Two visible differences, both read-only:
+
+- The new fields appear in API read models, with secret values stripped. `custom_header_names` lists which upstream headers an entity has; the values never leave the registry.
+- Entity forms in the UI show a proxy toggle.
+
+## Turning it on: the flag and three prerequisites
+
+`GATEWAY_GENERIC_PROXY_ENABLED=true` is necessary and not sufficient. Both the registry and the auth-server must receive the same value — the registry renders the routes, the auth-server serves the hop.
+
+**1. `DEPLOYMENT_MODE=with-gateway`.** In `registry-only` mode there is no nginx to render into, and the feature stays off.
+
+**2. A stable `SECRET_KEY`.** It derives the encryption key for stored upstream credentials. Rotating it makes every stored credential undecryptable, and each affected entity then returns 502 on every request. Rotate the provider keys instead, or re-register the headers after a `SECRET_KEY` change.
+
+**3. An enforced network egress policy.** At startup the auth-server probes a cloud metadata IP (`169.254.169.254`, `fd00:ec2::254`) from inside its own container. If the address answers, the feature disables itself for that process and logs at critical:
+
+```text
+Generic proxy egress self-check FAILED: a cloud metadata IP
+(169.254.169.254 / fd00:ec2::254) is REACHABLE from the auth-server.
+The required network egress policy is NOT enforced — DISABLING the
+generic-proxy feature for this process (fail-closed). Deploy the
+egress NetworkPolicy/security-group before enabling this feature.
+```
+
+The gauge `mcpgw_registry_gateway_egress_policy_unverified` reads `1` in that state. A standing `1` on a deployment you believe is enabled means the routes render and the hop refuses every request. On a passing deployment the log reads `Generic proxy egress self-check PASSED; feature active`.
+
+You can opt out of the check with `GATEWAY_EGRESS_SELFCHECK_ENABLED=false`, which logs a warning and leaves DNS rebinding to the metadata IP unmitigated. Do that only when the egress policy is enforced by something the container cannot see.
+
+## Custom records need a second flag
+
+`CUSTOM_ENTITY_TYPES_ENABLED` is separately false by default. Without it the registry never registers `/api/custom-types` or `/api/custom/{type}`, and both return **404**.
+
+Worth knowing because the symptom misleads: a 404 reads as a missing route or a version mismatch, when the cause is a disabled feature. Skills and A2A agents need only `GATEWAY_GENERIC_PROXY_ENABLED`; custom records need both flags.
+
+## Checking what your deployment is doing
+
+```bash
+# the flags each service actually received (both must agree on the first one)
+docker compose exec -T registry env | grep -E '^(GATEWAY_GENERIC_PROXY_ENABLED|CUSTOM_ENTITY_TYPES_ENABLED|DEPLOYMENT_MODE)='
+docker compose exec -T auth-server env | grep -E '^GATEWAY_GENERIC_PROXY_ENABLED='
+
+# did the hop come up, or did the self-check latch it off?
+docker compose logs auth-server | grep -iE 'egress self-check|Generic proxy'
+
+# which entities are proxied right now
+curl -sS --compressed -H "Authorization: Bearer $GW" "$REGISTRY_URL/api/skills" \
+  | jq -r '.skills[] | select(.is_proxied) | "\(.path) -> \(.proxy_target_url)"'
+```
+
+On a working deployment the first command prints all three variables as `true` / `true` / `with-gateway`, and the last prints one line per proxied entity:
+
+```text
+/skills/pdf -> https://raw.githubusercontent.com
+```
+
+The log line tells you which of three states the hop is in:
+
+| Log line | State |
+|---|---|
+| `Generic proxy egress self-check PASSED; feature active` | enabled and verified |
+| `Generic proxy egress self-check FAILED: ... DISABLING the generic-proxy feature` | routes render, hop refuses every request |
+| `Generic proxy ENABLED with egress self-check OPTED OUT` | `GATEWAY_EGRESS_SELFCHECK_ENABLED=false`; you own the egress policy |
+| `Generic proxy feature disabled (gateway_generic_proxy_enabled=false)` | off, the default |
+
+The System Config page in the UI shows the same flags. `GET /api/config/full` backs that page and authenticates with a session cookie, so a Bearer token returns `{"detail": "Authentication required"}` — read the values from the container env or the UI instead.
+
+If a route 404s while the feature is on, check that nginx has regenerated. The registry rewrites the config when a proxied entity changes, and a record created seconds ago may not have a location yet.
+
+## If you upgrade past 1.30.0, three metric labels change
+
+The gateway-proxy metrics work in 1.30.0 alters labels on an existing counter. Saved queries and alert rules need a look:
+
+- `mcpgw_registry_auth_request_total` now classifies gateway traffic as `target_kind="generic_proxy_skill"`, `generic_proxy_agent`, or `generic_proxy_custom`. Anything filtering `target_kind="unknown"` stops matching it.
+- On those series `server` holds the entity's authz key — `skill/skills/pdf` — instead of the literal `gateway`.
+- `success` is lowercase `true` / `false` on every exporter. A query written `success="True"` returns an empty result rather than an error, so it looks like zero traffic.
+- `mcpgw_registry_auth_request_duration_milliseconds` no longer carries `server`. Group it by `target_kind`.
+
+The shipped Grafana dashboards are already updated. See [Observability](../OBSERVABILITY.md#target-type-routing-target_kind) for the full label reference.
+
+## Related documentation
+
+- [Gateway generic proxy operational guide](../gateway-proxy-operational-guide.md) — routes, credentials, streaming limits, troubleshooting
+- [How do I let my team call OpenAI or Bedrock through the gateway?](registering-model-inference-endpoints.md)
+- [Unified parameter reference](../unified-parameter-reference.md) — every flag above across Docker, Terraform, and Helm
+- [Observability](../OBSERVABILITY.md) — the metrics and labels named here

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -6,6 +6,7 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [What is MCP and why do I need a gateway?](what-is-mcp-and-gateway.md)
 - [How do I deploy and register MCP servers and agents?](deploying-and-registering-servers-agents.md)
+- [What changes when I upgrade to a release with the gateway generic proxy?](gateway-proxy-backwards-compatibility.md)
 
 ## Tool and Agent Discovery
 
@@ -18,6 +19,7 @@ Common questions and answers about the MCP Gateway Registry.
 
 - [How do I get my AI coding assistant to work with this registry?](connect-ai-coding-assistant.md)
 - [How do I register commonly used third-party MCP servers like GitHub, Slack, and Atlassian?](registering-third-party-mcp-servers.md)
+- [How do I let my team call OpenAI or Bedrock through the gateway?](registering-model-inference-endpoints.md)
 - [How do I configure the Datadog MCP server with per-user egress OAuth (public client + PKCE)?](configuring-datadog-mcp-server.md)
 - [How do I connect my agent to multiple MCP servers through the gateway?](connecting-multiple-mcp-servers.md)
 - [How do I test my agent's integration with the MCP Gateway locally?](local-testing-agent-integration.md)

--- a/docs/faq/registering-model-inference-endpoints.md
+++ b/docs/faq/registering-model-inference-endpoints.md
@@ -1,0 +1,221 @@
+# How do I let my team call OpenAI or Bedrock through the gateway?
+
+Put a model-inference endpoint behind the gateway as a **proxied custom record**. Callers then hold a gateway token and reach the provider through a registry URL, and every call carries the registry's authorization, audit, and rate-limit checks.
+
+Two credential models exist, and you pick one per record:
+
+- **Caller passthrough** — each caller brings their own provider key. The registry stores nothing. The provider sees one client per user, so quota and billing stay per-user.
+- **Fixed operator header** — you store one team key, encrypted, and every authorized caller uses it. Callers never see the key; the provider sees a single client and pools your quota.
+
+The steps below use caller passthrough, which is what `--auth-passthrough` sets up. Depth on the feature itself lives in the [gateway generic proxy operational guide](../gateway-proxy-operational-guide.md).
+
+## What you need before you start
+
+- `GATEWAY_GENERIC_PROXY_ENABLED=true` and `CUSTOM_ENTITY_TYPES_ENABLED=true` in `.env`, with the stack restarted. Both default to false. See [what changes when you upgrade](gateway-proxy-backwards-compatibility.md).
+- `DEPLOYMENT_MODE=with-gateway`. In `registry-only` mode no route renders.
+- Registry admin access — creating a custom entity type is admin-only.
+- A provider key: an OpenAI API key, or a Bedrock long-term API key scoped to the region you target.
+
+Set the two variables the commands below use:
+
+```bash
+export REGISTRY_URL=https://mcpgateway.example.com
+export TOKEN_FILE=.token
+```
+
+## Step 1 — Create the custom type, once
+
+A custom type is a schema for records of that kind. Create it from a JSON descriptor:
+
+```bash
+cat > /tmp/rest-endpoint.json <<'EOF'
+{
+  "name": "rest-endpoint",
+  "description": "Proxied generic REST/HTTP endpoints",
+  "fields": [
+    {"name": "notes", "datatype": "string", "required": false}
+  ]
+}
+EOF
+
+uv run python api/registry_management.py \
+  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
+  custom-type-create --config /tmp/rest-endpoint.json
+```
+
+**Every field must be optional.** `custom-proxy-create` sends no attributes, so a required field rejects the record you are about to create. One type serves every provider — OpenAI, Bedrock, and any other REST backend become records of `rest-endpoint`.
+
+Check what already exists before creating a duplicate:
+
+```bash
+uv run python api/registry_management.py --registry-url "$REGISTRY_URL" \
+  --token-file "$TOKEN_FILE" custom-type-list --json | jq -r '.custom_types[].name'
+```
+
+## Step 2 — Register the endpoint
+
+```bash
+# OpenAI
+uv run python api/registry_management.py \
+  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
+  custom-proxy-create --type rest-endpoint --name openai-proxy \
+  --target-url https://api.openai.com \
+  --streaming true --auth-passthrough
+
+# Bedrock, us-east-2
+uv run python api/registry_management.py \
+  --registry-url "$REGISTRY_URL" --token-file "$TOKEN_FILE" \
+  custom-proxy-create --type rest-endpoint --name bedrock-proxy-use2 \
+  --target-url https://bedrock-runtime.us-east-2.amazonaws.com \
+  --streaming true --auth-passthrough
+```
+
+`--auth-passthrough` registers `Authorization` as a **caller-overridable** upstream header with no stored value: the caller's key travels to the provider, and the registry keeps no secret. A fixed operator `Authorization` value is refused at registration — operator-owned bearers belong in the [per-user egress credential vault](../egress-credential-vault.md).
+
+`--streaming true` sets `proxy_streaming` on the record. That is a property of the **record**, not of a request: an entity with it on takes the streaming path on every call, whatever the request body asks for.
+
+Read back the client URL rather than assembling it:
+
+```bash
+uv run python api/registry_management.py --registry-url "$REGISTRY_URL" \
+  --token-file "$TOKEN_FILE" custom-record-list --type rest-endpoint --json \
+  | jq -r '.records[] | "\(.name)  \(.proxy_client_url)  -> \(.proxy_target_url)"'
+```
+
+```text
+openai-proxy         /gateway/rest-endpoint/6160de6a-...  -> https://api.openai.com
+bedrock-proxy-use2   /gateway/rest-endpoint/d7ff8465-...  -> https://bedrock-runtime.us-east-2.amazonaws.com
+```
+
+## Step 3 — Grant the HTTP verbs
+
+This is where a first attempt usually fails. **A legacy `methods: ["all"]` rule grants no HTTP verb.** The split is deliberate: an existing MCP grant must not become arbitrary HTTP access. The caller's group needs an explicit verb — or `http:*` — on the record's authz key:
+
+```text
+{entity_type}/{registered_path}
+```
+
+For the record above that key is `rest-endpoint/rest-endpoint/6160de6a-...`. Read it from the record rather than building it by hand, and note it is not the client URL: the generated path drops the namespace segment, so a skill registered at `/skills/pdf` has the key `skill/skills/pdf` and the client URL `/gateway/skill/pdf`.
+
+Without the rule, the gateway returns **403** and the `server` label on `mcpgw_registry_auth_request_total{success="false"}` holds the exact key to name in the rule. The helper scripts write it for you:
+
+```bash
+uv run python tests/scripts/openai_gateway_client.py --registry-url "$REGISTRY_URL" \
+  --entity openai-proxy --ensure-scope
+```
+
+## Step 4 — Call it, with the credentials split
+
+Two headers, two different secrets:
+
+| Header | Value |
+|---|---|
+| `X-Authorization` | the gateway JWT — authenticates the caller to the registry |
+| `Authorization` | the provider key — forwarded to OpenAI or Bedrock |
+
+Sending the gateway token in both trips the equal-token guard and returns **401**. That guard exists so a gateway credential cannot leak to a third-party backend.
+
+```bash
+export GW=$(jq -r '.tokens.access_token // .access_token' .token)
+export OAI=$(cat .scratchpad/.oai)
+export BASE="$REGISTRY_URL/gateway/rest-endpoint/6160de6a-..."
+
+curl -sS --compressed -X POST "$BASE/v1/chat/completions" \
+  -H "X-Authorization: Bearer $GW" -H "Authorization: Bearer $OAI" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say hello in five words."}]}' \
+  | jq -r '.choices[0].message.content'
+```
+
+Always pass `--compressed`. The gateway gzips JSON, and without it a working call prints unreadable bytes while `-w '%{http_code}'` still reports 200.
+
+The official SDKs work unchanged — point the base URL at the client path and give the SDK the provider key:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url=f"{REGISTRY_URL}/gateway/rest-endpoint/6160de6a-.../v1",
+    api_key=openai_key,                              # travels as Authorization
+    default_headers={"X-Authorization": f"Bearer {gateway_jwt}"},
+)
+print(client.chat.completions.create(model="gpt-4o-mini", messages=[...]))
+```
+
+## Step 5 — Verify streaming instead of assuming it
+
+A 200 says nothing about incremental delivery. A buffered response and a streamed one both return 200, and the difference only shows in the timing of the chunks. Two scripts measure it and fail when the response arrives in one piece:
+
+```bash
+uv run python tests/scripts/openai_gateway_client.py --registry-url "$REGISTRY_URL" \
+  --entity openai-proxy --mode all
+```
+
+Output from a live run against a deployment with the record above:
+
+```text
+Entity      : rest-endpoint/openai-proxy
+Streaming   : True
+Header names: ['Authorization'] (overridable: ['Authorization'])
+Authz key   : rest-endpoint/rest-endpoint/6160de6a-...
+Scope grant : present in group 'registry-admins' for GET, POST
+models      : OK 125 models in 1.30s
+chat        : OK in 0.94s -> 'Hello! How are you today?'
+stream      : 10 chunks, first at 0.90s, span 0.11s, max gap 0.071s
+stream      : OK (incremental delivery confirmed)
+Summary     : 3/3 checks passed (models, chat, stream)
+```
+
+Ten chunks spread over 0.11s is real streaming. One chunk, or ten chunks with a max gap of 0.000s, means the response was buffered somewhere and the script fails.
+
+## Bedrock specifics
+
+The request the gateway forwards is a plain Converse call with a bearer key — no SigV4, no boto3:
+
+```text
+POST https://bedrock-runtime.<region>.amazonaws.com/model/<model-id>/converse
+Authorization: Bearer <bedrock api key>
+{"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}
+```
+
+Three things differ from OpenAI:
+
+**The key is region-scoped.** It must match the region in `proxy_target_url`. A key from another region returns a Bedrock-side 403 while the proxy path itself worked.
+
+**`converse-stream` is not SSE.** It returns `application/vnd.amazon.eventstream` — length-prefixed binary frames. `curl -N` shows bytes and no `data:` lines, and a client needs a frame decoder. `tests/scripts/bedrock_gateway_client.py` decodes them with `botocore.eventstream`:
+
+```bash
+uv run python tests/scripts/bedrock_gateway_client.py --registry-url "$REGISTRY_URL" \
+  --entity bedrock-proxy-use2 --mode all --model us.anthropic.claude-opus-4-8
+```
+
+**Read whose 403 it is.** A gateway scope denial and a provider refusal share the status code, so check the body. This is a real failure from a run where the stored key had lapsed:
+
+```text
+converse    : FAILED - HTTP 403
+Upstream/gateway reported HTTP 403: {"Message":"Bearer Token has expired"}
+```
+
+`{"Message":"Bearer Token has expired"}` is Bedrock's own wording, so the request reached Bedrock and the hop is fine — the provider key needs replacing. A gateway denial returns `{"error": "Access forbidden"}` instead, and that one means the scope rule from step 3 is missing.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `200` with `text/html`, roughly 889 bytes | No gateway location matched, so nginx served the frontend shell. Wrong type spelling, the record is not proxied, or nginx has not regenerated yet. Check the content type, not the status |
+| `401` | Expired gateway token, or the same value in `X-Authorization` and `Authorization` |
+| `403` with `{"error": "Access forbidden"}` | The caller's group has no verb rule on the authz key. `methods: ["all"]` does not count |
+| `403` with a provider message | The provider refused: wrong region, expired key, or no access to that model |
+| `404` on the gateway route | The feature is off, self-disabled by the egress self-check, or nginx has not reloaded |
+| `301` | The trailing slash is missing. `curl -L` follows it, and a POST becomes a GET when it does |
+| `502 Upstream auth unavailable` | The credential vend failed. For a passthrough record, check that the caller sent `Authorization` |
+| `503` | The concurrency pool is full |
+
+Watch `mcpgw_registry_generic_proxy_request_total{entity_type,outcome}` for what callers actually get — `auth_request_total{success}` reports the authorization decision, so a request that authorizes and then fails at the hop reads there as a success. See [Observability](../OBSERVABILITY.md#the-13-hop-outcomes-and-why-the-set-is-not-just-status-code).
+
+## Related documentation
+
+- [Gateway generic proxy operational guide](../gateway-proxy-operational-guide.md)
+- [What changes when I upgrade to a release with the gateway generic proxy?](gateway-proxy-backwards-compatibility.md)
+- [Per-User Egress Credential Vault](../egress-credential-vault.md) — for operator-owned credentials and per-user OAuth
+- [Observability](../OBSERVABILITY.md) — the metrics named above


### PR DESCRIPTION
Closes #1725 — the last open follow-up from #1714.

Two FAQ articles, both linked from `docs/faq/index.md`:

- **[How do I let my team call OpenAI or Bedrock through the gateway?](https://github.com/agentic-community/mcp-gateway-registry/blob/docs/faq-gateway-proxy-articles/docs/faq/registering-model-inference-endpoints.md)** → Connecting and Integration
- **[What changes when I upgrade to a release with the gateway generic proxy?](https://github.com/agentic-community/mcp-gateway-registry/blob/docs/faq-gateway-proxy-articles/docs/faq/gateway-proxy-backwards-compatibility.md)** → Getting Started

## Article 1 — registering a model-inference endpoint

Four steps, with the failure that actually happens called out. **Step 3 is where a first attempt dies:** a legacy `methods: ["all"]` rule authorizes no HTTP verb, so a caller holding an existing MCP grant gets a 403 until an explicit verb rule names the entity's authz key. The article also says the key is *not* the client URL — the generated path drops the namespace segment, so `/skills/pdf` has the key `skill/skills/pdf` and the client URL `/gateway/skill/pdf`.

Also covered: the credential split (gateway JWT in `X-Authorization`, provider key in `Authorization`; the same value in both returns 401 from the equal-token guard), the passthrough-vs-operator-header choice and what it does to provider quota, Bedrock's region-scoped key and `application/vnd.amazon.eventstream` body, and how to tell a gateway denial from a provider refusal when both return 403.

## Article 2 — the upgrade question

Nothing changes until you opt in. No schema migration, no backfill, existing `/mcp-proxy/...` and `/agent/...` routes untouched, and enabling the feature grants nobody anything.

Names the three prerequisites beyond the flag — `DEPLOYMENT_MODE=with-gateway`, a stable `SECRET_KEY` (rotating it makes stored upstream credentials undecryptable), an enforced egress policy — plus `CUSTOM_ENTITY_TYPES_ENABLED`, whose absence looks like a missing route rather than a disabled feature. The four egress self-check log lines are quoted from the code that emits them, mapped to the state each one means.

It also lists the 1.30.0 metric label changes, since saved queries filtering `target_kind="unknown"` or `success="True"` stop matching after #1736.

## Verification

Every command ran against a live deployment. The numbers in article 1 are from that run:

```
Scope grant : present in group 'registry-admins' for GET, POST
models      : OK 125 models in 1.30s
chat        : OK in 0.94s -> 'Hello! How are you today?'
stream      : 10 chunks, first at 0.90s, span 0.11s, max gap 0.071s
Summary     : 3/3 checks passed (models, chat, stream)
```

Also verified: the equal-token guard returns 401, the documented `curl` chat call returns a completion, `custom-type-list` returns the four types on that deployment, and the proxied-skills `jq` prints `/skills/pdf -> https://raw.githubusercontent.com`.

The Bedrock 403 example is a real failure — the stored key had lapsed — and that is what makes it useful: the body was `{"Message":"Bearer Token has expired"}`, Bedrock's own wording, so the request reached Bedrock and the hop was fine. A gateway denial returns `{"error": "Access forbidden"}` instead.

**One documented command did not survive verification and was replaced.** `GET /api/config/full` authenticates with a session cookie, so a Bearer token returns `{"detail": "Authentication required"}`. The article now reads the flags from the container env and points at the System Config page.

## Acceptance criteria from #1725

- [x] Both articles exist and are linked from `docs/faq/index.md` under existing sections
- [x] Every command is copy-pasteable and states its prerequisites
- [x] The 403-from-missing-verb-rule case appears in article 1
- [x] Article 2 states plainly that a default upgrade changes no behaviour, and names all three prerequisites plus the separate custom-entity flag
- [x] Both link to the operational guide for depth rather than restating it
- [x] No emoji