### PR TITLE
fix(skills): detect redirects from history, not the pinned-IP URL

### DIFF
--- a/registry/services/skill_service.py
+++ b/registry/services/skill_service.py
@@ -113,6 +113,53 @@ def _is_safe_url(
         return False
 
 
+def _unsafe_redirect_target(
+    response: httpx.Response,
+) -> str | None:
+    """Return the first redirect hop that fails SSRF validation, else None.
+
+    Only real redirects are examined. ``response.url`` cannot be used for this:
+    the guarded transport pins every request to a validated IP by rewriting the
+    URL host (``url_guard._rewrite_to_pinned_ip``), so ``response.url`` differs
+    from the requested URL on EVERY fetch and reads as an IP literal. Comparing
+    it rejected SKILL.md fetches from forges whose hostname is allowlisted via
+    ``github_extra_hosts`` but resolves to a private address -- no redirect
+    involved (issue #1740).
+
+    Identity, not the pinned address, is what needs checking. The transport
+    preserves the intended hostname in the ``Host`` header and the
+    ``sni_hostname`` extension, so each hop is validated under the name the
+    server was asked for. A hop whose host was already an IP literal (no
+    rewrite, so no ``Host`` override) is validated as-is.
+
+    This is defense in depth: the transport itself validates, resolves, and pins
+    every hop including redirects, so a redirect to a denied address raises
+    UrlValidationError before any connect. This adds a second, independent check
+    that the redirect CHAIN stayed within policy.
+
+    Args:
+        response: The completed httpx response, possibly with a redirect history.
+
+    Returns:
+        The offending URL (identity form) if a hop fails validation, else None.
+    """
+    if not response.history:
+        return None
+
+    for hop in (*response.history, response):
+        request = hop.request
+        # Recover the pre-pinning identity the transport stashed; fall back to
+        # the request URL when no rewrite happened (literal-IP targets).
+        hostname = request.extensions.get("sni_hostname") or request.headers.get("host")
+        identity_url = str(request.url)
+        if hostname:
+            host_only = str(hostname).rsplit(":", 1)[0] if ":" in str(hostname) else str(hostname)
+            identity_url = str(request.url.copy_with(host=host_only))
+        if not _is_safe_url(identity_url):
+            return identity_url
+    return None
+
+
 def _append_page_param(
     url: str,
     page: str,
@@ -546,12 +593,12 @@ async def _validate_skill_md_url(
                 timeout=URL_VALIDATION_TIMEOUT,
             )
 
-            final_url = str(response.url)
-            if final_url != fetch_url and not _is_safe_url(final_url):
+            unsafe_hop = _unsafe_redirect_target(response)
+            if unsafe_hop is not None:
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(final_url)}"
+                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(unsafe_hop)}"
                 )
-                raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {final_url}")
+                raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {unsafe_hop}")
 
             if response.status_code >= 400:
                 raise SkillUrlValidationError(url, f"HTTP {response.status_code}")
@@ -643,13 +690,13 @@ async def _parse_skill_md_content(
                 fetch_url, headers=headers, follow_redirects=True, timeout=URL_VALIDATION_TIMEOUT
             )
 
-            # SSRF protection: validate final URL after redirects
-            final_url = str(response.url)
-            if final_url != str(raw_url) and not _is_safe_url(final_url):
+            # SSRF protection: validate every hop of a real redirect chain
+            unsafe_hop = _unsafe_redirect_target(response)
+            if unsafe_hop is not None:
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {redact_url(raw_url)} to unsafe URL {redact_url(final_url)}"
+                    f"SSRF protection: Blocked redirect from {redact_url(raw_url)} to unsafe URL {redact_url(unsafe_hop)}"
                 )
-                raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {final_url}")
+                raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {unsafe_hop}")
 
             if response.status_code >= 400:
                 raise SkillUrlValidationError(url, f"HTTP {response.status_code}")
@@ -839,17 +886,17 @@ async def _check_skill_health(
                 timeout=URL_VALIDATION_TIMEOUT,
             )
 
