### PR TITLE
fix(prm): resolve RFC 9728 path-aware per-server PRM under a path-prefixed registry_url

### DIFF
--- a/docs/oauth-discovery-endpoints.md
+++ b/docs/oauth-discovery-endpoints.md
@@ -156,6 +156,21 @@ the client expects (e.g. `https://claude.ai/api/mcp/auth_callback` for
 Claude.ai's Custom Connector UI) and paste the resulting `client_id`/
 `client_secret` into the connector's "Advanced settings" panel.
 
+## Path-prefixed deployments
+
+When the gateway is served under a path prefix (`ROOT_PATH=/registry`,
+`REGISTRY_URL=https://gw.example.com/registry`), the per-server resource is
+`https://gw.example.com/registry/<server>/mcp`. RFC 9728 section 3.1 forms the
+path-aware well-known URL by inserting the well-known segment between host and
+path, so a client that derives it from the resource requests
+`https://gw.example.com/.well-known/oauth-protected-resource/registry/<server>/mcp`.
+The registry resolves that form (the gateway's own prefix is stripped before the
+server lookup), and the bundled nginx already forwards `location ^~ /.well-known/`
+to the app. If an external ingress or load balancer sits in front and only routes
+`/<ROOT_PATH>/*`, route `/.well-known/*` to the registry as well, or clients that
+do not follow the `resource_metadata` hint from the 401 will get a 404 and fall
+back to legacy discovery.
+
 ## Common diagnostic checks
 
 | Symptom | Likely cause |

--- a/registry/api/wellknown_routes.py
+++ b/registry/api/wellknown_routes.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -310,6 +311,20 @@ async def get_oauth_protected_resource() -> JSONResponse:
     return JSONResponse(content=document, headers=OAUTH_DISCOVERY_CACHE_HEADERS)
 
 
+def _registry_url_path_prefix() -> str:
+    """Path component of ``settings.registry_url`` (e.g. ``/registry``), or ``""``.
+
+    Path-prefixed deployments (``ROOT_PATH`` / ``REGISTRY_URL`` with a path)
+    advertise per-server resources of the form ``https://gw/<prefix>/<server>/mcp``.
+    """
+    try:
+        path = urlparse(settings.registry_url).path or ""
+    except (TypeError, ValueError, AttributeError):
+        return ""
+    path = path.rstrip("/")
+    return path if path and path != "/" else ""
+
+
 def _normalize_prm_server_path(server_path: str) -> str:
     """Reduce a path-aware PRM suffix to the registered server path.
 
@@ -317,8 +332,18 @@ def _normalize_prm_server_path(server_path: str) -> str:
     ``/.well-known/oauth-protected-resource/<server>/mcp`` (the connection URL's
     path). Strip a trailing ``/mcp`` transport segment and normalize to the
     leading-slash registered path (e.g. ``obo-echo/mcp`` -> ``/obo-echo``).
+
+    When the gateway runs under a path prefix, the advertised resource is
+    ``https://gw/<prefix>/<server>/mcp`` and RFC 9728 section 3.1 places the
+    well-known segment between host and path, so a client derives
+    ``/.well-known/oauth-protected-resource/<prefix>/<server>/mcp``. Drop the
+    gateway's own prefix first (``registry/obo-echo/mcp`` -> ``/obo-echo``);
+    deployments without a prefix are unaffected.
     """
     p = "/" + server_path.strip("/")
+    prefix = _registry_url_path_prefix()
+    if prefix and (p == prefix or p.startswith(prefix + "/")):
+        p = p[len(prefix) :] or "/"
     if p.endswith("/mcp"):
         p = p[: -len("/mcp")]
     return p or "/"

--- a/tests/unit/api/test_wellknown_routes.py
+++ b/tests/unit/api/test_wellknown_routes.py
@@ -722,3 +722,57 @@ class TestPerServerOAuthProtectedResource:
             client = TestClient(_make_oauth_discovery_app(fake_provider))
             client.get("/.well-known/oauth-protected-resource/obo-echo/mcp")
             assert seen["path"] == "/obo-echo"
+
+    def test_path_normalization_strips_registry_url_prefix(self, fake_provider):
+        """RFC 9728 section 3.1 path-aware URL under a path-prefixed registry_url.
+
+        With ``registry_url=https://gw.example.com/registry`` the advertised
+        per-server resource is ``https://gw.example.com/registry/obo-echo/mcp``, so
+        a client deriving the well-known URL requests
+        ``/.well-known/oauth-protected-resource/registry/obo-echo/mcp``. The handler
+        must look up ``/obo-echo``, not ``/registry/obo-echo``.
+        """
+        s = self._settings()
+        s.registry_url = "https://gw.example.com/registry"
+        seen = {}
+
+        async def _capture(path, *a, **k):
+            seen["path"] = path
+            return {"path": "/obo-echo", "egress_auth_mode": "obo_exchange"}
+
+        with (
+            patch(
+                "registry.api.wellknown_routes._get_active_auth_provider",
+                return_value=fake_provider,
+            ),
+            patch("registry.auth.oauth_metadata.settings", s),
+            patch("registry.api.wellknown_routes.settings", s),
+            patch("registry.api.wellknown_routes.server_service.get_server_info", new=_capture),
+        ):
+            client = TestClient(_make_oauth_discovery_app(fake_provider))
+            resp = client.get("/.well-known/oauth-protected-resource/registry/obo-echo/mcp")
+            assert seen["path"] == "/obo-echo"
+            assert resp.status_code == 200
+            assert resp.json()["resource"] == "https://gw.example.com/registry/obo-echo/mcp"
+
+    def test_path_normalization_without_prefix_is_unchanged(self, fake_provider):
+        """No registry_url path: a leading segment is part of the server path."""
+        s = self._settings()  # registry_url = https://gw.example.com
+        seen = {}
+
+        async def _capture(path, *a, **k):
+            seen["path"] = path
+            return None
+
+        with (
+            patch(
+                "registry.api.wellknown_routes._get_active_auth_provider",
+                return_value=fake_provider,
+            ),
+            patch("registry.auth.oauth_metadata.settings", s),
+            patch("registry.api.wellknown_routes.settings", s),
+            patch("registry.api.wellknown_routes.server_service.get_server_info", new=_capture),
+        ):
+            client = TestClient(_make_oauth_discovery_app(fake_provider))
+            client.get("/.well-known/oauth-protected-resource/registry/obo-echo/mcp")
+            assert seen["path"] == "/registry/obo-echo"


### PR DESCRIPTION
## What

`_normalize_prm_server_path()` now strips the path component of `settings.registry_url` (for example `/registry`) from the incoming `server_path` before the existing `/mcp` trimming. With `REGISTRY_URL=https://gw.example.com/registry`:

- `GET /.well-known/oauth-protected-resource/registry/my-server/mcp` → looks up `/my-server` (previously `/registry/my-server`, 404)
- `GET /.well-known/oauth-protected-resource/my-server/mcp` → unchanged

Deployments whose `registry_url` has no path are unaffected.

## Why

RFC 9728 §3.1 forms the well-known URL by inserting `/.well-known/oauth-protected-resource` between host and path of the resource. For the advertised per-server resource `https://gw.example.com/registry/my-server/mcp` that is `https://gw.example.com/.well-known/oauth-protected-resource/registry/my-server/mcp`. Clients that derive the URL this way (as a first attempt, or as a fallback after `resource_metadata` from the 401 header) get a 404 and end up in legacy discovery. Closes #1746.

## Testing

- New unit tests in `tests/unit/api/test_wellknown_routes.py`: `test_path_normalization_strips_registry_url_prefix` (path-prefixed `registry_url` → handler looks up `/obo-echo`, 200, resource unchanged) and `test_path_normalization_without_prefix_is_unchanged`.
- `uv run pytest tests/unit/api/test_wellknown_routes.py`: 37 passed locally (the coverage gate fails on a single-file run, as expected). Full `./tests/run_all_tests.sh` not run locally; relying on CI.

## Notes

The bundled nginx already forwards `location ^~ /.well-known/` to the registry app. Operators with an external ingress that only routes `/<ROOT_PATH>` still need to route `/.well-known/` too; a one-line note is added to `docs/oauth-discovery-endpoints.md`.
