### PR TITLE
docs(faq): backend credential is used for health checks and discovery, not injected on the MCP proxy hop

### DIFF
--- a/docs/faq/registering-auth-protected-servers.md
+++ b/docs/faq/registering-auth-protected-servers.md
@@ -51,9 +51,11 @@ Once registered with credentials, the registry automatically:
 
 1. **Health checks** -- Injects the decrypted credential when checking if the server is reachable
 2. **Tool discovery** -- Uses the credential to call the MCP `tools/list` method on the backend server
-3. **Request proxying** -- When clients connect through the gateway, the credential is injected into proxied requests
+3. **Request proxying** -- the registration-time credential is **not** injected into proxied client requests. On the MCP proxy hop the gateway strips the client's ingress auth headers and adds an upstream credential only when the server has an `egress_auth_mode` configured (per-user `pat`, `oauth_user`, or `obo_exchange`; see [Per-User Egress Credential Vault](../egress-credential-vault.md) and [Same-IdP OBO Token Exchange](../obo-token-exchange.md)). `auth_scheme` is the gateway's own credential for health checks and tool discovery
 
 This means tool discovery works the same way for protected servers as it does for public ones -- no additional configuration is needed beyond providing the credential at registration time.
+
+If the upstream also expects a shared, operator-owned credential at runtime, the registration-time credential alone is not enough: configure an egress mode for the server, otherwise proxied calls reach the upstream without any credential.
 
 ## Manually Providing Tools
 


### PR DESCRIPTION
## What

`docs/faq/registering-auth-protected-servers.md` said that the Backend Authentication credential is "injected into proxied requests". On the auth-server MCP proxy hop the client's ingress auth headers are stripped and no server-level credential is added unless an `egress_auth_mode` is configured (#1265, #1266). The credential is used by the registry for health checks and tool discovery only (`registry/core/mcp_client.py`, `registry/health/service.py`).

This PR rewrites bullet 3 of "How Tool Discovery Works with Auth" and adds a short pointer to the egress credential broker docs, so operators fronting a third-party MCP server do not expect the stored credential to reach the upstream at runtime.

## Why

Operators (us included) configure `auth_scheme=bearer`, see the server become healthy, then get 401 from the upstream on every proxied call and spend time debugging the wrong layer. See issue #1745 for the full analysis and the follow-up proposal (apply `custom_headers` and an opt-in operator credential on the MCP hop).

## Checklist

- [x] Docs only, no code change.
- [x] `ruff` not applicable.
- [x] Links checked against current `main`.