-            # SSRF protection: validate final URL after redirects
-            final_url = str(response.url)
-            if final_url != str(url) and not _is_safe_url(final_url):
+            # SSRF protection: validate every hop of a real redirect chain
+            unsafe_hop = _unsafe_redirect_target(response)
+            if unsafe_hop is not None:
                 logger.warning(
-                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(final_url)}"
+                    f"SSRF protection: Blocked redirect from {redact_url(url)} to unsafe URL {redact_url(unsafe_hop)}"
                 )
                 response_time_ms = (time.perf_counter() - start_time) * 1000
                 return {
                     "healthy": False,
                     "status_code": None,
-                    "error": f"Redirect to unsafe URL blocked: {final_url}",
+                    "error": f"Redirect to unsafe URL blocked: {unsafe_hop}",
                     "response_time_ms": round(response_time_ms, 2),
                 }
 
@@ -1031,9 +1078,9 @@ async def _fetch_authenticated_content(
                 timeout=timeout,
             )
 
-            final_url = str(response.url)
-            if final_url != fetch_url and not _is_safe_url(final_url):
-                raise SkillContentSSRFError(final_url)
+            unsafe_hop = _unsafe_redirect_target(response)
+            if unsafe_hop is not None:
+                raise SkillContentSSRFError(unsafe_hop)
 
             if response.status_code >= 400:
                 raise SkillContentFetchError(

--- a/tests/unit/services/test_skill_service_pinned_redirect.py
+++ b/tests/unit/services/test_skill_service_pinned_redirect.py
@@ -18,6 +18,7 @@ the transport.
 
 import asyncio
 import http.server
+import socket
 import socketserver
 import threading
 from collections.abc import Iterator
@@ -63,12 +64,30 @@ class _Origin(http.server.BaseHTTPRequestHandler):
 
 @pytest.fixture(scope="module")
 def origin() -> Iterator[int]:
-    """A loopback origin. Loopback is private, which is the point of the fixture."""
-    server = socketserver.TCPServer(("127.0.0.1", 0), _Origin)
+    """A loopback origin bound where the guard will actually dial.
+
+    ``url_guard`` resolves the hostname itself and pins the first address
+    ``getaddrinfo`` returns, so the fixture must bind that same address. Hosts
+    resolving ``localhost`` to ``::1`` first (GitHub runners) would otherwise get
+    a connection failure that looks like an SSRF refusal. Loopback is a private
+    address, which is what makes it a valid stand-in for an internal forge.
+    """
+    family, _, _, _, sockaddr = socket.getaddrinfo("localhost", 0, proto=socket.IPPROTO_TCP)[0]
+
+    class _Server(socketserver.TCPServer):
+        address_family = family
+        allow_reuse_address = True
+
+    server = _Server((sockaddr[0], 0), _Origin)
     port = server.server_address[1]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
+        # Fail loudly here rather than let an unreachable origin surface later as
+        # a "redirect blocked" error, which is the very confusion under test.
+        with socket.socket(family, socket.SOCK_STREAM) as probe:
+            probe.settimeout(5)
+            probe.connect((sockaddr[0], port))
         yield port
     finally:
         server.shutdown()
@@ -176,9 +195,17 @@ class TestRealRedirectsStillRefused:
             _validate_skill_md_url,
         )
 
-        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError):
+        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError) as exc:
             asyncio.run(_validate_skill_md_url(f"http://localhost:{origin}/to-metadata"))
         _clear_allowlist_cache()
+
+        # Assert the reason, not just the type. A transport error raises the same
+        # class, which would let an unreachable origin pose as a security refusal.
+        # These hops are refused by the guarded transport's own per-hop validation
+        # before any connect, so the message names the failure, not the target.
+        message = str(exc.value)
+        assert "All connection attempts failed" not in message
+        assert "SSRF validation" in message or "Redirect to unsafe URL blocked" in message
 
     def test_redirect_to_non_allowlisted_private_ip_is_refused(self, origin: int) -> None:
         """Allowlisting one internal host must not admit every internal host.
@@ -191,9 +218,13 @@ class TestRealRedirectsStillRefused:
             _validate_skill_md_url,
         )
 
-        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError):
+        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError) as exc:
             asyncio.run(_validate_skill_md_url(f"http://localhost:{origin}/to-other-private"))
         _clear_allowlist_cache()
+
+        message = str(exc.value)
+        assert "All connection attempts failed" not in message
+        assert "SSRF validation" in message or "Redirect to unsafe URL blocked" in message
 
 
 class TestRedirectDetectionHelper:

--- a/tests/unit/services/test_skill_service_pinned_redirect.py
+++ b/tests/unit/services/test_skill_service_pinned_redirect.py
@@ -1,0 +1,232 @@
+"""Regression tests for issue #1740: the pinned-IP rewrite vs the redirect check.
+
+The guarded transport pins every request to a validated IP by rewriting the URL
+host (``url_guard._rewrite_to_pinned_ip``), keeping identity in the ``Host``
+header and TLS SNI. That makes ``response.url`` differ from the requested URL on
+**every** fetch, and read as an IP literal.
+
+``skill_service`` used to treat that difference as evidence of a redirect, so a
+SKILL.md on a forge whose hostname is allowlisted via ``github_extra_hosts`` but
+resolves to a private address was rejected with "Redirect to unsafe URL blocked"
+even though the origin returned 200 and no ``Location`` header existed. The check
+shipped in 1.23.0 and stayed harmless until the pinning rewrite landed in 1.29.0.
+
+These tests use a real local origin so the transport genuinely pins and rewrites.
+A mocked client would not reproduce the bug, because the rewrite happens inside
+the transport.
+"""
+
+import asyncio
+import http.server
+import socketserver
+import threading
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SKILL_MD = b"---\nname: pinned-repro\ndescription: regression fixture\n---\n\n# Body\n"
+METADATA_URL = "http://169.254.169.254/latest/meta-data/"
+
+
+class _Origin(http.server.BaseHTTPRequestHandler):
+    """Serves SKILL.md at /, and two redirect shapes for the negative cases."""
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path == "/to-metadata":
+            self.send_response(302)
+            self.send_header("Location", METADATA_URL)
+            self.end_headers()
+        elif self.path == "/to-other-private":
+            # 127.0.0.2 is private and NOT on the allowlist, unlike this origin's
+            # own hostname, so a redirect there must still be refused.
+            self.send_response(302)
+            self.send_header("Location", "http://127.0.0.2:9/SKILL.md")
+            self.end_headers()
+        else:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(SKILL_MD)))
+            self.end_headers()
+            self.wfile.write(SKILL_MD)
+
+    def do_HEAD(self) -> None:  # noqa: N802 - used by the health check path
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(SKILL_MD)))
+        self.end_headers()
+
+    def log_message(self, *args: object) -> None:
+        """Silence the default stderr access log."""
+
+
+@pytest.fixture(scope="module")
+def origin() -> Iterator[int]:
+    """A loopback origin. Loopback is private, which is the point of the fixture."""
+    server = socketserver.TCPServer(("127.0.0.1", 0), _Origin)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class _Settings:
+    """Settings stub: an internal forge host on the operator bypass allowlist."""
+
+    github_extra_hosts = "localhost"
+    ssrf_allowed_hosts = ""
+    ssrf_allowed_cidrs = ""
+    gateway_proxy_allow_private_targets = False
+
+    def __getattr__(self, name: str) -> None:
+        return None
+
+
+def _allowlisted_settings():
+    """Patch the guard's settings and clear the cached skill allowlist."""
+    import registry.utils.url_guard as url_guard
+
+    url_guard._skill_allowlist.cache_clear()
+    return patch.object(url_guard, "_get_settings", return_value=_Settings())
+
+
+def _clear_allowlist_cache() -> None:
+    import registry.utils.url_guard as url_guard
+
+    url_guard._skill_allowlist.cache_clear()
+
+
+class TestPinnedIpIsNotARedirect:
+    """A 200 with no Location must never be reported as an unsafe redirect."""
+
+    def test_validate_accepts_allowlisted_private_host(self, origin: int) -> None:
+        """The 1.29.0 regression: registration rejected a fetch that succeeded.
+
+        The origin answers 200 and sends no Location, so any "redirect blocked"
+        error here comes from our own pinning rewrite rather than the server.
+        """
+        from registry.services.skill_service import _validate_skill_md_url
+
+        with _allowlisted_settings():
+            result = asyncio.run(_validate_skill_md_url(f"http://localhost:{origin}/SKILL.md"))
+        _clear_allowlist_cache()
+
+        assert result["valid"] is True
+        assert result["content_version"]
+
+    def test_parse_accepts_allowlisted_private_host(self, origin: int) -> None:
+        """Same fetch through the parse path, which is what the UI dialog calls."""
+        from registry.services.skill_service import _parse_skill_md_content
+
+        with _allowlisted_settings():
+            result = asyncio.run(_parse_skill_md_content(f"http://localhost:{origin}/SKILL.md"))
+        _clear_allowlist_cache()
+
+        assert result["name"] == "pinned-repro"
+        assert result["description"] == "regression fixture"
+
+    def test_health_check_reports_healthy(self, origin: int) -> None:
+        """Existing skills on an internal forge must not flip to unhealthy."""
+        from registry.services.skill_service import _check_skill_health
+
+        with _allowlisted_settings():
+            result = asyncio.run(_check_skill_health(f"http://localhost:{origin}/SKILL.md"))
+        _clear_allowlist_cache()
+
+        assert result["healthy"] is True, result
+        assert result["error"] is None
+
+    def test_content_fetch_succeeds_for_allowlisted_private_host(self, origin: int) -> None:
+        """The fourth call site, behind ``GET /api/skills/{path}/content``.
+
+        Serving stored SKILL.md content used the same ``response.url`` inference,
+        so the content endpoint returned an SSRF error for an internal forge.
+        """
+        from registry.schemas.skill_models import SkillCard
+        from registry.services.skill_service import _fetch_authenticated_content
+
+        url = f"http://localhost:{origin}/SKILL.md"
+        skill = SkillCard(
+            path="/skills/internal-forge-probe",
+            name="internal-forge-probe",
+            description="fixture",
+            skill_md_url=url,
+            auth_scheme="none",
+        )
+
+        with _allowlisted_settings():
+            response = asyncio.run(_fetch_authenticated_content(url, skill))
+        _clear_allowlist_cache()
+
+        assert response.status_code == 200
+        assert b"pinned-repro" in response.content
+
+
+class TestRealRedirectsStillRefused:
+    """The CWE-918 protection the check was added for must survive the fix."""
+
+    def test_redirect_to_metadata_ip_is_refused(self, origin: int) -> None:
+        from registry.services.skill_service import (
+            SkillUrlValidationError,
+            _validate_skill_md_url,
+        )
+
+        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError):
+            asyncio.run(_validate_skill_md_url(f"http://localhost:{origin}/to-metadata"))
+        _clear_allowlist_cache()
+
+    def test_redirect_to_non_allowlisted_private_ip_is_refused(self, origin: int) -> None:
+        """Allowlisting one internal host must not admit every internal host.
+
+        The origin's own hostname is on the allowlist; the redirect target is a
+        different private address that is not.
+        """
+        from registry.services.skill_service import (
+            SkillUrlValidationError,
+            _validate_skill_md_url,
+        )
+
+        with _allowlisted_settings(), pytest.raises(SkillUrlValidationError):
+            asyncio.run(_validate_skill_md_url(f"http://localhost:{origin}/to-other-private"))
+        _clear_allowlist_cache()
+
+
+class TestRedirectDetectionHelper:
+    """The helper reads redirect history, never the transport-rewritten URL."""
+
+    def test_no_history_means_no_redirect(self) -> None:
+        """Guards the exact inference that broke: url difference is not a redirect."""
+        import httpx
+
+        from registry.services.skill_service import _unsafe_redirect_target
+
+        request = httpx.Request("GET", "http://10.0.0.5/SKILL.md")  # pinned-IP form
+        response = httpx.Response(200, request=request)
+
+        assert _unsafe_redirect_target(response) is None
+
+    def test_hop_is_validated_under_its_hostname_not_the_pinned_ip(self) -> None:
+        """A hop rewritten to a private IP is judged by the name it was asked for."""
+        import httpx
+
+        from registry.services.skill_service import _unsafe_redirect_target
+
+        # What the transport produces: URL holds the pinned IP, identity is kept
+        # in the Host header and the sni_hostname extension.
+        pinned = httpx.Request(
+            "GET",
+            "http://127.0.0.1:8080/SKILL.md",
+            headers={"Host": "localhost:8080"},
+            extensions={"sni_hostname": "localhost"},
+        )
+        first = httpx.Response(302, request=httpx.Request("GET", "http://localhost:8080/x"))
+        final = httpx.Response(200, request=pinned, history=[first])
+
+        with _allowlisted_settings():
+            assert _unsafe_redirect_target(final) is None
+        _clear_allowlist_cache()


### PR DESCRIPTION
Closes #1740.

## The bug

`registry/utils/url_guard.py:1033-1035` pins every request to a validated IP by rewriting the URL host, keeping identity in the `Host` header and the `sni_hostname` extension:

```python
request.url = url.copy_with(host=pinned_ip)
request.headers["Host"] = hostname
request.extensions["sni_hostname"] = hostname
```

That is a DNS-rebinding defence and it is correct. The consequence is that `response.url` holds an IP literal on **every** fetch, not just redirected ones.

`skill_service.py` compared that value against the URL it asked for and treated any difference as a redirect:

```python
final_url = str(response.url)
if final_url != fetch_url and not _is_safe_url(final_url):
    raise SkillUrlValidationError(url, f"Redirect to unsafe URL blocked: {final_url}")
```

`final_url` always differs. For a public forge the pinned IP is public, so `_is_safe_url` passes and nobody notices. For a forge on a private network — self-hosted GitLab or GitHub Enterprise Server, allowlisted with `GITHUB_EXTRA_HOSTS` — the pinned IP is private, so the check fires and blames a redirect that never happened, naming an address the operator never typed.

The check shipped in 1.23.0 (`d84cdfaa`, CWE-918) and was harmless for six releases. The pinning rewrite landed in 1.29.0 (`68a366be`) and made it fire.

## The fix

`_unsafe_redirect_target` reads `response.history`. Empty history means no redirect, so nothing is judged. Each real hop is validated under the identity the transport preserved (`sni_hostname`, else `Host`) instead of the address it dialled. Four call sites now share it:

| Site | Symptom before |
|---|---|
| `_validate_skill_md_url` | registration returned 400 |
| `_parse_skill_md_content` | the UI's parse dialog returned 400 |
| `_check_skill_health` | existing skills flipped to "With Issues" |
| `_fetch_authenticated_content` | `GET /api/skills/{path}/content` raised an SSRF error |

## Why not the alternatives

- **Config workaround** — none exists. I tested adding the node IPs to `GITHUB_EXTRA_HOSTS`: still blocked. `url_guard.py:856` calls `_is_blocked_ip` for an IP-literal host **without** `trusted_hostname=True`, so the `hosts` allowlist is never consulted, and only a CIDR can relax a private address (`_ip_denial_reason:331`) while `_skill_allowlist()` sets `cidrs=()`.
- **Add a CIDR knob to the skill profile** — asks operators to allowlist an address range to compensate for us mis-reading our own rewritten URL. It widens the SSRF surface to paper over a string comparison.
- **Delete the check** — the transport already validates every hop with the same profile, so coverage is provably duplicated. Rejected anyway: removing a deliberate CWE-918 mitigation wants a security review, not a bug fix.

## Verification

**Reproduced and fixed on the live deployment** (`https://mcpgateway.ddns.net`), using an origin inside the docker network on a private address with its hostname on `GITHUB_EXTRA_HOSTS`, answering `200` with no `Location` header:

| Call | Before | After |
|---|---|---|
| `POST /api/skills` | `400 Redirect to unsafe URL blocked: http://172.18.0.17:8080/SKILL.md` | `201` |
| `POST /api/skills/parse-skill-md` | `400 Failed to parse SKILL.md: Redirect to unsafe URL blocked` | `200`, frontmatter parsed |
| `GET /api/skills/{path}/health` | unhealthy | `healthy: true, 200` |

The before/after ran against the same container; the fix was hot-copied in between, so nothing else changed.

**No regression on the public path:** deregistered and re-registered `algorithmic-art` (`raw.githubusercontent.com`) end to end — `204` delete, `201` register with `content_version=3bc4092c09804853`, `PUT` restoring `is_proxied` and its `/gateway/skill/algorithmic-art` route, health `200` in 23.65ms.

**Tests:** 8 in `tests/unit/services/test_skill_service_pinned_redirect.py`, against a real local origin so the transport genuinely pins — a mocked client cannot reproduce this, because the rewrite happens inside the transport. Stashing the fix makes 6 fail. The 2 that pass either way are the security negatives: a redirect to `169.254.169.254`, and a redirect from an allowlisted private host to a different private host that is not allowlisted. Both stay refused.

